### PR TITLE
fix(python-bindings): default crypto provider initialization for Reqwest crate

### DIFF
--- a/data-plane/core/config/src/tls.rs
+++ b/data-plane/core/config/src/tls.rs
@@ -4,3 +4,4 @@
 pub mod client;
 pub mod common;
 pub mod server;
+pub mod provider;

--- a/data-plane/core/config/src/tls/provider.rs
+++ b/data-plane/core/config/src/tls/provider.rs
@@ -1,0 +1,15 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Once;
+
+static RUSTLS: Once = Once::new();
+
+pub fn initialize_crypto_provider() {
+    RUSTLS.call_once(|| {
+        // Set aws-lc as default crypto provider
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .unwrap();
+    });
+}

--- a/data-plane/python/bindings/examples/src/slim_bindings_examples/common.py
+++ b/data-plane/python/bindings/examples/src/slim_bindings_examples/common.py
@@ -105,7 +105,7 @@ def jwt_identity(
     verifier = slim_bindings.PyIdentityVerifier.Jwt(
         public_key=pykey,
         issuer=iss,
-        audience=aud,
+        audience=[aud],
         subject=sub,
     )
 

--- a/data-plane/python/bindings/src/lib.rs
+++ b/data-plane/python/bindings/src/lib.rs
@@ -7,6 +7,8 @@ mod pyservice;
 mod pysession;
 mod utils;
 
+use slim_config::tls::provider;
+
 use pyo3::prelude::*;
 use pyo3_stub_gen::define_stub_info_gatherer;
 
@@ -35,6 +37,9 @@ mod _slim_bindings {
 
     #[pymodule_init]
     fn module_init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        // initialize crypto provider
+        provider::initialize_crypto_provider();
+
         m.add("__version__", build_info::BUILD_INFO.version)?;
         m.add("build_profile", build_info::BUILD_INFO.profile)?;
         m.add("build_info", build_info::BUILD_INFO.to_string())?;


### PR DESCRIPTION
# Description

When the Reqwest crate is installed without a crypto
provider feature enabled, it requires an explicit default
crypto provider to be set. This differs from Rustls,
which can fallback to using aws-lc-rs if no provider is specified.

The issue arises because we install Reqwest without its crypto
provider feature, intending to use aws-lc-rs as the default crypto
provider for all components, including Reqwest.

To resolve this, we initialize the default crypto provider with
aws-lc-rs early during the Python bindings initialization.
This ensures the provider is available when Reqwest attempts
to access it.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
