### PR TITLE
perf(rnd): Random number generation per match

### DIFF
--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -193,38 +193,44 @@ impl Connections {
         Ok(())
     }
 
-    /// Next pool slot index in round-robin order among active slots whose connection id is not
-    /// `except_conn`. Updates thread-local [`LAST_USED_POOL_INDEX`].
+    /// Next pool slot index for a connection other than `except_conn`.
+    ///
+    /// Single-connection case is O(1) on [`Self::index`]. Otherwise walks pool slots in ring order
+    /// starting after the thread-local last index (see `next_slot` below), without allocating.
     fn next_round_robin_pool_index(&self, except_conn: u64) -> Option<usize> {
-        // Build eligible slot indices using `max_set`/`get` (occupied slots with conn != except).
-        let mut eligible = Vec::new();
-        for idx in 0..=self.pool.max_set() {
-            if self.pool.get(idx).is_some_and(|c| c.conn_id != except_conn) {
-                eligible.push(idx);
+        if self.index.len() == 1 {
+            if self.index.contains_key(&except_conn) {
+                debug!("the only available connection cannot be used");
+                return None;
+            }
+            let (&conn_id, &slot_idx) = self.index.iter().next().unwrap();
+            debug_assert!(self.pool.get(slot_idx).is_some_and(|c| c.conn_id == conn_id));
+            LAST_USED_POOL_INDEX.with(|c| c.set(slot_idx));
+            return Some(slot_idx);
+        }
+
+        let num_slots = self.pool.max_set() + 1;
+        let last_raw = LAST_USED_POOL_INDEX.with(|c| c.get());
+        // First slot to try: advance one past last pick, wrapped into [0, num_slots).
+        let next_slot = if last_raw == LAST_USED_POOL_INDEX_NONE {
+            0
+        } else {
+            (last_raw + 1) % num_slots
+        };
+
+        // Ring traversal without per-step `%`: indices next_slot..end, then 0..next_slot.
+        for i in (next_slot..num_slots).chain(0..next_slot) {
+            if let Some(c) = self.pool.get(i)
+                && c.conn_id != except_conn
+            {
+                LAST_USED_POOL_INDEX.with(|c| c.set(i));
+                return Some(i);
             }
         }
 
-        if eligible.is_empty() {
-            LAST_USED_POOL_INDEX.with(|c| c.set(LAST_USED_POOL_INDEX_NONE));
-            debug!("no output connection available");
-            return None;
-        }
-
-        let n = eligible.len();
-        let last_raw = LAST_USED_POOL_INDEX.with(|c| c.get());
-        let next_pos = if last_raw == LAST_USED_POOL_INDEX_NONE {
-            0
-        } else {
-            eligible
-                .iter()
-                .position(|&idx| idx == last_raw)
-                .map(|p| (p + 1) % n)
-                .unwrap_or(0)
-        };
-
-        let idx = eligible[next_pos];
-        LAST_USED_POOL_INDEX.with(|c| c.set(idx));
-        Some(idx)
+        LAST_USED_POOL_INDEX.with(|c| c.set(LAST_USED_POOL_INDEX_NONE));
+        debug!("no output connection available");
+        None
     }
 
     fn get_one(&self, except_conn: u64) -> Option<u64> {

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -15,14 +15,17 @@ use crate::errors::DataPathError;
 use crate::messages::Name;
 
 thread_local! {
-    /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot
-    /// (initialized to `0` before the first pick).
-    static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(0_usize) };
-    /// Per-name round-robin (RR): last **used connection position** (index in the sorted candidate list) for
-    /// [`NameState::get_one_connection`] (key = `(name id, 0 = local pool / 1 = remote pool)`).
-    /// Missing keys use `0_usize` like [`LAST_USED_POOL_INDEX`] before the first pick for that key.
-    static LAST_USED_CONN_POS: RefCell<HashMap<(u64, u8), usize>> =
-        RefCell::new(HashMap::new());
+    /// Per-thread cursor for [`next_index`]: used by [`Connections::get_one`] and [`NameState::get_one_connection`].
+    static NEXT_INDEX: Cell<usize> = const { Cell::new(0_usize) };
+}
+
+/// Returns the current [`NEXT_INDEX`] modulo `n`, then sets it to `(that + 1) % n`.
+fn next_index(n: usize) -> usize {
+    NEXT_INDEX.with(|cell| {
+        let i = cell.get() % n;
+        cell.set(i + 1);
+        i
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -190,11 +193,9 @@ impl Connections {
         Ok(())
     }
 
-    /// Pick a connection id other than `except_conn` using round-robin over pool slots.
-    ///
-    /// Single-connection case is O(1) on [`Self::index`]. Otherwise walks pool slots in ring order
-    /// starting from one slot after the thread-local last-used index, without allocating.
+    /// Pick a connection id other than `except_conn` using pseudo-random selection
     fn get_one(&self, except_conn: u64) -> Option<u64> {
+        let num_slots = self.pool.max_set() + 1;
         if self.index.len() == 1 {
             let (&conn_id, &slot_idx) = self
                 .index
@@ -210,23 +211,15 @@ impl Connections {
                     .get(slot_idx)
                     .is_some_and(|c| c.conn_id == conn_id)
             );
-            LAST_USED_POOL_INDEX.with(|c| c.set(slot_idx));
+            let _ = next_index(num_slots);
             return Some(conn_id);
         }
 
-        let num_slots = self.pool.max_set() + 1;
-        // First slot to try: one past last used, wrapped into [0, num_slots).
-        // Read last-used slot once; compute where to start this scan (no write here).
-        let last_used = LAST_USED_POOL_INDEX.with(|c| c.get());
-        let next_slot = (last_used + 1) % num_slots;
-
-        // Ring traversal without per-step `%`: indices next_slot..end, then 0..next_slot.
-        for i in (next_slot..num_slots).chain(0..next_slot) {
+        let start = next_index(num_slots);
+        for i in (start..num_slots).chain(0..start) {
             if let Some(c) = self.pool.get(i)
                 && c.conn_id != except_conn
             {
-                // Store the last **used** slot; next call will start at `(i + 1) % num_slots`.
-                LAST_USED_POOL_INDEX.with(|c| c.set(i));
                 return Some(c.conn_id);
             }
         }
@@ -388,7 +381,6 @@ impl NameState {
             return None;
         }
 
-        let rr_key = (id, side as u8);
         let mut non_incoming_conn_ids: Vec<u64> = Vec::with_capacity(refs.len());
         non_incoming_conn_ids.extend(refs.keys().copied().filter(|&c| c != incoming_conn));
 
@@ -404,14 +396,8 @@ impl NameState {
         non_incoming_conn_ids.sort_unstable();
         let n = non_incoming_conn_ids.len();
 
-        let conn_id = LAST_USED_CONN_POS.with(|m| {
-            let mut map = m.borrow_mut();
-            let last_pos = *map.get(&rr_key).unwrap_or(&0_usize);
-            let next_pos = (last_pos + 1) % n;
-            let picked = non_incoming_conn_ids[next_pos];
-            map.insert(rr_key, next_pos);
-            picked
-        });
+        let idx = next_index(n);
+        let conn_id = non_incoming_conn_ids[idx];
 
         Some(conn_id)
     }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -208,7 +208,11 @@ impl Connections {
                 debug!("the only available connection cannot be used");
                 return None;
             }
-            debug_assert!(self.pool.get(slot_idx).is_some_and(|c| c.conn_id == conn_id));
+            debug_assert!(
+                self.pool
+                    .get(slot_idx)
+                    .is_some_and(|c| c.conn_id == conn_id)
+            );
             LAST_USED_POOL_INDEX.with(|c| c.set(slot_idx));
             return Some(slot_idx);
         }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -18,10 +18,10 @@ thread_local! {
     /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot
     /// (initialized to `0` before the first pick).
     static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(0_usize) };
-    /// Last picked index in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
-    /// (key = `(name id, 0 = local pool / 1 = remote pool)`). Missing keys use `0_usize` like
-    /// [`LAST_USED_POOL_INDEX`] before the first pick for that key.
-    static LAST_USED_NON_INCOMING_CONN_RR_POS: RefCell<HashMap<(u64, u8), usize>> =
+    /// Per-name round-robin (RR): last **used connection position** (index in the sorted candidate list) for
+    /// [`NameState::get_one_connection`] (key = `(name id, 0 = local pool / 1 = remote pool)`).
+    /// Missing keys use `0_usize` like [`LAST_USED_POOL_INDEX`] before the first pick for that key.
+    static LAST_USED_CONN_POS: RefCell<HashMap<(u64, u8), usize>> =
         RefCell::new(HashMap::new());
 }
 
@@ -404,7 +404,7 @@ impl NameState {
         non_incoming_conn_ids.sort_unstable();
         let n = non_incoming_conn_ids.len();
 
-        let conn_id = LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
+        let conn_id = LAST_USED_CONN_POS.with(|m| {
             let mut map = m.borrow_mut();
             let last_pos = *map.get(&rr_key).unwrap_or(&0_usize);
             let next_pos = (last_pos + 1) % n;

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -1,18 +1,32 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use parking_lot::{RawRwLock, RwLock, lock_api::RwLockWriteGuard};
-use rand::Rng;
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use tracing::{debug, error, warn};
 
 use super::SubscriptionTable;
 use super::pool::Pool;
 use crate::errors::DataPathError;
 use crate::messages::Name;
+
+thread_local! {
+    static THREAD_RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_os_rng());
+}
+
+fn random_index(upper: usize) -> usize {
+    THREAD_RNG.with(|rng| rng.borrow_mut().random_range(0..upper))
+}
+
+/// Sentinel for `Connections::last_used_pool_index`: no slot chosen yet. Real pool indices are
+/// always far below `usize::MAX`.
+const LAST_USED_POOL_INDEX_NONE: usize = usize::MAX;
 
 #[derive(Debug, Clone)]
 struct InternalName(Name);
@@ -126,6 +140,8 @@ struct Connections {
     index: HashMap<u64, usize>,
     // pool of all connections ids that can to be used in the match
     pool: Pool<ConnId>,
+    /// Last pool slot index chosen by round-robin ([`LAST_USED_POOL_INDEX_NONE`] until first use).
+    last_used_pool_index: AtomicUsize,
 }
 
 impl Default for Connections {
@@ -133,6 +149,7 @@ impl Default for Connections {
         Connections {
             index: HashMap::new(),
             pool: Pool::with_capacity(2),
+            last_used_pool_index: AtomicUsize::new(LAST_USED_POOL_INDEX_NONE),
         }
     }
 }
@@ -179,36 +196,44 @@ impl Connections {
         Ok(())
     }
 
-    fn get_one(&self, except_conn: u64) -> Option<u64> {
-        if self.index.len() == 1 {
-            if self.index.contains_key(&except_conn) {
-                debug!("the only available connection cannot be used");
-                return None;
-            } else {
-                let val = self.index.iter().next().unwrap();
-                return Some(*val.0);
+    /// Next pool slot index in round-robin order among active slots whose connection id is not
+    /// `except_conn`. Updates `last_used_pool_index`.
+    fn next_round_robin_pool_index(&self, except_conn: u64) -> Option<usize> {
+        // Build eligible slot indices using `max_set`/`get` (occupied slots with conn != except).
+        let mut eligible = Vec::new();
+        for idx in 0..=self.pool.max_set() {
+            if self.pool.get(idx).is_some_and(|c| c.conn_id != except_conn) {
+                eligible.push(idx);
             }
         }
 
-        // we need to iterate and find a value starting from a random point in the pool
-        let mut rng = rand::rng();
-        let index = rng.random_range(0..self.pool.max_set() + 1);
-        let mut stop = false;
-        let mut i = index;
-        while !stop {
-            let opt = self.pool.get(i);
-            if let Some(opt) = opt
-                && opt.conn_id != except_conn
-            {
-                return Some(opt.conn_id);
-            }
-            i = (i + 1) % (self.pool.max_set() + 1);
-            if i == index {
-                stop = true;
-            }
+        if eligible.is_empty() {
+            self.last_used_pool_index
+                .store(LAST_USED_POOL_INDEX_NONE, Ordering::Relaxed);
+            debug!("no output connection available");
+            return None;
         }
-        debug!("no output connection available");
-        None
+
+        let n = eligible.len();
+        let last_raw = self.last_used_pool_index.load(Ordering::Relaxed);
+        let next_pos = if last_raw == LAST_USED_POOL_INDEX_NONE {
+            0
+        } else {
+            eligible
+                .iter()
+                .position(|&idx| idx == last_raw)
+                .map(|p| (p + 1) % n)
+                .unwrap_or(0)
+        };
+
+        let idx = eligible[next_pos];
+        self.last_used_pool_index.store(idx, Ordering::Relaxed);
+        Some(idx)
+    }
+
+    fn get_one(&self, except_conn: u64) -> Option<u64> {
+        self.next_round_robin_pool_index(except_conn)
+            .and_then(|idx| self.pool.get(idx).map(|conn| conn.conn_id))
     }
 
     fn get_all(&self, except_conn: u64) -> Option<Vec<u64>> {
@@ -384,23 +409,21 @@ impl NameState {
                     }
                 }
 
-                // we need to iterate and find a value starting from a random point
-                let conns: Vec<u64> = refs[index].keys().copied().collect();
-                let mut rng = rand::rng();
-                let pos = rng.random_range(0..conns.len());
-                let mut stop = false;
-                let mut i = pos;
-                while !stop {
-                    if conns[i] != incoming_conn {
-                        return Some(conns[i]);
-                    }
-                    i = (i + 1) % conns.len();
-                    if i == pos {
-                        stop = true;
-                    }
+                let eligible_count = refs[index]
+                    .keys()
+                    .filter(|&&conn_id| conn_id != incoming_conn)
+                    .count();
+                if eligible_count == 0 {
+                    debug!("no output connection available");
+                    return None;
                 }
-                debug!("no output connection available");
-                None
+
+                let selected = random_index(eligible_count);
+                refs[index]
+                    .keys()
+                    .filter(|&&conn_id| conn_id != incoming_conn)
+                    .nth(selected)
+                    .copied()
             }
         }
     }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -375,17 +375,14 @@ impl NameState {
             return None;
         }
 
-        let mut non_incoming_conn_ids: Vec<u64> = Vec::with_capacity(refs.len());
-        non_incoming_conn_ids.extend(refs.keys().copied().filter(|&c| c != incoming_conn));
-
-        if non_incoming_conn_ids.is_empty() {
+        let mut conn_ids: Vec<u64> = refs.keys().copied().collect();
+        conn_ids.sort_unstable();
+        let n = conn_ids.len();
+        let result = pick_one(n, incoming_conn, |i| Some(conn_ids[i]));
+        if result.is_none() {
             debug!("no output connection available");
-            return None;
         }
-
-        non_incoming_conn_ids.sort_unstable();
-        let n = non_incoming_conn_ids.len();
-        pick_one(n, incoming_conn, |i| Some(non_incoming_conn_ids[i]))
+        result
     }
 
     fn get_all_connections(

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -14,15 +14,13 @@ use super::pool::Pool;
 use crate::errors::DataPathError;
 use crate::messages::Name;
 
-/// Sentinel: no pool slot used yet on this thread (see [`Connections::get_one`]).
-const LAST_USED_POOL_INDEX_NONE: usize = usize::MAX;
 /// Sentinel for round-robin position maps that still use "uninitialized" state.
 const LAST_USED_REF_POS_NONE: usize = usize::MAX;
 
 thread_local! {
-    /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot, or
-    /// [`LAST_USED_POOL_INDEX_NONE`] until the first successful pick on this thread.
-    static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(LAST_USED_POOL_INDEX_NONE) };
+    /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot
+    /// (initialized to `0` before the first pick).
+    static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(0 as usize) };
     /// Last picked position in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
     /// (key = `(name id, 0 = local pool / 1 = remote pool)`).
     static LAST_USED_NON_INCOMING_CONN_RR_POS: RefCell<HashMap<(u64, u8), usize>> =
@@ -222,11 +220,7 @@ impl Connections {
         // First slot to try: one past last used, wrapped into [0, num_slots).
         // Read last-used slot once; compute where to start this scan (no write here).
         let last_used = LAST_USED_POOL_INDEX.with(|c| c.get());
-        let next_slot = if last_used == LAST_USED_POOL_INDEX_NONE {
-            0
-        } else {
-            (last_used + 1) % num_slots
-        };
+        let next_slot = (last_used + 1) % num_slots;
 
         // Ring traversal without per-step `%`: indices next_slot..end, then 0..next_slot.
         for i in (next_slot..num_slots).chain(0..next_slot) {
@@ -401,7 +395,7 @@ impl NameState {
         non_incoming_conn_ids.extend(refs.keys().copied().filter(|&c| c != incoming_conn));
 
         if non_incoming_conn_ids.is_empty() {
-            debug!("the only available connection cannot be used");
+            debug!("no output connection available");
             return None;
         }
 
@@ -442,9 +436,6 @@ impl NameState {
         }
 
         let Some(name_refs) = self.ids.get(&id) else {
-            if pool.index.len() == 1 {
-                return pool.get_all(incoming_conn);
-            }
             debug!(name = %id, "cannot find out connection, name does not exists");
             return None;
         };

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -14,11 +14,14 @@ use super::pool::Pool;
 use crate::errors::DataPathError;
 use crate::messages::Name;
 
-/// Sentinel for round-robin cursors: none chosen yet. Real indices are far below `usize::MAX`.
+/// Sentinel: no pool slot used yet on this thread (see [`Connections::get_one`]).
 const LAST_USED_POOL_INDEX_NONE: usize = usize::MAX;
+/// Sentinel for round-robin position maps that still use "uninitialized" state.
+const LAST_USED_REF_POS_NONE: usize = usize::MAX;
 
 thread_local! {
-    /// Per-thread round-robin cursor for [`Connections::next_round_robin_pool_index`] (pool slot).
+    /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot, or
+    /// [`LAST_USED_POOL_INDEX_NONE`] until the first successful pick on this thread.
     static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(LAST_USED_POOL_INDEX_NONE) };
     /// Last picked position in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
     /// (key = `(name id, 0 = local pool / 1 = remote pool)`).
@@ -191,11 +194,11 @@ impl Connections {
         Ok(())
     }
 
-    /// Next pool slot index for a connection other than `except_conn`.
+    /// Pick a connection id other than `except_conn` using round-robin over pool slots.
     ///
     /// Single-connection case is O(1) on [`Self::index`]. Otherwise walks pool slots in ring order
-    /// starting after the thread-local last index (see `next_slot` below), without allocating.
-    fn next_round_robin_pool_index(&self, except_conn: u64) -> Option<usize> {
+    /// starting from one slot after the thread-local last-used index, without allocating.
+    fn get_one(&self, except_conn: u64) -> Option<u64> {
         if self.index.len() == 1 {
             let (&conn_id, &slot_idx) = self
                 .index
@@ -212,16 +215,17 @@ impl Connections {
                     .is_some_and(|c| c.conn_id == conn_id)
             );
             LAST_USED_POOL_INDEX.with(|c| c.set(slot_idx));
-            return Some(slot_idx);
+            return Some(conn_id);
         }
 
         let num_slots = self.pool.max_set() + 1;
-        let last_raw = LAST_USED_POOL_INDEX.with(|c| c.get());
-        // First slot to try: advance one past last pick, wrapped into [0, num_slots).
-        let next_slot = if last_raw == LAST_USED_POOL_INDEX_NONE {
+        // First slot to try: one past last used, wrapped into [0, num_slots).
+        // Read last-used slot once; compute where to start this scan (no write here).
+        let last_used = LAST_USED_POOL_INDEX.with(|c| c.get());
+        let next_slot = if last_used == LAST_USED_POOL_INDEX_NONE {
             0
         } else {
-            (last_raw + 1) % num_slots
+            (last_used % num_slots + 1) % num_slots
         };
 
         // Ring traversal without per-step `%`: indices next_slot..end, then 0..next_slot.
@@ -229,19 +233,14 @@ impl Connections {
             if let Some(c) = self.pool.get(i)
                 && c.conn_id != except_conn
             {
+                // Store the last **used** slot; next call will start at `(i + 1) % num_slots`.
                 LAST_USED_POOL_INDEX.with(|c| c.set(i));
-                return Some(i);
+                return Some(c.conn_id);
             }
         }
 
-        LAST_USED_POOL_INDEX.with(|c| c.set(LAST_USED_POOL_INDEX_NONE));
         debug!("no output connection available");
         None
-    }
-
-    fn get_one(&self, except_conn: u64) -> Option<u64> {
-        self.next_round_robin_pool_index(except_conn)
-            .and_then(|idx| self.pool.get(idx).map(|conn| conn.conn_id))
     }
 
     fn get_all(&self, except_conn: u64) -> Option<Vec<u64>> {
@@ -403,7 +402,7 @@ impl NameState {
 
         if non_incoming_conn_ids.is_empty() {
             LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
-                m.borrow_mut().insert(rr_key, LAST_USED_POOL_INDEX_NONE);
+                m.borrow_mut().insert(rr_key, LAST_USED_REF_POS_NONE);
             });
             debug!("the only available connection cannot be used");
             return None;
@@ -418,8 +417,8 @@ impl NameState {
 
         let conn_id = LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
             let mut map = m.borrow_mut();
-            let last_raw = *map.get(&rr_key).unwrap_or(&LAST_USED_POOL_INDEX_NONE);
-            let next_pos = if last_raw == LAST_USED_POOL_INDEX_NONE {
+            let last_raw = *map.get(&rr_key).unwrap_or(&LAST_USED_REF_POS_NONE);
+            let next_pos = if last_raw == LAST_USED_REF_POS_NONE {
                 0
             } else {
                 (last_raw + 1) % n

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -14,15 +14,13 @@ use super::pool::Pool;
 use crate::errors::DataPathError;
 use crate::messages::Name;
 
-/// Sentinel for round-robin position maps that still use "uninitialized" state.
-const LAST_USED_REF_POS_NONE: usize = usize::MAX;
-
 thread_local! {
     /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot
     /// (initialized to `0` before the first pick).
     static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(0_usize) };
-    /// Last picked position in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
-    /// (key = `(name id, 0 = local pool / 1 = remote pool)`).
+    /// Last picked index in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
+    /// (key = `(name id, 0 = local pool / 1 = remote pool)`). Missing keys use `0_usize` like
+    /// [`LAST_USED_POOL_INDEX`] before the first pick for that key.
     static LAST_USED_NON_INCOMING_CONN_RR_POS: RefCell<HashMap<(u64, u8), usize>> =
         RefCell::new(HashMap::new());
 }
@@ -408,12 +406,8 @@ impl NameState {
 
         let conn_id = LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
             let mut map = m.borrow_mut();
-            let last_raw = *map.get(&rr_key).unwrap_or(&LAST_USED_REF_POS_NONE);
-            let next_pos = if last_raw == LAST_USED_REF_POS_NONE {
-                0
-            } else {
-                (last_raw + 1) % n
-            };
+            let last_pos = *map.get(&rr_key).unwrap_or(&0_usize);
+            let next_pos = (last_pos + 1) % n;
             let picked = non_incoming_conn_ids[next_pos];
             map.insert(rr_key, next_pos);
             picked

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -462,8 +462,7 @@ impl NameState {
             let Some(conn_id) = refs
                 .keys()
                 .copied()
-                .filter(|&conn_id| conn_id != incoming_conn)
-                .next()
+                .find(|&conn_id| conn_id != incoming_conn)
             else {
                 debug!("the only available connection cannot be used");
                 return None;

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -45,6 +45,11 @@ fn pick_one(n: usize, except: u64, get: impl Fn(usize) -> Option<u64>) -> Option
     None
 }
 
+#[cfg(test)]
+fn reset_next_index_for_test() {
+    NEXT_INDEX.with(|c| c.set(0));
+}
+
 #[derive(Debug, Clone)]
 struct InternalName(Name);
 
@@ -1180,5 +1185,115 @@ mod tests {
             matches!(err, Err(DataPathError::NoMatch(_))),
             "No connections should remain"
         );
+    }
+
+    /// Covers `pick_one` early exit, full-ring skip, and `next_index` round-robin.
+    #[test]
+    fn pick_one_and_next_index_helpers() {
+        reset_next_index_for_test();
+        assert_eq!(pick_one(0, 0, |_| Some(1)), None);
+
+        reset_next_index_for_test();
+        assert_eq!(
+            pick_one(1, 42, |_| Some(42)),
+            None,
+            "only candidate equals except"
+        );
+
+        reset_next_index_for_test();
+        let values = [10_u64, 20, 30];
+        assert_eq!(
+            pick_one(3, 99, |i| Some(values[i])),
+            Some(10),
+            "cursor 0, first acceptable"
+        );
+        assert_eq!(
+            pick_one(3, 99, |i| Some(values[i])),
+            Some(20),
+            "cursor advanced"
+        );
+        assert_eq!(pick_one(3, 99, |i| Some(values[i])), Some(30));
+        assert_eq!(pick_one(3, 99, |i| Some(values[i])), Some(10));
+
+        reset_next_index_for_test();
+        assert_eq!(
+            pick_one(2, 10, |i| Some([10, 20][i])),
+            Some(20),
+            "skip first slot when it matches except"
+        );
+
+        reset_next_index_for_test();
+        assert_eq!(
+            pick_one(3, 0, |i| if i == 1 { None } else { Some([1, 2, 3][i]) }),
+            Some(1),
+            "ignore None from get"
+        );
+    }
+
+    /// Unknown `name.id()` with a single connection in the pool uses `pool.get_one` fallback.
+    #[test]
+    fn get_one_connection_unknown_id_single_pool_conn_fallback() {
+        reset_next_index_for_test();
+        let base = Name::from_strings(["agntcy", "default", "rr-fallback"]);
+        let name_known = base.clone().with_id(1);
+        let name_unknown = base.clone().with_id(999);
+        let t = SubscriptionTableImpl::default();
+
+        assert!(t.add_subscription(name_known, 42, false, 1).is_ok());
+        assert_eq!(t.match_one(&name_unknown, 100).unwrap(), 42);
+    }
+
+    /// Unknown `name.id()` with zero or multiple pool entries returns `NoMatch`.
+    #[test]
+    fn get_one_connection_unknown_id_no_fallback_when_pool_not_singleton() {
+        reset_next_index_for_test();
+        let base = Name::from_strings(["agntcy", "default", "rr-nofallback"]);
+        let name_known = base.clone().with_id(1);
+        let name_unknown = base.clone().with_id(888);
+        let t = SubscriptionTableImpl::default();
+
+        assert!(t.add_subscription(name_known.clone(), 10, false, 1).is_ok());
+        assert!(t.add_subscription(name_known, 20, false, 2).is_ok());
+
+        let err = t.match_one(&name_unknown, 100);
+        assert!(
+            matches!(err, Err(DataPathError::NoMatch(_))),
+            "pool has 2 remote conns, id missing -> no singleton fallback"
+        );
+    }
+
+    /// Named id exists but only connection equals `incoming_conn` -> `pick_one` finds nothing.
+    #[test]
+    fn get_one_connection_only_candidate_is_incoming() {
+        reset_next_index_for_test();
+        let name = Name::from_strings(["agntcy", "default", "only-incoming"]).with_id(7);
+        let t = SubscriptionTableImpl::default();
+        assert!(t.add_subscription(name.clone(), 55, false, 1).is_ok());
+        let err = t.match_one(&name, 55);
+        assert!(matches!(err, Err(DataPathError::NoMatch(_))));
+    }
+
+    /// `Connections::get_all` when the sole indexed connection is excluded.
+    #[test]
+    fn match_all_null_name_single_conn_excluded() {
+        let name = Name::from_strings(["agntcy", "default", "null-single"]);
+        let t = SubscriptionTableImpl::default();
+        assert!(t.add_subscription(name.clone(), 77, false, 1).is_ok());
+        let err = t.match_all(&name, 77);
+        assert!(matches!(err, Err(DataPathError::NoMatch(_))));
+    }
+
+    /// `get_all_connections` multi-ref path with `Vec::with_capacity` and non-empty output.
+    #[test]
+    fn get_all_connections_multi_sorted_excludes_incoming() {
+        let name = Name::from_strings(["agntcy", "default", "multi-all"]).with_id(3);
+        let t = SubscriptionTableImpl::default();
+        assert!(t.add_subscription(name.clone(), 1, true, 1).is_ok());
+        assert!(t.add_subscription(name.clone(), 2, true, 2).is_ok());
+        assert!(t.add_subscription(name.clone(), 3, true, 3).is_ok());
+
+        let mut out = t.match_all(&name, 2).unwrap();
+        out.sort_unstable();
+        assert_eq!(out, vec![1, 3]);
     }
 }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -7,7 +7,6 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 use parking_lot::{RawRwLock, RwLock, lock_api::RwLockWriteGuard};
-use rand::{Rng, SeedableRng, rngs::SmallRng};
 use tracing::{debug, error, warn};
 
 use super::SubscriptionTable;
@@ -15,17 +14,16 @@ use super::pool::Pool;
 use crate::errors::DataPathError;
 use crate::messages::Name;
 
-/// Sentinel for round-robin pool slot: none chosen yet. Real pool indices are far below `usize::MAX`.
+/// Sentinel for round-robin cursors: none chosen yet. Real indices are far below `usize::MAX`.
 const LAST_USED_POOL_INDEX_NONE: usize = usize::MAX;
 
 thread_local! {
-    static THREAD_RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_os_rng());
-    /// Per-thread round-robin cursor for [`Connections::next_round_robin_pool_index`].
+    /// Per-thread round-robin cursor for [`Connections::next_round_robin_pool_index`] (pool slot).
     static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(LAST_USED_POOL_INDEX_NONE) };
-}
-
-fn random_index(upper: usize) -> usize {
-    THREAD_RNG.with(|rng| rng.borrow_mut().random_range(0..upper))
+    /// Last picked position in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
+    /// (key = `(name id, 0 = local pool / 1 = remote pool)`).
+    static LAST_USED_NON_INCOMING_CONN_RR_POS: RefCell<HashMap<(u64, u8), usize>> =
+        RefCell::new(HashMap::new());
 }
 
 #[derive(Debug, Clone)]
@@ -379,63 +377,59 @@ impl NameState {
         incoming_conn: u64,
         get_local_connection: bool,
     ) -> Option<u64> {
-        let mut index = 0;
-        if !get_local_connection {
-            index = 1;
-        }
+        let side = if get_local_connection { 0 } else { 1 };
+        let pool = &self.connections[side];
 
         if id == Name::NULL_COMPONENT {
-            return self.connections[index].get_one(incoming_conn);
+            return pool.get_one(incoming_conn);
         }
 
-        let val = self.ids.get(&id);
-        match val {
-            None => {
-                // If there is only 1 connection for the name, we can still
-                // try to use it
-                if self.connections[index].index.len() == 1 {
-                    return self.connections[index].get_one(incoming_conn);
-                }
-
-                // We cannot return any connection for this name
-                debug!(name = %id, "cannot find out connection, name does not exists");
-                None
+        let Some(name_refs) = self.ids.get(&id) else {
+            if pool.index.len() == 1 {
+                return pool.get_one(incoming_conn);
             }
-            Some(refs) => {
-                if refs[index].is_empty() {
-                    // no connections available
-                    return None;
-                }
+            debug!(name = %id, "cannot find out connection, name does not exists");
+            return None;
+        };
 
-                if refs[index].len() == 1 {
-                    // Get the single connection id
-                    let conn_id = *refs[index].keys().next().unwrap();
-                    if conn_id == incoming_conn {
-                        // cannot return the incoming connection
-                        debug!("the only available connection cannot be used");
-                        return None;
-                    } else {
-                        return Some(conn_id);
-                    }
-                }
-
-                let eligible_count = refs[index]
-                    .keys()
-                    .filter(|&&conn_id| conn_id != incoming_conn)
-                    .count();
-                if eligible_count == 0 {
-                    debug!("no output connection available");
-                    return None;
-                }
-
-                let selected = random_index(eligible_count);
-                refs[index]
-                    .keys()
-                    .filter(|&&conn_id| conn_id != incoming_conn)
-                    .nth(selected)
-                    .copied()
-            }
+        let refs = &name_refs[side];
+        if refs.is_empty() {
+            return None;
         }
+
+        let rr_key = (id, side as u8);
+        let mut non_incoming_conn_ids: Vec<u64> = Vec::with_capacity(refs.len());
+        non_incoming_conn_ids.extend(refs.keys().copied().filter(|&c| c != incoming_conn));
+
+        if non_incoming_conn_ids.is_empty() {
+            LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
+                m.borrow_mut().insert(rr_key, LAST_USED_POOL_INDEX_NONE);
+            });
+            debug!("the only available connection cannot be used");
+            return None;
+        }
+
+        if non_incoming_conn_ids.len() == 1 {
+            return Some(non_incoming_conn_ids[0]);
+        }
+
+        non_incoming_conn_ids.sort_unstable();
+        let n = non_incoming_conn_ids.len();
+
+        let conn_id = LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
+            let mut map = m.borrow_mut();
+            let last_raw = *map.get(&rr_key).unwrap_or(&LAST_USED_POOL_INDEX_NONE);
+            let next_pos = if last_raw == LAST_USED_POOL_INDEX_NONE {
+                0
+            } else {
+                (last_raw + 1) % n
+            };
+            let picked = non_incoming_conn_ids[next_pos];
+            map.insert(rr_key, next_pos);
+            picked
+        });
+
+        Some(conn_id)
     }
 
     fn get_all_connections(
@@ -444,49 +438,46 @@ impl NameState {
         incoming_conn: u64,
         get_local_connection: bool,
     ) -> Option<Vec<u64>> {
-        let mut index = 0;
-        if !get_local_connection {
-            index = 1;
-        }
+        let side = if get_local_connection { 0 } else { 1 };
+        let pool = &self.connections[side];
 
         if id == Name::NULL_COMPONENT {
-            return self.connections[index].get_all(incoming_conn);
+            return pool.get_all(incoming_conn);
         }
 
-        let val = self.ids.get(&id);
-        match val {
-            None => {
-                debug!(%id, "cannot find out connection, id does not exists");
-                None
+        let Some(name_refs) = self.ids.get(&id) else {
+            if pool.index.len() == 1 {
+                return pool.get_all(incoming_conn);
             }
-            Some(refs) => {
-                if refs[index].is_empty() {
-                    // should never happen
-                    return None;
-                }
+            debug!(name = %id, "cannot find out connection, name does not exists");
+            return None;
+        };
 
-                if refs[index].len() == 1 {
-                    // Get the single connection id
-                    let conn_id = *refs[index].keys().next().unwrap();
-                    if conn_id == incoming_conn {
-                        // cannot return the incoming connection
-                        debug!("the only available connection cannot be used");
-                        return None;
-                    } else {
-                        return Some(vec![conn_id]);
-                    }
-                }
+        let refs = &name_refs[side];
+        if refs.is_empty() {
+            return None;
+        }
 
-                // we need to iterate over the refs and exclude the incoming connection
-                let mut out = Vec::new();
-                for conn_id in refs[index].keys() {
-                    if *conn_id != incoming_conn {
-                        out.push(*conn_id);
-                    }
-                }
-                if out.is_empty() { None } else { Some(out) }
+        if refs.len() == 1 {
+            let Some(conn_id) = refs
+                .keys()
+                .copied()
+                .filter(|&conn_id| conn_id != incoming_conn)
+                .next()
+            else {
+                debug!("the only available connection cannot be used");
+                return None;
+            };
+            return Some(vec![conn_id]);
+        }
+
+        let mut out = Vec::new();
+        for conn_id in refs.keys() {
+            if *conn_id != incoming_conn {
+                out.push(*conn_id);
             }
         }
+        if out.is_empty() { None } else { Some(out) }
     }
 }
 

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -1,11 +1,10 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use parking_lot::{RawRwLock, RwLock, lock_api::RwLockWriteGuard};
 use rand::{Rng, SeedableRng, rngs::SmallRng};
@@ -16,17 +15,18 @@ use super::pool::Pool;
 use crate::errors::DataPathError;
 use crate::messages::Name;
 
+/// Sentinel for round-robin pool slot: none chosen yet. Real pool indices are far below `usize::MAX`.
+const LAST_USED_POOL_INDEX_NONE: usize = usize::MAX;
+
 thread_local! {
     static THREAD_RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_os_rng());
+    /// Per-thread round-robin cursor for [`Connections::next_round_robin_pool_index`].
+    static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(LAST_USED_POOL_INDEX_NONE) };
 }
 
 fn random_index(upper: usize) -> usize {
     THREAD_RNG.with(|rng| rng.borrow_mut().random_range(0..upper))
 }
-
-/// Sentinel for `Connections::last_used_pool_index`: no slot chosen yet. Real pool indices are
-/// always far below `usize::MAX`.
-const LAST_USED_POOL_INDEX_NONE: usize = usize::MAX;
 
 #[derive(Debug, Clone)]
 struct InternalName(Name);
@@ -140,8 +140,6 @@ struct Connections {
     index: HashMap<u64, usize>,
     // pool of all connections ids that can to be used in the match
     pool: Pool<ConnId>,
-    /// Last pool slot index chosen by round-robin ([`LAST_USED_POOL_INDEX_NONE`] until first use).
-    last_used_pool_index: AtomicUsize,
 }
 
 impl Default for Connections {
@@ -149,7 +147,6 @@ impl Default for Connections {
         Connections {
             index: HashMap::new(),
             pool: Pool::with_capacity(2),
-            last_used_pool_index: AtomicUsize::new(LAST_USED_POOL_INDEX_NONE),
         }
     }
 }
@@ -197,7 +194,7 @@ impl Connections {
     }
 
     /// Next pool slot index in round-robin order among active slots whose connection id is not
-    /// `except_conn`. Updates `last_used_pool_index`.
+    /// `except_conn`. Updates thread-local [`LAST_USED_POOL_INDEX`].
     fn next_round_robin_pool_index(&self, except_conn: u64) -> Option<usize> {
         // Build eligible slot indices using `max_set`/`get` (occupied slots with conn != except).
         let mut eligible = Vec::new();
@@ -208,14 +205,13 @@ impl Connections {
         }
 
         if eligible.is_empty() {
-            self.last_used_pool_index
-                .store(LAST_USED_POOL_INDEX_NONE, Ordering::Relaxed);
+            LAST_USED_POOL_INDEX.with(|c| c.set(LAST_USED_POOL_INDEX_NONE));
             debug!("no output connection available");
             return None;
         }
 
         let n = eligible.len();
-        let last_raw = self.last_used_pool_index.load(Ordering::Relaxed);
+        let last_raw = LAST_USED_POOL_INDEX.with(|c| c.get());
         let next_pos = if last_raw == LAST_USED_POOL_INDEX_NONE {
             0
         } else {
@@ -227,7 +223,7 @@ impl Connections {
         };
 
         let idx = eligible[next_pos];
-        self.last_used_pool_index.store(idx, Ordering::Relaxed);
+        LAST_USED_POOL_INDEX.with(|c| c.set(idx));
         Some(idx)
     }
 

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -199,11 +199,15 @@ impl Connections {
     /// starting after the thread-local last index (see `next_slot` below), without allocating.
     fn next_round_robin_pool_index(&self, except_conn: u64) -> Option<usize> {
         if self.index.len() == 1 {
-            if self.index.contains_key(&except_conn) {
+            let (&conn_id, &slot_idx) = self
+                .index
+                .iter()
+                .next()
+                .expect("len == 1 implies exactly one index entry");
+            if conn_id == except_conn {
                 debug!("the only available connection cannot be used");
                 return None;
             }
-            let (&conn_id, &slot_idx) = self.index.iter().next().unwrap();
             debug_assert!(self.pool.get(slot_idx).is_some_and(|c| c.conn_id == conn_id));
             LAST_USED_POOL_INDEX.with(|c| c.set(slot_idx));
             return Some(slot_idx);

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -20,7 +20,7 @@ const LAST_USED_REF_POS_NONE: usize = usize::MAX;
 thread_local! {
     /// Per-thread round-robin state for [`Connections::get_one`]: last **used** pool slot
     /// (initialized to `0` before the first pick).
-    static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(0 as usize) };
+    static LAST_USED_POOL_INDEX: Cell<usize> = const { Cell::new(0_usize) };
     /// Last picked position in the sorted non-incoming connection id list for [`NameState::get_one_connection`]
     /// (key = `(name id, 0 = local pool / 1 = remote pool)`).
     static LAST_USED_NON_INCOMING_CONN_RR_POS: RefCell<HashMap<(u64, u8), usize>> =

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -28,6 +28,23 @@ fn next_index(n: usize) -> usize {
     })
 }
 
+/// Round-robin over `0..n`: advance [`next_index`], then return the first `i` where `get(i)` is
+/// `Some(val)` and `val != except`.
+fn pick_one(n: usize, except: u64, get: impl Fn(usize) -> Option<u64>) -> Option<u64> {
+    if n == 0 {
+        return None;
+    }
+    let start = next_index(n);
+    for i in (start..n).chain(0..start) {
+        if let Some(val) = get(i)
+            && val != except
+        {
+            return Some(val);
+        }
+    }
+    None
+}
+
 #[derive(Debug, Clone)]
 struct InternalName(Name);
 
@@ -196,36 +213,13 @@ impl Connections {
     /// Pick a connection id other than `except_conn` using pseudo-random selection
     fn get_one(&self, except_conn: u64) -> Option<u64> {
         let num_slots = self.pool.max_set() + 1;
-        if self.index.len() == 1 {
-            let (&conn_id, &slot_idx) = self
-                .index
-                .iter()
-                .next()
-                .expect("len == 1 implies exactly one index entry");
-            if conn_id == except_conn {
-                debug!("the only available connection cannot be used");
-                return None;
-            }
-            debug_assert!(
-                self.pool
-                    .get(slot_idx)
-                    .is_some_and(|c| c.conn_id == conn_id)
-            );
-            let _ = next_index(num_slots);
-            return Some(conn_id);
+        let result = pick_one(num_slots, except_conn, |i| {
+            self.pool.get(i).map(|c| c.conn_id)
+        });
+        if result.is_none() {
+            debug!("no output connection available");
         }
-
-        let start = next_index(num_slots);
-        for i in (start..num_slots).chain(0..start) {
-            if let Some(c) = self.pool.get(i)
-                && c.conn_id != except_conn
-            {
-                return Some(c.conn_id);
-            }
-        }
-
-        debug!("no output connection available");
-        None
+        result
     }
 
     fn get_all(&self, except_conn: u64) -> Option<Vec<u64>> {
@@ -389,17 +383,9 @@ impl NameState {
             return None;
         }
 
-        if non_incoming_conn_ids.len() == 1 {
-            return Some(non_incoming_conn_ids[0]);
-        }
-
         non_incoming_conn_ids.sort_unstable();
         let n = non_incoming_conn_ids.len();
-
-        let idx = next_index(n);
-        let conn_id = non_incoming_conn_ids[idx];
-
-        Some(conn_id)
+        pick_one(n, incoming_conn, |i| Some(non_incoming_conn_ids[i]))
     }
 
     fn get_all_connections(

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -225,7 +225,7 @@ impl Connections {
         let next_slot = if last_used == LAST_USED_POOL_INDEX_NONE {
             0
         } else {
-            (last_used % num_slots + 1) % num_slots
+            (last_used + 1) % num_slots
         };
 
         // Ring traversal without per-step `%`: indices next_slot..end, then 0..next_slot.
@@ -401,9 +401,6 @@ impl NameState {
         non_incoming_conn_ids.extend(refs.keys().copied().filter(|&c| c != incoming_conn));
 
         if non_incoming_conn_ids.is_empty() {
-            LAST_USED_NON_INCOMING_CONN_RR_POS.with(|m| {
-                m.borrow_mut().insert(rr_key, LAST_USED_REF_POS_NONE);
-            });
             debug!("the only available connection cannot be used");
             return None;
         }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -437,7 +437,7 @@ impl NameState {
             return Some(vec![conn_id]);
         }
 
-        let mut out = Vec::new();
+        let mut out = Vec::with_capacity(refs.len());
         for conn_id in refs.keys() {
             if *conn_id != incoming_conn {
                 out.push(*conn_id);


### PR DESCRIPTION
Fixes #1384 

## Summary

Replace random output-connection selection in the subscription datapath with **per-thread round-robin** via a shared `NEXT_INDEX` cursor and a **`pick_one`** helper used by **`Connections::get_one`** and **`NameState::get_one_connection`**.

## Why

Deterministic, cheaper selection without RNG; predictable spread across candidates.

## Key changes

- `next_index(n)` + `pick_one(n, except, get)` for ring-ordered scans.
- Pool picks: indices over `0..pool.max_set()+1`.
- Named picks: collect IDs, **sort** for stable order, `pick_one` skips `incoming_conn` via `except`.

## Testing

`cargo test -p agntcy-slim-datapath subscription_table` (and CI datapath tests).

## Note

**Behavior change:** selection is round-robin, not random; pool and name paths share the same thread-local cursor.