### PR TITLE
ci: fix version format in helm charts

### DIFF
--- a/.github/workflows/reusable-helm-release.yaml
+++ b/.github/workflows/reusable-helm-release.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "value=${_chart_name%-v*}" >> "$GITHUB_OUTPUT"
 
           # extract the chart version form the tag
-          echo "version=${_chart_name##*-v}" >> "$GITHUB_OUTPUT"
+          echo "version=v${_chart_name##*-v}" >> "$GITHUB_OUTPUT"
 
 
       - name: Helm lint


### PR DESCRIPTION
# Description

Keep the "v" in front of helm chart versions when releasing.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
