### PR TITLE
refactor(srpc): prefix private channel methods with underscore

### DIFF
--- a/data-plane/python-bindings/slima2a/README.md
+++ b/data-plane/python-bindings/slima2a/README.md
@@ -47,6 +47,6 @@ client = factory.create(ac)
 
 try:
     response = client.send_message(...)
-except srpc.ErrorResponse as e:
+except srpc.SRPCResponseError as e:
     ...
 ```

--- a/data-plane/python-bindings/slima2a/examples/echo_agent/client.py
+++ b/data-plane/python-bindings/slima2a/examples/echo_agent/client.py
@@ -162,7 +162,7 @@ async def send_message(
 
                 if update:
                     logger.info(f"update: {update.model_dump(mode='json')}")
-    except srpc.ErrorResponse as e:
+    except srpc.SRPCResponseError as e:
         logger.error(
             f"failed sending message or processing response on SRPC: {e}",
             exc_info=True,

--- a/data-plane/python-bindings/slima2a/slima2a/handler.py
+++ b/data-plane/python-bindings/slima2a/slima2a/handler.py
@@ -18,7 +18,7 @@ from a2a.utils import proto_utils
 from a2a.utils.errors import ServerError
 from a2a.utils.helpers import validate, validate_async_generator
 from google.rpc import code_pb2
-from srpc import ErrorResponse
+from srpc import SRPCResponseError
 from srpc import context as srpc_context
 
 from slima2a.types import a2a_pb2_srpc
@@ -309,62 +309,62 @@ class SRPCHandler(a2a_pb2_srpc.A2AServiceServicer):
         """Sets the srpc errors appropriately in the context."""
         match error.error:
             case types.JSONParseError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.INTERNAL,
                     message=f"JSONParseError: {error.error.message}",
                 )
             case types.InvalidRequestError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.INVALID_ARGUMENT,
                     message=f"InvalidRequestError: {error.error.message}",
                 )
             case types.MethodNotFoundError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.NOT_FOUND,
                     message=f"MethodNotFoundError: {error.error.message}",
                 )
             case types.InvalidParamsError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.INVALID_ARGUMENT,
                     message=f"InvalidParamsError: {error.error.message}",
                 )
             case types.InternalError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.INTERNAL,
                     message=f"InternalError: {error.error.message}",
                 )
             case types.TaskNotFoundError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.NOT_FOUND,
                     message=f"TaskNotFoundError: {error.error.message}",
                 )
             case types.TaskNotCancelableError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.UNIMPLEMENTED,
                     message=f"TaskNotCancelableError: {error.error.message}",
                 )
             case types.PushNotificationNotSupportedError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.UNIMPLEMENTED,
                     message=f"PushNotificationNotSupportedError: {error.error.message}",
                 )
             case types.UnsupportedOperationError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.UNIMPLEMENTED,
                     message=f"UnsupportedOperationError: {error.error.message}",
                 )
             case types.ContentTypeNotSupportedError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.UNIMPLEMENTED,
                     message=f"ContentTypeNotSupportedError: {error.error.message}",
                 )
             case types.InvalidAgentResponseError():
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.INTERNAL,
                     message=f"InvalidAgentResponseError: {error.error.message}",
                 )
             case _:
-                raise ErrorResponse(
+                raise SRPCResponseError(
                     code=code_pb2.UNKNOWN,
                     message=f"Unknown error type: {error.error}",
                 )

--- a/data-plane/python-bindings/slima2a/slima2a/types/a2a_pb2_srpc.py
+++ b/data-plane/python-bindings/slima2a/slima2a/types/a2a_pb2_srpc.py
@@ -170,81 +170,71 @@ class A2AServiceServicer:
 
 def add_A2AServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        "SendMessage": srpc.Rpc(
-            method_name="SendMessage",
-            handler=servicer.SendMessage,
+        "SendMessage": srpc.RPCHandler(
+            behaviour=servicer.SendMessage,
             request_deserializer=a2a__pb2.SendMessageRequest.FromString,
             response_serializer=a2a__pb2.SendMessageResponse.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "SendStreamingMessage": srpc.Rpc(
-            method_name="SendStreamingMessage",
-            handler=servicer.SendStreamingMessage,
+        "SendStreamingMessage": srpc.RPCHandler(
+            behaviour=servicer.SendStreamingMessage,
             request_deserializer=a2a__pb2.SendMessageRequest.FromString,
             response_serializer=a2a__pb2.StreamResponse.SerializeToString,
             request_streaming=False,
             response_streaming=True,
         ),
-        "GetTask": srpc.Rpc(
-            method_name="GetTask",
-            handler=servicer.GetTask,
+        "GetTask": srpc.RPCHandler(
+            behaviour=servicer.GetTask,
             request_deserializer=a2a__pb2.GetTaskRequest.FromString,
             response_serializer=a2a__pb2.Task.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "CancelTask": srpc.Rpc(
-            method_name="CancelTask",
-            handler=servicer.CancelTask,
+        "CancelTask": srpc.RPCHandler(
+            behaviour=servicer.CancelTask,
             request_deserializer=a2a__pb2.CancelTaskRequest.FromString,
             response_serializer=a2a__pb2.Task.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "TaskSubscription": srpc.Rpc(
-            method_name="TaskSubscription",
-            handler=servicer.TaskSubscription,
+        "TaskSubscription": srpc.RPCHandler(
+            behaviour=servicer.TaskSubscription,
             request_deserializer=a2a__pb2.TaskSubscriptionRequest.FromString,
             response_serializer=a2a__pb2.StreamResponse.SerializeToString,
             request_streaming=False,
             response_streaming=True,
         ),
-        "CreateTaskPushNotificationConfig": srpc.Rpc(
-            method_name="CreateTaskPushNotificationConfig",
-            handler=servicer.CreateTaskPushNotificationConfig,
+        "CreateTaskPushNotificationConfig": srpc.RPCHandler(
+            behaviour=servicer.CreateTaskPushNotificationConfig,
             request_deserializer=a2a__pb2.CreateTaskPushNotificationConfigRequest.FromString,
             response_serializer=a2a__pb2.TaskPushNotificationConfig.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "GetTaskPushNotificationConfig": srpc.Rpc(
-            method_name="GetTaskPushNotificationConfig",
-            handler=servicer.GetTaskPushNotificationConfig,
+        "GetTaskPushNotificationConfig": srpc.RPCHandler(
+            behaviour=servicer.GetTaskPushNotificationConfig,
             request_deserializer=a2a__pb2.GetTaskPushNotificationConfigRequest.FromString,
             response_serializer=a2a__pb2.TaskPushNotificationConfig.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "ListTaskPushNotificationConfig": srpc.Rpc(
-            method_name="ListTaskPushNotificationConfig",
-            handler=servicer.ListTaskPushNotificationConfig,
+        "ListTaskPushNotificationConfig": srpc.RPCHandler(
+            behaviour=servicer.ListTaskPushNotificationConfig,
             request_deserializer=a2a__pb2.ListTaskPushNotificationConfigRequest.FromString,
             response_serializer=a2a__pb2.ListTaskPushNotificationConfigResponse.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "GetAgentCard": srpc.Rpc(
-            method_name="GetAgentCard",
-            handler=servicer.GetAgentCard,
+        "GetAgentCard": srpc.RPCHandler(
+            behaviour=servicer.GetAgentCard,
             request_deserializer=a2a__pb2.GetAgentCardRequest.FromString,
             response_serializer=a2a__pb2.AgentCard.SerializeToString,
             request_streaming=False,
             response_streaming=False,
         ),
-        "DeleteTaskPushNotificationConfig": srpc.Rpc(
-            method_name="DeleteTaskPushNotificationConfig",
-            handler=servicer.DeleteTaskPushNotificationConfig,
+        "DeleteTaskPushNotificationConfig": srpc.RPCHandler(
+            behaviour=servicer.DeleteTaskPushNotificationConfig,
             request_deserializer=a2a__pb2.DeleteTaskPushNotificationConfigRequest.FromString,
             response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             request_streaming=False,

--- a/data-plane/python-bindings/slima2a/slima2a/types/a2a_pb2_srpc.py
+++ b/data-plane/python-bindings/slima2a/slima2a/types/a2a_pb2_srpc.py
@@ -101,7 +101,7 @@ class A2AServiceServicer:
         """Send a message to the agent. This is a blocking call that will return the
         task once it is completed, or a LRO if requested.
         """
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
@@ -109,13 +109,13 @@ class A2AServiceServicer:
         """SendStreamingMessage is a streaming call that will return a stream of
         task update events until the Task is in an interrupted or terminal state.
         """
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
     def GetTask(self, request, context):
         """Get the current state of a task from the agent."""
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
@@ -123,7 +123,7 @@ class A2AServiceServicer:
         """Cancel a task from the agent. If supported one should expect no
         more task updates for the task.
         """
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
@@ -133,37 +133,37 @@ class A2AServiceServicer:
         If the task is complete the stream will return the completed task (like
         GetTask) and close the stream.
         """
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
     def CreateTaskPushNotificationConfig(self, request, context):
         """Set a push notification config for a task."""
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
     def GetTaskPushNotificationConfig(self, request, context):
         """Get a push notification config for a task."""
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
     def ListTaskPushNotificationConfig(self, request, context):
         """Get a list of push notifications configured for a task."""
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
     def GetAgentCard(self, request, context):
         """GetAgentCard returns the agent card for the agent."""
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 
     def DeleteTaskPushNotificationConfig(self, request, context):
         """Delete a push notification config for a task."""
-        raise srpc_rpc.ErrorResponse(
+        raise srpc_rpc.SRPCResponseError(
             code=code__pb2.UNIMPLEMENTED, message="Method not implemented!"
         )
 

--- a/data-plane/python-bindings/srpc/srpc/__init__.py
+++ b/data-plane/python-bindings/srpc/srpc/__init__.py
@@ -6,8 +6,8 @@ from google.rpc.code_pb2 import Code as StatusCode
 from srpc.channel import Channel
 from srpc.context import Context
 from srpc.rpc import (
-    ErrorResponse,
     RPCHandler,
+    SRPCResponseError,
     stream_stream_rpc_method_handler,
     stream_unary_rpc_method_handler,
     unary_stream_rpc_method_handler,
@@ -18,7 +18,7 @@ from srpc.server import Server
 __all__ = [
     "StatusCode",
     "Context",
-    "ErrorResponse",
+    "SRPCResponseError",
     "RPCHandler",
     "stream_stream_rpc_method_handler",
     "stream_unary_rpc_method_handler",

--- a/data-plane/python-bindings/srpc/srpc/__init__.py
+++ b/data-plane/python-bindings/srpc/srpc/__init__.py
@@ -3,7 +3,7 @@
 
 from grpc import StatusCode
 
-from srpc.client import Channel
+from srpc.channel import Channel
 from srpc.context import Context
 from srpc.rpc import (
     ErrorResponse,

--- a/data-plane/python-bindings/srpc/srpc/__init__.py
+++ b/data-plane/python-bindings/srpc/srpc/__init__.py
@@ -1,13 +1,13 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-from grpc import StatusCode
+from google.rpc.code_pb2 import Code as StatusCode
 
 from srpc.channel import Channel
 from srpc.context import Context
 from srpc.rpc import (
     ErrorResponse,
-    Rpc,
+    RPCHandler,
     stream_stream_rpc_method_handler,
     stream_unary_rpc_method_handler,
     unary_stream_rpc_method_handler,
@@ -19,7 +19,7 @@ __all__ = [
     "StatusCode",
     "Context",
     "ErrorResponse",
-    "Rpc",
+    "RPCHandler",
     "stream_stream_rpc_method_handler",
     "stream_unary_rpc_method_handler",
     "unary_stream_rpc_method_handler",

--- a/data-plane/python-bindings/srpc/srpc/common.py
+++ b/data-plane/python-bindings/srpc/srpc/common.py
@@ -8,8 +8,6 @@ import logging
 import click
 import slim_bindings
 
-from srpc.rpc import Rpc
-
 logger = logging.getLogger(__name__)
 
 
@@ -78,13 +76,15 @@ def service_and_method_to_pyname(
 
 
 def handler_name_to_pyname(
-    name: slim_bindings.PyName, rpc_handler: Rpc
+    name: slim_bindings.PyName,
+    service_name,
+    method_name,
 ) -> slim_bindings.PyName:
     """
     Convert a handler name to a PyName.
     """
 
-    return method_to_pyname(name, rpc_handler.service_name, rpc_handler.method_name)
+    return method_to_pyname(name, service_name, method_name)
 
 
 # Create a shared secret identity provider and verifier
@@ -113,9 +113,9 @@ def shared_secret_identity(identity, secret):
 def jwt_identity(
     jwt_path: str,
     jwk_path: str,
-    iss: str = None,
-    sub: str = None,
-    aud: list = None,
+    iss: str | None = None,
+    sub: str | None = None,
+    aud: list | None = None,
 ):
     """
     Parse the JWK and JWT from the provided strings.

--- a/data-plane/python-bindings/srpc/srpc/examples/simple/client.py
+++ b/data-plane/python-bindings/srpc/srpc/examples/simple/client.py
@@ -20,7 +20,7 @@ async def amain():
         },
         enable_opentelemetry=False,
         shared_secret="my_shared_secret",
-        remote="agntcy/grpc/server"
+        remote="agntcy/grpc/server",
     )
 
     # Stubs

--- a/data-plane/python-bindings/srpc/srpc/examples/simple/server.py
+++ b/data-plane/python-bindings/srpc/srpc/examples/simple/server.py
@@ -3,7 +3,10 @@ import logging
 from collections.abc import AsyncIterable
 
 from srpc.examples.simple.types.example_pb2 import ExampleRequest, ExampleResponse
-from srpc.examples.simple.types.example_pb2_srpc import TestServicer, add_TestServicer_to_server
+from srpc.examples.simple.types.example_pb2_srpc import (
+    TestServicer,
+    add_TestServicer_to_server,
+)
 from srpc.server import Server
 
 logging.basicConfig(level=logging.DEBUG)

--- a/data-plane/python-bindings/srpc/srpc/examples/simple/types/example_pb2_srpc.py
+++ b/data-plane/python-bindings/srpc/srpc/examples/simple/types/example_pb2_srpc.py
@@ -67,22 +67,22 @@ class TestServicer:
 def add_TestServicer_to_server(servicer, server: srpc.Server):
     rpc_method_handlers = {
         "ExampleUnaryUnary": srpc.unary_unary_rpc_method_handler(
-            handler=servicer.ExampleUnaryUnary,
+            behaviour=servicer.ExampleUnaryUnary,
             request_deserializer=example__pb2.ExampleRequest.FromString,
             response_serializer=example__pb2.ExampleResponse.SerializeToString,
         ),
         "ExampleUnaryStream": srpc.unary_stream_rpc_method_handler(
-            handler=servicer.ExampleUnaryStream,
+            behaviour=servicer.ExampleUnaryStream,
             request_deserializer=example__pb2.ExampleRequest.FromString,
             response_serializer=example__pb2.ExampleResponse.SerializeToString,
         ),
         "ExampleStreamUnary": srpc.stream_unary_rpc_method_handler(
-            handler=servicer.ExampleStreamUnary,
+            behaviour=servicer.ExampleStreamUnary,
             request_deserializer=example__pb2.ExampleRequest.FromString,
             response_serializer=example__pb2.ExampleResponse.SerializeToString,
         ),
         "ExampleStreamStream": srpc.stream_stream_rpc_method_handler(
-            handler=servicer.ExampleStreamStream,
+            behaviour=servicer.ExampleStreamStream,
             request_deserializer=example__pb2.ExampleRequest.FromString,
             response_serializer=example__pb2.ExampleResponse.SerializeToString,
         ),

--- a/data-plane/python-bindings/srpc/srpc/rpc.py
+++ b/data-plane/python-bindings/srpc/srpc/rpc.py
@@ -9,7 +9,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-class ErrorResponse(Exception):
+class SRPCResponseError(Exception):
     def __init__(self, code, message, details=None):
         self.code = code
         self.message = message

--- a/data-plane/python-bindings/srpc/srpc/rpc.py
+++ b/data-plane/python-bindings/srpc/srpc/rpc.py
@@ -2,13 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from collections.abc import AsyncGenerator, AsyncIterable, Awaitable
-from typing import Any
-
-import slim_bindings
-from google.rpc import code_pb2, status_pb2
-
-from srpc.context import Context
+from collections.abc import Callable
+from dataclasses import dataclass
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -22,99 +17,22 @@ class ErrorResponse(Exception):
         super().__init__(message)
 
 
-class Rpc:
-    """
-    Base class for RPC object. It holds the method name, handler, serializers, and
-    deserializers for the request and response.
-    """
-
-    def __init__(
-        self,
-        handler: Awaitable,  # Or Callable?
-        request_deserializer: callable = lambda x: x,
-        response_serializer: callable = lambda x: x,
-        method_name: str | None = None,
-        service_name: str | None = None,
-        request_streaming: bool = False,
-        response_streaming: bool = False,
-    ):
-        self.service_name = service_name
-        self.method_name = method_name
-        self.handler = handler
-        self.request_deserializer = request_deserializer
-        self.response_serializer = response_serializer
-        self.request_streaming = request_streaming
-        self.response_streaming = response_streaming
-
-    def request_generator(
-        self, local_app: slim_bindings.Slim, session_info: slim_bindings.PySessionInfo
-    ) -> AsyncGenerator[Any, Context]:
-        async def generator():
-            try:
-                while True:
-                    session_recv, request_bytes = await local_app.receive(
-                        session=session_info.id,
-                    )
-
-                    if not self.request_streaming:
-                        break
-
-                    if (
-                        session_recv.metadata.get("code") == str(code_pb2.OK)
-                        and not request_bytes
-                    ):
-                        logger.debug("end of stream received")
-                        break
-
-                    request = self.request_deserializer(request_bytes)
-                    context = Context.from_sessioninfo(session_recv)
-
-                    yield request, context
-            except Exception as e:
-                logger.error(f"Error receiving messages from SLIM: {e}")
-                raise
-
-        return generator()
-
-    async def call_handler(self, *args, **kwargs) -> AsyncGenerator[int, Any]:
-        """
-        Call the handler with the given arguments.
-        """
-
-        code = code_pb2.OK
-
-        try:
-            if not self.response_streaming:
-                response = await self.handler(*args, **kwargs)
-                yield code, response
-            else:
-                async for response in self.handler(*args, **kwargs):
-                    yield code, response
-
-            return
-        except ErrorResponse as e:
-            logger.error("Error while calling handler 1")
-            response = status_pb2.Status(
-                code=e.code, message=e.message, details=e.details
-            )
-            code = e.code
-        except Exception as e:
-            logger.error(f"Error while calling handler 2 {e}")
-            response = status_pb2.Status(
-                code=code_pb2.UNKNOWN, message="Internal Error", details=None
-            )
-            code = code_pb2.UNKNOWN
-
-        yield code, response
+@dataclass
+class RPCHandler:
+    behaviour: Callable
+    request_deserializer: Callable
+    response_serializer: Callable
+    request_streaming: bool = False
+    response_streaming: bool = False
 
 
 def unary_unary_rpc_method_handler(
-    handler: Awaitable,
-    request_deserializer: callable = lambda x: x,
-    response_serializer: callable = lambda x: x,
-) -> Rpc:
-    return Rpc(
-        handler=handler,
+    behaviour: Callable,
+    request_deserializer: Callable = lambda x: x,
+    response_serializer: Callable = lambda x: x,
+) -> RPCHandler:
+    return RPCHandler(
+        behaviour=behaviour,
         request_deserializer=request_deserializer,
         response_serializer=response_serializer,
         request_streaming=False,
@@ -123,12 +41,12 @@ def unary_unary_rpc_method_handler(
 
 
 def unary_stream_rpc_method_handler(
-    handler: AsyncIterable,
-    request_deserializer: callable = lambda x: x,
-    response_serializer: callable = lambda x: x,
-) -> Rpc:
-    return Rpc(
-        handler=handler,
+    behaviour: Callable,
+    request_deserializer: Callable = lambda x: x,
+    response_serializer: Callable = lambda x: x,
+) -> RPCHandler:
+    return RPCHandler(
+        behaviour=behaviour,
         request_deserializer=request_deserializer,
         response_serializer=response_serializer,
         request_streaming=False,
@@ -137,12 +55,12 @@ def unary_stream_rpc_method_handler(
 
 
 def stream_unary_rpc_method_handler(
-    handler: Awaitable,
-    request_deserializer: callable = lambda x: x,
-    response_serializer: callable = lambda x: x,
-) -> Rpc:
-    return Rpc(
-        handler=handler,
+    behaviour: Callable,
+    request_deserializer: Callable = lambda x: x,
+    response_serializer: Callable = lambda x: x,
+) -> RPCHandler:
+    return RPCHandler(
+        behaviour=behaviour,
         request_deserializer=request_deserializer,
         response_serializer=response_serializer,
         request_streaming=True,
@@ -151,12 +69,12 @@ def stream_unary_rpc_method_handler(
 
 
 def stream_stream_rpc_method_handler(
-    handler: Awaitable,
-    request_deserializer: callable = lambda x: x,
-    response_serializer: callable = lambda x: x,
-) -> Rpc:
-    return Rpc(
-        handler=handler,
+    behaviour: Callable,
+    request_deserializer: Callable = lambda x: x,
+    response_serializer: Callable = lambda x: x,
+) -> RPCHandler:
+    return RPCHandler(
+        behaviour=behaviour,
         request_deserializer=request_deserializer,
         response_serializer=response_serializer,
         request_streaming=True,

--- a/data-plane/python-bindings/srpc/srpc/server.py
+++ b/data-plane/python-bindings/srpc/srpc/server.py
@@ -15,7 +15,7 @@ from srpc.common import (
     split_id,
 )
 from srpc.context import Context
-from srpc.rpc import ErrorResponse, RPCHandler
+from srpc.rpc import RPCHandler, SRPCResponseError
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -185,7 +185,7 @@ async def call_handler(
         # For streaming responses yield each response from the handler
         async for response in handler.behaviour(request_or_iterator, context):
             yield code_pb2.OK, response
-    except ErrorResponse as e:
+    except SRPCResponseError as e:
         logger.error("Error while calling handler 1")
         yield (
             e.code,


### PR DESCRIPTION
[refactor(srpc): prefix private channel methods with underscore](https://github.com/agntcy/slim/commit/5434b5af40744fc8123bb2d9e99f6807fa646ad0)

[refactor(srpc): Cleanup and mypy fixes](https://github.com/agntcy/slim/commit/aaa5fa1bc69abaf6839ddde182c9e2c777179991)

[refactor(srpc,slima2a): Rename ErrorResponse to SRPCResponseError](https://github.com/agntcy/slim/commit/da2282cef68685dfc47b3f3f29330c7ccf8ba679)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
