### PR TITLE
fix(dp,py,slima2a): fix async timeout < py3.11

### DIFF
--- a/data-plane/python-bindings/srpc/pyproject.toml
+++ b/data-plane/python-bindings/srpc/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "googleapis-common-protos>=1.70.0",
     "anyio>=4.9.0",
     "grpcio>=1.74.0",
+    "async-timeout>=5.0.1",
 ]
 
 [dependency-groups]

--- a/data-plane/python-bindings/srpc/srpc/channel.py
+++ b/data-plane/python-bindings/srpc/srpc/channel.py
@@ -4,8 +4,14 @@
 import asyncio
 import datetime
 import logging
+import sys
 from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from typing import Any
+
+if sys.version_info >= (3, 11):
+    from asyncio import asyncio_timeout_at
+else:
+    from async_timeout import timeout_at as asyncio_timeout_at
 
 import slim_bindings
 from google.rpc import code_pb2
@@ -151,7 +157,7 @@ class Channel:
         # Wait for the response
         assert self.local_app is not None
 
-        async with asyncio.timeout_at(deadline):
+        async with asyncio_timeout_at(deadline):
             session_recv, response_bytes = await self.local_app.receive(
                 session=session.id,
             )
@@ -186,7 +192,7 @@ class Channel:
                 logger.error(f"error receiving messages: {e}")
                 raise
 
-        async with asyncio.timeout_at(deadline):
+        async with asyncio_timeout_at(deadline):
             async for response in generator():
                 yield response
 

--- a/data-plane/python-bindings/srpc/srpc/server.py
+++ b/data-plane/python-bindings/srpc/srpc/server.py
@@ -3,8 +3,14 @@
 
 import asyncio
 import logging
+import sys
 from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from typing import Any, Tuple
+
+if sys.version_info >= (3, 11):
+    from asyncio import asyncio_timeout_at
+else:
+    from async_timeout import timeout_at as asyncio_timeout_at
 
 import slim_bindings
 from google.rpc import code_pb2, status_pb2
@@ -130,7 +136,7 @@ class Server:
             # Get deadline from request
             deadline = float(session_info.metadata.get(DEADLINE_KEY, str(MAX_TIMEOUT)))
 
-            async with asyncio.timeout_at(deadline):
+            async with asyncio_timeout_at(deadline):
                 if not rpc_handler.request_streaming:
                     # Read the request from slim
                     session_recv, request_bytes = await local_app.receive(

--- a/data-plane/python-bindings/uv.lock
+++ b/data-plane/python-bindings/uv.lock
@@ -66,6 +66,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1358,6 +1367,7 @@ version = "0.1.0"
 source = { editable = "srpc" }
 dependencies = [
     { name = "anyio" },
+    { name = "async-timeout" },
     { name = "click" },
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -1372,6 +1382,7 @@ linting = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.9.0" },
+    { name = "async-timeout", specifier = ">=5.0.1" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "googleapis-common-protos", specifier = ">=1.70.0" },
     { name = "grpcio", specifier = ">=1.74.0" },


### PR DESCRIPTION
# Description

Currently the srpc Channel and Server implementation uses `asyncio.timeout_at()` for some context management.
This function was only introduced in Python 3.11, but the current project target is 3.9/3.10 (3.9 for the python-bindings, 3.10 for the slima2a). For python 3.10- there is a 3rd party drop-in replacement package `async-timeout` which can provide the missing functionality, so I used a conditional import to chose between the stdlib and 3rd party implementation based on Python version.

Tested on 3.10 and 3.13, both worked fine.

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
