### PR TITLE
SLIM node ID should be unique in a deployment

### DIFF
--- a/charts/slim/Chart.yaml
+++ b/charts/slim/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/slim/templates/daemonset.yaml
+++ b/charts/slim/templates/daemonset.yaml
@@ -3,19 +3,23 @@ Copyright AGNTCY Contributors (https://github.com/agntcy)
 SPDX-License-Identifier: Apache-2.0
 */}}
 
+{{- if eq .Values.slim.daemonset true }}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "slim.fullname" . }}
   labels:
     {{- include "slim.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.slim.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "slim.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.slim.updateStrategy.type | default "RollingUpdate" }}
+    {{- if eq (.Values.slim.updateStrategy.type | default "RollingUpdate") "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.slim.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
+    {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -62,13 +66,20 @@ spec:
           args:
             - "--config"
             - "/config.yaml"
+          env:
+            - name: SLIM_SVC_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName            
           ports:
             - name: data-plane
               containerPort: {{ .Values.slim.service.data.port }}
               protocol: TCP
+              hostPort: {{ .Values.slim.service.data.port }}
             - name: controller
               containerPort: {{ .Values.slim.service.control.port }}
               protocol: TCP
+              hostPort: {{ .Values.slim.service.control.port }}
           resources:
             {{- toYaml .Values.slim.resources | nindent 12 }}
           volumeMounts:
@@ -110,3 +121,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.slim.hostNetwork | default false }}
+      dnsPolicy: {{ .Values.slim.dnsPolicy | default "ClusterFirst" }}
+{{- end }}

--- a/charts/slim/templates/service.yaml
+++ b/charts/slim/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- include "slim.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.slim.service.type }}
+  clusterIP: None
   ports:
     - port: {{ .Values.slim.service.data.port }}
       targetPort: data-plane

--- a/charts/slim/templates/service.yaml
+++ b/charts/slim/templates/service.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- include "slim.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.slim.service.type }}
+  {{- if eq .Values.slim.service.headless true }}
   clusterIP: None
+  {{- end }}
   ports:
     - port: {{ .Values.slim.service.data.port }}
       targetPort: data-plane

--- a/charts/slim/templates/statefulset.yaml
+++ b/charts/slim/templates/statefulset.yaml
@@ -1,0 +1,126 @@
+{{/*
+Copyright AGNTCY Contributors (https://github.com/agntcy)
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- if or (not .Values.slim.daemonset) (eq .Values.slim.daemonset false) }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "slim.fullname" . }}
+  labels:
+    {{- include "slim.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "slim.fullname" . }}-headless
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.slim.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "slim.selectorLabels" . | nindent 6 }}
+  podManagementPolicy: {{ .Values.slim.podManagementPolicy | default "OrderedReady" }}
+  updateStrategy:
+    type: {{ .Values.slim.updateStrategy.type | default "RollingUpdate" }}
+    {{- if eq (.Values.slim.updateStrategy.type | default "RollingUpdate") "RollingUpdate" }}
+    rollingUpdate:
+      partition: {{ .Values.slim.updateStrategy.rollingUpdate.partition | default 0 }}
+    {{- end }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "slim.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "slim.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+       {{- if eq .Values.spire.enabled true }}
+        - name: spiffe-helper
+          image: {{ .Values.spire.helperImage.repository }}:{{ .Values.spire.helperImage.tag | default "0.10.0" }}
+          imagePullPolicy: {{ .Values.spire.helperImage.pullPolicy }}
+          args: [ "-config", "config/helper.conf" ]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config/helper.conf
+              subPath: helper.conf
+            - name: spire-agent-socket
+              mountPath: /run/spire/agent-sockets
+              readOnly: false
+            - name: svids-volume
+              mountPath: /svids
+              readOnly: false
+        {{- end }}
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.slim.image.repository }}:{{ .Values.slim.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.slim.image.pullPolicy }}
+          command:
+            - "/slim"
+          args:
+            - "--config"
+            - "/config.yaml"
+          env:
+            - name: SLIM_SVC_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: data-plane
+              containerPort: {{ .Values.slim.service.data.port }}
+              protocol: TCP
+            - name: controller
+              containerPort: {{ .Values.slim.service.control.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.slim.resources | nindent 12 }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config.yaml
+              subPath: config.yaml
+{{- if eq .Values.spire.enabled true }}
+            - name: svids-volume
+              mountPath: /svids
+              readOnly: false
+{{- end }}
+{{- with .Values.slim.extraVolumeMounts }}
+{{ toYaml . | nindent 12 }}
+{{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "slim.fullname" . }}
+        {{- with .Values.slim.extraVolumes }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+{{- if eq .Values.spire.enabled true }}
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/agent-sockets
+            type: Directory
+        - name: svids-volume
+          emptyDir: {}
+{{- end}}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}      

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 slim:
+  # Deploy as DaemonSet instead of StatefulSet
+  daemonset: false
   # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
   replicaCount: 1
 
@@ -29,6 +31,7 @@ slim:
 
     services:
       slim/0:
+        nodeId: ${env:SLIM_SVC_ID}
         pubsub:
           servers:
             - endpoint: "0.0.0.0:{{ .Values.slim.service.data.port }}"
@@ -41,6 +44,22 @@ slim:
             - endpoint: "0.0.0.0:{{ .Values.slim.service.control.port }}"
               tls:
                 insecure: true
+          # clients:
+          #   - endpoint: "http://slim-control:50052"              
+          #     tls:
+          #       insecure: true
+
+  # StatefulSet-specific settings
+  # DaemonSet-specific settings
+  hostNetwork: false
+  dnsPolicy: "ClusterFirst"  # or "ClusterFirstWithHostNet" if hostNetwork: true
+
+  # Updated updateStrategy to support DaemonSet maxUnavailable
+  updateStrategy:
+    type: "RollingUpdate"  # or "OnDelete"
+    rollingUpdate:
+      partition: 0  # StatefulSet only
+      maxUnavailable: 1  # DaemonSet only
 
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -45,7 +45,7 @@ slim:
               tls:
                 insecure: true
           # clients:
-          #   - endpoint: "http://slim-control:50052"              
+          #   - endpoint: "http://slim-control:50052"
           #     tls:
           #       insecure: true
 

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -65,6 +65,7 @@ slim:
   service:
     # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
+    headless: false
     data:
       port: 46357
     control:

--- a/data-plane/core/config/src/component/id.rs
+++ b/data-plane/core/config/src/component/id.rs
@@ -23,7 +23,7 @@ const KIND_AND_NAME_SEPARATOR: &str = "/";
 // Regex patterns for validating kind and names
 lazy_static::lazy_static! {
     static ref KIND_REGEX: Regex = Regex::new(r"^[a-zA-Z][0-9a-zA-Z_]{0,62}$").unwrap();
-    static ref NAME_REGEX: Regex = Regex::new(r"^[^\p{Z}\p{C}\p{S}]+$").unwrap();
+    static ref NAME_REGEX: Regex = Regex::new(r"^[a-z0-9-]+$").unwrap();
 }
 
 /// Kind represents the type of a component.

--- a/data-plane/core/config/src/component/id.rs
+++ b/data-plane/core/config/src/component/id.rs
@@ -160,8 +160,8 @@ mod tests {
         assert_eq!(id.kind().to_string(), "validKind");
         assert!(id.name().is_empty());
 
-        let id_with_name = ID::new_with_name(kind_val.clone(), "validName").unwrap();
-        assert_eq!(id_with_name.name(), "validName");
+        let id_with_name = ID::new_with_name(kind_val.clone(), "valid-name").unwrap();
+        assert_eq!(id_with_name.name(), "valid-name");
 
         assert!(ID::new_with_name(kind_val.clone(), "").is_ok());
         assert!(ID::new_with_name(kind_val.clone(), "Invalid Name!").is_err());

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -895,9 +895,9 @@ mod tests {
     async fn test_end_to_end() {
         // Create an ID for slim instance
         let id_server =
-            ID::new_with_name(Kind::new("slim").unwrap(), "test_server_instance").unwrap();
+            ID::new_with_name(Kind::new("slim").unwrap(), "test-server-instance").unwrap();
         let id_client =
-            ID::new_with_name(Kind::new("slim").unwrap(), "test_client_instance").unwrap();
+            ID::new_with_name(Kind::new("slim").unwrap(), "test-client-instance").unwrap();
 
         // Create a server configuration
         let server_config = ServerConfig::with_endpoint("127.0.0.1:50051")

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -410,11 +410,7 @@ impl ComponentBuilder for ServiceBuilder {
         name: &str,
         config: &Self::Config,
     ) -> Result<Self::Component, ComponentError> {
-        let node_name = if config.node_id.is_some() {
-            config.node_id.clone().unwrap()
-        } else {
-            name.to_string()
-        };
+        let node_name = config.node_id.unwrap_or(name.to_string());
         let id = ID::new_with_name(ServiceBuilder::kind(), &node_name)
             .map_err(|e| ComponentError::ConfigError(e.to_string()))?;
 

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -410,7 +410,7 @@ impl ComponentBuilder for ServiceBuilder {
         name: &str,
         config: &Self::Config,
     ) -> Result<Self::Component, ComponentError> {
-        let node_name = config.node_id.unwrap_or(name.to_string());
+        let node_name = config.node_id.clone().unwrap_or(name.to_string());
         let id = ID::new_with_name(ServiceBuilder::kind(), &node_name)
             .map_err(|e| ComponentError::ConfigError(e.to_string()))?;
 

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -56,6 +56,9 @@ pub const KIND: &str = "slim";
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ServiceConfiguration {
+
+    pub node_id: String,
+
     /// Pubsub API configuration
     #[serde(default)]
     pub dataplane: DataplaneConfig,
@@ -406,7 +409,13 @@ impl ComponentBuilder for ServiceBuilder {
         name: &str,
         config: &Self::Config,
     ) -> Result<Self::Component, ComponentError> {
-        let id = ID::new_with_name(ServiceBuilder::kind(), name)
+        
+        let node_name = if !config.node_id.is_empty() {
+            config.node_id.clone()
+        } else {
+            name.to_string()
+        };
+        let id = ID::new_with_name(ServiceBuilder::kind(), &node_name)
             .map_err(|e| ComponentError::ConfigError(e.to_string()))?;
 
         let service = config

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -56,8 +56,9 @@ pub const KIND: &str = "slim";
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ServiceConfiguration {
-
-    pub node_id: String,
+    /// Optional node ID for the service. If not set, the name of the component will be used.
+    #[serde(default)]
+    pub node_id: Option<String>,
 
     /// Pubsub API configuration
     #[serde(default)]
@@ -409,9 +410,8 @@ impl ComponentBuilder for ServiceBuilder {
         name: &str,
         config: &Self::Config,
     ) -> Result<Self::Component, ComponentError> {
-        
-        let node_name = if !config.node_id.is_empty() {
-            config.node_id.clone()
+        let node_name = if config.node_id.is_some() {
+            config.node_id.clone().unwrap()
         } else {
             name.to_string()
         };


### PR DESCRIPTION
# Description

SLIM nodes checks for SLIM_SVC_ID_SUFFIX env var and appends to it's  ID when they register to the Controller.

Add new flag to helm deployment: slim.daemonset. If set to true there will be a SLIM node deployed to each k8s node.
In case  slim.daemonset = false (default) there will be slim.replicaCount number of SLIM nodes  deployed as StatefulSet.
In case of a Daemonset will be set to the name of the node, while in case of SatefulSet will be set with name of the pod running the node, thus SLIm nodes will register with unique ID in the cluster.

Related issue: https://github.com/agntcy/slim/issues/629

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
