### PR TITLE
feat(grpc): add support for HTTP proxy

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -104,6 +104,7 @@ name = "agntcy-slim-config"
 version = "0.2.0"
 dependencies = [
  "agntcy-slim-auth",
+ "base64 0.22.1",
  "drain",
  "duration-str",
  "futures",

--- a/data-plane/config/base/client-config.yaml
+++ b/data-plane/config/base/client-config.yaml
@@ -15,6 +15,8 @@ services:
   slim/0:
     dataplane:
       clients:
-        - endpoint: "http://localhost:46357"
+        - endpoint: "https://10.60.16.63:46357"
           tls:
-            insecure: true
+            insecure_skip_verify: true
+          proxy:
+            url: http://proxy-wsa.esl.cisco.com:80

--- a/data-plane/config/base/client-config.yaml
+++ b/data-plane/config/base/client-config.yaml
@@ -15,8 +15,6 @@ services:
   slim/0:
     dataplane:
       clients:
-        - endpoint: "http://10.60.16.63:46357"
+        - endpoint: "http://localhost:46357"
           tls:
             insecure: true
-          proxy:
-            url: http://proxy-wsa.esl.cisco.com:80

--- a/data-plane/config/base/client-config.yaml
+++ b/data-plane/config/base/client-config.yaml
@@ -15,6 +15,8 @@ services:
   slim/0:
     dataplane:
       clients:
-        - endpoint: "http://localhost:46357"
+        - endpoint: "http://10.60.16.63:46357"
           tls:
             insecure: true
+          proxy:
+            url: http://proxy-wsa.esl.cisco.com:80

--- a/data-plane/config/base/client-config.yaml
+++ b/data-plane/config/base/client-config.yaml
@@ -15,8 +15,6 @@ services:
   slim/0:
     dataplane:
       clients:
-        - endpoint: "https://10.60.16.63:46357"
+        - endpoint: "http://localhost:46357"
           tls:
-            insecure_skip_verify: true
-          proxy:
-            url: http://proxy-wsa.esl.cisco.com:80
+            insecure: true

--- a/data-plane/config/proxy/client-config.yaml
+++ b/data-plane/config/proxy/client-config.yaml
@@ -15,9 +15,9 @@ services:
   slim/0:
     dataplane:
       clients:
-        - endpoint: "http://10.60.16.63:46357"
+        - endpoint: "https://external-slim-instance-address:46357"
           tls:
-            insecure: true
+            insecure_skip_verify: true
           # You can configure the proxy settings here or by specifying the usual
           # HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variable.
           # The value specified in the configuration has precedence

--- a/data-plane/config/proxy/client-config.yaml
+++ b/data-plane/config/proxy/client-config.yaml
@@ -1,0 +1,26 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+tracing:
+  log_level: info
+  display_thread_names: true
+  display_thread_ids: true
+
+runtime:
+  n_cores: 0
+  thread_name: "slim-data-plane"
+  drain_timeout: 10s
+
+services:
+  slim/0:
+    dataplane:
+      clients:
+        - endpoint: "http://10.60.16.63:46357"
+          tls:
+            insecure: true
+          # You can configure the proxy settings here or by specifying the usual
+          # HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variable.
+          # The value specified in the configuration has precedence
+          proxy:
+            # At the moment we only support http:// connections to proxies
+            url: http://your-http-proxy:80

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/grpc/schema/generate_schema.rs"
 
 [dependencies]
 agntcy-slim-auth.workspace = true
+base64 = { workspace = true }
 drain = { workspace = true }
 duration-str = { workspace = true }
 futures = { workspace = true }

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -20,7 +20,7 @@ duration-str = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 hyper-rustls = { workspace = true }
-hyper-util = { workspace = true }
+hyper-util = { workspace = true, features = ["client-proxy-system"] }
 lazy_static = { workspace = true }
 parking_lot = { workspace = true }
 prost = { workspace = true }

--- a/data-plane/core/config/src/grpc.rs
+++ b/data-plane/core/config/src/grpc.rs
@@ -6,3 +6,4 @@ pub mod compression;
 pub mod errors;
 pub mod headers_middleware;
 pub mod server;
+pub mod proxy;

--- a/data-plane/core/config/src/grpc.rs
+++ b/data-plane/core/config/src/grpc.rs
@@ -5,5 +5,5 @@ pub mod client;
 pub mod compression;
 pub mod errors;
 pub mod headers_middleware;
-pub mod server;
 pub mod proxy;
+pub mod server;

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -267,10 +267,7 @@ impl ClientConfig {
     }
 
     pub fn with_proxy(self, proxy: ProxyConfig) -> Self {
-        Self {
-            proxy: proxy,
-            ..self
-        }
+        Self { proxy, ..self }
     }
 
     pub fn with_connect_timeout(self, connect_timeout: Duration) -> Self {

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -805,28 +805,4 @@ mod test {
         let client = ClientConfig::with_endpoint("http://localhost:8080").with_proxy(proxy.clone());
         assert_eq!(client.proxy, proxy);
     }
-
-    #[test]
-    fn test_client_config_with_no_proxy() {
-        let no_proxy_list = "localhost,.internal.com";
-        let proxy = ProxyConfig::new("http://proxy.example.com:8080").with_no_proxy(no_proxy_list);
-
-        let client = ClientConfig::with_endpoint("http://localhost:8080").with_proxy(proxy);
-
-        // Test that the client config includes the no_proxy configuration
-        assert_eq!(client.proxy.no_proxy, Some(no_proxy_list.to_string()));
-        assert!(client.proxy.should_use_proxy("https://localhost").is_none());
-        assert!(
-            client
-                .proxy
-                .should_use_proxy("http://api.internal.com")
-                .is_none()
-        );
-        assert!(
-            client
-                .proxy
-                .should_use_proxy("http://external.com")
-                .is_some()
-        );
-    }
 }

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -453,9 +453,9 @@ impl ClientConfig {
         let endpoint_host = uri.host().unwrap_or("");
 
         // Check if this host should bypass the proxy
-        if let Some(intercept) = proxy_config.should_use_proxy(endpoint_host) {
+        if let Some(intercept) = self.proxy.should_use_proxy(endpoint_host) {
             // Use proxy for this host
-            let tunnel = self.create_proxy_tunnel(intercept, http_connector, proxy_config)?;
+            let tunnel = self.create_proxy_tunnel(intercept, http_connector, &self.proxy)?;
             self.apply_tls_to_tunnel_connector(builder, tunnel, tls_config)
         } else {
             // Skip proxy for this host, use direct connection

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -449,18 +449,6 @@ impl ClientConfig {
         http_connector: HttpConnector,
         tls_config: Option<rustls::ClientConfig>,
     ) -> Result<Channel, ConfigError> {
-        self.create_channel_with_proxy(uri, builder, http_connector, tls_config, &self.proxy)
-    }
-
-    /// Creates a channel with proxy configuration
-    fn create_channel_with_proxy(
-        &self,
-        uri: Uri,
-        builder: tonic::transport::Endpoint,
-        http_connector: HttpConnector,
-        tls_config: Option<rustls::ClientConfig>,
-        proxy_config: &ProxyConfig,
-    ) -> Result<Channel, ConfigError> {
         // Extract host from endpoint to check no_proxy rules
         let endpoint_host = uri.host().unwrap_or("");
 

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -456,7 +456,7 @@ impl ClientConfig {
         if let Some(intercept) = self.proxy.should_use_proxy(endpoint_host) {
             // Use proxy for this host
             let tunnel = self.create_proxy_tunnel(intercept, http_connector, &self.proxy)?;
-            self.apply_tls_to_tunnel_connector(builder, tunnel, tls_config)
+            self.create_tunneled_channel(builder, tunnel, tls_config)
         } else {
             // Skip proxy for this host, use direct connection
             self.create_direct_channel(builder, http_connector, tls_config)
@@ -536,7 +536,7 @@ impl ClientConfig {
     }
 
     /// Applies TLS configuration to a tunnel connector for proxy usage
-    fn apply_tls_to_tunnel_connector(
+    fn create_tunneled_channel(
         &self,
         builder: tonic::transport::Endpoint,
         tunnel: Tunnel<HttpConnector>,

--- a/data-plane/core/config/src/grpc/errors.rs
+++ b/data-plane/core/config/src/grpc/errors.rs
@@ -28,6 +28,8 @@ pub enum ConfigError {
     AuthConfigError(String),
     #[error("resolution error")]
     ResolutionError,
+    #[error("invalid uri")]
+    InvalidUri(String),
     #[error("unknown error")]
     Unknown,
 }

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ProxyConfig {
     /// The HTTP proxy URL (e.g., "http://proxy.example.com:8080")
+    /// If empty, the system proxy settings will be used.
     pub url: Option<String>,
 
     /// Optional username for proxy authentication

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -7,7 +7,7 @@ use hyper_util::client::proxy::matcher::{Intercept, Matcher};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ProxyConfig {
     /// The HTTP proxy URL (e.g., "http://proxy.example.com:8080")
     /// If empty, the system proxy settings will be used.
@@ -27,28 +27,6 @@ pub struct ProxyConfig {
     /// Based on hyper-utils matcher: https://github.com/hyperium/hyper-util/blob/master/src/client/proxy/matcher.rs
     #[serde(default)]
     pub no_proxy: Option<String>,
-}
-
-impl Clone for ProxyConfig {
-    fn clone(&self) -> Self {
-        Self {
-            url: self.url.clone(),
-            username: self.username.clone(),
-            password: self.password.clone(),
-            headers: self.headers.clone(),
-            no_proxy: self.no_proxy.clone(),
-        }
-    }
-}
-
-impl PartialEq for ProxyConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.url == other.url
-            && self.username == other.username
-            && self.password == other.password
-            && self.headers == other.headers
-            && self.no_proxy == other.no_proxy
-    }
 }
 
 impl ProxyConfig {

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -42,22 +42,28 @@ impl ProxyConfig {
     }
 
     /// Sets the proxy authentication credentials
-    pub fn with_auth(mut self, username: &str, password: &str) -> Self {
-        self.username = Some(username.to_string());
-        self.password = Some(password.to_string());
-        self
+    pub fn with_auth(self, username: &str, password: &str) -> Self {
+        Self {
+            username: Some(username.to_string()),
+            password: Some(password.to_string()),
+            ..self
+        }
     }
 
     /// Sets additional headers for proxy requests
-    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
-        self.headers = headers;
-        self
+    pub fn with_headers(self, headers: HashMap<String, String>) -> Self {
+        Self {
+            headers,
+            ..self
+        }
     }
 
     /// Sets the no_proxy list - hosts that should bypass the proxy
-    pub fn with_no_proxy(mut self, no_proxy: impl Into<String>) -> Self {
-        self.no_proxy = Some(no_proxy.into());
-        self
+    pub fn with_no_proxy(self, no_proxy: impl Into<String>) -> Self {
+        Self {
+            no_proxy: Some(no_proxy.into()),
+            ..self
+        }
     }
 
     /// Checks if the given host should bypass the proxy

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -107,7 +107,6 @@ impl ProxyConfig {
 mod test {
     use super::*;
 
-    #[test]
     fn test_proxy_config() {
         let proxy = ProxyConfig::new("http://proxy.example.com:8080");
         assert_eq!(proxy.url, Some("http://proxy.example.com:8080".to_string()));
@@ -126,7 +125,6 @@ mod test {
         assert_eq!(proxy_with_headers.headers, headers);
     }
 
-    #[test]
     fn test_proxy_no_proxy_functionality() {
         let no_proxy_list = [
             "localhost".to_string(),
@@ -157,19 +155,6 @@ mod test {
         assert!(proxy.should_use_proxy("http://192.168.1.1").is_some());
     }
 
-    #[test]
-    fn test_proxy_no_proxy_edge_cases() {
-        // Test empty no_proxy list
-        let proxy_empty = ProxyConfig::new("http://proxy.example.com:8080");
-        assert!(proxy_empty.should_use_proxy("http://localhost").is_none());
-        assert!(
-            proxy_empty
-                .should_use_proxy("http://anything.com")
-                .is_none()
-        );
-    }
-
-    #[test]
     fn test_proxy_system_matcher() {
         // Test system matcher when no URL is configured
         let mut proxy_config = ProxyConfig {
@@ -201,7 +186,6 @@ mod test {
         assert!(result.is_none()); // Should return None when no_proxy is None
     }
 
-    #[test]
     fn test_proxy_system_matcher_empty_no_proxy() {
         // Test system matcher with empty no_proxy string
         let proxy_config = ProxyConfig {
@@ -217,7 +201,6 @@ mod test {
         assert!(proxy_config.should_use_proxy("http://google.com").is_none());
     }
 
-    #[test]
     fn test_proxy_system_matcher_with_complex_no_proxy() {
         // Test system matcher with complex no_proxy patterns
         let proxy_config = ProxyConfig {
@@ -241,7 +224,6 @@ mod test {
         assert!(result.is_some() || result.is_none()); // System-dependent behavior
     }
 
-    #[test]
     fn test_proxy_config_default_creation() {
         // Test creating a config that will use system matcher
         let proxy_config = ProxyConfig::default();
@@ -261,58 +243,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_proxy_system_matcher_with_env_variables() {
-        // Test system matcher with various proxy environment variables
-
-        // Save original environment variables to restore later
-        let original_env = [
-            ("https_proxy", std::env::var("https_proxy").ok()),
-            ("HTTPS_PROXY", std::env::var("HTTPS_PROXY").ok()),
-            ("http_proxy", std::env::var("http_proxy").ok()),
-            ("HTTP_PROXY", std::env::var("HTTP_PROXY").ok()),
-            ("no_proxy", std::env::var("no_proxy").ok()),
-            ("NO_PROXY", std::env::var("NO_PROXY").ok()),
-            ("all_proxy", std::env::var("all_proxy").ok()),
-            ("ALL_PROXY", std::env::var("ALL_PROXY").ok()),
-        ];
-
-        // Clean up environment first
-        for (key, _) in &original_env {
-            unsafe {
-                std::env::remove_var(key);
-            }
-        }
-
-        // Test 1: Default proxy config
-        let proxy_config = ProxyConfig::default();
-
-        // With no environment proxy set, system matcher should return None
-        let result = proxy_config.should_use_proxy("http://localhost");
-        assert!(result.is_none()); // localhost should be bypassed
-
-        // Test 2: Set environment proxy and test behavior
-        unsafe {
-            std::env::set_var("http_proxy", "http://proxy.example.com:8080");
-        }
-
-        // As no_proxy is not set, any host will use the proxy
-        let result = proxy_config.should_use_proxy("http://external.com");
-        assert!(result.is_some()); // Should use the proxy now
-
-        // Restore original environment variables
-        for (key, original_value) in original_env {
-            unsafe {
-                match original_value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_proxy_env_variables_precedence() {
+    #[allow(clippy::disallowed_methods)]
+    fn test_proxy_env_variables() {
         // Test how different environment variables work with system matcher
 
         // Save original environment variables
@@ -402,5 +334,18 @@ mod test {
                 }
             }
         }
+    }
+
+    #[test]
+    fn run_all_tests() {
+        // Run tests consecutively as we are using the set/unset env variables,
+        // which may influence concurrent test execution
+        test_proxy_config();
+        test_proxy_env_variables();
+        test_proxy_no_proxy_functionality();
+        test_proxy_system_matcher();
+        test_proxy_system_matcher_empty_no_proxy();
+        test_proxy_system_matcher_with_complex_no_proxy();
+        test_proxy_config_default_creation();
     }
 }

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -52,10 +52,7 @@ impl ProxyConfig {
 
     /// Sets additional headers for proxy requests
     pub fn with_headers(self, headers: HashMap<String, String>) -> Self {
-        Self {
-            headers,
-            ..self
-        }
+        Self { headers, ..self }
     }
 
     /// Sets the no_proxy list - hosts that should bypass the proxy

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -1,0 +1,406 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use hyper_util::client::proxy::matcher::{Intercept, Matcher};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ProxyConfig {
+    /// The HTTP proxy URL (e.g., "http://proxy.example.com:8080")
+    pub url: Option<String>,
+
+    /// Optional username for proxy authentication
+    pub username: Option<String>,
+
+    /// Optional password for proxy authentication
+    pub password: Option<String>,
+
+    /// Headers to send with proxy requests
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+
+    /// List of hosts that should bypass the proxy.
+    /// Based on hyper-utils matcher: https://github.com/hyperium/hyper-util/blob/master/src/client/proxy/matcher.rs
+    #[serde(default)]
+    pub no_proxy: Option<String>,
+}
+
+impl Clone for ProxyConfig {
+    fn clone(&self) -> Self {
+        Self {
+            url: self.url.clone(),
+            username: self.username.clone(),
+            password: self.password.clone(),
+            headers: self.headers.clone(),
+            no_proxy: self.no_proxy.clone(),
+        }
+    }
+}
+
+impl PartialEq for ProxyConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.url == other.url
+            && self.username == other.username
+            && self.password == other.password
+            && self.headers == other.headers
+            && self.no_proxy == other.no_proxy
+    }
+}
+
+impl ProxyConfig {
+    /// Creates a new proxy configuration with the given URL
+    pub fn new(url: &str) -> Self {
+        Self {
+            url: Some(url.to_string()),
+            username: None,
+            password: None,
+            headers: HashMap::new(),
+            no_proxy: None,
+        }
+    }
+
+    /// Sets the proxy authentication credentials
+    pub fn with_auth(mut self, username: &str, password: &str) -> Self {
+        self.username = Some(username.to_string());
+        self.password = Some(password.to_string());
+        self
+    }
+
+    /// Sets additional headers for proxy requests
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Sets the no_proxy list - hosts that should bypass the proxy
+    pub fn with_no_proxy(mut self, no_proxy: impl Into<String>) -> Self {
+        self.no_proxy = Some(no_proxy.into());
+        self
+    }
+
+    /// Checks if the given host should bypass the proxy
+    pub fn should_use_proxy(&self, uri: &str) -> Option<Intercept> {
+        let no_proxy = self.no_proxy.clone().unwrap_or("".into());
+
+        // matcher builder
+        let matcher = match self.url.as_ref() {
+            Some(url) => Matcher::builder()
+                .http(url.clone())
+                .https(url.clone())
+                .no(no_proxy)
+                .build(),
+            None => Matcher::from_system(),
+        };
+
+        // Convert string uri into http::Uri
+        let dst = uri.parse::<http::Uri>().unwrap();
+
+        // Check if this should bypass the proxy
+        matcher.intercept(&dst)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_proxy_config() {
+        let proxy = ProxyConfig::new("http://proxy.example.com:8080");
+        assert_eq!(proxy.url, Some("http://proxy.example.com:8080".to_string()));
+        assert_eq!(proxy.username, None);
+        assert_eq!(proxy.password, None);
+        assert!(proxy.headers.is_empty());
+
+        let proxy_with_auth = proxy.with_auth("user", "pass");
+        assert_eq!(proxy_with_auth.username, Some("user".to_string()));
+        assert_eq!(proxy_with_auth.password, Some("pass".to_string()));
+
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom".to_string(), "value".to_string());
+        let proxy_with_headers =
+            ProxyConfig::new("http://proxy.example.com:8080").with_headers(headers.clone());
+        assert_eq!(proxy_with_headers.headers, headers);
+    }
+
+    #[test]
+    fn test_proxy_no_proxy_functionality() {
+        let no_proxy_list = [
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+            ".internal.com".to_string(),
+            ".example.org".to_string(),
+            "direct.access.com".to_string(),
+        ];
+
+        let proxy = ProxyConfig::new("http://proxy.example.com:8080")
+            .with_no_proxy(no_proxy_list.join(","));
+
+        assert_eq!(proxy.no_proxy, Some(no_proxy_list.join(",")));
+
+        // Test exact matches
+        assert!(proxy.should_use_proxy("http://localhost").is_none());
+        assert!(proxy.should_use_proxy("http://127.0.0.1").is_none());
+        assert!(proxy.should_use_proxy("http://direct.access.com").is_none());
+
+        // Test wildcard matching
+        assert!(proxy.should_use_proxy("https://api.internal.com").is_none());
+        assert!(proxy.should_use_proxy("http://sub.internal.com").is_none());
+        assert!(proxy.should_use_proxy("http://internal.com").is_none());
+
+        // Test non-matching hosts
+        assert!(proxy.should_use_proxy("http://google.com").is_some());
+        assert!(proxy.should_use_proxy("http://api.external.com").is_some());
+        assert!(proxy.should_use_proxy("http://192.168.1.1").is_some());
+    }
+
+    #[test]
+    fn test_proxy_no_proxy_edge_cases() {
+        // Test empty no_proxy list
+        let proxy_empty = ProxyConfig::new("http://proxy.example.com:8080");
+        assert!(proxy_empty.should_use_proxy("http://localhost").is_none());
+        assert!(
+            proxy_empty
+                .should_use_proxy("http://anything.com")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_proxy_system_matcher() {
+        // Test system matcher when no URL is configured
+        let mut proxy_config = ProxyConfig {
+            url: None,
+            username: None,
+            password: None,
+            headers: HashMap::new(),
+            no_proxy: Some("localhost,127.0.0.1,.internal.com".to_string()),
+        };
+
+        // System matcher should still respect no_proxy settings
+        assert!(proxy_config.should_use_proxy("http://localhost").is_none());
+        assert!(proxy_config.should_use_proxy("http://127.0.0.1").is_none());
+        assert!(
+            proxy_config
+                .should_use_proxy("https://api.internal.com")
+                .is_none()
+        );
+
+        // Test with external hosts - behavior depends on system proxy settings
+        // We can't assert specific behavior since it depends on the system configuration,
+        // but we can ensure the function doesn't panic and returns a valid result
+        let result = proxy_config.should_use_proxy("http://google.com");
+        assert!(result.is_some() || result.is_none()); // Either is valid
+
+        // Test system matcher with no no_proxy settings
+        proxy_config.no_proxy = None;
+        let result = proxy_config.should_use_proxy("http://localhost");
+        assert!(result.is_none()); // Should return None when no_proxy is None
+    }
+
+    #[test]
+    fn test_proxy_system_matcher_empty_no_proxy() {
+        // Test system matcher with empty no_proxy string
+        let proxy_config = ProxyConfig {
+            url: None,
+            username: None,
+            password: None,
+            headers: HashMap::new(),
+            no_proxy: Some("".to_string()),
+        };
+
+        // Empty no_proxy should return None
+        assert!(proxy_config.should_use_proxy("http://localhost").is_none());
+        assert!(proxy_config.should_use_proxy("http://google.com").is_none());
+    }
+
+    #[test]
+    fn test_proxy_system_matcher_with_complex_no_proxy() {
+        // Test system matcher with complex no_proxy patterns
+        let proxy_config = ProxyConfig {
+            url: None,
+            username: None,
+            password: None,
+            headers: HashMap::new(),
+            no_proxy: Some("*.local,10.0.0.0/8,192.168.0.0/16,.corp.internal".to_string()),
+        };
+
+        // Test various patterns that should bypass proxy
+        assert!(proxy_config.should_use_proxy("http://api.local").is_none());
+        assert!(
+            proxy_config
+                .should_use_proxy("https://service.corp.internal")
+                .is_none()
+        );
+
+        // Test patterns that should use proxy (system-dependent)
+        let result = proxy_config.should_use_proxy("http://external.com");
+        assert!(result.is_some() || result.is_none()); // System-dependent behavior
+    }
+
+    #[test]
+    fn test_proxy_config_default_creation() {
+        // Test creating a config that will use system matcher
+        let proxy_config = ProxyConfig::default();
+
+        // Verify all fields are None/empty as expected
+        assert!(proxy_config.url.is_none());
+        assert!(proxy_config.username.is_none());
+        assert!(proxy_config.password.is_none());
+        assert!(proxy_config.headers.is_empty());
+        assert!(proxy_config.no_proxy.is_none());
+
+        // Any call should return None when no_proxy is None
+        assert!(
+            proxy_config
+                .should_use_proxy("http://any-host.com")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_proxy_system_matcher_with_env_variables() {
+        // Test system matcher with various proxy environment variables
+
+        // Save original environment variables to restore later
+        let original_env = [
+            ("https_proxy", std::env::var("https_proxy").ok()),
+            ("HTTPS_PROXY", std::env::var("HTTPS_PROXY").ok()),
+            ("http_proxy", std::env::var("http_proxy").ok()),
+            ("HTTP_PROXY", std::env::var("HTTP_PROXY").ok()),
+            ("no_proxy", std::env::var("no_proxy").ok()),
+            ("NO_PROXY", std::env::var("NO_PROXY").ok()),
+            ("all_proxy", std::env::var("all_proxy").ok()),
+            ("ALL_PROXY", std::env::var("ALL_PROXY").ok()),
+        ];
+
+        // Clean up environment first
+        for (key, _) in &original_env {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+
+        // Test 1: Default proxy config
+        let proxy_config = ProxyConfig::default();
+
+        // With no environment proxy set, system matcher should return None
+        let result = proxy_config.should_use_proxy("http://localhost");
+        assert!(result.is_none()); // localhost should be bypassed
+
+        // Test 2: Set environment proxy and test behavior
+        unsafe {
+            std::env::set_var("http_proxy", "http://proxy.example.com:8080");
+        }
+
+        // As no_proxy is not set, any host will use the proxy
+        let result = proxy_config.should_use_proxy("http://external.com");
+        assert!(result.is_some()); // Should use the proxy now
+
+        // Restore original environment variables
+        for (key, original_value) in original_env {
+            unsafe {
+                match original_value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_proxy_env_variables_precedence() {
+        // Test how different environment variables work with system matcher
+
+        // Save original environment variables
+        let original_env = [
+            ("https_proxy", std::env::var("https_proxy").ok()),
+            ("HTTPS_PROXY", std::env::var("HTTPS_PROXY").ok()),
+            ("http_proxy", std::env::var("http_proxy").ok()),
+            ("HTTP_PROXY", std::env::var("HTTP_PROXY").ok()),
+            ("no_proxy", std::env::var("no_proxy").ok()),
+            ("NO_PROXY", std::env::var("NO_PROXY").ok()),
+            ("all_proxy", std::env::var("all_proxy").ok()),
+            ("ALL_PROXY", std::env::var("ALL_PROXY").ok()),
+        ];
+
+        // Clean up environment first
+        for (key, _) in &original_env {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+
+        // Test 1: Config with URL should ignore environment completely
+        let config_with_url = ProxyConfig {
+            url: Some("http://config-proxy.example.com:8080".to_string()),
+            username: None,
+            password: None,
+            headers: HashMap::new(),
+            no_proxy: Some("localhost,.config-domain".to_string()),
+        };
+
+        // Should use config's settings, not environment
+        assert!(
+            config_with_url
+                .should_use_proxy("http://localhost")
+                .is_none()
+        );
+        assert!(
+            config_with_url
+                .should_use_proxy("http://api.config-domain")
+                .is_none()
+        );
+        assert!(
+            config_with_url
+                .should_use_proxy("http://external.com")
+                .is_some()
+        );
+
+        // Test 2: Config without URL
+        let config_without_url = ProxyConfig::default();
+
+        // Now set environment variables and test system matcher behavior
+        unsafe {
+            std::env::set_var("http_proxy", "http://env-proxy.example.com:8080");
+            std::env::set_var("no_proxy", "localhost,.env-domain");
+        }
+
+        // Let's see if no_proxy is respected
+        assert!(
+            config_without_url
+                .should_use_proxy("http://localhost")
+                .is_none()
+        );
+        assert!(
+            config_without_url
+                .should_use_proxy("http://api.system-bypass")
+                .is_some()
+        );
+
+        // Unset no_proxy
+        unsafe {
+            std::env::remove_var("no_proxy");
+        }
+
+        // When no_proxy is None, it should always use the proxy
+        assert!(
+            config_without_url
+                .should_use_proxy("http://localhost")
+                .is_some()
+        );
+
+        // Restore original environment variables
+        for (key, original_value) in original_env {
+            unsafe {
+                match original_value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}

--- a/data-plane/core/config/src/grpc/proxy.rs
+++ b/data-plane/core/config/src/grpc/proxy.rs
@@ -55,12 +55,10 @@ impl ProxyConfig {
 
         // matcher builder
         let matcher = match self.url.as_ref() {
-            Some(url) => {
-                Matcher::builder()
-                    .http(url.clone())
-                    .https(url.clone())
-                    .build()
-            }
+            Some(url) => Matcher::builder()
+                .http(url.clone())
+                .https(url.clone())
+                .build(),
             None => Matcher::from_system(),
         };
 
@@ -181,9 +179,7 @@ mod test {
         assert!(
             config_with_url
                 .should_use_proxy("http://localhost")
-                .is_some_and(|proxy| {
-                    proxy.uri().to_string() == "http://config-proxy.example.com:8080/".to_string()
-                })
+                .is_some_and(|proxy| { *proxy.uri() == "http://config-proxy.example.com:8080/" })
         );
 
         // Test 2: Config without URL

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
@@ -73,6 +73,7 @@ name = "agntcy-slim-config"
 version = "0.2.0"
 dependencies = [
  "agntcy-slim-auth",
+ "base64 0.22.1",
  "drain",
  "duration-str",
  "futures",

--- a/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
+++ b/data-plane/integrations/mcp/mcp-proxy/Cargo.lock
@@ -2162,12 +2162,11 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2348,12 +2347,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -4015,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -4318,22 +4311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4341,12 +4318,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"


### PR DESCRIPTION
# Description

Add support for HTTP proxy, allowing connection
among SLIM instances with a HTTP proxy in between.

HTTPs proxy support will come in a future PR.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
