### PR TITLE
feat(proto): introduce SessionType in message header

### DIFF
--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -22,7 +22,7 @@ use crate::api::proto::api::v1::{
 };
 use crate::errors::ControllerError;
 use slim_config::grpc::client::ClientConfig;
-use slim_datapath::api::proto::pubsub::v1::Message as PubsubMessage;
+use slim_datapath::api::ProtoMessage as PubsubMessage;
 use slim_datapath::message_processing::MessageProcessor;
 use slim_datapath::messages::utils::SlimHeaderFlags;
 use slim_datapath::messages::{Agent, AgentType};

--- a/data-plane/core/datapath/proto/v1/pubsub.proto
+++ b/data-plane/core/datapath/proto/v1/pubsub.proto
@@ -44,17 +44,25 @@ message Agent {
   optional uint64 agent_id = 4;
 }
 
-enum SessionHeaderType {
+enum SessionType {
+  SESSION_UNKNOWN = 0;
+  SESSION_FIRE_FORGET = 1;
+  SESSION_REQUEST_REPLY = 2;
+  SESSION_STREAMING = 3;
+  SESSION_PUB_SUB = 4;
+}
+
+enum SessionMessageType {
   UNSPECIFIED = 0;
-  FNF = 1;
+  FNF_MSG = 1;
   FNF_RELIABLE = 2;
   FNF_ACK = 3;
   FNF_DISCOVERY = 4;
   FNF_DISCOVERY_REPLY = 5;
   REQUEST = 6;
   REPLY = 7;
-  STREAM = 8;
-  PUB_SUB = 9;
+  STREAM_MSG = 8;
+  PUB_SUB_MSG = 9;
   RTX_REQUEST = 10;
   RTX_REPLY = 11;
   BEACON_STREAM = 12;
@@ -71,7 +79,7 @@ enum SessionHeaderType {
 }
 // Session.session_id is the ID of the session
 
-// Session.message_id meaning according to the SessionHeaderType
+// Session.message_id meaning according to the SessionMessageType
 // FNF = nonce
 // FNF_RELIABLE = nonce
 // FNF_ACK = nonce of the received FNF_RELIABLE message
@@ -89,9 +97,10 @@ enum SessionHeaderType {
 // LEAVE_REPLY = nonce of the associated LEAVE_REQUEST
 
 message SessionHeader {
-  SessionHeaderType header_type = 1;
-  uint32 session_id = 2;
-  uint32 message_id = 3;
+  SessionType session_type = 1;
+  SessionMessageType session_message_type = 2;
+  uint32 session_id = 3;
+  uint32 message_id = 4;
 }
 
 message Content {

--- a/data-plane/core/datapath/src/api.rs
+++ b/data-plane/core/datapath/src/api.rs
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! gRPC bindings for pubsub service.
-pub mod proto;
+pub(crate) mod proto;
 
 pub use proto::pubsub::v1::Agent as ProtoAgent;
 pub use proto::pubsub::v1::Content;
 pub use proto::pubsub::v1::Message as ProtoMessage;
 pub use proto::pubsub::v1::Publish as ProtoPublish;
 pub use proto::pubsub::v1::SessionHeader;
+pub use proto::pubsub::v1::SessionMessageType as ProtoSessionMessageType;
+pub use proto::pubsub::v1::SessionType as ProtoSessionType;
 pub use proto::pubsub::v1::SlimHeader;
 pub use proto::pubsub::v1::Subscribe as ProtoSubscribe;
 pub use proto::pubsub::v1::Unsubscribe as ProtoUnsubscribe;
@@ -16,3 +18,5 @@ pub use proto::pubsub::v1::message::MessageType;
 pub use proto::pubsub::v1::message::MessageType::Publish as ProtoPublishType;
 pub use proto::pubsub::v1::message::MessageType::Subscribe as ProtoSubscribeType;
 pub use proto::pubsub::v1::message::MessageType::Unsubscribe as ProtoUnsubscribeType;
+pub use proto::pubsub::v1::pub_sub_service_client::PubSubServiceClient;
+pub use proto::pubsub::v1::pub_sub_service_server::PubSubServiceServer;

--- a/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs
+++ b/data-plane/core/datapath/src/api/gen/pubsub.proto.v1.rs
@@ -58,11 +58,13 @@ pub struct Agent {
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SessionHeader {
-    #[prost(enumeration = "SessionHeaderType", tag = "1")]
-    pub header_type: i32,
-    #[prost(uint32, tag = "2")]
-    pub session_id: u32,
+    #[prost(enumeration = "SessionType", tag = "1")]
+    pub session_type: i32,
+    #[prost(enumeration = "SessionMessageType", tag = "2")]
+    pub session_message_type: i32,
     #[prost(uint32, tag = "3")]
+    pub session_id: u32,
+    #[prost(uint32, tag = "4")]
     pub message_id: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -96,17 +98,52 @@ pub mod message {
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum SessionHeaderType {
+pub enum SessionType {
+    SessionUnknown = 0,
+    SessionFireForget = 1,
+    SessionRequestReply = 2,
+    SessionStreaming = 3,
+    SessionPubSub = 4,
+}
+impl SessionType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::SessionUnknown => "SESSION_UNKNOWN",
+            Self::SessionFireForget => "SESSION_FIRE_FORGET",
+            Self::SessionRequestReply => "SESSION_REQUEST_REPLY",
+            Self::SessionStreaming => "SESSION_STREAMING",
+            Self::SessionPubSub => "SESSION_PUB_SUB",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SESSION_UNKNOWN" => Some(Self::SessionUnknown),
+            "SESSION_FIRE_FORGET" => Some(Self::SessionFireForget),
+            "SESSION_REQUEST_REPLY" => Some(Self::SessionRequestReply),
+            "SESSION_STREAMING" => Some(Self::SessionStreaming),
+            "SESSION_PUB_SUB" => Some(Self::SessionPubSub),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SessionMessageType {
     Unspecified = 0,
-    Fnf = 1,
+    FnfMsg = 1,
     FnfReliable = 2,
     FnfAck = 3,
     FnfDiscovery = 4,
     FnfDiscoveryReply = 5,
     Request = 6,
     Reply = 7,
-    Stream = 8,
-    PubSub = 9,
+    StreamMsg = 8,
+    PubSubMsg = 9,
     RtxRequest = 10,
     RtxReply = 11,
     BeaconStream = 12,
@@ -121,7 +158,7 @@ pub enum SessionHeaderType {
     ChannelMlsWelcome = 21,
     ChannelMlsAck = 22,
 }
-impl SessionHeaderType {
+impl SessionMessageType {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
@@ -129,15 +166,15 @@ impl SessionHeaderType {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Self::Unspecified => "UNSPECIFIED",
-            Self::Fnf => "FNF",
+            Self::FnfMsg => "FNF_MSG",
             Self::FnfReliable => "FNF_RELIABLE",
             Self::FnfAck => "FNF_ACK",
             Self::FnfDiscovery => "FNF_DISCOVERY",
             Self::FnfDiscoveryReply => "FNF_DISCOVERY_REPLY",
             Self::Request => "REQUEST",
             Self::Reply => "REPLY",
-            Self::Stream => "STREAM",
-            Self::PubSub => "PUB_SUB",
+            Self::StreamMsg => "STREAM_MSG",
+            Self::PubSubMsg => "PUB_SUB_MSG",
             Self::RtxRequest => "RTX_REQUEST",
             Self::RtxReply => "RTX_REPLY",
             Self::BeaconStream => "BEACON_STREAM",
@@ -157,15 +194,15 @@ impl SessionHeaderType {
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "UNSPECIFIED" => Some(Self::Unspecified),
-            "FNF" => Some(Self::Fnf),
+            "FNF_MSG" => Some(Self::FnfMsg),
             "FNF_RELIABLE" => Some(Self::FnfReliable),
             "FNF_ACK" => Some(Self::FnfAck),
             "FNF_DISCOVERY" => Some(Self::FnfDiscovery),
             "FNF_DISCOVERY_REPLY" => Some(Self::FnfDiscoveryReply),
             "REQUEST" => Some(Self::Request),
             "REPLY" => Some(Self::Reply),
-            "STREAM" => Some(Self::Stream),
-            "PUB_SUB" => Some(Self::PubSub),
+            "STREAM_MSG" => Some(Self::StreamMsg),
+            "PUB_SUB_MSG" => Some(Self::PubSubMsg),
             "RTX_REQUEST" => Some(Self::RtxRequest),
             "RTX_REPLY" => Some(Self::RtxReply),
             "BEACON_STREAM" => Some(Self::BeaconStream),

--- a/data-plane/core/datapath/src/message_processing.rs
+++ b/data-plane/core/datapath/src/message_processing.rs
@@ -17,9 +17,9 @@ use tonic::{Request, Response, Status};
 use tracing::{Span, debug, error, info};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::api::proto::pubsub::v1::message::MessageType::Publish as PublishType;
-use crate::api::proto::pubsub::v1::message::MessageType::Subscribe as SubscribeType;
-use crate::api::proto::pubsub::v1::message::MessageType::Unsubscribe as UnsubscribeType;
+use crate::api::ProtoPublishType as PublishType;
+use crate::api::ProtoSubscribeType as SubscribeType;
+use crate::api::ProtoUnsubscribeType as UnsubscribeType;
 use crate::api::proto::pubsub::v1::pub_sub_service_client::PubSubServiceClient;
 use crate::api::proto::pubsub::v1::{Message, pub_sub_service_server::PubSubService};
 use crate::connection::{Channel, Connection, Type as ConnectionType};
@@ -87,7 +87,7 @@ fn create_span(function: &str, out_conn: u64, msg: &Message) -> Span {
     );
 
     if let PublishType(_) = msg.get_type() {
-        span.set_attribute("session_type", msg.get_header_type().as_str_name());
+        span.set_attribute("session_type", msg.get_session_message_type().as_str_name());
         span.set_attribute(
             "session_id",
             msg.get_session_header().get_session_id().to_string(),

--- a/data-plane/core/datapath/tests/data_path_test.rs
+++ b/data-plane/core/datapath/tests/data_path_test.rs
@@ -10,9 +10,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use slim_config::grpc::{client::ClientConfig, server::ServerConfig};
-    use slim_datapath::api::proto::pubsub::v1::{
-        Message, pub_sub_service_server::PubSubServiceServer,
-    };
+    use slim_datapath::api::{ProtoMessage as Message, PubSubServiceServer};
     use slim_datapath::message_processing::MessageProcessor;
 
     #[tokio::test]

--- a/data-plane/core/service/src/app.rs
+++ b/data-plane/core/service/src/app.rs
@@ -24,9 +24,9 @@ use crate::streaming::{self, StreamingConfiguration};
 use crate::{ServiceError, fire_and_forget, session};
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::Status;
-use slim_datapath::api::proto::pubsub::v1::Message;
-use slim_datapath::api::proto::pubsub::v1::SessionHeaderType;
+use slim_datapath::api::ProtoMessage as Message;
 use slim_datapath::api::{MessageType, SessionHeader, SlimHeader};
+use slim_datapath::api::{ProtoSessionMessageType, ProtoSessionType};
 use slim_datapath::messages::AgentType;
 use slim_datapath::messages::encoder::Agent;
 use slim_datapath::messages::utils::SlimHeaderFlags;
@@ -346,7 +346,8 @@ where
         ));
 
         let session_header = Some(SessionHeader::new(
-            SessionHeaderType::ChannelDiscoveryRequest.into(),
+            ProtoSessionType::SessionUnknown.into(),
+            ProtoSessionMessageType::ChannelDiscoveryRequest.into(),
             session_info.id,
             rand::random::<u32>(),
         ));
@@ -766,11 +767,11 @@ where
     async fn handle_message_from_slim_without_session(
         &self,
         message: &Message,
-        session_type: SessionHeaderType,
+        session_type: ProtoSessionMessageType,
         session_id: u32,
     ) -> Result<bool, SessionError> {
         match session_type {
-            SessionHeaderType::ChannelDiscoveryRequest => {
+            ProtoSessionMessageType::ChannelDiscoveryRequest => {
                 // reply direcetly without creating any new Session
                 let destination = message.get_source();
                 let msg_id = message.get_id();
@@ -783,7 +784,8 @@ where
                 ));
 
                 let session_header = Some(SessionHeader::new(
-                    SessionHeaderType::ChannelDiscoveryReply.into(),
+                    ProtoSessionType::SessionUnknown.into(),
+                    ProtoSessionMessageType::ChannelDiscoveryReply.into(),
                     session_id,
                     msg_id,
                 ));
@@ -814,15 +816,7 @@ where
             let header = message.message.get_session_header();
 
             // get the session type from the header
-            let session_type = match SessionHeaderType::try_from(header.header_type) {
-                Ok(session_type) => session_type,
-                Err(e) => {
-                    return Err(SessionError::ValidationError(format!(
-                        "session type is not valid: {}",
-                        e
-                    )));
-                }
-            };
+            let session_type = header.session_message_type();
 
             // get the session ID
             let id = header.session_id;
@@ -860,27 +854,27 @@ where
         }
 
         let new_session_id = match session_type {
-            SessionHeaderType::Fnf
-            | SessionHeaderType::FnfReliable
-            | SessionHeaderType::FnfDiscovery => {
+            ProtoSessionMessageType::FnfMsg
+            | ProtoSessionMessageType::FnfReliable
+            | ProtoSessionMessageType::FnfDiscovery => {
                 let conf = self.default_ff_conf.read().clone();
                 // TODO check if MLS is on (it should be in the received packet). Put false for the moment
                 self.create_session(SessionConfig::FireAndForget(conf), Some(id), false)
                     .await?
             }
-            SessionHeaderType::Request => {
+            ProtoSessionMessageType::Request => {
                 let conf = self.default_rr_conf.read().clone();
                 // TODO check if MLS is on (it should be in the received packet). Put false for the moment
                 self.create_session(SessionConfig::RequestResponse(conf), Some(id), false)
                     .await?
             }
-            SessionHeaderType::Stream | SessionHeaderType::BeaconStream => {
+            ProtoSessionMessageType::StreamMsg | ProtoSessionMessageType::BeaconStream => {
                 let conf = self.default_stream_conf.read().clone();
                 // TODO check if MLS is on (it should be in the received packet). Put false for the moment
                 self.create_session(session::SessionConfig::Streaming(conf), Some(id), false)
                     .await?
             }
-            SessionHeaderType::ChannelJoinRequest => {
+            ProtoSessionMessageType::ChannelJoinRequest => {
                 let mut conf = self.default_stream_conf.read().clone();
                 conf.direction = SessionDirection::Bidirectional;
                 let mut mls_enable = false;
@@ -894,24 +888,24 @@ where
                 )
                 .await?
             }
-            SessionHeaderType::ChannelDiscoveryRequest
-            | SessionHeaderType::ChannelDiscoveryReply
-            | SessionHeaderType::ChannelJoinReply
-            | SessionHeaderType::ChannelMlsCommit
-            | SessionHeaderType::ChannelMlsWelcome
-            | SessionHeaderType::ChannelMlsAck => {
+            ProtoSessionMessageType::ChannelDiscoveryRequest
+            | ProtoSessionMessageType::ChannelDiscoveryReply
+            | ProtoSessionMessageType::ChannelJoinReply
+            | ProtoSessionMessageType::ChannelMlsCommit
+            | ProtoSessionMessageType::ChannelMlsWelcome
+            | ProtoSessionMessageType::ChannelMlsAck => {
                 warn!("received channel message with unknown session id");
                 return Err(SessionError::SessionUnknown(
                     session_type.as_str_name().to_string(),
                 ));
             }
-            SessionHeaderType::PubSub => {
+            ProtoSessionMessageType::PubSubMsg => {
                 warn!("received pub/sub message with unknown session id");
                 return Err(SessionError::SessionUnknown(
                     session_type.as_str_name().to_string(),
                 ));
             }
-            SessionHeaderType::BeaconPubSub => {
+            ProtoSessionMessageType::BeaconPubSub => {
                 warn!("received beacon pub/sub message with unknown session id");
                 return Err(SessionError::SessionUnknown(
                     session_type.as_str_name().to_string(),
@@ -1179,7 +1173,8 @@ mod tests {
         // set the session id in the message
         let header = message.get_session_header_mut();
         header.session_id = 1;
-        header.header_type = i32::from(SessionHeaderType::Fnf);
+        header.set_session_type(ProtoSessionType::SessionFireForget);
+        header.set_session_message_type(ProtoSessionMessageType::FnfMsg);
 
         let res = app
             .session_layer
@@ -1255,7 +1250,8 @@ mod tests {
         // set the session id in the message
         let header = message.get_session_header_mut();
         header.session_id = 1;
-        header.header_type = i32::from(SessionHeaderType::Fnf);
+        header.set_session_type(ProtoSessionType::SessionFireForget);
+        header.set_session_message_type(ProtoSessionMessageType::FnfMsg);
 
         let res = app
             .session_layer

--- a/data-plane/core/service/src/channel_endpoint.rs
+++ b/data-plane/core/service/src/channel_endpoint.rs
@@ -20,8 +20,8 @@ use crate::{
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
     api::{
-        SessionHeader, SlimHeader,
-        proto::pubsub::v1::{Message, SessionHeaderType},
+        ProtoMessage as Message, ProtoSessionMessageType, ProtoSessionType, SessionHeader,
+        SlimHeader,
     },
     messages::{Agent, AgentType, utils::SlimHeaderFlags},
 };
@@ -274,6 +274,9 @@ where
     /// id of the current session
     session_id: Id,
 
+    /// Session Type associated to this endpoint
+    session_type: ProtoSessionType,
+
     /// connection id to the next hop SLIM
     conn: Option<u64>,
 
@@ -298,6 +301,7 @@ where
         channel_name: AgentType,
         channel_id: Option<u64>,
         session_id: Id,
+        session_type: ProtoSessionType,
         mls_state: Option<MlsState<P, V>>,
         tx: T,
     ) -> Self {
@@ -306,6 +310,7 @@ where
             channel_name,
             channel_id,
             session_id,
+            session_type,
             conn: None,
             subscribed: false,
             mls_state,
@@ -318,7 +323,7 @@ where
         destination: &AgentType,
         destination_id: Option<u64>,
         broadcast: bool,
-        request_type: SessionHeaderType,
+        request_type: ProtoSessionMessageType,
         message_id: u32,
         payload: Vec<u8>,
     ) -> Message {
@@ -336,6 +341,7 @@ where
         ));
 
         let session_header = Some(SessionHeader::new(
+            self.session_type.into(),
             request_type.into(),
             self.session_id,
             message_id,
@@ -412,10 +418,19 @@ where
         channel_name: AgentType,
         channel_id: Option<u64>,
         session_id: Id,
+        session_type: ProtoSessionType,
         mls: Option<MlsState<P, V>>,
         tx: T,
     ) -> Self {
-        let endpoint = Endpoint::new(name, channel_name, channel_id, session_id, mls, tx);
+        let endpoint = Endpoint::new(
+            name,
+            channel_name,
+            channel_id,
+            session_id,
+            session_type,
+            mls,
+            tx,
+        );
         ChannelParticipant { endpoint }
     }
 
@@ -473,7 +488,7 @@ where
             src.agent_type(),
             src.agent_id_option(),
             false,
-            SessionHeaderType::ChannelJoinReply,
+            ProtoSessionMessageType::ChannelJoinReply,
             msg.get_id(),
             payload,
         );
@@ -500,7 +515,7 @@ where
             src.agent_type(),
             src.agent_id_option(),
             false,
-            SessionHeaderType::ChannelMlsAck,
+            ProtoSessionMessageType::ChannelMlsAck,
             msg.get_id(),
             vec![],
         );
@@ -524,7 +539,7 @@ where
             src.agent_type(),
             src.agent_id_option(),
             false,
-            SessionHeaderType::ChannelMlsAck,
+            ProtoSessionMessageType::ChannelMlsAck,
             msg.get_id(),
             vec![],
         );
@@ -540,9 +555,9 @@ where
     T: SessionTransmitter + Send + Sync + Clone + 'static,
 {
     async fn on_message(&mut self, msg: Message) -> Result<(), SessionError> {
-        let msg_type = msg.get_session_header().header_type();
+        let msg_type = msg.get_session_header().session_message_type();
         match msg_type {
-            SessionHeaderType::ChannelDiscoveryRequest => {
+            ProtoSessionMessageType::ChannelDiscoveryRequest => {
                 error!(
                     "Received discovery request message, this should not happen. drop the message"
                 );
@@ -551,19 +566,19 @@ where
                     "Received discovery request message, this should not happen".to_string(),
                 ))
             }
-            SessionHeaderType::ChannelJoinRequest => {
+            ProtoSessionMessageType::ChannelJoinRequest => {
                 debug!("Received join request message");
                 self.on_join_request(msg).await
             }
-            SessionHeaderType::ChannelMlsWelcome => {
+            ProtoSessionMessageType::ChannelMlsWelcome => {
                 debug!("Received mls welcome message");
                 self.on_mls_welcome(msg).await
             }
-            SessionHeaderType::ChannelMlsCommit => {
+            ProtoSessionMessageType::ChannelMlsCommit => {
                 debug!("Received mls commit message");
                 self.on_mls_commit(msg).await
             }
-            SessionHeaderType::ChannelLeaveRequest => {
+            ProtoSessionMessageType::ChannelLeaveRequest => {
                 debug!("Received leave request message");
                 // leave the channell
                 self.endpoint.leave().await?;
@@ -574,7 +589,7 @@ where
                     src.agent_type(),
                     src.agent_id_option(),
                     false,
-                    SessionHeaderType::ChannelLeaveReply,
+                    ProtoSessionMessageType::ChannelLeaveReply,
                     msg.get_id(),
                     vec![],
                 );
@@ -636,6 +651,7 @@ where
         channel_name: AgentType,
         channel_id: Option<u64>,
         session_id: Id,
+        session_type: ProtoSessionType,
         max_retries: u32,
         retries_interval: Duration,
         mls: Option<MlsState<P, V>>,
@@ -645,7 +661,15 @@ where
         let invite_payload: Vec<u8> = bincode::encode_to_vec(p, bincode::config::standard())
             .expect("unable to parse channel name as payload");
 
-        let endpoint = Endpoint::new(name, channel_name, channel_id, session_id, mls, tx);
+        let endpoint = Endpoint::new(
+            name,
+            channel_name,
+            channel_id,
+            session_id,
+            session_type,
+            mls,
+            tx,
+        );
         ChannelModerator {
             endpoint,
             channel_list: HashSet::new(),
@@ -746,7 +770,7 @@ where
             src.agent_type(),
             src.agent_id_option(),
             false,
-            SessionHeaderType::ChannelJoinRequest,
+            ProtoSessionMessageType::ChannelJoinRequest,
             new_msg_id,
             self.invite_payload.clone(),
         );
@@ -797,7 +821,7 @@ where
                 &self.endpoint.channel_name,
                 None,
                 true,
-                SessionHeaderType::ChannelMlsCommit,
+                ProtoSessionMessageType::ChannelMlsCommit,
                 commit_id,
                 commit_payload,
             );
@@ -805,7 +829,7 @@ where
                 src.agent_type(),
                 src.agent_id_option(),
                 false,
-                SessionHeaderType::ChannelMlsWelcome,
+                ProtoSessionMessageType::ChannelMlsWelcome,
                 welcome_id,
                 welcome_payload,
             );
@@ -853,31 +877,31 @@ where
     T: SessionTransmitter + Send + Sync + Clone + 'static,
 {
     async fn on_message(&mut self, msg: Message) -> Result<(), SessionError> {
-        let msg_type = msg.get_session_header().header_type();
+        let msg_type = msg.get_session_header().session_message_type();
         match msg_type {
-            SessionHeaderType::ChannelDiscoveryRequest => {
+            ProtoSessionMessageType::ChannelDiscoveryRequest => {
                 debug!("Invite new participant to the channel, send discovery message");
                 // discovery message coming from the application
                 self.forward(msg).await
             }
-            SessionHeaderType::ChannelDiscoveryReply => {
+            ProtoSessionMessageType::ChannelDiscoveryReply => {
                 debug!("Received discovery reply message");
                 self.on_discovery_reply(msg).await
             }
-            SessionHeaderType::ChannelJoinReply => {
+            ProtoSessionMessageType::ChannelJoinReply => {
                 debug!("Received join reply message");
                 self.on_join_reply(msg).await
             }
-            SessionHeaderType::ChannelMlsAck => {
+            ProtoSessionMessageType::ChannelMlsAck => {
                 debug!("Received mls ack message");
                 self.on_msl_ack(msg).await
             }
-            SessionHeaderType::ChannelLeaveRequest => {
+            ProtoSessionMessageType::ChannelLeaveRequest => {
                 // leave message coming from the application
                 debug!("Received leave request message");
                 self.forward(msg).await
             }
-            SessionHeaderType::ChannelLeaveReply => {
+            ProtoSessionMessageType::ChannelLeaveReply => {
                 debug!("Received leave reply message");
                 let src = msg.get_slim_header().get_source();
                 let msg_id = msg.get_id();
@@ -954,6 +978,7 @@ mod tests {
             channel_name.clone(),
             channel_id,
             SESSION_ID,
+            ProtoSessionType::SessionUnknown,
             3,
             Duration::from_millis(100),
             Some(moderator_mls),
@@ -964,6 +989,7 @@ mod tests {
             channel_name.clone(),
             channel_id,
             SESSION_ID,
+            ProtoSessionType::SessionUnknown,
             Some(participant_mls),
             participant_tx,
         );
@@ -979,7 +1005,8 @@ mod tests {
         ));
 
         let session_header = Some(SessionHeader::new(
-            SessionHeaderType::ChannelDiscoveryRequest.into(),
+            ProtoSessionType::SessionUnknown.into(),
+            ProtoSessionMessageType::ChannelDiscoveryRequest.into(),
             SESSION_ID,
             rand::random::<u32>(),
         ));
@@ -1008,7 +1035,8 @@ mod tests {
         ));
 
         let session_header = Some(SessionHeader::new(
-            SessionHeaderType::ChannelDiscoveryReply.into(),
+            ProtoSessionType::SessionUnknown.into(),
+            ProtoSessionMessageType::ChannelDiscoveryReply.into(),
             session_id,
             msg_id,
         ));
@@ -1042,7 +1070,7 @@ mod tests {
             participant.agent_type(),
             participant.agent_id_option(),
             false,
-            SessionHeaderType::ChannelJoinRequest,
+            ProtoSessionMessageType::ChannelJoinRequest,
             0,
             payload,
         );
@@ -1074,7 +1102,7 @@ mod tests {
             moderator.agent_type(),
             moderator.agent_id_option(),
             false,
-            SessionHeaderType::ChannelJoinReply,
+            ProtoSessionMessageType::ChannelJoinReply,
             msg_id,
             vec![],
         );
@@ -1093,7 +1121,7 @@ mod tests {
             participant.agent_type(),
             participant.agent_id_option(),
             false,
-            SessionHeaderType::ChannelMlsWelcome,
+            ProtoSessionMessageType::ChannelMlsWelcome,
             0,
             vec![],
         );
@@ -1128,7 +1156,7 @@ mod tests {
             moderator.agent_type(),
             moderator.agent_id_option(),
             false,
-            SessionHeaderType::ChannelMlsAck,
+            ProtoSessionMessageType::ChannelMlsAck,
             msg_id,
             vec![],
         );

--- a/data-plane/core/service/src/interceptor.rs
+++ b/data-plane/core/service/src/interceptor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use slim_auth::traits::StandardClaims;
 use slim_auth::traits::{TokenProvider, Verifier};
-use slim_datapath::api::proto::pubsub::v1::Message;
+use slim_datapath::api::ProtoMessage as Message;
 use slim_datapath::messages::utils::SLIM_IDENTITY;
 
 use crate::errors::SessionError;

--- a/data-plane/core/service/src/interceptor_mls.rs
+++ b/data-plane/core/service/src/interceptor_mls.rs
@@ -3,8 +3,8 @@
 
 use crate::{errors::SessionError, interceptor::SessionInterceptor};
 use parking_lot::Mutex;
-use slim_datapath::api::proto::pubsub::v1::Message;
-use slim_datapath::api::{MessageType, proto::pubsub::v1::SessionHeaderType};
+use slim_datapath::api::ProtoMessage as Message;
+use slim_datapath::api::{MessageType, ProtoSessionMessageType};
 use slim_mls::mls::Mls;
 use std::sync::Arc;
 use tracing::{debug, error, warn};
@@ -45,16 +45,16 @@ where
             return Ok(());
         }
 
-        match msg.get_session_header().header_type() {
-            SessionHeaderType::ChannelDiscoveryRequest
-            | SessionHeaderType::ChannelDiscoveryReply
-            | SessionHeaderType::ChannelJoinRequest
-            | SessionHeaderType::ChannelJoinReply
-            | SessionHeaderType::ChannelLeaveRequest
-            | SessionHeaderType::ChannelLeaveReply
-            | SessionHeaderType::ChannelMlsCommit
-            | SessionHeaderType::ChannelMlsWelcome
-            | SessionHeaderType::ChannelMlsAck => {
+        match msg.get_session_header().session_message_type() {
+            ProtoSessionMessageType::ChannelDiscoveryRequest
+            | ProtoSessionMessageType::ChannelDiscoveryReply
+            | ProtoSessionMessageType::ChannelJoinRequest
+            | ProtoSessionMessageType::ChannelJoinReply
+            | ProtoSessionMessageType::ChannelLeaveRequest
+            | ProtoSessionMessageType::ChannelLeaveReply
+            | ProtoSessionMessageType::ChannelMlsCommit
+            | ProtoSessionMessageType::ChannelMlsWelcome
+            | ProtoSessionMessageType::ChannelMlsAck => {
                 debug!("Skipping channel messages type in encryption path");
                 return Ok(());
             }
@@ -100,16 +100,16 @@ where
             return Ok(());
         }
 
-        match msg.get_session_header().header_type() {
-            SessionHeaderType::ChannelDiscoveryRequest
-            | SessionHeaderType::ChannelDiscoveryReply
-            | SessionHeaderType::ChannelJoinRequest
-            | SessionHeaderType::ChannelJoinReply
-            | SessionHeaderType::ChannelLeaveRequest
-            | SessionHeaderType::ChannelLeaveReply
-            | SessionHeaderType::ChannelMlsCommit
-            | SessionHeaderType::ChannelMlsWelcome
-            | SessionHeaderType::ChannelMlsAck => {
+        match msg.get_session_header().session_message_type() {
+            ProtoSessionMessageType::ChannelDiscoveryRequest
+            | ProtoSessionMessageType::ChannelDiscoveryReply
+            | ProtoSessionMessageType::ChannelJoinRequest
+            | ProtoSessionMessageType::ChannelJoinReply
+            | ProtoSessionMessageType::ChannelLeaveRequest
+            | ProtoSessionMessageType::ChannelLeaveReply
+            | ProtoSessionMessageType::ChannelMlsCommit
+            | ProtoSessionMessageType::ChannelMlsWelcome
+            | ProtoSessionMessageType::ChannelMlsAck => {
                 debug!("Skipping channel messages type in decryption path");
                 return Ok(());
             }

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -43,7 +43,7 @@ use slim_config::grpc::client::ClientConfig;
 use slim_config::grpc::server::ServerConfig;
 use slim_controller::api::proto::api::v1::controller_service_server::ControllerServiceServer;
 use slim_controller::service::ControllerService;
-use slim_datapath::api::proto::pubsub::v1::pub_sub_service_server::PubSubServiceServer;
+use slim_datapath::api::PubSubServiceServer;
 use slim_datapath::message_processing::MessageProcessor;
 
 use crate::app::App;

--- a/data-plane/core/service/src/producer_buffer.rs
+++ b/data-plane/core/service/src/producer_buffer.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use slim_datapath::{api::proto::pubsub::v1::Message, messages::AgentType};
+use slim_datapath::{api::ProtoMessage as Message, messages::AgentType};
 
 pub struct ProducerBuffer {
     capacity: usize,
@@ -91,8 +91,10 @@ impl ProducerBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use slim_datapath::api::proto::pubsub::v1::SessionHeaderType;
-    use slim_datapath::api::{SessionHeader, SlimHeader};
+    use slim_datapath::api::{
+        ProtoSessionMessageType as SessionMessageType, ProtoSessionType as SessionType,
+        SessionHeader, SlimHeader,
+    };
     use slim_datapath::messages::encoder::{Agent, AgentType};
 
     #[test]
@@ -106,11 +108,36 @@ mod tests {
 
         let slim_header = SlimHeader::new(&src, &name_type, Some(1), None);
 
-        let h0 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 0);
-        let h1 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 1);
-        let h2 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 2);
-        let h3 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 3);
-        let h4 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 4);
+        let h0 = SessionHeader::new(
+            SessionType::SessionUnknown.into(),
+            SessionMessageType::FnfMsg.into(),
+            0,
+            0,
+        );
+        let h1 = SessionHeader::new(
+            SessionType::SessionUnknown.into(),
+            SessionMessageType::FnfMsg.into(),
+            0,
+            1,
+        );
+        let h2 = SessionHeader::new(
+            SessionType::SessionUnknown.into(),
+            SessionMessageType::FnfMsg.into(),
+            0,
+            2,
+        );
+        let h3 = SessionHeader::new(
+            SessionType::SessionUnknown.into(),
+            SessionMessageType::FnfMsg.into(),
+            0,
+            3,
+        );
+        let h4 = SessionHeader::new(
+            SessionType::SessionUnknown.into(),
+            SessionMessageType::FnfMsg.into(),
+            0,
+            4,
+        );
 
         let p0 = Message::new_publish_with_headers(Some(slim_header), Some(h0), "", vec![]);
         let p1 = Message::new_publish_with_headers(Some(slim_header), Some(h1), "", vec![]);

--- a/data-plane/core/service/src/receiver_buffer.rs
+++ b/data-plane/core/service/src/receiver_buffer.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use slim_datapath::api::proto::pubsub::v1::Message;
+use slim_datapath::api::ProtoMessage as Message;
 
 use tracing::{debug, info, trace};
 
@@ -260,8 +260,9 @@ impl ReceiverBuffer {
 // tests
 #[cfg(test)]
 mod tests {
-    use slim_datapath::api::proto::pubsub::v1::SessionHeaderType;
-    use slim_datapath::api::{SessionHeader, SlimHeader};
+    use slim_datapath::api::{
+        ProtoSessionMessageType, ProtoSessionType, SessionHeader, SlimHeader,
+    };
     use slim_datapath::messages::encoder::{Agent, AgentType};
     use tracing_test::traced_test;
 
@@ -275,12 +276,42 @@ mod tests {
 
         let slim_header = SlimHeader::new(&src, &name_type, Some(1), None);
 
-        let h0 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 0);
-        let h1 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 1);
-        let h2 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 2);
-        let h3 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 3);
-        let h4 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 4);
-        let h5 = SessionHeader::new(SessionHeaderType::Fnf.into(), 0, 5);
+        let h0 = SessionHeader::new(
+            ProtoSessionType::SessionFireForget.into(),
+            ProtoSessionMessageType::FnfMsg.into(),
+            0,
+            0,
+        );
+        let h1 = SessionHeader::new(
+            ProtoSessionType::SessionFireForget.into(),
+            ProtoSessionMessageType::FnfMsg.into(),
+            0,
+            1,
+        );
+        let h2 = SessionHeader::new(
+            ProtoSessionType::SessionFireForget.into(),
+            ProtoSessionMessageType::FnfMsg.into(),
+            0,
+            2,
+        );
+        let h3 = SessionHeader::new(
+            ProtoSessionType::SessionFireForget.into(),
+            ProtoSessionMessageType::FnfMsg.into(),
+            0,
+            3,
+        );
+        let h4 = SessionHeader::new(
+            ProtoSessionType::SessionFireForget.into(),
+            ProtoSessionMessageType::FnfMsg.into(),
+            0,
+            4,
+        );
+        let h5 = SessionHeader::new(
+            ProtoSessionType::SessionFireForget.into(),
+            ProtoSessionMessageType::FnfMsg.into(),
+            0,
+            5,
+        );
 
         let p0 = Message::new_publish_with_headers(Some(slim_header), Some(h0), "", vec![]);
         let p1 = Message::new_publish_with_headers(Some(slim_header), Some(h1), "", vec![]);

--- a/data-plane/core/service/src/request_response.rs
+++ b/data-plane/core/service/src/request_response.rs
@@ -15,7 +15,7 @@ use crate::session::{
 };
 use crate::session::{MessageHandler, SessionConfig, SessionTransmitter};
 use crate::{SessionMessage, timer};
-use slim_datapath::api::proto::pubsub::v1::SessionHeaderType;
+use slim_datapath::api::{ProtoSessionMessageType, ProtoSessionType};
 use slim_datapath::messages::encoder::Agent;
 
 /// Configuration for the Request Response session
@@ -267,8 +267,8 @@ where
         // clone tx
         match direction {
             MessageDirection::North => {
-                match message.info.session_header_type {
-                    SessionHeaderType::Reply => {
+                match message.info.session_message_type {
+                    ProtoSessionMessageType::Reply => {
                         // this is a reply - remove the timer
                         let message_id = session_header.message_id;
                         match self.internal.timers.write().remove(&message_id) {
@@ -284,14 +284,14 @@ where
                             }
                         }
                     }
-                    SessionHeaderType::Request => {
+                    ProtoSessionMessageType::Request => {
                         // this is a request - set the session_type of the session
                         // info to reply to allow the app to reply using this session info
-                        message.info.session_header_type = SessionHeaderType::Reply;
+                        message.info.session_message_type = ProtoSessionMessageType::Reply;
                     }
                     _ => Err(SessionError::AppTransmission(format!(
                         "request/reply session: unsupported session type: {:?}",
-                        message.info.session_header_type
+                        message.info.session_message_type
                     )))?,
                 }
 
@@ -308,13 +308,14 @@ where
                 session_header.session_id = self.internal.common.id();
                 message.info.id = self.internal.common.id();
 
-                match message.info.session_header_type {
-                    SessionHeaderType::Reply => {
+                match message.info.session_message_type {
+                    ProtoSessionMessageType::Reply => {
                         // this is a reply - make sure the message_id matches the request
                         match message.info.message_id {
                             Some(message_id) => {
                                 session_header.message_id = message_id;
-                                session_header.header_type = i32::from(SessionHeaderType::Reply);
+                                session_header
+                                    .set_session_message_type(ProtoSessionMessageType::Reply);
 
                                 self.internal
                                     .common
@@ -334,7 +335,8 @@ where
                         // In any other case, we are sending a request
                         // set the message id to something random
                         session_header.set_message_id(rand::random::<u32>());
-                        session_header.set_header_type(SessionHeaderType::Request);
+                        session_header.set_session_message_type(ProtoSessionMessageType::Request);
+                        session_header.set_session_type(ProtoSessionType::SessionRequestReply);
 
                         message.info.set_message_id(session_header.message_id);
 
@@ -425,7 +427,7 @@ mod tests {
 
         // set the session type to request
         let header = msg.get_session_header_mut();
-        header.header_type = i32::from(SessionHeaderType::Request);
+        header.set_session_message_type(ProtoSessionMessageType::Request);
 
         // set the session id in the message
         header.session_id = 1;

--- a/data-plane/core/service/src/session.rs
+++ b/data-plane/core/service/src/session.rs
@@ -16,7 +16,7 @@ use crate::interceptor::{SessionInterceptor, SessionInterceptorProvider};
 use crate::interceptor_mls::MlsInterceptor;
 use crate::request_response::{RequestResponse, RequestResponseConfiguration};
 use crate::streaming::{Streaming, StreamingConfiguration};
-use slim_datapath::api::proto::pubsub::v1::{Message, SessionHeaderType};
+use slim_datapath::api::{ProtoMessage as Message, ProtoSessionMessageType};
 use slim_datapath::messages::encoder::Agent;
 
 /// Session ID
@@ -96,7 +96,7 @@ pub struct Info {
     /// The message nonce used to identify the message
     pub message_id: Option<u32>,
     /// The Message Type
-    pub session_header_type: SessionHeaderType,
+    pub session_message_type: ProtoSessionMessageType,
     /// The identifier of the agent that sent the message
     pub message_source: Option<Agent>,
     /// The input connection id
@@ -109,7 +109,7 @@ impl Info {
         Info {
             id,
             message_id: None,
-            session_header_type: SessionHeaderType::Unspecified,
+            session_message_type: ProtoSessionMessageType::Unspecified,
             message_source: None,
             input_connection: None,
         }
@@ -119,8 +119,8 @@ impl Info {
         self.message_id = Some(message_id);
     }
 
-    pub fn set_session_header_type(&mut self, session_header_type: SessionHeaderType) {
-        self.session_header_type = session_header_type;
+    pub fn set_session_header_type(&mut self, session_header_type: ProtoSessionMessageType) {
+        self.session_message_type = session_header_type;
     }
 
     pub fn set_message_source(&mut self, message_source: Agent) {
@@ -135,8 +135,8 @@ impl Info {
         self.message_id
     }
 
-    pub fn get_session_header_type(&self) -> SessionHeaderType {
-        self.session_header_type
+    pub fn get_session_message_type(&self) -> ProtoSessionMessageType {
+        self.session_message_type
     }
 
     pub fn get_message_source(&self) -> Option<Agent> {
@@ -157,13 +157,12 @@ impl From<&Message> for Info {
         let message_id = session_header.message_id;
         let message_source = message.get_source();
         let input_connection = slim_header.incoming_conn;
-        let session_header_type = session_header.header_type;
+        let session_message_type = session_header.session_message_type();
 
         Info {
             id,
             message_id: Some(message_id),
-            session_header_type: SessionHeaderType::try_from(session_header_type)
-                .unwrap_or(SessionHeaderType::Unspecified),
+            session_message_type,
             message_source: Some(message_source),
             input_connection,
         }

--- a/data-plane/core/service/src/streaming.rs
+++ b/data-plane/core/service/src/streaming.rs
@@ -1,9 +1,11 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use slim_auth::traits::{TokenProvider, Verifier};
 use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
 use tokio::sync::mpsc;
+use tracing::{debug, error, trace, warn};
 
 use crate::{
     MessageDirection, SessionMessage,
@@ -18,15 +20,15 @@ use crate::{
 };
 use producer_buffer::ProducerBuffer;
 use receiver_buffer::ReceiverBuffer;
-
-use slim_datapath::messages::{AgentType, utils::SlimHeaderFlags};
+use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
-    api::proto::pubsub::v1::{Message, SessionHeader, SessionHeaderType, SlimHeader},
-    messages::Agent,
+    Status,
+    api::{
+        ProtoMessage as Message, ProtoSessionMessageType, ProtoSessionType, SessionHeader,
+        SlimHeader,
+    },
+    messages::{Agent, AgentType, utils::SlimHeaderFlags},
 };
-
-use tonic::{Status, async_trait};
-use tracing::{debug, error, trace, warn};
 
 // this must be a number > 1
 const STREAM_BROADCAST: u32 = 50;
@@ -350,6 +352,7 @@ where
                         session_config.channel_name.clone(),
                         None,
                         id,
+                        ProtoSessionType::SessionPubSub,
                         60,
                         Duration::from_secs(1),
                         mls,
@@ -363,6 +366,7 @@ where
                         session_config.channel_name.clone(),
                         None,
                         id,
+                        ProtoSessionType::SessionPubSub,
                         mls,
                         tx.clone(),
                     );
@@ -392,8 +396,8 @@ where
                                                 trace!("received message from the gataway on producer session {}", session_id);
                                                 // received a message from the SLIM
                                                 // this must be an RTX message otherwise drop it
-                                                match msg.get_session_header().header_type() {
-                                                    SessionHeaderType::RtxRequest => {}
+                                                match msg.get_session_header().session_message_type() {
+                                                    ProtoSessionMessageType::RtxRequest => {}
                                                     _ => {
                                                         error!("received invalid packet type on producer session {}: not RTX request", session_id);
                                                         continue;
@@ -418,16 +422,16 @@ where
                                                 // in this case the message can be a stream message to send to the app, a rtx request,
                                                 // or a channel control message to handle in the channel endpoint
                                                 trace!("received message from the gataway on bidirectional session {}", session_id);
-                                                match msg.get_session_header().header_type() {
-                                                    SessionHeaderType::ChannelDiscoveryRequest |
-                                                    SessionHeaderType::ChannelDiscoveryReply |
-                                                    SessionHeaderType::ChannelJoinRequest |
-                                                    SessionHeaderType::ChannelJoinReply |
-                                                    SessionHeaderType::ChannelLeaveRequest |
-                                                    SessionHeaderType::ChannelLeaveReply |
-                                                    SessionHeaderType::ChannelMlsWelcome |
-                                                    SessionHeaderType::ChannelMlsCommit |
-                                                    SessionHeaderType::ChannelMlsAck => {
+                                                match msg.get_session_header().session_message_type() {
+                                                    ProtoSessionMessageType::ChannelDiscoveryRequest |
+                                                    ProtoSessionMessageType::ChannelDiscoveryReply |
+                                                    ProtoSessionMessageType::ChannelJoinRequest |
+                                                    ProtoSessionMessageType::ChannelJoinReply |
+                                                    ProtoSessionMessageType::ChannelLeaveRequest |
+                                                    ProtoSessionMessageType::ChannelLeaveReply |
+                                                    ProtoSessionMessageType::ChannelMlsWelcome |
+                                                    ProtoSessionMessageType::ChannelMlsCommit |
+                                                    ProtoSessionMessageType::ChannelMlsAck => {
                                                         match channel_endpoint.on_message(msg).await {
                                                             Ok(_) => {},
                                                             Err(e) => {
@@ -435,7 +439,7 @@ where
                                                             },
                                                         }
                                                     }
-                                                    SessionHeaderType::RtxRequest => {
+                                                    ProtoSessionMessageType::RtxRequest => {
                                                         // handle RTX request
                                                         process_incoming_rtx_request(msg, session_id, &state.producer, &source, &tx).await;
                                                     }
@@ -446,9 +450,9 @@ where
                                             }
                                             MessageDirection::South => {
                                                 // received a message from the APP
-                                                match msg.get_session_header().header_type() {
-                                                    SessionHeaderType::ChannelDiscoveryRequest |
-                                                    SessionHeaderType::ChannelLeaveRequest => {
+                                                match msg.get_session_header().session_message_type() {
+                                                    ProtoSessionMessageType::ChannelDiscoveryRequest |
+                                                    ProtoSessionMessageType::ChannelLeaveRequest => {
                                                         match channel_endpoint.on_message(msg).await {
                                                             Ok(_) => {},
                                                             Err(e) => {
@@ -518,13 +522,13 @@ where
                                             let last_msg_id = producer.next_id - 1;
                                             debug!("received producer timer, last packet = {}", last_msg_id);
 
-                                            send_beacon_msg(&source, producer.buffer.get_destination_name(), SessionHeaderType::BeaconStream, last_msg_id, session_id, &tx).await;
+                                            send_beacon_msg(&source, producer.buffer.get_destination_name(), ProtoSessionMessageType::BeaconStream, last_msg_id, session_id, &tx).await;
                                         }
                                         Endpoint::Bidirectional(state) => {
                                             let last_msg_id = state.producer.next_id - 1;
                                             debug!("received producer timer, last packet = {}", last_msg_id);
 
-                                            send_beacon_msg(&source, state.producer.buffer.get_destination_name(), SessionHeaderType::BeaconPubSub, last_msg_id, session_id, &tx).await;
+                                            send_beacon_msg(&source, state.producer.buffer.get_destination_name(), ProtoSessionMessageType::BeaconPubSub, last_msg_id, session_id, &tx).await;
                                         }
                                         _ => {
                                             error!("received producer timer on a non producer buffer");
@@ -597,7 +601,8 @@ async fn process_incoming_rtx_request<T>(
             ));
 
             let session_header = Some(SessionHeader::new(
-                SessionHeaderType::RtxReply.into(),
+                ProtoSessionType::SessionStreaming.into(),
+                ProtoSessionMessageType::RtxReply.into(),
                 session_id,
                 msg_rtx_id,
             ));
@@ -628,7 +633,8 @@ async fn process_incoming_rtx_request<T>(
             ));
 
             let session_header = Some(SessionHeader::new(
-                SessionHeaderType::RtxReply.into(),
+                ProtoSessionType::SessionStreaming.into(),
+                ProtoSessionMessageType::RtxReply.into(),
                 session_id,
                 msg_rtx_id,
             ));
@@ -656,9 +662,11 @@ async fn process_message_from_app<T>(
     trace!("received message from the app on session {}", session_id);
 
     if is_bidirectional {
-        msg.set_header_type(SessionHeaderType::PubSub);
+        msg.set_session_type(ProtoSessionType::SessionPubSub);
+        msg.set_session_message_type(ProtoSessionMessageType::PubSubMsg);
     } else {
-        msg.set_header_type(SessionHeaderType::Stream);
+        msg.set_session_type(ProtoSessionType::SessionStreaming);
+        msg.set_session_message_type(ProtoSessionMessageType::StreamMsg);
     }
     msg.set_message_id(producer.next_id);
     msg.set_fanout(STREAM_BROADCAST);
@@ -733,17 +741,17 @@ async fn process_message_from_slim<T>(
 
     let mut recv = Vec::new();
     let mut rtx = Vec::new();
-    let header_type = msg.get_header_type();
+    let header_type = msg.get_session_message_type();
     let msg_id = msg.get_id();
 
     match header_type {
-        SessionHeaderType::Stream => {
+        ProtoSessionMessageType::StreamMsg => {
             (recv, rtx) = receiver.buffer.on_received_message(msg);
         }
-        SessionHeaderType::PubSub => {
+        ProtoSessionMessageType::PubSubMsg => {
             (recv, rtx) = receiver.buffer.on_received_message(msg);
         }
-        SessionHeaderType::RtxReply => {
+        ProtoSessionMessageType::RtxReply => {
             if msg.get_error().is_some() && msg.get_error().unwrap() {
                 recv = receiver.buffer.on_lost_message(msg_id);
             } else {
@@ -764,11 +772,11 @@ async fn process_message_from_slim<T>(
                 }
             }
         }
-        SessionHeaderType::BeaconStream => {
+        ProtoSessionMessageType::BeaconStream => {
             debug!("received stream beacon for message {}", msg_id);
             rtx = receiver.buffer.on_beacon_message(msg_id);
         }
-        SessionHeaderType::BeaconPubSub => {
+        ProtoSessionMessageType::BeaconPubSub => {
             debug!("received pubsub beacon for message {}", msg_id);
             rtx = receiver.buffer.on_beacon_message(msg_id);
         }
@@ -802,7 +810,8 @@ async fn process_message_from_slim<T>(
         ));
 
         let session_header = Some(SessionHeader::new(
-            SessionHeaderType::RtxRequest.into(),
+            ProtoSessionType::SessionStreaming.into(),
+            ProtoSessionMessageType::RtxRequest.into(),
             session_id,
             r,
         ));
@@ -905,7 +914,7 @@ async fn handle_rtx_failure<T>(
 async fn send_beacon_msg<T>(
     source: &Agent,
     topic: &AgentType,
-    beacon_type: SessionHeaderType,
+    beacon_type: ProtoSessionMessageType,
     last_msg_id: u32,
     session_id: u32,
     tx: &T,
@@ -920,6 +929,7 @@ async fn send_beacon_msg<T>(
     ));
 
     let session_header = Some(SessionHeader::new(
+        ProtoSessionType::SessionStreaming.into(),
         beacon_type.into(),
         session_id,
         last_msg_id,
@@ -1164,7 +1174,8 @@ mod tests {
 
         // set session header type for test check
         let mut expected_msg = message.clone();
-        expected_msg.set_header_type(SessionHeaderType::Stream);
+        expected_msg.set_session_message_type(ProtoSessionMessageType::StreamMsg);
+        expected_msg.set_session_type(ProtoSessionType::SessionStreaming);
         expected_msg.set_fanout(STREAM_BROADCAST);
 
         let session_msg = SessionMessage::new(message.clone(), Info::new(0));
@@ -1230,7 +1241,7 @@ mod tests {
 
         // set the session type
         let header = message.get_session_header_mut();
-        header.header_type = SessionHeaderType::Stream.into();
+        header.set_session_message_type(ProtoSessionMessageType::StreamMsg);
 
         let session_msg: SessionMessage = SessionMessage::new(message.clone(), Info::new(0));
 
@@ -1260,8 +1271,8 @@ mod tests {
             assert_eq!(rtx_header.session_id, 0);
             assert_eq!(rtx_header.message_id, 1);
             assert_eq!(
-                rtx_header.header_type,
-                i32::from(SessionHeaderType::RtxRequest)
+                rtx_header.session_message_type(),
+                ProtoSessionMessageType::RtxRequest,
             );
         }
 
@@ -1331,7 +1342,10 @@ mod tests {
             let msg_header = msg.get_session_header();
             assert_eq!(msg_header.session_id, 120);
             assert_eq!(msg_header.message_id, i);
-            assert_eq!(msg_header.header_type, i32::from(SessionHeaderType::Stream));
+            assert_eq!(
+                msg_header.session_message_type(),
+                ProtoSessionMessageType::StreamMsg
+            );
         }
 
         let slim_header = Some(SlimHeader::new(
@@ -1346,7 +1360,8 @@ mod tests {
         ));
 
         let session_header = Some(SessionHeader::new(
-            SessionHeaderType::RtxRequest.into(),
+            ProtoSessionType::SessionStreaming.into(),
+            ProtoSessionMessageType::RtxRequest.into(),
             1,
             2,
         ));
@@ -1368,8 +1383,8 @@ mod tests {
         assert_eq!(msg_header.session_id, 120);
         assert_eq!(msg_header.message_id, 2);
         assert_eq!(
-            msg_header.header_type,
-            i32::from(SessionHeaderType::RtxReply)
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::RtxReply
         );
         assert_eq!(msg.get_payload().unwrap().blob, vec![0x1, 0x2, 0x3, 0x4]);
     }
@@ -1455,7 +1470,10 @@ mod tests {
             let msg_header = msg.get_session_header();
             assert_eq!(msg_header.session_id, 0);
             assert_eq!(msg_header.message_id, i);
-            assert_eq!(msg_header.header_type, i32::from(SessionHeaderType::Stream));
+            assert_eq!(
+                msg_header.session_message_type(),
+                ProtoSessionMessageType::StreamMsg
+            );
 
             // the receiver should detect a loss for packet 1
             if i != 1 {
@@ -1474,7 +1492,10 @@ mod tests {
         let msg_header = msg.message.get_session_header();
         assert_eq!(msg_header.session_id, 0);
         assert_eq!(msg_header.message_id, 0);
-        assert_eq!(msg_header.header_type, i32::from(SessionHeaderType::Stream));
+        assert_eq!(
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::StreamMsg
+        );
         assert_eq!(
             msg.message.get_source(),
             Agent::from_strings("cisco", "default", "sender", 0)
@@ -1493,8 +1514,8 @@ mod tests {
         assert_eq!(msg_header.session_id, 0);
         assert_eq!(msg_header.message_id, 1);
         assert_eq!(
-            msg_header.header_type,
-            i32::from(SessionHeaderType::RtxRequest)
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::RtxRequest,
         );
         assert_eq!(
             msg.get_source(),
@@ -1513,8 +1534,8 @@ mod tests {
         assert_eq!(msg_header.session_id, 0);
         assert_eq!(msg_header.message_id, 1);
         assert_eq!(
-            msg_header.header_type,
-            i32::from(SessionHeaderType::RtxRequest)
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::RtxRequest
         );
         assert_eq!(
             msg.get_source(),
@@ -1543,8 +1564,8 @@ mod tests {
         assert_eq!(msg_header.session_id, 0);
         assert_eq!(msg_header.message_id, 1);
         assert_eq!(
-            msg_header.header_type,
-            i32::from(SessionHeaderType::RtxReply)
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::RtxReply
         );
         assert_eq!(
             msg.get_source(),
@@ -1572,8 +1593,8 @@ mod tests {
         assert_eq!(msg_header.session_id, 0);
         assert_eq!(msg_header.message_id, 1);
         assert_eq!(
-            msg_header.header_type,
-            i32::from(SessionHeaderType::RtxReply)
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::RtxReply,
         );
         assert_eq!(
             msg.message.get_source(),
@@ -1591,7 +1612,10 @@ mod tests {
         let msg_header = msg.message.get_session_header();
         assert_eq!(msg_header.session_id, 0);
         assert_eq!(msg_header.message_id, 2);
-        assert_eq!(msg_header.header_type, i32::from(SessionHeaderType::Stream));
+        assert_eq!(
+            msg_header.session_message_type(),
+            ProtoSessionMessageType::StreamMsg
+        );
         assert_eq!(
             msg.message.get_source(),
             Agent::from_strings("cisco", "default", "sender", 0)

--- a/data-plane/core/service/src/testutils.rs
+++ b/data-plane/core/service/src/testutils.rs
@@ -11,7 +11,7 @@ use crate::{
     session::{AppChannelSender, SessionTransmitter, SlimChannelSender},
 };
 use slim_datapath::Status;
-use slim_datapath::api::proto::pubsub::v1::Message;
+use slim_datapath::api::ProtoMessage as Message;
 
 #[derive(Clone)]
 pub(crate) struct MockTransmitter {

--- a/data-plane/integrations/mcp/mcp-proxy/src/proxy.rs
+++ b/data-plane/integrations/mcp/mcp-proxy/src/proxy.rs
@@ -13,7 +13,7 @@ use rmcp::{
 use slim::config::ConfigResult;
 use slim_auth::simple::SimpleGroup;
 use slim_datapath::{
-    api::proto::pubsub::v1::Message,
+    api::ProtoMessage as Message,
     messages::{Agent, AgentType},
 };
 use slim_service::{


### PR DESCRIPTION
# Description

Introduce the concept of `SessionType` in the session header of messages.
This is required as now we have message types that can be shared across
different sessions (like MLS ones). This will allow to understand the SessionType
for these kind of messages as well.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
