### PR TITLE
feat(srpc): Improve SRPCChannel usability

### DIFF
--- a/data-plane/python-bindings/slima2a/examples/echo_agent/client.py
+++ b/data-plane/python-bindings/slima2a/examples/echo_agent/client.py
@@ -57,6 +57,7 @@ async def main() -> None:
     def channel_factory(topic) -> SRPCChannel:
         channel = SRPCChannel(
             local="agntcy/demo/client",
+            remote=topic,
             slim={
                 "endpoint": "http://localhost:46357",
                 "tls": {
@@ -65,8 +66,7 @@ async def main() -> None:
             },
             shared_secret="secret",
         )
-        task = asyncio.get_running_loop().create_task(channel.connect(topic))
-        return task, channel
+        return channel
 
     client_config = ClientConfig(
             supported_transports=["JSONRPC", "srpc"],


### PR DESCRIPTION
This makes the SRPCChannel kick off the preparation in the background
and then lazyily awaits that preparation task to be completed.

This allows the SRPCChannel creation to remain a sync interface which
makes it more compatible with things like the A2A SDK but still prepare
itself using async tasks from the SLIM python bindings.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
