### PR TITLE
ci: publish slim-srpc and slim-a2a wheels to pypi

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -44,6 +44,14 @@
         "data-plane/python/examples": {
             "package-name": "slim-bindings-examples",
             "release-type": "python"
+        },
+        "data-plane/python/integrations/srpc": {
+            "package-name": "slim-srpc",
+            "release-type": "python"
+        },
+        "data-plane/python/integrations/slima2a": {
+            "package-name": "slim-a2a",
+            "release-type": "python"
         }
     }
 }

--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -9,7 +9,5 @@
     "data-plane/testing": "0.2.1",
     "control-plane/control-plane": "0.1.0",
     "charts/slim-control-plane": "0.1.3",
-    "data-plane/python/examples": "0.1.0",
-    "data-plane/python/integrations/srpc": "0.0.0",
-    "data-plane/python/integrations/slima2a": "0.0.0"
+    "data-plane/python/examples": "0.1.0"
 }

--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -9,5 +9,7 @@
     "data-plane/testing": "0.2.1",
     "control-plane/control-plane": "0.1.0",
     "charts/slim-control-plane": "0.1.3",
-    "data-plane/python/examples": "0.1.0"
+    "data-plane/python/examples": "0.1.0",
+    "data-plane/python/integrations/srpc": "0.0.0",
+    "data-plane/python/integrations/slima2a": "0.0.0"
 }

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -52,10 +52,14 @@ jobs:
     needs:
       - build-bindings-wheels
       - build-mcp-wheels
+      - build-srpc
+      - build-slima2a
     if: |
       always() &&
       (needs.build-bindings-wheels.result == 'skipped' || needs.build-bindings-wheels.result == 'success') &&
-      (needs.build-mcp-wheels.result == 'skipped' || needs.build-mcp-wheels.result == 'success')
+      (needs.build-mcp-wheels.result == 'skipped' || needs.build-mcp-wheels.result == 'success') &&
+      (needs.build-srpc.result == 'skipped' || needs.build-srpc.result == 'success') &&
+      (needs.build-slima2a.result == 'skipped' || needs.build-slima2a.result == 'success')
     environment: pypi
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing

--- a/data-plane/python/integrations/slima2a/pyproject.toml
+++ b/data-plane/python/integrations/slima2a/pyproject.toml
@@ -3,8 +3,8 @@
 
 [project]
 name = "slim-a2a"
-version = "0.1.0"
-description = "Add your description here"
+version = "0.0.1"
+description = "A2A over SRPC"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
 dependencies = ["a2a-sdk[telemetry]>=0.3.0", "slim-srpc"]

--- a/data-plane/python/integrations/slima2a/pyproject.toml
+++ b/data-plane/python/integrations/slima2a/pyproject.toml
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
-name = "slima2a"
+name = "slim-a2a"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-dependencies = ["a2a-sdk[telemetry]>=0.3.0", "srpc"]
+dependencies = ["a2a-sdk[telemetry]>=0.3.0", "slim-srpc"]
 
 [dependency-groups]
 linting = ["types-protobuf>=6.30.2.20250703", "ruff>=0.12"]

--- a/data-plane/python/integrations/srpc/pyproject.toml
+++ b/data-plane/python/integrations/srpc/pyproject.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
-name = "srpc"
+name = "slim-srpc"
 version = "0.1.0"
 description = "RPC over Slim Library"
 requires-python = ">=3.9"

--- a/data-plane/python/integrations/srpc/pyproject.toml
+++ b/data-plane/python/integrations/srpc/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "slim-srpc"
-version = "0.1.0"
+version = "0.0.1"
 description = "RPC over Slim Library"
 requires-python = ">=3.9"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description

Automate publication of slim-a2a and slim-srpc pypi packages to pypi.org

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] CI

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
