### PR TITLE
fix(chart): extraVolumes and extraVolumeMounts indentation

### DIFF
--- a/charts/slim/templates/deployment.yaml
+++ b/charts/slim/templates/deployment.yaml
@@ -55,14 +55,14 @@ spec:
               mountPath: /config.yaml
               subPath: config.yaml
             {{- with .Values.slim.extraVolumeMounts }}
-            {{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: config-volume
           configMap:
             name: {{ include "slim.fullname" . }}
         {{- with .Values.slim.extraVolumes }}
-        {{ toYaml . | indent 8 }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
# Description

Fix: intention using `nindent` instead of `indent` for `extraVolumes` and `extraVolumeMounts`

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
