### PR TITLE
fix: control plane config is not loaded

### DIFF
--- a/control-plane/Taskfile.yaml
+++ b/control-plane/Taskfile.yaml
@@ -209,4 +209,4 @@ tasks:
     cmds:
       - |
         {{.OUTPUT_DIR}}/bin/control-plane \
-          --config {{.REPO_ROOT}}/control-plane/config.yaml
+          --config {{.REPO_ROOT}}/control-plane/control-plane/config/config.yaml

--- a/control-plane/control-plane/internal/config/config.go
+++ b/control-plane/control-plane/internal/config/config.go
@@ -33,8 +33,8 @@ func (l LogConfig) Validate() error {
 }
 
 type APIConfig struct {
-	HTTPHost  string    `yaml:"HTTPHost"`
-	HTTPPort  string    `yaml:"HTTPPort"`
+	HTTPHost  string    `yaml:"httpHost"`
+	HTTPPort  string    `yaml:"httpPort"`
 	LogConfig LogConfig `yaml:"logging"`
 }
 


### PR DESCRIPTION
# Description

Fix config field name mapping to fix the problem of config.yaml is not loaded by Control Plane on startup.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
