### PR TITLE
task: add missing task in mcp-proxy Taskfile

### DIFF
--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
@@ -3436,9 +3436,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/data-plane/integrations/mcp/mcp-proxy/Taskfile.yaml
+++ b/data-plane/integrations/mcp/mcp-proxy/Taskfile.yaml
@@ -22,6 +22,11 @@ tasks:
     cmds:
       - echo "no python bindings exists for mcp-proxy"
 
+  mcp-proxy:core:test:
+    desc: "Test the core functionality"
+    cmds:
+      - echo "no core tests defined for mcp-proxy"
+
   mcp-proxy:lint:
     desc: "Run the linter"
     cmds:


### PR DESCRIPTION
# Description
This PR fixes the missing task reference in the mcp-proxy Taskfile.

Currently, the mcp-proxy:test task depends on multiple subtasks defined in rust.yaml. However, bindings:test is present in the mcp-proxy Taskfile, while core:test is missing. As a result, running mcp-proxy:test fails with a missing task error (mcp-proxy:core:test).

Changes in this PR:
Added the missing core:test task to the mcp-proxy Taskfile dependencies.

Ensured that mcp-proxy:test runs successfully without errors.

Why this is needed:
Without this fix, the mcp-proxy:test task cannot be executed, which blocks test execution and CI workflows that rely on it.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
