### PR TITLE
fix: mls update timer duration

### DIFF
--- a/data-plane/core/service/src/streaming.rs
+++ b/data-plane/core/service/src/streaming.rs
@@ -355,7 +355,7 @@ where
             let mls = mls.map(|mls| MlsState::new(mls).expect("failed to create MLS state"));
 
             let mls_enable = mls.is_some();
-            let sleep = time::sleep(Duration::from_secs(10));
+            let sleep = time::sleep(Duration::from_secs(3600));
             tokio::pin!(sleep);
 
             // create the channel endpoint
@@ -556,7 +556,7 @@ where
                     }
                     () = &mut sleep, if mls_enable => {
                         let _ = channel_endpoint.update_mls_keys().await;
-                        sleep.as_mut().reset(Instant::now() + Duration::from_secs(10));
+                        sleep.as_mut().reset(Instant::now() + Duration::from_secs(3600));
                     }
                 }
             }


### PR DESCRIPTION
# Description
Fix MLS update timer duration (move from 10sec to 1 hour) in streaming session

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
