### PR TITLE
fix: add missing channel binary to testing Cargo.toml

### DIFF
--- a/data-plane/testing/Cargo.toml
+++ b/data-plane/testing/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/bin/subscriber.rs"
 name = "publisher"
 path = "src/bin/publisher.rs"
 
+[[bin]]
+name = "channel"
+path = "src/bin/channel.rs"
+
 [dependencies]
 agntcy-slim = { workspace = true }
 agntcy-slim-auth = { workspace = true }

--- a/data-plane/testing/README.md
+++ b/data-plane/testing/README.md
@@ -78,6 +78,26 @@ Options:
   -V, --version                 Print version
 ```
 
+### Channel
+```channel``` is an application that tests streaming sessions with MLS encryption support. It can run in moderator mode (creates and manages the channel) or participant mode (joins an existing channel). It supports both MLS-enabled and MLS-disabled modes for testing purposes. It can be run as follow:
+```
+$ cargo run --release --bin channel -- --help
+Usage: channel [OPTIONS] --config <CONFIGURATION> --name <ENDOPOINT>
+
+Options:
+  -c, --config <CONFIGURATION>     Slim config file
+  -n, --name <ENDOPOINT>           Local endpoint name in the form org/ns/type/id
+  -i, --is-moderator               Runs the endpoint in moderator mode
+  -a, --is-attacker                Runs the endpoint in attacker mode
+  -m, --mls-disabled               Runs the endpoint with MLS disabled
+  -p, --participants <PARITICIPANTS>... List of participant types to add to the channel (moderator mode only)
+  -o, --moderator-name <MODERATOR_NAME> Moderator name (participant mode only)
+  -f, --frequency <FREQUENCY>      Time between publications in milliseconds [default: 1000]
+      --max-packets <MAX_PACKETS>  Maximum number of packets to send (moderator only)
+  -h, --help                       Print help
+  -V, --version                    Print version
+```
+
 #### Message format and test verification
 The payload of a publication message has this format
 ```


### PR DESCRIPTION
# Description

This PR fixes issue #390 by adding the missing `channel` binary configuration to the testing workspace's `Cargo.toml` file. The `channel.rs` binary was present in `src/bin/` and referenced in `Taskfile.yml` but was missing from the `Cargo.toml` binary definitions, making it unbuildable with `cargo run --bin channel`.

**Changes made:**
- Added `[[bin]]` section for `channel` binary in `data-plane/testing/Cargo.toml`
- Updated `data-plane/testing/README.md` to document the channel binary usage and options

**Testing:**
- Verified the channel binary builds successfully with `cargo check --bin channel`
- All existing binaries remain functional

Fixes: #390

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/slim/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
