### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agntcy-slim"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -34,13 +34,13 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "core/slim", version = "0.4.0" }
+agntcy-slim = { path = "core/slim", version = "0.4.1" }
 agntcy-slim-auth = { path = "core/auth", version = "0.2.0" }
 agntcy-slim-config = { path = "core/config", version = "0.2.0" }
 agntcy-slim-controller = { path = "core/controller", version = "0.2.0" }
 agntcy-slim-datapath = { path = "core/datapath", version = "0.8.0" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.0" }
-agntcy-slim-service = { path = "core/service", version = "0.5.0" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.1" }
+agntcy-slim-service = { path = "core/service", version = "0.5.1" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.3" }
 agntcy-slim-tracing = { path = "core/tracing", version = "0.2.2" }
 

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/agntcy/slim/compare/slim-mls-v0.1.0...slim-mls-v0.1.1) - 2025-08-01
+
+### Other
+
+- *(agntcy-slim-mls)* release v0.1.0 ([#493](https://github.com/agntcy/slim/pull/493))
+
 ## [0.1.0](https://github.com/agntcy/slim/releases/tag/slim-mls-v0.1.0) - 2025-07-31
 
 ### Added

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.0"
+version = "0.1.1"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/agntcy/slim/compare/slim-service-v0.5.0...slim-service-v0.5.1) - 2025-08-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-mls
+
 ## [0.5.0](https://github.com/agntcy/slim/compare/slim-service-v0.4.2...slim-service-v0.5.0) - 2025-07-31
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.0"
+version = "0.5.1"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/agntcy/slim/compare/slim-v0.4.0...slim-v0.4.1) - 2025-08-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-service
+
 ## [0.4.0](https://github.com/agntcy/slim/compare/slim-v0.3.15...slim-v0.4.0) - 2025-07-31
 
 ### Other

--- a/data-plane/core/slim/Cargo.toml
+++ b/data-plane/core/slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "The main SLIM executable."


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-mls`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `agntcy-slim-service`: 0.5.0 -> 0.5.1
* `agntcy-slim`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-mls`

<blockquote>

## [0.1.1](https://github.com/agntcy/slim/compare/slim-mls-v0.1.0...slim-mls-v0.1.1) - 2025-08-01

### Other

- *(agntcy-slim-mls)* release v0.1.0 ([#493](https://github.com/agntcy/slim/pull/493))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.5.1](https://github.com/agntcy/slim/compare/slim-service-v0.5.0...slim-service-v0.5.1) - 2025-08-01

### Other

- updated the following local packages: agntcy-slim-mls
</blockquote>

## `agntcy-slim`

<blockquote>

## [0.4.1](https://github.com/agntcy/slim/compare/slim-v0.4.0...slim-v0.4.1) - 2025-08-01

### Other

- updated the following local packages: agntcy-slim-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).