### PR TITLE
(bug): fixed the slimctl version cmd crash

### DIFF
--- a/control-plane/slimctl/internal/cmd/version/version.go
+++ b/control-plane/slimctl/internal/cmd/version/version.go
@@ -66,14 +66,22 @@ func NewVersionCmd(opts *options.CommonOptions) *cobra.Command {
 
 // Run executes the business logic for the version command.
 func Run(v *version, opts *options.CommonOptions, _ *cobra.Command) error {
-	opts.Logger.Info(
-		"Version",
-		zap.String("SemVersion", v.SemVersion),
-		zap.String("GitCommit", v.GitCommit),
-		zap.String("BuildData", v.BuildDate),
-		zap.String("GoVersion", v.GoVersion),
-		zap.String("Compiler", v.Compiler),
-		zap.String("Platform", v.Platform),
+	if opts != nil && opts.Logger != nil {
+		opts.Logger.Info(
+			"Version",
+			zap.String("SemVersion", v.SemVersion),
+			zap.String("GitCommit", v.GitCommit),
+			zap.String("BuildDate", v.BuildDate),
+			zap.String("GoVersion", v.GoVersion),
+			zap.String("Compiler", v.Compiler),
+			zap.String("Platform", v.Platform),
+		)
+		return nil
+	}
+
+	// Fallback to plain stdout to avoid crashing if logger isn't initialized yet.
+	fmt.Printf("Version: sem=%s git=%s build=%s go=%s compiler=%s platform=%s\n",
+		v.SemVersion, v.GitCommit, v.BuildDate, v.GoVersion, v.Compiler, v.Platform,
 	)
 
 	return nil


### PR DESCRIPTION
# Description

Slimctl version cmd is crashing so as part of this PR we have initialized a Logger and added additional null check for avoiding the crash.

Fixes: #585

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
