### PR TITLE
fix(dp,py,srpc): use google.rpc.Code response code

### DIFF
--- a/data-plane/python-bindings/srpc/src/srpc/client.py
+++ b/data-plane/python-bindings/srpc/src/srpc/client.py
@@ -1,15 +1,11 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import AsyncIterable
-import datetime
+
 import logging
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterable
 
-from google.rpc import code_pb2
-
-import anyio
-from srpc.codes import Code
+from google.rpc.code_pb2 import Code
 
 import slim_bindings
 from srpc.common import (

--- a/data-plane/python-bindings/srpc/src/srpc/server.py
+++ b/data-plane/python-bindings/srpc/src/srpc/server.py
@@ -3,12 +3,9 @@
 
 import asyncio
 import logging
-from contextlib import asynccontextmanager
 
 from google.rpc import code_pb2, status_pb2
-
-import anyio
-from srpc.codes import Code
+from google.rpc.code_pb2 import Code
 
 import slim_bindings
 from srpc.common import (


### PR DESCRIPTION
# Description

Fixed the imports to use google.rpc.Code.

The rest was the import autoformatting (probably ruff).

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
