### PR TITLE
feat(auth): support JWK as decoding keys

### DIFF
--- a/data-plane/core/auth/src/jwt.rs
+++ b/data-plane/core/auth/src/jwt.rs
@@ -7,9 +7,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 pub use jsonwebtoken_aws_lc::Algorithm;
+use jsonwebtoken_aws_lc::jwk::KeyAlgorithm;
 use jsonwebtoken_aws_lc::{
     DecodingKey, EncodingKey, Header as JwtHeader, TokenData, Validation, decode, decode_header,
-    encode, errors::ErrorKind,
+    encode, errors::ErrorKind, jwk::Jwk,
 };
 
 use parking_lot::RwLock;
@@ -22,12 +23,18 @@ use crate::file_watcher::FileWatcher;
 use crate::resolver::KeyResolver;
 use crate::traits::{Signer, StandardClaims, TokenProvider, Verifier};
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum KeyFormat {
+    Pem,
+    Jwk,
+}
+
 /// Enum representing key data types
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum KeyData {
-    /// PEM encoded key
-    Pem(String),
+    /// String with encoded key
+    Str(String),
     /// File path to the key
     File(String),
 }
@@ -39,10 +46,49 @@ pub struct Key {
     #[schemars(skip)]
     pub algorithm: Algorithm,
 
-    /// PEM encoded key or file path
+    /// Key format - PEM or JWK
+    #[schemars(skip)]
+    pub format: KeyFormat,
+
+    /// Eencoded key or file path
     #[schemars(skip)]
     #[serde(flatten, with = "serde_yaml::with::singleton_map")]
     pub key: KeyData,
+}
+
+fn key_alg_to_algorithm(key: &KeyAlgorithm) -> Result<Algorithm, AuthError> {
+    match key {
+        KeyAlgorithm::ES256 => Ok(Algorithm::ES256),
+        KeyAlgorithm::ES384 => Ok(Algorithm::ES384),
+        KeyAlgorithm::HS256 => Ok(Algorithm::HS256),
+        KeyAlgorithm::HS384 => Ok(Algorithm::HS384),
+        KeyAlgorithm::HS512 => Ok(Algorithm::HS512),
+        KeyAlgorithm::RS256 => Ok(Algorithm::RS256),
+        KeyAlgorithm::RS384 => Ok(Algorithm::RS384),
+        KeyAlgorithm::RS512 => Ok(Algorithm::RS512),
+        KeyAlgorithm::PS256 => Ok(Algorithm::PS256),
+        KeyAlgorithm::PS384 => Ok(Algorithm::PS384),
+        KeyAlgorithm::PS512 => Ok(Algorithm::PS512),
+        KeyAlgorithm::EdDSA => Ok(Algorithm::EdDSA),
+        _ => Err(AuthError::ConfigError(format!(
+            "Unsupported key algorithm: {:?}",
+            key
+        ))),
+    }
+}
+
+pub fn algorithm_from_jwk(jwk: &str) -> Result<Algorithm, AuthError> {
+    let jwk: Jwk = serde_json::from_str(jwk)
+        .map_err(|e| AuthError::ConfigError(format!("Failed to parse JWK: {}", e)))?;
+
+    tracing::info!(?jwk, "JWK parsed successfully");
+
+    let alg = jwk
+        .common
+        .key_algorithm
+        .ok_or_else(|| AuthError::ConfigError("JWK does not contain an algorithm".to_string()))?;
+
+    key_alg_to_algorithm(&alg)
 }
 
 /// Cache entry for validated tokens
@@ -513,7 +559,7 @@ mod tests {
     use std::collections::HashMap;
     use std::fs::{File, OpenOptions};
     use std::io::{Seek, SeekFrom, Write};
-    use std::{env, fs};
+    use std::{env, fs, vec};
 
     use super::*;
     use jsonwebtoken_aws_lc::{Algorithm, Header};
@@ -554,10 +600,11 @@ mod tests {
         // create jwt builder
         let jwt = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(file_name.to_string()),
             })
             .build()
@@ -566,7 +613,7 @@ mod tests {
         let claims = jwt.create_claims();
 
         assert_eq!(claims.iss.unwrap(), "test-issuer");
-        assert_eq!(claims.aud.unwrap(), "test-audience");
+        assert_eq!(claims.aud.unwrap(), ["test-audience"]);
         assert_eq!(claims.sub.unwrap(), "test-subject");
 
         assert!(jwt.decoding_key.is_none());
@@ -633,10 +680,11 @@ mod tests {
         // create jwt builder
         let jwt = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(file_name.to_string()),
             })
             .build()
@@ -648,11 +696,12 @@ mod tests {
         // test the verifier with the first key
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem(String::from(first_key)),
+                format: KeyFormat::Pem,
+                key: KeyData::Str(String::from(first_key)),
             })
             .build()
             .unwrap();
@@ -663,7 +712,7 @@ mod tests {
         let verified_claims: StandardClaims = jwt.verify(token.clone()).await.unwrap();
 
         assert_eq!(verified_claims.iss.unwrap(), "test-issuer");
-        assert_eq!(verified_claims.aud.unwrap(), "test-audience");
+        assert_eq!(verified_claims.aud.unwrap(), &["test-audience"]);
         assert_eq!(verified_claims.sub.unwrap(), "test-subject");
 
         let second_key = "another-test-key";
@@ -676,11 +725,12 @@ mod tests {
         // test the verifier with the second key
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem(String::from(second_key)),
+                format: KeyFormat::Pem,
+                key: KeyData::Str(String::from(second_key)),
             })
             .build()
             .unwrap();
@@ -691,7 +741,7 @@ mod tests {
         let verified_claims: StandardClaims = jwt.verify(token.clone()).await.unwrap();
 
         assert_eq!(verified_claims.iss.unwrap(), "test-issuer");
-        assert_eq!(verified_claims.aud.unwrap(), "test-audience");
+        assert_eq!(verified_claims.aud.unwrap(), &["test-audience"]);
         assert_eq!(verified_claims.sub.unwrap(), "test-subject");
 
         delete_file(file_name).expect("error deleting file");
@@ -701,22 +751,24 @@ mod tests {
     async fn test_jwt_sign_and_verify() {
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             })
             .build()
             .unwrap();
 
         let verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             })
             .build()
             .unwrap();
@@ -727,7 +779,7 @@ mod tests {
         let verified_claims: StandardClaims = verifier.verify(token.clone()).await.unwrap();
 
         assert_eq!(verified_claims.iss.unwrap(), "test-issuer");
-        assert_eq!(verified_claims.aud.unwrap(), "test-audience");
+        assert_eq!(verified_claims.aud.unwrap(), ["test-audience"]);
         assert_eq!(verified_claims.sub.unwrap(), "test-subject");
 
         // Try to verify with an invalid token
@@ -742,11 +794,12 @@ mod tests {
         // Create a verifier with the wrong key
         let wrong_verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("wrong-secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("wrong-secret-key".to_string()),
             })
             .build()
             .unwrap();
@@ -761,22 +814,24 @@ mod tests {
     async fn test_jwt_sign_and_verify_custom_claims() {
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             })
             .build()
             .unwrap();
 
         let verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             })
             .build()
             .unwrap();
@@ -821,18 +876,19 @@ mod tests {
         // Build the JWT with auto key resolution
         let signer = JwtBuilder::new()
             .issuer(mock_server.uri())
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm,
-                key: KeyData::Pem(test_key),
+                format: KeyFormat::Pem,
+                key: KeyData::Str(test_key),
             })
             .build()
             .unwrap();
 
         let verifier = JwtBuilder::new()
             .issuer(mock_server.uri())
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .auto_resolve_keys(true)
             .build()
@@ -844,7 +900,7 @@ mod tests {
 
         // Validate the claims
         assert_eq!(claims.iss.unwrap(), mock_server.uri());
-        assert_eq!(claims.aud.unwrap(), "test-audience");
+        assert_eq!(claims.aud.unwrap(), vec!["test-audience"]);
         assert_eq!(claims.sub.unwrap(), "test-subject");
     }
 
@@ -895,26 +951,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_jwk() {
+        let token = "eyJhbGciOiJSUzI1NiIsImtpZCI6InFLWXBwMTVJb2x0WXFaTEZFUHd4VnQ4aFlWeHFTN1A4IiwidHlwIjoiSldUIn0.eyJhdWQiOlsic2xpbS1kZW1vIl0sImV4cCI6MTc1MzE3MTMzMSwiaWF0IjoxNzUzMTY3NzMxLCJpc3MiOiJodHRwczovL29pZGMtZGlzY292ZXJ5LmV4YW1wbGUub3JnIiwic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvbnMvc2xpbS1jbGllbnRzL3NhL3NsaW0tY2xpZW50LTEifQ.ajYghAS0drv4zH8hLj5rY811e6WrgXS9Sf-26xWxtO-ILiJZJp1Ehry_86ijlH3UAFKuwLOsXckIErCP1VisgQi0pXFx_R0RvPi66IPWXdRjE0IORabM6XMVspfcd3eHdz60sJ9FAgw4NoZ8TSceu0oXaK2LWX0BmkrpgP1L4jGELOPRr4MmQo1bC4fFBFC9hUyZG80DslIb6Ra5vNZgSfUzeDy3-RTG4DbUJYzilZ9cFiulnc57lApEohzGQfgZDRRUQWao3ZK7BUCBKihzUbPPfraK7y6XeZRlOEE8MY4V0iMCKawNg-tiK1b39tbwq6MF0Bk2v-my4Q-x4d91VA";
+
+        let verifier = JwtBuilder::new()
+            .issuer("https://oidc-discovery.example.org")
+            .audience(&["slim-demo"])
+            .subject("spiffe://example.org/ns/slim-clients/sa/slim-client-1")
+            .public_key(&Key {
+                algorithm: Algorithm::RS256,
+                format: KeyFormat::Jwk,
+                key: KeyData::Str(
+                    r#"{
+                            "kty": "RSA",
+                            "kid": "qKYpp15IoltYqZLFEPwxVt8hYVxqS7P8",
+                            "n": "l4D_vzJlSAME60UrMZfmFDCYf-wo1icFBK8IPd_8v1vW2J72rzCrY6DwkZV_Y-xzisagpj8MeHOnakDN5NovU7ciAMucIpUjDenWlvSaVHgRj2g99RjO3_tAa423Hv91H_2RGRv0eiHDNSr_kogQ3WZTRs1QRV7Xpr0xQtj6DOCD7HF6kOjN-Mklh7r9zdrjFYZbdQsvvTjUo6lco24DeoD_sjBWMkoeQfTEEfleNGDmD_qtTwLcLBb3fO0TFmMh6_3lHdWBOpOaDL5S7rTv84C_KAXqyhkSQp-aeicZCiAH1Z6rUzQoNRjkos6zNV4nrH8sZVNv56qzTfJIUWL5hw",
+                            "e": "AQAB"
+                        }"#.to_string())})
+            .build()
+            .unwrap();
+
+        // Verify the token
+        let _result: StandardClaims = verifier.try_verify(token.to_string()).unwrap();
+    }
+
+    #[tokio::test]
     async fn test_jwt_verify_caching() {
         // Create test JWT objects
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             })
             .build()
             .unwrap();
 
         let mut verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS512,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             })
             .build()
             .unwrap();

--- a/data-plane/core/auth/src/jwt.rs
+++ b/data-plane/core/auth/src/jwt.rs
@@ -951,31 +951,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_jwk() {
-        let token = "eyJhbGciOiJSUzI1NiIsImtpZCI6InFLWXBwMTVJb2x0WXFaTEZFUHd4VnQ4aFlWeHFTN1A4IiwidHlwIjoiSldUIn0.eyJhdWQiOlsic2xpbS1kZW1vIl0sImV4cCI6MTc1MzE3MTMzMSwiaWF0IjoxNzUzMTY3NzMxLCJpc3MiOiJodHRwczovL29pZGMtZGlzY292ZXJ5LmV4YW1wbGUub3JnIiwic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvbnMvc2xpbS1jbGllbnRzL3NhL3NsaW0tY2xpZW50LTEifQ.ajYghAS0drv4zH8hLj5rY811e6WrgXS9Sf-26xWxtO-ILiJZJp1Ehry_86ijlH3UAFKuwLOsXckIErCP1VisgQi0pXFx_R0RvPi66IPWXdRjE0IORabM6XMVspfcd3eHdz60sJ9FAgw4NoZ8TSceu0oXaK2LWX0BmkrpgP1L4jGELOPRr4MmQo1bC4fFBFC9hUyZG80DslIb6Ra5vNZgSfUzeDy3-RTG4DbUJYzilZ9cFiulnc57lApEohzGQfgZDRRUQWao3ZK7BUCBKihzUbPPfraK7y6XeZRlOEE8MY4V0iMCKawNg-tiK1b39tbwq6MF0Bk2v-my4Q-x4d91VA";
-
-        let verifier = JwtBuilder::new()
-            .issuer("https://oidc-discovery.example.org")
-            .audience(&["slim-demo"])
-            .subject("spiffe://example.org/ns/slim-clients/sa/slim-client-1")
-            .public_key(&Key {
-                algorithm: Algorithm::RS256,
-                format: KeyFormat::Jwk,
-                key: KeyData::Str(
-                    r#"{
-                            "kty": "RSA",
-                            "kid": "qKYpp15IoltYqZLFEPwxVt8hYVxqS7P8",
-                            "n": "l4D_vzJlSAME60UrMZfmFDCYf-wo1icFBK8IPd_8v1vW2J72rzCrY6DwkZV_Y-xzisagpj8MeHOnakDN5NovU7ciAMucIpUjDenWlvSaVHgRj2g99RjO3_tAa423Hv91H_2RGRv0eiHDNSr_kogQ3WZTRs1QRV7Xpr0xQtj6DOCD7HF6kOjN-Mklh7r9zdrjFYZbdQsvvTjUo6lco24DeoD_sjBWMkoeQfTEEfleNGDmD_qtTwLcLBb3fO0TFmMh6_3lHdWBOpOaDL5S7rTv84C_KAXqyhkSQp-aeicZCiAH1Z6rUzQoNRjkos6zNV4nrH8sZVNv56qzTfJIUWL5hw",
-                            "e": "AQAB"
-                        }"#.to_string())})
-            .build()
-            .unwrap();
-
-        // Verify the token
-        let _result: StandardClaims = verifier.try_verify(token.to_string()).unwrap();
-    }
-
-    #[tokio::test]
     async fn test_jwt_verify_caching() {
         // Create test JWT objects
         let signer = JwtBuilder::new()

--- a/data-plane/core/auth/src/jwt_middleware.rs
+++ b/data-plane/core/auth/src/jwt_middleware.rs
@@ -309,7 +309,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::jwt::Algorithm;
+    use crate::jwt::{Algorithm, KeyFormat};
     use crate::traits::{Signer, StandardClaims};
     use crate::{builder::JwtBuilder, jwt::Key, jwt::KeyData};
     use futures::future::{self, Ready};
@@ -365,11 +365,12 @@ mod tests {
         // Set up a JWT signer
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("test-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("test-key".to_string()),
             })
             .build()
             .unwrap();
@@ -397,11 +398,12 @@ mod tests {
         // Set up a JWT signer
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("test-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("test-key".to_string()),
             })
             .build()
             .unwrap();
@@ -480,22 +482,24 @@ mod tests {
         // Set up a JWT signer and verifier with the same key
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("shared-secret".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("shared-secret".to_string()),
             })
             .build()
             .unwrap();
 
         let verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("shared-secret".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("shared-secret".to_string()),
             })
             .build()
             .unwrap();
@@ -537,11 +541,12 @@ mod tests {
         // Set up a JWT verifier
         let verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("test-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("test-key".to_string()),
             })
             .build()
             .unwrap();
@@ -555,11 +560,12 @@ mod tests {
         // Set up a JWT signer with the same key as the verifier
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("test-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("test-key".to_string()),
             })
             .build()
             .unwrap();
@@ -638,11 +644,12 @@ mod tests {
         // Set up a JWT signer and verifier with the same key
         let signer = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .private_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("shared-secret".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("shared-secret".to_string()),
             })
             .custom_claims(claims.clone())
             .build()
@@ -650,11 +657,12 @@ mod tests {
 
         let verifier = JwtBuilder::new()
             .issuer("test-issuer")
-            .audience("test-audience")
+            .audience(&["test-audience"])
             .subject("test-subject")
             .public_key(&Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("shared-secret".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("shared-secret".to_string()),
             })
             .build()
             .unwrap();
@@ -699,7 +707,7 @@ mod tests {
 
         // Check the claims are as expected
         assert_eq!(ret_claims.iss, Some("test-issuer".to_string()));
-        assert_eq!(ret_claims.aud, Some("test-audience".to_string()));
+        assert_eq!(ret_claims.aud, Some(vec!["test-audience".to_string()]));
         assert_eq!(ret_claims.sub, Some("test-subject".to_string()));
         assert_eq!(
             ret_claims.custom_claims.get("claim1"),

--- a/data-plane/core/auth/src/traits.rs
+++ b/data-plane/core/auth/src/traits.rs
@@ -25,7 +25,7 @@ pub struct StandardClaims {
 
     /// Audience (who the JWT is intended for)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub aud: Option<String>,
+    pub aud: Option<Vec<String>>,
 
     /// Expiration time (when the JWT expires)
     pub exp: u64,

--- a/data-plane/core/config/tests/e2e.rs
+++ b/data-plane/core/config/tests/e2e.rs
@@ -66,6 +66,7 @@ mod tests {
 
     use super::*;
     use slim_auth::jwt::Algorithm;
+    use slim_auth::jwt::KeyFormat;
     use slim_config::auth::basic::Config as BasicAuthConfig;
     use slim_config::auth::bearer::Config as BearerAuthConfig;
     use slim_config::auth::jwt::Config as JwtAuthConfig;
@@ -290,7 +291,7 @@ mod tests {
         let claims = slim_config::auth::jwt::Claims::default()
             .with_issuer("test-issuer")
             .with_subject("test-subject")
-            .with_audience("test-audience");
+            .with_audience(&["test-audience"]);
 
         let client_config = ClientAuthenticationConfig::Jwt(JwtAuthConfig::new(
             claims.clone(),
@@ -321,15 +322,18 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             },
             Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("secret-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("secret-key".to_string()),
             },
             Key {
                 algorithm: Algorithm::HS256,
-                key: KeyData::Pem("wrong-key".to_string()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str("wrong-key".to_string()),
             },
             50057,
         )
@@ -343,14 +347,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::RS256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa.pem"),
             },
             Key {
                 algorithm: Algorithm::RS256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::RS256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
             50058,
@@ -365,14 +372,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::RS384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa.pem"),
             },
             Key {
                 algorithm: Algorithm::RS384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::RS384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
             50059,
@@ -387,14 +397,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::RS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa.pem"),
             },
             Key {
                 algorithm: Algorithm::RS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::RS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
             50060,
@@ -409,14 +422,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::ES256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec256.pem"),
             },
             Key {
                 algorithm: Algorithm::ES256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec256-public.pem"),
             },
             Key {
                 algorithm: Algorithm::ES256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec256-wrong.pem"),
             },
             50061,
@@ -431,14 +447,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::ES384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec384.pem"),
             },
             Key {
                 algorithm: Algorithm::ES384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec384-public.pem"),
             },
             Key {
                 algorithm: Algorithm::ES384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec384-wrong.pem"),
             },
             50062,
@@ -453,14 +472,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::PS256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa.pem"),
             },
             Key {
                 algorithm: Algorithm::PS256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::PS256,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
             50063,
@@ -475,14 +497,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::PS384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa.pem"),
             },
             Key {
                 algorithm: Algorithm::PS384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::PS384,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
             50064,
@@ -497,14 +522,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::PS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa.pem"),
             },
             Key {
                 algorithm: Algorithm::PS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::PS512,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
             50065,
@@ -519,14 +547,17 @@ mod tests {
         test_tls_jwt_grpc_configuration(
             Key {
                 algorithm: Algorithm::EdDSA,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/eddsa.pem"),
             },
             Key {
                 algorithm: Algorithm::EdDSA,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/eddsa-public.pem"),
             },
             Key {
                 algorithm: Algorithm::EdDSA,
+                format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/eddsa-wrong.pem"),
             },
             50066,
@@ -541,14 +572,15 @@ mod tests {
         let claims = slim_config::auth::jwt::Claims::default()
             .with_issuer(mock_server.uri())
             .with_subject("test-subject")
-            .with_audience("test-audience");
+            .with_audience(&["test-audience"]);
 
         let client_config = ClientAuthenticationConfig::Jwt(JwtAuthConfig::new(
             claims.clone(),
             Duration::from_secs(3600),
             JwtKey::Encoding(Key {
                 algorithm,
-                key: KeyData::Pem(test_key.clone()),
+                format: KeyFormat::Pem,
+                key: KeyData::Str(test_key.clone()),
             }),
         ));
 
@@ -576,6 +608,7 @@ mod tests {
             Duration::from_secs(3600),
             JwtKey::Encoding(Key {
                 algorithm,
+                format: KeyFormat::Pem,
                 key: KeyData::File(key_path),
             }),
         ));

--- a/data-plane/python-bindings/slim_bindings/__init__.py
+++ b/data-plane/python-bindings/slim_bindings/__init__.py
@@ -43,6 +43,12 @@ from ._slim_bindings import (
     PyKey as PyKey,
 )
 from ._slim_bindings import (
+    PyKeyData as PyKeyData,
+)
+from ._slim_bindings import (
+    PyKeyFormat as PyKeyFormat,
+)
+from ._slim_bindings import (
     PySessionDirection as PySessionDirection,
 )
 from ._slim_bindings import (

--- a/data-plane/python-bindings/slim_bindings/_slim_bindings.pyi
+++ b/data-plane/python-bindings/slim_bindings/_slim_bindings.pyi
@@ -14,6 +14,12 @@ class PyAgentType:
     agent_type: builtins.str
     def __new__(cls,agent_org:builtins.str, agent_ns:builtins.str, agent_class:builtins.str): ...
 
+class PyKey:
+    algorithm: PyAlgorithm
+    format: PyKeyFormat
+    key: PyKeyData
+    def __new__(cls,algorithm:PyAlgorithm, format:PyKeyFormat, key:PyKeyData): ...
+
 class PyService:
     id: builtins.int
 
@@ -44,9 +50,13 @@ class PyIdentityVerifier(Enum):
     Jwt = auto()
     SharedSecret = auto()
 
-class PyKey(Enum):
+class PyKeyData(Enum):
     File = auto()
-    String = auto()
+    Content = auto()
+
+class PyKeyFormat(Enum):
+    Pem = auto()
+    Jwk = auto()
 
 class PySessionConfiguration(Enum):
     FireAndForget = auto()

--- a/data-plane/python-bindings/src/lib.rs
+++ b/data-plane/python-bindings/src/lib.rs
@@ -29,7 +29,10 @@ mod _slim_bindings {
     use utils::{PyAgentType, init_tracing};
 
     #[pymodule_export]
-    use pyidentity::{PyAlgorithm, PyIdentityProvider, PyIdentityVerifier, PyKey};
+    use pyidentity::{
+        PyAlgorithm, PyIdentityProvider, PyIdentityVerifier, PyKey, PyKeyData,
+        PyKeyFormat,
+    };
 
     #[pymodule_init]
     fn module_init(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/data-plane/python-bindings/src/pyidentity.rs
+++ b/data-plane/python-bindings/src/pyidentity.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use pyo3::prelude::*;
-use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pymethods};
 
 use slim_auth::builder::JwtBuilder;
 use slim_auth::jwt::Key;
@@ -10,7 +10,6 @@ use slim_auth::jwt::KeyFormat;
 use slim_auth::jwt::SignerJwt;
 use slim_auth::jwt::StaticTokenProvider;
 use slim_auth::jwt::VerifierJwt;
-use slim_auth::jwt::algorithm_from_jwk;
 use slim_auth::jwt::{Algorithm, KeyData};
 use slim_auth::shared_secret::SharedSecret;
 use slim_auth::traits::TokenProvider;
@@ -89,7 +88,7 @@ impl From<PyKeyData> for KeyData {
 #[pyclass(eq)]
 pub(crate) enum PyKeyFormat {
     Pem,
-    Jwk
+    Jwk,
 }
 
 impl From<PyKeyFormat> for KeyFormat {
@@ -105,9 +104,27 @@ impl From<PyKeyFormat> for KeyFormat {
 #[pyclass]
 #[derive(Clone, PartialEq)]
 pub(crate) struct PyKey {
-    pub(crate) algorithm: PyAlgorithm,
-    pub(crate) format: KeyFormat,
-    pub(crate) key: PyKeyData,
+    #[pyo3(get, set)]
+    algorithm: PyAlgorithm,
+
+    #[pyo3(get, set)]
+    format: PyKeyFormat,
+
+    #[pyo3(get, set)]
+    key: PyKeyData,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyKey {
+    #[new]
+    pub fn new(algorithm: PyAlgorithm, format: PyKeyFormat, key: PyKeyData) -> Self {
+        PyKey {
+            algorithm,
+            format,
+            key,
+        }
+    }
 }
 
 impl From<PyKey> for Key {

--- a/data-plane/python-bindings/src/pyidentity.rs
+++ b/data-plane/python-bindings/src/pyidentity.rs
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use pyo3::prelude::*;
-use pyo3_stub_gen::derive::gen_stub_pyclass_enum;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 
 use slim_auth::builder::JwtBuilder;
 use slim_auth::jwt::Key;
+use slim_auth::jwt::KeyFormat;
 use slim_auth::jwt::SignerJwt;
 use slim_auth::jwt::StaticTokenProvider;
 use slim_auth::jwt::VerifierJwt;
+use slim_auth::jwt::algorithm_from_jwk;
 use slim_auth::jwt::{Algorithm, KeyData};
 use slim_auth::shared_secret::SharedSecret;
 use slim_auth::traits::TokenProvider;
@@ -66,27 +68,54 @@ impl From<PyAlgorithm> for Algorithm {
 #[gen_stub_pyclass_enum]
 #[derive(Clone, PartialEq)]
 #[pyclass(eq)]
-pub(crate) enum PyKey {
-    #[pyo3(constructor = (algorithm, path))]
-    File {
-        algorithm: PyAlgorithm,
-        path: String,
-    },
-    #[pyo3(constructor = (algorithm, pem))]
-    String { algorithm: PyAlgorithm, pem: String },
+pub(crate) enum PyKeyData {
+    #[pyo3(constructor = (path))]
+    File { path: String },
+    #[pyo3(constructor = (content))]
+    Content { content: String },
+}
+
+impl From<PyKeyData> for KeyData {
+    fn from(value: PyKeyData) -> Self {
+        match value {
+            PyKeyData::File { path } => KeyData::File(path),
+            PyKeyData::Content { content } => KeyData::Str(content),
+        }
+    }
+}
+
+#[gen_stub_pyclass_enum]
+#[derive(Clone, PartialEq)]
+#[pyclass(eq)]
+pub(crate) enum PyKeyFormat {
+    Pem,
+    Jwk
+}
+
+impl From<PyKeyFormat> for KeyFormat {
+    fn from(value: PyKeyFormat) -> Self {
+        match value {
+            PyKeyFormat::Pem => KeyFormat::Pem,
+            PyKeyFormat::Jwk => KeyFormat::Jwk,
+        }
+    }
+}
+
+#[gen_stub_pyclass]
+#[pyclass]
+#[derive(Clone, PartialEq)]
+pub(crate) struct PyKey {
+    pub(crate) algorithm: PyAlgorithm,
+    pub(crate) format: KeyFormat,
+    pub(crate) key: PyKeyData,
 }
 
 impl From<PyKey> for Key {
     fn from(value: PyKey) -> Self {
-        match value {
-            PyKey::File { algorithm, path } => Key {
-                algorithm: algorithm.into(),
-                key: KeyData::File(path),
-            },
-            PyKey::String { algorithm, pem } => Key {
-                algorithm: algorithm.into(),
-                key: KeyData::Pem(pem),
-            },
+        Key {
+            algorithm: value.algorithm.into(),
+            format: value.format.into(),
+            key: value.key.into(),
         }
     }
 }
@@ -109,7 +138,7 @@ pub(crate) enum PyIdentityProvider {
         private_key: PyKey,
         duration: std::time::Duration,
         issuer: Option<String>,
-        audience: Option<String>,
+        audience: Option<Vec<String>>,
         subject: Option<String>,
     },
     #[pyo3(constructor = (identity, shared_secret))]
@@ -138,7 +167,7 @@ impl From<PyIdentityProvider> for IdentityProvider {
                     builder = builder.issuer(issuer);
                 }
                 if let Some(audience) = audience {
-                    builder = builder.audience(audience);
+                    builder = builder.audience(&audience);
                 }
                 if let Some(subject) = subject {
                     builder = builder.subject(subject);
@@ -185,7 +214,7 @@ pub(crate) enum PyIdentityVerifier {
         public_key: Option<PyKey>,
         autoresolve: bool,
         issuer: Option<String>,
-        audience: Option<String>,
+        audience: Option<Vec<String>>,
         subject: Option<String>,
         require_iss: bool,
         require_aud: bool,
@@ -218,7 +247,7 @@ impl From<PyIdentityVerifier> for IdentityVerifier {
                 }
 
                 if let Some(audience) = audience {
-                    builder = builder.audience(audience);
+                    builder = builder.audience(&audience);
                 }
 
                 if let Some(subject) = subject {

--- a/data-plane/python-bindings/tests/test_identity.py
+++ b/data-plane/python-bindings/tests/test_identity.py
@@ -10,7 +10,7 @@ import slim_bindings
 
 keys_folder = "./tests/testdata"
 
-test_audience = "test.audience"
+test_audience = ["test.audience"]
 
 
 def create_slim(
@@ -23,25 +23,29 @@ def create_slim(
     public_key_algorithm,
     wrong_audience=None,
 ):
-    private_key = slim_bindings.PyKey.File(
-        path=private_key, algorithm=private_key_algorithm
+    private_key = slim_bindings.PyKey(
+        algorithm=private_key_algorithm,
+        format=slim_bindings.PyKeyFormat.Pem,
+        key=slim_bindings.PyKeyData.File(path=private_key),
     )
 
-    public_key = slim_bindings.PyKey.File(
-        path=public_key, algorithm=public_key_algorithm
+    public_key = slim_bindings.PyKey(
+        algorithm=public_key_algorithm,
+        format=slim_bindings.PyKeyFormat.Pem,
+        key=slim_bindings.PyKeyData.File(path=public_key),
     )
 
     provider = slim_bindings.PyIdentityProvider.Jwt(
         private_key=private_key,
         duration=datetime.timedelta(seconds=60),
         issuer="test-issuer",
-        audience="test.audience",
+        audience=test_audience,
         subject=agent_type,
     )
     verifier = slim_bindings.PyIdentityVerifier.Jwt(
         public_key=public_key,
         issuer="test-issuer",
-        audience=wrong_audience or "test.audience",
+        audience=wrong_audience or test_audience,
         require_iss=True,
         require_aud=True,
     )
@@ -53,7 +57,7 @@ def create_slim(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server", ["127.0.0.1:52345"], indirect=True)
-@pytest.mark.parametrize("audience", [test_audience, "wrong.audience"])
+@pytest.mark.parametrize("audience", [test_audience, ["wrong.audience"]])
 async def test_identity_verification(server, audience):
     org = "org"
     ns = "default"


### PR DESCRIPTION
# Description

Add support for [JWK](https://datatracker.ietf.org/doc/html/rfc7517) encoded keys,
to be used as Decoding key to verify the token.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
