### PR TITLE
fix(control-plane): run go generate when running linter

### DIFF
--- a/control-plane/Taskfile.yaml
+++ b/control-plane/Taskfile.yaml
@@ -59,6 +59,7 @@ tasks:
     deps:
       - tools
     cmds:
+      - task: control-plane:gogen
       - task: control-plane:foreach-module
         vars:
           CMD: "echo ${PWD} && {{.TOOLS_INSTALL_DIR}}/golangci-lint run"


### PR DESCRIPTION
# Description

Ru go generate when running linter as well.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
