### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agntcy-slim"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-auth",
  "drain",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-datapath",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "tokio",
  "tracing",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agntcy-slim-config",
  "once_cell",

--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agntcy-slim"
-version = "0.3.16"
+version = "0.4.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "0.3.16" }
+agntcy-slim = { path = "core/slim", version = "0.4.0" }
 agntcy-slim-auth = { path = "core/auth", version = "0.2.0" }
 agntcy-slim-config = { path = "core/config", version = "0.2.0" }
 agntcy-slim-controller = { path = "core/controller", version = "0.2.0" }

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -34,15 +34,15 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "0.3.15" }
-agntcy-slim-auth = { path = "core/auth", version = "0.1.0" }
-agntcy-slim-config = { path = "core/config", version = "0.1.8" }
-agntcy-slim-controller = { path = "core/controller", version = "0.1.1" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.7.0" }
+agntcy-slim = { path = "core/slim", version = "0.3.16" }
+agntcy-slim-auth = { path = "core/auth", version = "0.2.0" }
+agntcy-slim-config = { path = "core/config", version = "0.2.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.2.0" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.8.0" }
 agntcy-slim-mls = { path = "core/mls", version = "0.1.0" }
-agntcy-slim-service = { path = "core/service", version = "0.4.2" }
-agntcy-slim-signal = { path = "core/signal", version = "0.1.2" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.2.1" }
+agntcy-slim-service = { path = "core/service", version = "0.5.0" }
+agntcy-slim-signal = { path = "core/signal", version = "0.1.3" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.2.2" }
 
 async-trait = "0.1.88"
 aws-lc-rs = "1.13.1"

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/agntcy/slim/compare/slim-auth-v0.1.0...slim-auth-v0.2.0) - 2025-07-31
+
+### Added
+
+- *(python-bindings)* update examples and make them packageable ([#468](https://github.com/agntcy/slim/pull/468))
+- *(auth)* support JWK as decoding keys ([#461](https://github.com/agntcy/slim/pull/461))
+- add identity and mls options to python bindings ([#436](https://github.com/agntcy/slim/pull/436))
+- implement MLS key rotation ([#412](https://github.com/agntcy/slim/pull/412))
+- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
+- push and verify identities in message headers ([#384](https://github.com/agntcy/slim/pull/384))
+- add auth support in sessions ([#382](https://github.com/agntcy/slim/pull/382))
+- implement MLS ([#307](https://github.com/agntcy/slim/pull/307))
+- support hot reload of TLS certificates ([#359](https://github.com/agntcy/slim/pull/359))
+- *(auth)* get JWT from file ([#358](https://github.com/agntcy/slim/pull/358))
+- *(config)* update the public/private key on file change ([#356](https://github.com/agntcy/slim/pull/356))
+- *(auth)* introduce token provider trait ([#357](https://github.com/agntcy/slim/pull/357))
+- *(auth)* jwt middleware ([#352](https://github.com/agntcy/slim/pull/352))
+
+### Fixed
+
+- *(auth)* make simple identity usable for groups ([#387](https://github.com/agntcy/slim/pull/387))
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+- *(session)* use parking_lot to sync access to MlsState ([#401](https://github.com/agntcy/slim/pull/401))

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.1.0"
+version = "0.2.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/slim/compare/slim-config-v0.1.8...slim-config-v0.2.0) - 2025-07-31
+
+### Added
+
+- *(auth)* support JWK as decoding keys ([#461](https://github.com/agntcy/slim/pull/461))
+- add client connections to control plane ([#429](https://github.com/agntcy/slim/pull/429))
+- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
+- support hot reload of TLS certificates ([#359](https://github.com/agntcy/slim/pull/359))
+- *(config)* update the public/private key on file change ([#356](https://github.com/agntcy/slim/pull/356))
+- *(auth)* introduce token provider trait ([#357](https://github.com/agntcy/slim/pull/357))
+- *(config)* add watcher for file modifications ([#353](https://github.com/agntcy/slim/pull/353))
+- *(auth)* jwt middleware ([#352](https://github.com/agntcy/slim/pull/352))
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+
 ## [0.1.8](https://github.com/agntcy/slim/compare/slim-config-v0.1.7...slim-config-v0.1.8) - 2025-05-14
 
 ### Fixed

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.1.8"
+version = "0.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/slim/compare/slim-controller-v0.1.1...slim-controller-v0.2.0) - 2025-07-31
+
+### Added
+
+- control plane service & slimctl cp commands ([#388](https://github.com/agntcy/slim/pull/388))
+- add client connections to control plane ([#429](https://github.com/agntcy/slim/pull/429))
+- add node register call to proto ([#406](https://github.com/agntcy/slim/pull/406))
+- *(proto)* introduce SessionType in message header ([#410](https://github.com/agntcy/slim/pull/410))
+- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+
 ## [0.1.1](https://github.com/agntcy/slim/compare/slim-controller-v0.1.0...slim-controller-v0.1.1) - 2025-05-14
 
 ### Other

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-controller"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.1"
+version = "0.2.0"
 description = "Controller service and control API to configure the SLIM data plane through the control plane."
 
 [lib]

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.7.0...slim-datapath-v0.8.0) - 2025-07-31
+
+### Added
+
+- implement key rotation proposal message exchange ([#434](https://github.com/agntcy/slim/pull/434))
+- *(proto)* introduce SessionType in message header ([#410](https://github.com/agntcy/slim/pull/410))
+- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
+- add mls message types in slim messages ([#386](https://github.com/agntcy/slim/pull/386))
+- push and verify identities in message headers ([#384](https://github.com/agntcy/slim/pull/384))
+- add auth support in sessions ([#382](https://github.com/agntcy/slim/pull/382))
+- channel creation in session layer ([#374](https://github.com/agntcy/slim/pull/374))
+- implement MLS ([#307](https://github.com/agntcy/slim/pull/307))
+- derive name id from provided identity ([#345](https://github.com/agntcy/slim/pull/345))
+- add identity into the SLIM message ([#342](https://github.com/agntcy/slim/pull/342))
+- *(data-plane)* upgrade to rust 1.87 ([#317](https://github.com/agntcy/slim/pull/317))
+
+### Fixed
+
+- *(channel_endpoint)* extend mls for all sessions ([#411](https://github.com/agntcy/slim/pull/411))
+- [**breaking**] remove request-reply session type ([#416](https://github.com/agntcy/slim/pull/416))
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+
 ## [0.7.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.6.0...slim-datapath-v0.7.0) - 2025-05-14
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.7.0"
+version = "0.8.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/slim/compare/slim-service-v0.4.2...slim-service-v0.5.0) - 2025-07-31
+
+### Added
+
+- get source and destination name form python ([#485](https://github.com/agntcy/slim/pull/485))
+- *(python-bindings)* update examples and make them packageable ([#468](https://github.com/agntcy/slim/pull/468))
+- process concurrent modification to the group ([#451](https://github.com/agntcy/slim/pull/451))
+- add identity and mls options to python bindings ([#436](https://github.com/agntcy/slim/pull/436))
+- improve handling of commit broadcast ([#433](https://github.com/agntcy/slim/pull/433))
+- implement key rotation proposal message exchange ([#434](https://github.com/agntcy/slim/pull/434))
+- add client connections to control plane ([#429](https://github.com/agntcy/slim/pull/429))
+- implement MLS key rotation ([#412](https://github.com/agntcy/slim/pull/412))
+- *(proto)* introduce SessionType in message header ([#410](https://github.com/agntcy/slim/pull/410))
+- *(channel_endpoint)* add error handling ([#409](https://github.com/agntcy/slim/pull/409))
+- do no create session on discovery request ([#402](https://github.com/agntcy/slim/pull/402))
+- integrate MLS with auth ([#385](https://github.com/agntcy/slim/pull/385))
+- add mls message types in slim messages ([#386](https://github.com/agntcy/slim/pull/386))
+- push and verify identities in message headers ([#384](https://github.com/agntcy/slim/pull/384))
+- add auth support in sessions ([#382](https://github.com/agntcy/slim/pull/382))
+- channel creation in session layer ([#374](https://github.com/agntcy/slim/pull/374))
+- add the ability to drop messages from the interceptor ([#371](https://github.com/agntcy/slim/pull/371))
+- implement MLS ([#307](https://github.com/agntcy/slim/pull/307))
+- add identity into the SLIM message ([#342](https://github.com/agntcy/slim/pull/342))
+- *(data-plane)* upgrade to rust 1.87 ([#317](https://github.com/agntcy/slim/pull/317))
+
+### Fixed
+
+- prevent message publication before mls setup ([#458](https://github.com/agntcy/slim/pull/458))
+- remove all state on session close ([#449](https://github.com/agntcy/slim/pull/449))
+- mls update timer duration ([#437](https://github.com/agntcy/slim/pull/437))
+- *(channel_endpoint)* extend mls for all sessions ([#411](https://github.com/agntcy/slim/pull/411))
+- fix building problem ([#422](https://github.com/agntcy/slim/pull/422))
+- [**breaking**] remove request-reply session type ([#416](https://github.com/agntcy/slim/pull/416))
+- *(auth)* make simple identity usable for groups ([#387](https://github.com/agntcy/slim/pull/387))
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+- 397 remove endpoints in mls groups ([#413](https://github.com/agntcy/slim/pull/413))
+- *(session)* use parking_lot to sync access to MlsState ([#401](https://github.com/agntcy/slim/pull/401))
+- fix test channel endpoint ([#405](https://github.com/agntcy/slim/pull/405))
+- *(streaming)* remove lock from channel_endpoint ([#399](https://github.com/agntcy/slim/pull/399))
+
 ## [0.4.2](https://github.com/agntcy/slim/compare/slim-service-v0.4.1...slim-service-v0.4.2) - 2025-05-14
 
 ### Other

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.2"
+version = "0.5.0"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/signal/CHANGELOG.md
+++ b/data-plane/core/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/agntcy/slim/compare/slim-signal-v0.1.2...slim-signal-v0.1.3) - 2025-07-31
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+
 ## [0.1.2](https://github.com/agntcy/slim/compare/slim-signal-v0.1.1...slim-signal-v0.1.2) - 2025-04-24
 
 ### Other

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.2"
+version = "0.1.3"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.16](https://github.com/agntcy/slim/compare/slim-v0.3.15...slim-v0.3.16) - 2025-07-31
+## [0.4.0](https://github.com/agntcy/slim/compare/slim-v0.3.15...slim-v0.4.0) - 2025-07-31
 
 ### Other
 

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/agntcy/slim/compare/slim-v0.3.15...slim-v0.3.16) - 2025-07-31
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+
 ## [0.3.15](https://github.com/agntcy/slim/compare/slim-v0.3.14...slim-v0.3.15) - 2025-05-14
 
 ### Fixed

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "0.3.16"
+version = "0.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "0.3.15"
+version = "0.3.16"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.2.1...slim-tracing-v0.2.2) - 2025-07-31
+
+### Other
+
+- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
+
 ## [0.2.1](https://github.com/agntcy/slim/compare/slim-tracing-v0.2.0...slim-tracing-v0.2.1) - 2025-05-14
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.2.2"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agntcy-slim"
-version = "0.3.15"
+version = "0.4.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-auth",
  "drain",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-datapath",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "tokio",
  "tracing",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agntcy-slim-config",
  "once_cell",

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.toml
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.toml
@@ -22,12 +22,12 @@ name = "slim-mcp-proxy"
 path = "src/main.rs"
 
 [dependencies]
-agntcy-slim = { path = "../../../core/slim", version = "0.3.14" }
-agntcy-slim-auth = { path = "../../../core/auth", version = "0.1.0" }
-agntcy-slim-config = { path = "../../../core/config", version = "0.1.8" }
-agntcy-slim-datapath = { path = "../../../core/datapath", version = "0.7.0" }
-agntcy-slim-service = { path = "../../../core/service", version = "0.4.2" }
-agntcy-slim-signal = { path = "../../../core/signal", version = "0.1.2" }
+agntcy-slim = { path = "../../../core/slim", version = "0.4.0" }
+agntcy-slim-auth = { path = "../../../core/auth", version = "0.2.0" }
+agntcy-slim-config = { path = "../../../core/config", version = "0.2.0" }
+agntcy-slim-datapath = { path = "../../../core/datapath", version = "0.8.0" }
+agntcy-slim-service = { path = "../../../core/service", version = "0.5.0" }
+agntcy-slim-signal = { path = "../../../core/signal", version = "0.1.3" }
 async-trait = "0.1"
 clap = "4.5.37"
 futures-util = "0.3.31"


### PR DESCRIPTION

## 🤖 New release

* `agntcy-slim-auth`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.1.8 -> 0.2.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `agntcy-slim-signal`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)
* `agntcy-slim`: 0.3.15 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type KeyResolver no longer derives Clone, in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/resolver.rs:63

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthError:GetTokenError in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/errors.rs:21
  variant AuthError:InvalidHeader in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/errors.rs:27

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Jwt::builder, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-auth/src/jwt.rs:31
  Jwt::create_standard_claims, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-auth/src/jwt.rs:70

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_auth::builder::JwtBuilder::private_key now takes 2 parameters instead of 3, in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/builder.rs:235
  slim_auth::builder::JwtBuilder::public_key now takes 2 parameters instead of 3, in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/builder.rs:253

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct slim_auth::builder::state::Final, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-auth/src/builder.rs:43

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method slim_auth::traits::Signer::sign_standard_claims in file /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/traits.rs:93
  trait method slim_auth::traits::Verifier::try_verify in file /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/traits.rs:78

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait slim_auth::traits::Claimer, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-auth/src/traits.rs:50

--- failure trait_removed_supertrait: supertrait removed or renamed ---

Description:
A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.
        ref: https://doc.rust-lang.org/reference/items/traits.html#supertraits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_removed_supertrait.ron

Failed in:
  supertrait slim_auth::traits::Claimer of trait Signer in file /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/traits.rs:84
  supertrait slim_auth::traits::Claimer of trait Verifier in file /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/traits.rs:68

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait Jwt (0 -> 1 required generic types) in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/jwt.rs:157

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct Jwt (0 -> 1 required generic types) in /tmp/.tmpSwBSgn/slim/data-plane/core/auth/src/jwt.rs:157
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthenticationConfig:Jwt in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/grpc/client.rs:97
  variant AuthError:TokenExpired in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/auth.rs:16
  variant AuthError:TokenInvalid in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/auth.rs:19
  variant AuthError:SigningError in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/auth.rs:22
  variant AuthError:InvalidHeader in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/auth.rs:25
  variant AuthenticationConfig:Jwt in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/grpc/server.rs:66
  variant ConfigError:InvalidFile in /tmp/.tmpSwBSgn/slim/data-plane/core/config/src/tls/common.rs:170
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SessionHeader.session_type in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs:62
  field SessionHeader.session_message_type in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs:64
  field Subscribe.component_0 in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs:7
  field Subscribe.component_1 in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs:9
  field Subscribe.component_2 in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs:11

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum slim_datapath::api::proto::pubsub::v1::message::MessageType, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:88
  enum slim_datapath::api::proto::pubsub::v1::SessionHeaderType, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:99

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant SubscriptionTableError:IdNotFound in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/tables/errors.rs:13

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant SubscriptionTableError::AgentIdNotFound, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/tables/errors.rs:13

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Message::get_source_agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/utils.rs:649
  Message::get_name, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/utils.rs:653
  Message::get_name_as_agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/utils.rs:671
  Message::get_header_type, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/utils.rs:696
  Message::set_header_type, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/utils.rs:731
  SessionHeader::header_type, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:59
  SessionHeader::set_header_type, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:59

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_datapath::api::ProtoMessage::new_subscribe now takes 3 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:426
  slim_datapath::api::ProtoMessage::new_unsubscribe now takes 3 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:432
  slim_datapath::api::ProtoMessage::new_publish now takes 5 parameters instead of 6, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:438
  slim_datapath::api::SlimHeader::new now takes 3 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:147
  slim_datapath::api::ProtoSubscribe::new now takes 3 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:305
  slim_datapath::api::ProtoUnsubscribe::new now takes 3 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:334
  slim_datapath::api::ProtoPublish::new now takes 5 parameters instead of 6, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:366
  slim_datapath::api::SessionHeader::new now takes 4 parameters instead of 3, in /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/messages/utils.rs:266

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod slim_datapath::api::proto::pubsub::v1::pub_sub_service_client, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:160
  mod slim_datapath::api::proto, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/proto.rs:4
  mod slim_datapath::api::proto::pubsub::v1, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/proto.rs:5
  mod slim_datapath::api::proto::pubsub::v1::pub_sub_service_server, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:277
  mod slim_datapath::api::proto::pubsub, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/proto.rs:4
  mod slim_datapath::api::proto::pubsub::v1::message, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:86

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  SERVICE_NAME in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:460
  DEFAULT_AGENT_ID in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/encoder.rs:8

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct slim_datapath::api::proto::pubsub::v1::Message, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:76
  struct slim_datapath::messages::encoder::Agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/encoder.rs:106
  struct slim_datapath::messages::Agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/encoder.rs:106
  struct slim_datapath::api::proto::pubsub::v1::SlimHeader, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:32
  struct slim_datapath::api::proto::pubsub::v1::Subscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:3
  struct slim_datapath::api::proto::pubsub::v1::Agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:49
  struct slim_datapath::api::ProtoAgent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:49
  struct slim_datapath::api::proto::pubsub::v1::pub_sub_service_client::PubSubServiceClient, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:171
  struct slim_datapath::api::proto::pubsub::v1::Unsubscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:14
  struct slim_datapath::messages::encoder::AgentType, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/encoder.rs:11
  struct slim_datapath::messages::AgentType, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/messages/encoder.rs:11
  struct slim_datapath::api::proto::pubsub::v1::Publish, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:19
  struct slim_datapath::api::proto::pubsub::v1::Content, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:69
  struct slim_datapath::api::proto::pubsub::v1::pub_sub_service_server::PubSubServiceServer, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:304
  struct slim_datapath::api::proto::pubsub::v1::SessionHeader, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:60

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field organization of struct Subscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:7
  field namespace of struct Subscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:9
  field agent_type of struct Subscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:11
  field header_type of struct SessionHeader, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:62

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  SubscriptionTable::add_subscription now takes 4 instead of 5 parameters, in file /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/tables.rs:22
  SubscriptionTable::remove_subscription now takes 4 instead of 5 parameters, in file /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/tables.rs:29
  SubscriptionTable::match_one now takes 3 instead of 4 parameters, in file /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/tables.rs:38
  SubscriptionTable::match_all now takes 3 instead of 4 parameters, in file /tmp/.tmpSwBSgn/slim/data-plane/core/datapath/src/tables.rs:40

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait slim_datapath::api::proto::pubsub::v1::pub_sub_service_server::PubSubService, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-datapath/src/api/gen/pubsub.proto.v1.rs:288
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Connection.config_data in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:40
  field SubscriptionEntry.component_0 in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:83
  field SubscriptionEntry.component_1 in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:85
  field SubscriptionEntry.component_2 in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:87
  field SubscriptionEntry.id in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:89
  field Subscription.component_0 in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:45
  field Subscription.component_1 in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:47
  field Subscription.component_2 in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:49
  field Subscription.id in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:51
  field ConnectionEntry.config_data in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:102

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Payload:RegisterNodeRequest in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:26
  variant Payload:RegisterNodeResponse in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:28
  variant Payload:DeregisterNodeRequest in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:30
  variant Payload:DeregisterNodeResponse in /tmp/.tmpSwBSgn/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:32

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct slim_controller::service::ControllerService, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/service.rs:35

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field organization of struct SubscriptionEntry, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:77
  field namespace of struct SubscriptionEntry, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:79
  field agent_type of struct SubscriptionEntry, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:81
  field agent_id of struct SubscriptionEntry, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:83
  field ip of struct ConnectionEntry, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:96
  field port of struct ConnectionEntry, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:98
  field remote_address of struct Connection, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:32
  field remote_port of struct Connection, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:34
  field organization of struct Subscription, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:39
  field namespace of struct Subscription, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:41
  field agent_type of struct Subscription, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:43
  field agent_id of struct Subscription, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:45
```

### ⚠ `agntcy-slim-service` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FireAndForgetConfiguration.mls_enabled in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/fire_and_forget.rs:36
  field StreamingConfiguration.channel_name in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:45
  field StreamingConfiguration.moderator in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:46
  field StreamingConfiguration.mls_enabled in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:49
  field StreamingConfiguration.channel_name in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:45
  field StreamingConfiguration.moderator in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:46
  field StreamingConfiguration.mls_enabled in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:49
  field Info.session_message_type in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/session.rs:97
  field Info.session_type in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/session.rs:99
  field Info.message_destination in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/session.rs:103

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field FireAndForgetConfiguration.initiator in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/fire_and_forget.rs:37

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant SessionType::Streaming 2 -> 1 in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/session.rs:231

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionError:InterceptorError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:95
  variant SessionError:MlsEncryptionFailed in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:97
  variant SessionError:MlsDecryptionFailed in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:99
  variant SessionError:MlsNoPayload in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:101
  variant SessionError:IdentityError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:103
  variant SessionError:IdentityPushError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:105
  variant SessionError:MLSInit in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:109
  variant SessionError:NoMls in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:111
  variant SessionError:MLSKeyPackage in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:113
  variant SessionError:MLSIdMessage in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:115
  variant SessionError:WelcomeMessage in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:117
  variant SessionError:CommitMessage in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:119
  variant SessionError:ParseProposalMessage in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:121
  variant SessionError:NewProposalMessage in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:123
  variant SessionError:AddParticipant in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:125
  variant SessionError:RemoveParticipant in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:127
  variant SessionError:TimerNotFound in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:129
  variant SessionError:JoinChannelPayload in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:131
  variant SessionError:KeyRotationPending in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:133
  variant SessionError:ModeratorTask in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:137
  variant ServiceError:AppAlreadyRegistered in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:13
  variant ServiceError:AppNotFound in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:15
  variant ServiceError:ControllerError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:43
  variant ServiceError:StorageError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:45
  variant ServiceError:AppAlreadyRegistered in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:13
  variant ServiceError:AppNotFound in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:15
  variant ServiceError:ControllerError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:43
  variant ServiceError:StorageError in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/errors.rs:45

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ServiceError::AgentAlreadyRegistered, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/errors.rs:13
  variant ServiceError::AgentNotFound, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/errors.rs:15
  variant ServiceError::AgentAlreadyRegistered, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/errors.rs:13
  variant ServiceError::AgentNotFound, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/errors.rs:15
  variant SessionType::RequestResponse, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/session.rs:178
  variant SessionConfig::RequestResponse, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/session.rs:195

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Service::create_agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:267
  Service::delete_agent, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:302
  Service::subscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:463
  Service::unsubscribe, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:481
  Service::set_route, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:499
  Service::remove_route, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:518
  Service::publish_to, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:537
  Service::publish, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:557
  Service::publish_with_flags, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:576
  Service::create_session, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:692
  Service::set_session_config, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:710
  Service::get_session_config, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:730
  Service::get_default_session_config, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:746
  Service::delete_session, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:765
  ServiceConfiguration::controller_server, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:106
  ServiceConfiguration::controller_client, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:110
  Info::set_session_header_type, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/session.rs:100
  Info::get_session_header_type, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/session.rs:116

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_service::streaming::StreamingConfiguration::new now takes 6 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:101
  slim_service::StreamingConfiguration::new now takes 6 parameters instead of 4, in /tmp/.tmpSwBSgn/slim/data-plane/core/service/src/streaming.rs:101

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct slim_service::ControllerConfig, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/lib.rs:62
  struct slim_service::RequestResponseConfiguration, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/request_response.rs:24

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field session_header_type of struct Info, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/session.rs:77
  field topic of struct StreamingConfiguration, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/streaming.rs:36
  field topic of struct StreamingConfiguration, previously in file /tmp/.tmpvoi2Oa/agntcy-slim-service/src/streaming.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.2.0](https://github.com/agntcy/slim/compare/slim-auth-v0.1.0...slim-auth-v0.2.0) - 2025-07-31

### Added

- *(python-bindings)* update examples and make them packageable ([#468](https://github.com/agntcy/slim/pull/468))
- *(auth)* support JWK as decoding keys ([#461](https://github.com/agntcy/slim/pull/461))
- add identity and mls options to python bindings ([#436](https://github.com/agntcy/slim/pull/436))
- implement MLS key rotation ([#412](https://github.com/agntcy/slim/pull/412))
- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
- push and verify identities in message headers ([#384](https://github.com/agntcy/slim/pull/384))
- add auth support in sessions ([#382](https://github.com/agntcy/slim/pull/382))
- implement MLS ([#307](https://github.com/agntcy/slim/pull/307))
- support hot reload of TLS certificates ([#359](https://github.com/agntcy/slim/pull/359))
- *(auth)* get JWT from file ([#358](https://github.com/agntcy/slim/pull/358))
- *(config)* update the public/private key on file change ([#356](https://github.com/agntcy/slim/pull/356))
- *(auth)* introduce token provider trait ([#357](https://github.com/agntcy/slim/pull/357))
- *(auth)* jwt middleware ([#352](https://github.com/agntcy/slim/pull/352))

### Fixed

- *(auth)* make simple identity usable for groups ([#387](https://github.com/agntcy/slim/pull/387))

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
- *(session)* use parking_lot to sync access to MlsState ([#401](https://github.com/agntcy/slim/pull/401))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.2.0](https://github.com/agntcy/slim/compare/slim-config-v0.1.8...slim-config-v0.2.0) - 2025-07-31

### Added

- *(auth)* support JWK as decoding keys ([#461](https://github.com/agntcy/slim/pull/461))
- add client connections to control plane ([#429](https://github.com/agntcy/slim/pull/429))
- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
- support hot reload of TLS certificates ([#359](https://github.com/agntcy/slim/pull/359))
- *(config)* update the public/private key on file change ([#356](https://github.com/agntcy/slim/pull/356))
- *(auth)* introduce token provider trait ([#357](https://github.com/agntcy/slim/pull/357))
- *(config)* add watcher for file modifications ([#353](https://github.com/agntcy/slim/pull/353))
- *(auth)* jwt middleware ([#352](https://github.com/agntcy/slim/pull/352))

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.2.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.2.1...slim-tracing-v0.2.2) - 2025-07-31

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.8.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.7.0...slim-datapath-v0.8.0) - 2025-07-31

### Added

- implement key rotation proposal message exchange ([#434](https://github.com/agntcy/slim/pull/434))
- *(proto)* introduce SessionType in message header ([#410](https://github.com/agntcy/slim/pull/410))
- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))
- add mls message types in slim messages ([#386](https://github.com/agntcy/slim/pull/386))
- push and verify identities in message headers ([#384](https://github.com/agntcy/slim/pull/384))
- add auth support in sessions ([#382](https://github.com/agntcy/slim/pull/382))
- channel creation in session layer ([#374](https://github.com/agntcy/slim/pull/374))
- implement MLS ([#307](https://github.com/agntcy/slim/pull/307))
- derive name id from provided identity ([#345](https://github.com/agntcy/slim/pull/345))
- add identity into the SLIM message ([#342](https://github.com/agntcy/slim/pull/342))
- *(data-plane)* upgrade to rust 1.87 ([#317](https://github.com/agntcy/slim/pull/317))

### Fixed

- *(channel_endpoint)* extend mls for all sessions ([#411](https://github.com/agntcy/slim/pull/411))
- [**breaking**] remove request-reply session type ([#416](https://github.com/agntcy/slim/pull/416))

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.3](https://github.com/agntcy/slim/compare/slim-signal-v0.1.2...slim-signal-v0.1.3) - 2025-07-31

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.2.0](https://github.com/agntcy/slim/compare/slim-controller-v0.1.1...slim-controller-v0.2.0) - 2025-07-31

### Added

- control plane service & slimctl cp commands ([#388](https://github.com/agntcy/slim/pull/388))
- add client connections to control plane ([#429](https://github.com/agntcy/slim/pull/429))
- add node register call to proto ([#406](https://github.com/agntcy/slim/pull/406))
- *(proto)* introduce SessionType in message header ([#410](https://github.com/agntcy/slim/pull/410))
- *(control-plane)* handle all configuration parameters when creating a new connection ([#360](https://github.com/agntcy/slim/pull/360))

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.5.0](https://github.com/agntcy/slim/compare/slim-service-v0.4.2...slim-service-v0.5.0) - 2025-07-31

### Added

- get source and destination name form python ([#485](https://github.com/agntcy/slim/pull/485))
- *(python-bindings)* update examples and make them packageable ([#468](https://github.com/agntcy/slim/pull/468))
- process concurrent modification to the group ([#451](https://github.com/agntcy/slim/pull/451))
- add identity and mls options to python bindings ([#436](https://github.com/agntcy/slim/pull/436))
- improve handling of commit broadcast ([#433](https://github.com/agntcy/slim/pull/433))
- implement key rotation proposal message exchange ([#434](https://github.com/agntcy/slim/pull/434))
- add client connections to control plane ([#429](https://github.com/agntcy/slim/pull/429))
- implement MLS key rotation ([#412](https://github.com/agntcy/slim/pull/412))
- *(proto)* introduce SessionType in message header ([#410](https://github.com/agntcy/slim/pull/410))
- *(channel_endpoint)* add error handling ([#409](https://github.com/agntcy/slim/pull/409))
- do no create session on discovery request ([#402](https://github.com/agntcy/slim/pull/402))
- integrate MLS with auth ([#385](https://github.com/agntcy/slim/pull/385))
- add mls message types in slim messages ([#386](https://github.com/agntcy/slim/pull/386))
- push and verify identities in message headers ([#384](https://github.com/agntcy/slim/pull/384))
- add auth support in sessions ([#382](https://github.com/agntcy/slim/pull/382))
- channel creation in session layer ([#374](https://github.com/agntcy/slim/pull/374))
- add the ability to drop messages from the interceptor ([#371](https://github.com/agntcy/slim/pull/371))
- implement MLS ([#307](https://github.com/agntcy/slim/pull/307))
- add identity into the SLIM message ([#342](https://github.com/agntcy/slim/pull/342))
- *(data-plane)* upgrade to rust 1.87 ([#317](https://github.com/agntcy/slim/pull/317))

### Fixed

- prevent message publication before mls setup ([#458](https://github.com/agntcy/slim/pull/458))
- remove all state on session close ([#449](https://github.com/agntcy/slim/pull/449))
- mls update timer duration ([#437](https://github.com/agntcy/slim/pull/437))
- *(channel_endpoint)* extend mls for all sessions ([#411](https://github.com/agntcy/slim/pull/411))
- fix building problem ([#422](https://github.com/agntcy/slim/pull/422))
- [**breaking**] remove request-reply session type ([#416](https://github.com/agntcy/slim/pull/416))
- *(auth)* make simple identity usable for groups ([#387](https://github.com/agntcy/slim/pull/387))

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
- 397 remove endpoints in mls groups ([#413](https://github.com/agntcy/slim/pull/413))
- *(session)* use parking_lot to sync access to MlsState ([#401](https://github.com/agntcy/slim/pull/401))
- fix test channel endpoint ([#405](https://github.com/agntcy/slim/pull/405))
- *(streaming)* remove lock from channel_endpoint ([#399](https://github.com/agntcy/slim/pull/399))
</blockquote>

## `agntcy-slim`

<blockquote>

## [0.4.0](https://github.com/agntcy/slim/compare/slim-v0.3.15...slim-v0.4.0) - 2025-07-31

### Other

- remove Agent and AgentType and adopt Name as application identifier ([#477](https://github.com/agntcy/slim/pull/477))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).