### PR TITLE
test: add MLS benchmark

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -172,13 +172,17 @@ dependencies = [
 name = "agntcy-slim-mls"
 version = "0.1.0"
 dependencies = [
+ "agntcy-slim",
+ "agntcy-slim-config",
  "agntcy-slim-datapath",
  "agntcy-slim-service",
  "async-trait",
  "base64 0.22.1",
+ "criterion",
  "mls-rs",
  "mls-rs-crypto-awslc",
  "parking_lot",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "tempfile",

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -9,6 +9,7 @@ description = "Messaging Layer Security for SLIM data plane."
 name = "slim_mls"
 
 [dependencies]
+agntcy-slim-config = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-service = { workspace = true }
 async-trait = "0.1"
@@ -23,4 +24,11 @@ tokio.workspace = true
 tracing = { workspace = true }
 
 [dev-dependencies]
+agntcy-slim = { workspace = true }
+criterion = { workspace = true }
+rand = { workspace = true }
 tempfile = "3.3"
+
+[[bench]]
+name = "message_exchange"
+harness = false

--- a/data-plane/core/mls/benches/message_exchange.rs
+++ b/data-plane/core/mls/benches/message_exchange.rs
@@ -1,0 +1,286 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use parking_lot::Mutex;
+use slim_config::component::id::ID;
+use slim_config::grpc::server::ServerConfig;
+use slim_config::tls::server::TlsServerConfig;
+use slim_datapath::messages::Agent;
+use slim_mls::{identity::FileBasedIdentityProvider, interceptor::MlsInterceptor, mls::Mls};
+use slim_service::{FireAndForgetConfiguration, ServiceConfiguration, session::SessionConfig};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::runtime::Runtime;
+use tokio::time::sleep;
+
+fn bench_message_exchange(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let mut group = c.benchmark_group("message_exchange");
+    group.sample_size(10);
+    group.measurement_time(std::time::Duration::from_secs(15));
+
+    for &message_count in &[1, 10, 100, 1000] {
+        group.throughput(Throughput::Elements(message_count as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("without_mls", message_count),
+            &message_count,
+            |b, &msg_count| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        match message_exchange_without_mls(msg_count).await {
+                            Ok(duration) => duration,
+                            Err(e) => {
+                                eprintln!("Benchmark without MLS failed: {}", e);
+                                panic!("Benchmark failed: {}", e);
+                            }
+                        }
+                    })
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("with_mls", message_count),
+            &message_count,
+            |b, &msg_count| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        match message_exchange_with_mls(msg_count).await {
+                            Ok(duration) => duration,
+                            Err(e) => {
+                                eprintln!("Benchmark with MLS failed: {}", e);
+                                panic!("Benchmark failed: {}", e);
+                            }
+                        }
+                    })
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+async fn message_exchange_with_mls(
+    message_count: usize,
+) -> Result<Duration, Box<dyn std::error::Error + Send + Sync>> {
+    let unique_id = rand::random::<u64>();
+
+    let mls_dir = format!("/tmp/mls_bench_{}", unique_id);
+    std::fs::create_dir_all(&mls_dir)?;
+
+    let pub_identity = Arc::new(FileBasedIdentityProvider::new(format!(
+        "{}/publisher",
+        mls_dir
+    ))?);
+    let mut pub_mls = Mls::new(format!("publisher_{}", unique_id), pub_identity);
+    pub_mls.initialize().await?;
+    let group_id = pub_mls.create_group()?;
+
+    let sub_identity = Arc::new(FileBasedIdentityProvider::new(format!(
+        "{}/subscriber",
+        mls_dir
+    ))?);
+    let mut sub_mls = Mls::new(format!("subscriber_{}", unique_id), sub_identity);
+    sub_mls.initialize().await?;
+
+    let key_package = sub_mls.generate_key_package()?;
+    let welcome_msg = pub_mls.add_member(&group_id, &key_package)?;
+    let sub_group_id = sub_mls.join_group(&welcome_msg)?;
+
+    let tls_config = TlsServerConfig::new().with_insecure(true);
+    let server_config = ServerConfig::with_endpoint("127.0.0.1:0").with_tls_settings(tls_config);
+    let service_config = ServiceConfiguration::new().with_server(vec![server_config]);
+    let service = service_config.build_server(
+        ID::new_with_name(
+            slim_service::ServiceBuilder::kind(),
+            &format!("benchmark_{}", unique_id),
+        )
+        .unwrap(),
+    )?;
+
+    let publisher_agent = Agent::from_strings("bench", "org", "publisher", unique_id);
+    let subscriber_agent = Agent::from_strings("bench", "org", "subscriber", unique_id);
+
+    let _pub_rx = service.create_agent(&publisher_agent).await?;
+    let mut sub_rx = service.create_agent(&subscriber_agent).await?;
+
+    sleep(Duration::from_millis(100)).await;
+
+    service
+        .subscribe(
+            &subscriber_agent,
+            subscriber_agent.agent_type(),
+            Some(subscriber_agent.agent_id()),
+            None,
+        )
+        .await?;
+
+    sleep(Duration::from_millis(100)).await;
+
+    let pub_session_info = service
+        .create_session(
+            &publisher_agent,
+            SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
+        )
+        .await?;
+
+    let sub_session_info = service
+        .create_session(
+            &subscriber_agent,
+            SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
+        )
+        .await?;
+
+    let pub_interceptor = MlsInterceptor::new(Arc::new(Mutex::new(pub_mls)), group_id);
+    let sub_interceptor = MlsInterceptor::new(Arc::new(Mutex::new(sub_mls)), sub_group_id);
+
+    service
+        .add_session_interceptor(
+            &publisher_agent,
+            pub_session_info.id,
+            Box::new(pub_interceptor),
+        )
+        .await?;
+
+    service
+        .add_session_interceptor(
+            &subscriber_agent,
+            sub_session_info.id,
+            Box::new(sub_interceptor),
+        )
+        .await?;
+
+    let start = Instant::now();
+
+    for i in 0..message_count {
+        let message = format!("benchmark message {}", i).into_bytes();
+        service
+            .publish(
+                &publisher_agent,
+                pub_session_info.clone(),
+                subscriber_agent.agent_type(),
+                Some(subscriber_agent.agent_id()),
+                message,
+            )
+            .await?;
+    }
+
+    for i in 0..message_count {
+        match tokio::time::timeout(Duration::from_secs(5), sub_rx.recv()).await {
+            Ok(Some(Ok(_msg))) => {
+                // Message received successfully
+            }
+            Ok(Some(Err(e))) => {
+                return Err(format!("Message {} receive error: {}", i, e).into());
+            }
+            Ok(None) => {
+                return Err(format!("Channel closed at message {}", i).into());
+            }
+            Err(_) => {
+                return Err(
+                    format!("Timeout waiting for message {} of {}", i, message_count).into(),
+                );
+            }
+        }
+    }
+
+    let duration = start.elapsed();
+
+    let _ = std::fs::remove_dir_all(&mls_dir);
+
+    Ok(duration)
+}
+
+async fn message_exchange_without_mls(
+    message_count: usize,
+) -> Result<Duration, Box<dyn std::error::Error + Send + Sync>> {
+    let unique_id = rand::random::<u64>();
+
+    let tls_config = TlsServerConfig::new().with_insecure(true);
+    let server_config = ServerConfig::with_endpoint("127.0.0.1:0").with_tls_settings(tls_config);
+    let service_config = ServiceConfiguration::new().with_server(vec![server_config]);
+    let service = service_config.build_server(
+        ID::new_with_name(
+            slim_service::ServiceBuilder::kind(),
+            &format!("benchmark_{}", unique_id),
+        )
+        .unwrap(),
+    )?;
+
+    let publisher_agent = Agent::from_strings("bench", "org", "publisher", unique_id);
+    let subscriber_agent = Agent::from_strings("bench", "org", "subscriber", unique_id);
+
+    let _pub_rx = service.create_agent(&publisher_agent).await?;
+    let mut sub_rx = service.create_agent(&subscriber_agent).await?;
+
+    sleep(Duration::from_millis(100)).await;
+
+    service
+        .subscribe(
+            &subscriber_agent,
+            subscriber_agent.agent_type(),
+            Some(subscriber_agent.agent_id()),
+            None,
+        )
+        .await?;
+
+    sleep(Duration::from_millis(100)).await;
+
+    let pub_session_info = service
+        .create_session(
+            &publisher_agent,
+            SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
+        )
+        .await?;
+
+    let _sub_session_info = service
+        .create_session(
+            &subscriber_agent,
+            SessionConfig::FireAndForget(FireAndForgetConfiguration::default()),
+        )
+        .await?;
+
+    let start = Instant::now();
+
+    for i in 0..message_count {
+        let message = format!("benchmark message {}", i).into_bytes();
+        service
+            .publish(
+                &publisher_agent,
+                pub_session_info.clone(),
+                subscriber_agent.agent_type(),
+                Some(subscriber_agent.agent_id()),
+                message,
+            )
+            .await?;
+    }
+
+    for i in 0..message_count {
+        match tokio::time::timeout(Duration::from_secs(5), sub_rx.recv()).await {
+            Ok(Some(Ok(_msg))) => {
+                // Message received successfully
+            }
+            Ok(Some(Err(e))) => {
+                return Err(format!("Message {} receive error: {}", i, e).into());
+            }
+            Ok(None) => {
+                return Err(format!("Channel closed at message {}", i).into());
+            }
+            Err(_) => {
+                return Err(
+                    format!("Timeout waiting for message {} of {}", i, message_count).into(),
+                );
+            }
+        }
+    }
+
+    let duration = start.elapsed();
+
+    Ok(duration)
+}
+
+criterion_group!(benches, bench_message_exchange);
+criterion_main!(benches);


### PR DESCRIPTION
# Description

```
❯ cargo bench

message_exchange/without_mls/1
                        time:   [204.98 ms 205.33 ms 205.65 ms]
                        thrpt:  [4.8626  elem/s 4.8702  elem/s 4.8786  elem/s]
                 change:
                        time:   [+0.0686% +0.3038% +0.5542%] (p = 0.02 < 0.05)
                        thrpt:  [-0.5512% -0.3029% -0.0686%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
message_exchange/with_mls/1
                        time:   [212.37 ms 214.29 ms 215.65 ms]
                        thrpt:  [4.6370  elem/s 4.6665  elem/s 4.7089  elem/s]
                 change:
                        time:   [-0.1521% +0.6342% +1.3829%] (p = 0.15 > 0.05)
                        thrpt:  [-1.3640% -0.6302% +0.1523%]
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
message_exchange/without_mls/10
                        time:   [204.78 ms 205.18 ms 205.62 ms]
                        thrpt:  [48.634  elem/s 48.738  elem/s 48.834  elem/s]
                 change:
                        time:   [+0.0876% +0.3047% +0.5365%] (p = 0.02 < 0.05)
                        thrpt:  [-0.5336% -0.3038% -0.0875%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
message_exchange/with_mls/10
                        time:   [211.69 ms 212.58 ms 213.24 ms]
                        thrpt:  [46.895  elem/s 47.041  elem/s 47.238  elem/s]
                 change:
                        time:   [-0.4775% +0.0694% +0.6313%] (p = 0.81 > 0.05)
                        thrpt:  [-0.6273% -0.0693% +0.4798%]
                        No change in performance detected.
message_exchange/without_mls/100
                        time:   [205.69 ms 205.86 ms 206.09 ms]
                        thrpt:  [485.23  elem/s 485.76  elem/s 486.17  elem/s]
                 change:
                        time:   [+0.1920% +0.3369% +0.4948%] (p = 0.00 < 0.05)
                        thrpt:  [-0.4924% -0.3358% -0.1917%]
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
message_exchange/with_mls/100
                        time:   [213.32 ms 213.67 ms 214.00 ms]
                        thrpt:  [467.28  elem/s 468.01  elem/s 468.78  elem/s]
                 change:
                        time:   [+0.0514% +0.3803% +0.7465%] (p = 0.06 > 0.05)
                        thrpt:  [-0.7410% -0.3789% -0.0514%]
                        No change in performance detected.
message_exchange/without_mls/1000
                        time:   [210.77 ms 211.00 ms 211.17 ms]
                        thrpt:  [4.7356 Kelem/s 4.7394 Kelem/s 4.7445 Kelem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
message_exchange/with_mls/1000
                        time:   [233.74 ms 234.28 ms 234.92 ms]
                        thrpt:  [4.2567 Kelem/s 4.2685 Kelem/s 4.2782 Kelem/s]
```

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
