### PR TITLE
fix: update CSIT remote workflow call inputs after default changes

### DIFF
--- a/.github/actions/trigger-integrations/action.yaml
+++ b/.github/actions/trigger-integrations/action.yaml
@@ -40,7 +40,7 @@ runs:
               workflow_id: 'test-integrations.yaml',
               ref: 'main',
               inputs: {
-                  skip_directory_test: true,
+                  skip_slim_test: false,
                   override_slim_image_tag: '${{ steps.tags.outputs.IMAGE_TAG }}',
                   override_slim_chart_tag: '${{ steps.tags.outputs.CHART_TAG }}',
               },


### PR DESCRIPTION
# Description

The CSIT repository integration workflow inputs default are changed to explicitly include the tests instead of explicitly exclude those. This change is helpful to avoid future problems, where can be more tests and this way does not need every dependent repository to update the remote trigger call.

https://github.com/agntcy/csit/pull/122

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [] New code contribution is covered by automated tests
- [X] All new and existing tests pass
