### PR TITLE
fix: add slim.overrideConfig to helm values

### DIFF
--- a/charts/slim/Chart.yaml
+++ b/charts/slim/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/slim/templates/configmap.yaml
+++ b/charts/slim/templates/configmap.yaml
@@ -9,7 +9,11 @@ metadata:
     {{- include "slim.labels" . | nindent 4 }}
 data:
   config.yaml: |
+    {{- if .Values.slim.overrideConfig }}
+    {{- tpl (toYaml .Values.slim.overrideConfig) . | nindent 4 }}
+    {{- else }}
     {{- tpl (toYaml .Values.slim.config) . | nindent 4 }}
+    {{- end }}    
     {{- if eq .Values.spire.enabled true }}
   helper.conf: |
     agent_address =  "/run/spire/agent-sockets/api.sock"

--- a/charts/slim/templates/service.yaml
+++ b/charts/slim/templates/service.yaml
@@ -11,9 +11,9 @@ spec:
   type: {{ .Values.slim.service.type }}
   ports:
     - port: {{ .Values.slim.service.data.port }}
-      targetPort: messenger
+      targetPort: data-plane
       protocol: TCP
-      name: messenger
+      name: data-plane
     - port: {{ .Values.slim.service.control.port }}
       targetPort: controller
       protocol: TCP

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -13,6 +13,9 @@ slim:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  # This is for overriding the default config below
+  overrideConfig:
+
   config:
     tracing:
       log_level: debug
@@ -37,8 +40,8 @@ slim:
           servers:
             - endpoint: "0.0.0.0:{{ .Values.slim.service.control.port }}"
               tls:
-                insecure: true
-
+                insecure: true    
+    
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
     # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
@@ -47,6 +50,7 @@ slim:
       port: 46357
     control:
       port: 46358
+  # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 
   # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
   ingress:

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -50,7 +50,6 @@ slim:
       port: 46357
     control:
       port: 46358
-  # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 
   # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
   ingress:

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -40,8 +40,8 @@ slim:
           servers:
             - endpoint: "0.0.0.0:{{ .Values.slim.service.control.port }}"
               tls:
-                insecure: true    
-    
+                insecure: true
+
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
     # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types


### PR DESCRIPTION
# Description

Add slim.overrideConfig property to values file, to have a possibility to override the whole default SLIM service config.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
