### PR TITLE
chore(mypy): Be explict about ignoring untyped imports

### DIFF
--- a/data-plane/python/integrations/slim-mcp/pyproject.toml
+++ b/data-plane/python/integrations/slim-mcp/pyproject.toml
@@ -65,3 +65,11 @@ packages = ["slim_mcp"]
 [project.scripts]
 mcp-server-time = "slim_mcp.examples.mcp_server_time:main"
 llamaindex-time-agent = "slim_mcp.examples.llamaindex_time_agent:main"
+
+[[tool.mypy.overrides]]
+module = ["slim_bindings.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["llama_index.*"]
+follow_untyped_imports = true

--- a/data-plane/python/integrations/slima2a/pyproject.toml
+++ b/data-plane/python/integrations/slima2a/pyproject.toml
@@ -43,3 +43,7 @@ exclude = ["examples"]
 
 [tool.hatch.build.targets.sdist]
 exclude = ["examples"]
+
+[[tool.mypy.overrides]]
+module = ["google.rpc.*"]
+follow_untyped_imports = true

--- a/data-plane/python/integrations/slimrpc/pyproject.toml
+++ b/data-plane/python/integrations/slimrpc/pyproject.toml
@@ -42,3 +42,11 @@ exclude = ["*_pb2.py", "*_pb2.pyi", "*_pb2_slimrpc.py"]
 [tool.ruff.lint]
 extend-select = ["I", "ASYNC", "SIM", "B", "ANN"]
 exclude = ["*_pb2.py", "*_pb2.pyi", "*_pb2_slimrpc.py"]
+
+[[tool.mypy.overrides]]
+module = ["google.rpc.*"]
+follow_untyped_imports = true
+
+[[tool.mypy.overrides]]
+module = ["slim_bindings.*"]
+ignore_missing_imports = true

--- a/data-plane/python/integrations/slimrpc/slimrpc/rpc.py
+++ b/data-plane/python/integrations/slimrpc/slimrpc/rpc.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Iterable, Mapping, Optional, Union
 
 from google.protobuf.any_pb2 import Any as pb_Any
-from google.rpc import code_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +14,7 @@ logger = logging.getLogger(__name__)
 class SRPCResponseError(Exception):
     def __init__(
         self,
-        code: code_pb2.Code,
+        code: int,
         message: str,
         details: Optional[Iterable[Union[pb_Any, Mapping]]] = None,
     ) -> None:

--- a/tasks/python.yaml
+++ b/tasks/python.yaml
@@ -13,17 +13,18 @@ vars:
 
 tasks:
   fix-lint:
-    desc: "Automatically fix code style and formatting issues using ruff and mypy"
+    desc: "Lint and fix (where possible) code style and formatting issues using ruff and mypy"
     cmds:
-      - uv run {{.UV_ARGS}} ruff format
       - uv run {{.UV_ARGS}} ruff check --fix
+      - uv run {{.UV_ARGS}} mypy --explicit-package-bases .
+      - uv run {{.UV_ARGS}} ruff format
 
   lint:
     desc: "Check code style, formatting, and type hints without making changes"
     cmds:
       - uv run {{.UV_ARGS}} ruff check
+      - uv run {{.UV_ARGS}} mypy --explicit-package-bases .
       - uv run {{.UV_ARGS}} ruff format --check
-      - uv run {{.UV_ARGS}} mypy --ignore-missing-imports --explicit-package-bases .
 
   test:
     desc: "Run pytest test suite with optional test path specification"


### PR DESCRIPTION
# Description

Certain packages define type annotations well even thought
they are missing the py.typed marker, in this case we can use
follow_untyped_imports to get good type checking anyway.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
