### PR TITLE
fix(python-bindings): remove destination_name property

### DIFF
--- a/data-plane/core/service/src/session/config.rs
+++ b/data-plane/core/service/src/session/config.rs
@@ -3,6 +3,8 @@
 
 use std::collections::HashMap;
 
+use slim_datapath::messages::Name;
+
 use crate::session::multicast::MulticastConfiguration;
 use crate::session::point_to_point::PointToPointConfiguration;
 
@@ -26,6 +28,13 @@ impl SessionConfig {
         match self {
             SessionConfig::PointToPoint(c) => c.metadata.clone(),
             SessionConfig::Multicast(c) => c.metadata.clone(),
+        }
+    }
+
+    pub fn destination_name(&self) -> Option<Name> {
+        match self {
+            SessionConfig::PointToPoint(c) => c.unicast_name.as_ref().cloned(),
+            SessionConfig::Multicast(c) => Some(c.channel_name.clone()),
         }
     }
 }

--- a/data-plane/python/bindings/slim_bindings/session.py
+++ b/data-plane/python/bindings/slim_bindings/session.py
@@ -71,6 +71,39 @@ class PySession:
     async def publish(
         self,
         msg: bytes,
+        payload_type: str | None = None,
+        metadata: dict | None = None,
+    ) -> None:
+        """
+        Publish a message on the current session.
+
+        Args:
+            msg (bytes): The message payload to publish.
+            payload_type (str, optional): The type of the payload, if applicable.
+            metadata (dict, optional): Additional metadata to include with the
+                message.
+
+        Returns:
+            None
+        """
+
+        if self._ctx.session_type == PySessionType.ANYCAST:
+            raise RuntimeError("unexpected session type: expected UNICAST or MULTICAST")
+
+        await _publish(
+            self._svc,
+            self._ctx,
+            1,
+            msg,
+            message_ctx=None,
+            name=None,
+            payload_type=payload_type,
+            metadata=metadata,
+        )
+
+    async def publish_with_destination(
+        self,
+        msg: bytes,
         dest: PyName,
         payload_type: str | None = None,
         metadata: dict | None = None,

--- a/data-plane/python/bindings/src/pysession.rs
+++ b/data-plane/python/bindings/src/pysession.rs
@@ -113,6 +113,11 @@ impl PySessionContext {
         Ok(session.session_config().into())
     }
 
+    /// Replace the underlying session configuration with a new one.
+    ///
+    /// Safety/Consistency:
+    /// The underlying service validates and applies changes atomically.
+    /// Errors (e.g. invalid transitions) are surfaced as Python exceptions.
     pub fn set_session_config(&self, config: PySessionConfiguration) -> PyResult<()> {
         let session = strong_session(&self.internal.session)?;
         session


### PR DESCRIPTION
# Description

The destination_name as property collides with dst. Remove it from the properties exposed in the bindings.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
