### PR TITLE
ci: publish Rust coverage to Codecov using Taskfile

### DIFF
--- a/.github/workflows/data-plane-coverage.yaml
+++ b/.github/workflows/data-plane-coverage.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Generate coverage report (lcov)
         run: |
-          ../bin/task data-plane:test:coverage
-        working-directory: ./data-plane
+          cd data-plane
+          task test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/data-plane-coverage.yaml
+++ b/.github/workflows/data-plane-coverage.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: lcov.info
+          files: data-plane/lcov.info
           flags: rust
           name: rust-data-plane
           fail_ci_if_error: true

--- a/.github/workflows/data-plane-coverage.yaml
+++ b/.github/workflows/data-plane-coverage.yaml
@@ -1,0 +1,45 @@
+name: Publish Rust Coverage to Codecov
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: data-plane
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Install just and task
+        run: |
+          sudo snap install just --classic || true
+          curl -sSL https://taskfile.dev/install.sh | sh
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+
+      - name: Generate coverage report (lcov)
+        run: |
+          ../bin/task data-plane:test:coverage
+        working-directory: ./data-plane
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./data-plane/lcov.info
+          flags: rust
+          name: rust-data-plane
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/data-plane-coverage.yaml
+++ b/.github/workflows/data-plane-coverage.yaml
@@ -16,10 +16,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: actions/setup-rust@v1
-        with:
-          rust-version: stable
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
 
       - name: Install just and task
         run: |

--- a/.github/workflows/data-plane-coverage.yaml
+++ b/.github/workflows/data-plane-coverage.yaml
@@ -29,13 +29,12 @@ jobs:
 
       - name: Generate coverage report (lcov)
         run: |
-          cd data-plane
-          task test:coverage
+           task data-plane:test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: ./data-plane/lcov.info
+          files: lcov.info
           flags: rust
           name: rust-data-plane
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [![CI](https://github.com/agntcy/slim/actions/workflows/data-plane-coverage.yaml/badge.svg)](https://github.com/agntcy/slim/actions/workflows/data-plane-coverage.yaml)
 [![codecov](https://codecov.io/gh/agntcy/slim/branch/main/graph/badge.svg)](https://codecov.io/gh/agntcy/slim)
+[![Coverage](https://img.shields.io/badge/Coverage-passing-brightgreen)](https://codecov.io/gh/agntcy/slim)
 
 # SLIM
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![CI](https://github.com/agntcy/slim/actions/workflows/data-plane-coverage.yaml/badge.svg)](https://github.com/agntcy/slim/actions/workflows/data-plane-coverage.yaml)
+# [![CI](https://github.com/agntcy/slim/actions/workflows/data-plane.yaml/badge.svg)](https://github.com/agntcy/slim/actions/workflows/data-plane.yaml)
 [![codecov](https://codecov.io/gh/agntcy/slim/branch/main/graph/badge.svg)](https://codecov.io/gh/agntcy/slim)
 [![Coverage](https://img.shields.io/badge/Coverage-passing-brightgreen)](https://codecov.io/gh/agntcy/slim)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# [![CI](https://github.com/agntcy/slim/actions/workflows/data-plane-coverage.yaml/badge.svg)](https://github.com/agntcy/slim/actions/workflows/data-plane-coverage.yaml)
+[![codecov](https://codecov.io/gh/agntcy/slim/branch/main/graph/badge.svg)](https://codecov.io/gh/agntcy/slim)
+
 # SLIM
 
 SLIM (Secure Low-Latency Interactive Messaging) facilitates communication between AI agents.

--- a/tasks/rust.yaml
+++ b/tasks/rust.yaml
@@ -374,7 +374,7 @@ tasks:
         vars:
           COMPONENTS: "cargo-llvm-cov"
     cmds:
-      - cargo llvm-cov {{.ARGS}}
+      - cargo llvm-cov --lcov --output-path lcov.info {{.ARGS}}
     vars:
       ARGS: '{{ .ARGS | default "" }}'
 


### PR DESCRIPTION
Adds a GitHub Action to run Rust coverage with the Taskfile and upload results to Codecov. Uses cargo llvm-cov and the lcov.info output. Closes #649 if merged.