### PR TITLE
refactor(datapath): replace Pool bitmap/vec with three-vec design

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -204,7 +204,6 @@ dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
- "bit-vec",
  "criterion",
  "display-error-chain",
  "drain",
@@ -722,12 +721,6 @@ checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -60,7 +60,6 @@ async-trait = "0.1.88"
 aws-lc-rs = "1.16"
 base64 = "0.22"
 bincode = "2.0.1"
-bit-vec = "0.8"
 bytes = "1.9.0"
 chrono = "0.4"
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -1093,7 +1093,7 @@ impl ControllerService {
                                 }
 
                                 for &cid in remote {
-                                    if let Some(conn) = conn_table.get(cid as usize) {
+                                    if let Some(conn) = conn_table.get(cid) {
                                         entry.remote_connections.push(ConnectionEntry {
                                             id: cid,
                                             connection_type: ConnectionType::Remote as i32,
@@ -1148,7 +1148,7 @@ impl ControllerService {
                                     "connection entry",
                                 );
                                 all_entries.push(ConnectionEntry {
-                                    id: id as u64,
+                                    id,
                                     connection_type: ConnectionType::Remote as i32,
                                     config_data: match conn.config_data() {
                                         Some(data) => serde_json::to_string(data)

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -703,7 +703,7 @@ impl ControllerService {
             .connection_table()
             .for_each(|id, conn| {
                 if conn.link_id().as_deref() == Some(link_id) && resolved.is_none() {
-                    resolved = Some(id as u64);
+                    resolved = Some(id);
                 }
             });
 

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -12,7 +12,6 @@ name = "slim_datapath"
 agntcy-slim-config = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
 agntcy-slim-version = { workspace = true }
-bit-vec = { workspace = true }
 display-error-chain = { workspace = true }
 drain = { workspace = true }
 h2 = { workspace = true }

--- a/data-plane/core/datapath/benches/pool_benchmark.rs
+++ b/data-plane/core/datapath/benches/pool_benchmark.rs
@@ -96,9 +96,7 @@ fn bench_next_id(c: &mut Criterion) {
         pool.insert(i);
     }
 
-    c.bench_function("pool next_id", |b| {
-        b.iter(|| black_box(pool.next_id()))
-    });
+    c.bench_function("pool next_id", |b| b.iter(|| black_box(pool.next_id())));
 }
 
 fn bench_next_val(c: &mut Criterion) {
@@ -107,9 +105,7 @@ fn bench_next_val(c: &mut Criterion) {
         pool.insert(i);
     }
 
-    c.bench_function("pool next_val", |b| {
-        b.iter(|| black_box(pool.next_val()))
-    });
+    c.bench_function("pool next_val", |b| b.iter(|| black_box(pool.next_val())));
 }
 
 criterion_group!(

--- a/data-plane/core/datapath/benches/pool_benchmark.rs
+++ b/data-plane/core/datapath/benches/pool_benchmark.rs
@@ -67,7 +67,7 @@ fn bench_remove(c: &mut Criterion) {
     c.bench_function("pool remove", |b| {
         b.iter(|| {
             let mut pool = Pool::with_capacity(1024);
-            let ids: Vec<usize> = (0..1024).map(|i| pool.insert(i)).collect();
+            let ids: Vec<u64> = (0..1024).map(|i| pool.insert(i)).collect();
             for id in &ids {
                 black_box(pool.remove(*id));
             }
@@ -80,7 +80,7 @@ fn bench_remove_insert_cycle(c: &mut Criterion) {
     c.bench_function("pool remove+insert cycle", |b| {
         b.iter(|| {
             let mut pool = Pool::with_capacity(1024);
-            let ids: Vec<usize> = (0..1024).map(|i| pool.insert(i)).collect();
+            let ids: Vec<u64> = (0..1024).map(|i| pool.insert(i)).collect();
             for (i, &id) in ids.iter().enumerate() {
                 pool.remove(id);
                 black_box(pool.insert(i as i32));

--- a/data-plane/core/datapath/benches/pool_benchmark.rs
+++ b/data-plane/core/datapath/benches/pool_benchmark.rs
@@ -1,31 +1,15 @@
-use bit_vec::BitVec;
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use slim_datapath::tables::pool::Pool;
 use std::mem::MaybeUninit;
 
 fn bench_lookup(c: &mut Criterion) {
     let mut pool = Pool::with_capacity(1024);
-    for i in 0..1024 {
-        pool.insert(i);
-    }
+    let ids: Vec<u64> = (0..1024i32).map(|i| pool.insert(i)).collect();
 
     c.bench_function("pool lookup", |b| {
         b.iter(|| {
-            for i in 0..1024 {
-                black_box(pool.get(i));
-            }
-        })
-    });
-}
-
-fn bench_bitvec_lookup(c: &mut Criterion) {
-    let size = 1024;
-    let bitvec = BitVec::from_elem(size, true);
-
-    c.bench_function("bitvec lookup", |b| {
-        b.iter(|| {
-            for i in 0..size {
-                black_box(bitvec.get(i));
+            for &id in &ids {
+                black_box(pool.get(id));
             }
         })
     });
@@ -108,7 +92,6 @@ fn bench_remove_insert_cycle(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_lookup,
-    bench_bitvec_lookup,
     bench_assume_init_ref,
     bench_insert,
     bench_grow,

--- a/data-plane/core/datapath/benches/pool_benchmark.rs
+++ b/data-plane/core/datapath/benches/pool_benchmark.rs
@@ -89,6 +89,29 @@ fn bench_remove_insert_cycle(c: &mut Criterion) {
     });
 }
 
+fn bench_next_id(c: &mut Criterion) {
+    // Representative pool size: a handful of outbound connections per name.
+    let mut pool = Pool::with_capacity(8);
+    for i in 0..8i32 {
+        pool.insert(i);
+    }
+
+    c.bench_function("pool next_id", |b| {
+        b.iter(|| black_box(pool.next_id()))
+    });
+}
+
+fn bench_next_val(c: &mut Criterion) {
+    let mut pool = Pool::with_capacity(8);
+    for i in 0..8i32 {
+        pool.insert(i);
+    }
+
+    c.bench_function("pool next_val", |b| {
+        b.iter(|| black_box(pool.next_val()))
+    });
+}
+
 criterion_group!(
     benches,
     bench_lookup,
@@ -98,6 +121,8 @@ criterion_group!(
     bench_capacity,
     bench_remove,
     bench_remove_insert_cycle,
+    bench_next_id,
+    bench_next_val,
 );
 
 criterion_main!(benches);

--- a/data-plane/core/datapath/src/forwarder.rs
+++ b/data-plane/core/datapath/src/forwarder.rs
@@ -40,11 +40,8 @@ where
         match existing_index {
             None => Some(self.connection_table.insert(conn)),
             Some(x) => {
-                if self.connection_table.insert_at(conn, x) {
-                    existing_index
-                } else {
-                    None
-                }
+                self.connection_table.insert_at(conn, x);
+                existing_index
             }
         }
     }

--- a/data-plane/core/datapath/src/forwarder.rs
+++ b/data-plane/core/datapath/src/forwarder.rs
@@ -38,12 +38,9 @@ where
 
     pub fn on_connection_established(&self, conn: T, existing_index: Option<u64>) -> Option<u64> {
         match existing_index {
-            None => {
-                let x = self.connection_table.insert(conn) as u64;
-                Some(x)
-            }
+            None => Some(self.connection_table.insert(conn)),
             Some(x) => {
-                if self.connection_table.insert_at(conn, x as usize) {
+                if self.connection_table.insert_at(conn, x) {
                     existing_index
                 } else {
                     None
@@ -57,7 +54,7 @@ where
         conn_index: u64,
         is_local: bool,
     ) -> (HashMap<Name, HashSet<u64>>, HashSet<SubscriptionInfo>) {
-        self.connection_table.remove(conn_index as usize);
+        self.connection_table.remove(conn_index);
         let local_subs = self
             .subscription_table
             .remove_connection(conn_index, is_local)
@@ -72,7 +69,7 @@ where
     }
 
     pub fn get_connection(&self, conn_index: u64) -> Option<Arc<T>> {
-        self.connection_table.get(conn_index as usize)
+        self.connection_table.get(conn_index)
     }
 
     pub fn get_subscriptions_forwarded_on_connection(

--- a/data-plane/core/datapath/src/message_processing.rs
+++ b/data-plane/core/datapath/src/message_processing.rs
@@ -2125,7 +2125,7 @@ mod tests {
         let rx = processor.internal.sub_ack_manager.register(sub_id);
 
         // Drop the remote connection so send_msg fails on retry.
-        processor.connection_table().remove(remote_conn as usize);
+        processor.connection_table().remove(remote_conn);
 
         let proc_clone = processor.clone();
         let handle = tokio::spawn(crate::subscription_ack::retry_loop(

--- a/data-plane/core/datapath/src/tables/connection_table.rs
+++ b/data-plane/core/datapath/src/tables/connection_table.rs
@@ -27,73 +27,63 @@ where
         }
     }
 
-    /// Add a connection to the table. This cannot fail
-    pub fn insert(&self, connection: T) -> usize {
-        // Get a write lock on the pool
+    /// Add a connection to the table, returning its stable ID.
+    pub fn insert(&self, connection: T) -> u64 {
         let mut pool = self.pool.write();
         pool.insert(Arc::new(connection))
     }
 
-    /// Add a connection to the table on a give index
-    pub fn insert_at(&self, connection: T, index: usize) -> bool {
-        // Get a write lock on the pool
+    /// Add a connection at a specific ID.
+    pub fn insert_at(&self, connection: T, id: u64) -> bool {
         let mut pool = self.pool.write();
-        pool.insert_at(Arc::new(connection), index)
+        pool.insert_at(Arc::new(connection), id)
     }
 
-    /// remove a connection from the table
-    pub fn remove(&self, index: usize) -> bool {
-        // Get a write lock on the pool
+    /// Remove the connection with the given ID.
+    pub fn remove(&self, id: u64) -> bool {
         let mut pool = self.pool.write();
-        pool.remove(index)
+        pool.remove(id)
     }
 
-    /// Get the number of connections in the table
+    /// Number of connections in the table.
     #[allow(dead_code)]
     pub fn len(&self) -> usize {
-        // Get a read lock on the pool
         let pool = self.pool.read();
         pool.len()
     }
 
-    /// Get the capacity of the table
+    /// Current allocated capacity.
     #[allow(dead_code)]
     pub fn capacity(&self) -> usize {
-        // Get a read lock on the pool
         let pool = self.pool.read();
         pool.capacity()
     }
 
-    /// Check if the table is empty
+    /// Returns `true` if the table contains no connections.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         let pool = self.pool.read();
         pool.is_empty()
     }
 
-    /// Get a connection from the table
-    pub fn get(&self, index: usize) -> Option<Arc<T>> {
-        // get a read lock on the pool
+    /// Look up a connection by its stable ID.
+    pub fn get(&self, id: u64) -> Option<Arc<T>> {
         let pool = self.pool.read();
-        pool.get(index).cloned()
+        pool.get(id).cloned()
     }
 
+    /// Call `f(id, connection)` for every live connection.
     pub fn for_each<F>(&self, mut f: F)
     where
-        F: FnMut(usize, Arc<T>),
+        F: FnMut(u64, Arc<T>),
     {
         let pool = self.pool.read();
-
-        let max_index = pool.max_set();
-        for idx in 0..=max_index {
-            if let Some(conn_arc) = pool.get(idx) {
-                f(idx, Arc::clone(conn_arc));
-            }
+        for (id, conn_arc) in pool.iter_with_ids() {
+            f(id, Arc::clone(conn_arc));
         }
     }
 }
 
-// tests
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,22 +92,25 @@ mod tests {
     fn test_connection_table() {
         let table = ConnectionTable::with_capacity(10);
         assert_eq!(table.len(), 0);
-        assert_eq!(table.capacity(), 10);
+        assert!(table.capacity() >= 10);
         assert!(table.is_empty());
 
         let connection = 10;
-        let index = table.insert(connection);
+        let id = table.insert(connection);
         assert_eq!(table.len(), 1);
         assert!(!table.is_empty());
 
         // get element from the table
-        let connection_ret = table.get(index).unwrap();
+        let connection_ret = table.get(id).unwrap();
         assert_eq!(*connection_ret, connection);
 
         // remove element from the table
-        assert!(table.remove(index));
+        assert!(table.remove(id));
 
-        // remove an element that does not exist
-        assert!(!table.remove(index));
+        // removing again returns false
+        assert!(!table.remove(id));
+
+        // element is no longer accessible
+        assert!(table.get(id).is_none());
     }
 }

--- a/data-plane/core/datapath/src/tables/connection_table.rs
+++ b/data-plane/core/datapath/src/tables/connection_table.rs
@@ -34,7 +34,7 @@ where
     }
 
     /// Add a connection at a specific ID.
-    pub fn insert_at(&self, connection: T, id: u64) -> bool {
+    pub fn insert_at(&self, connection: T, id: u64) {
         let mut pool = self.pool.write();
         pool.insert_at(Arc::new(connection), id)
     }

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -1,6 +1,8 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use tracing::trace;
 
 /// A collection that assigns each inserted element a stable `u64` ID.
@@ -26,9 +28,10 @@ pub struct Pool<T> {
     free_slots: Vec<usize>,
 
     /// Cursor for the persistent round-robin iterator (`next_id`).
-    /// Holds a position in `active_indexes`; wrapped on each call and
-    /// clamped on entry if elements have been removed since last use.
-    cursor: usize,
+    /// Stored as an `AtomicUsize` so that `next_id` can advance it through
+    /// a shared `&self` reference — callers that hold only a read lock on
+    /// an outer container are not forced to upgrade to a write lock.
+    cursor: AtomicUsize,
 }
 
 impl<T> Pool<T> {
@@ -38,7 +41,7 @@ impl<T> Pool<T> {
             pool: Vec::with_capacity(capacity),
             active_indexes: Vec::with_capacity(capacity),
             free_slots: Vec::new(),
-            cursor: 0,
+            cursor: AtomicUsize::new(0),
         }
     }
 
@@ -150,21 +153,18 @@ impl<T> Pool<T> {
     /// element on each call, cycling back to the first when the end is
     /// reached.  Returns `None` if the pool is empty.
     ///
-    /// The cursor survives across calls.  If elements are removed between
-    /// calls the cursor is clamped back into range automatically, so the
-    /// sequence remains valid even as the pool changes size.
-    pub fn next_id(&mut self) -> Option<u64> {
+    /// The cursor survives across calls and is advanced atomically, so
+    /// `next_id` only requires `&self` — callers that hold a shared
+    /// (read) lock on an outer container are not forced to upgrade to a
+    /// write lock.  If elements are removed between calls the modulo
+    /// wraps the cursor back into range automatically.
+    pub fn next_id(&self) -> Option<u64> {
         let n = self.active_indexes.len();
         if n == 0 {
             return None;
         }
-        // Clamp in case removals shrank active_indexes since the last call.
-        if self.cursor >= n {
-            self.cursor = 0;
-        }
-        let id = self.active_indexes[self.cursor] as u64;
-        self.cursor = (self.cursor + 1) % n;
-        Some(id)
+        let pos = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
+        Some(self.active_indexes[pos] as u64)
     }
 
     /// Number of elements currently in the pool.
@@ -346,6 +346,7 @@ mod tests {
         let id0 = pool.insert(10u32);
         let id1 = pool.insert(20u32);
         let id2 = pool.insert(30u32);
+        let pool = pool; // rebind as immutable — next_id only needs &self
 
         // Collect the sequence emitted by the first full cycle.
         let first: Vec<u64> = (0..3).map(|_| pool.next_id().unwrap()).collect();

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -66,10 +66,7 @@ impl<T> Pool<T> {
     /// Grows `pool` if `id` is beyond the current length.  If the slot was
     /// empty the index is added to `active_indexes`; if it was already
     /// occupied the element is replaced (length unchanged).
-    ///
-    /// Returns `true` always; the bool return mirrors the old API for
-    /// compatibility with call-sites that check the return value.
-    pub fn insert_at(&mut self, element: T, id: u64) -> bool {
+    pub fn insert_at(&mut self, element: T, id: u64) {
         let idx = id as usize;
 
         // Grow the pool with None slots until it covers `idx`.
@@ -83,7 +80,6 @@ impl<T> Pool<T> {
         if was_empty {
             self.active_indexes.push(idx);
         }
-        true
     }
 
     /// Remove the element with the given `id`.  Returns `true` if an element
@@ -182,12 +178,12 @@ mod tests {
         assert_eq!(pool.len(), 3);
 
         // insert_at with an occupied ID replaces the element.
-        assert!(pool.insert_at(99u32, id1));
+        pool.insert_at(99u32, id1);
         assert_eq!(pool.len(), 3);
         assert_eq!(pool.get(id1), Some(&99));
 
         // insert_at with a fresh ID inserts a new element.
-        assert!(pool.insert_at(55u32, 50));
+        pool.insert_at(55u32, 50);
         assert_eq!(pool.len(), 4);
         assert_eq!(pool.get(50), Some(&55));
 
@@ -310,19 +306,4 @@ mod tests {
         assert_eq!(pairs, vec![(id0, 10), (id2, 30)]);
     }
 
-    #[test]
-    fn test_remove_updates_max_set_to_previous_index() {
-        let mut pool = Pool::with_capacity(10);
-
-        for v in 0..4 {
-            let idx = pool.insert(v);
-            assert_eq!(idx, v as usize);
-        }
-        assert_eq!(pool.max_set(), 3);
-
-        assert!(pool.remove(3));
-        assert_eq!(pool.max_set(), 2);
-        assert_eq!(pool.get(2), Some(&2));
-        assert_eq!(pool.get(3), None);
-    }
 }

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -133,6 +133,17 @@ impl<T> Pool<T> {
         })
     }
 
+    /// Return the element at dense position `pos` (0-based rank among live
+    /// elements), without requiring a stable ID.  Useful for random sampling:
+    /// pick a position in `0..pool.len()` and call this to get the element.
+    pub fn get_by_position(&self, pos: usize) -> Option<&T> {
+        self.active_indexes.get(pos).map(|&i| {
+            self.pool[i]
+                .as_ref()
+                .expect("active_indexes must point to live slots")
+        })
+    }
+
     /// Number of elements currently in the pool.
     pub fn len(&self) -> usize {
         self.active_indexes.len()

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -312,5 +312,4 @@ mod tests {
         pairs.sort_by_key(|&(id, _)| id);
         assert_eq!(pairs, vec![(id0, 10), (id2, 30)]);
     }
-
 }

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -133,15 +133,11 @@ impl<T> Pool<T> {
         })
     }
 
-    /// Return the element at dense position `pos` (0-based rank among live
-    /// elements), without requiring a stable ID.  Useful for random sampling:
-    /// pick a position in `0..pool.len()` and call this to get the element.
-    pub fn get_by_position(&self, pos: usize) -> Option<&T> {
-        self.active_indexes.get(pos).map(|&i| {
-            self.pool[i]
-                .as_ref()
-                .expect("active_indexes must point to live slots")
-        })
+    /// Iterate over the stable IDs of all live elements, analogous to
+    /// `HashMap::keys()`.  Order is unspecified but consistent within a single
+    /// borrow of the pool.
+    pub fn ids(&self) -> impl Iterator<Item = u64> + '_ {
+        self.active_indexes.iter().map(|&i| i as u64)
     }
 
     /// Number of elements currently in the pool.

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -118,9 +118,11 @@ impl<T> Pool<T> {
 
     /// Iterate over all live elements.  No empty slots are visited.
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.active_indexes
-            .iter()
-            .map(|&i| self.pool[i].as_ref().expect("active_indexes must point to live slots"))
+        self.active_indexes.iter().map(|&i| {
+            self.pool[i]
+                .as_ref()
+                .expect("active_indexes must point to live slots")
+        })
     }
 
     /// Iterate over all `(id, element)` pairs.

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -5,6 +5,16 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tracing::trace;
 
+/// Internal wrapper stored in `pool`.  Bundles the user value with the
+/// element's current position in `active_indexes` so that `remove` can
+/// find and patch that dense list in O(1) without scanning.
+#[derive(Debug)]
+struct PoolEntry<T> {
+    value: T,
+    /// Index of this slot's entry within `active_indexes`.
+    active_pos: usize,
+}
+
 /// A collection that assigns each inserted element a stable `u64` ID.
 ///
 /// IDs map directly to Vec indices, giving O(1) `get()` with no hash
@@ -16,9 +26,9 @@ use tracing::trace;
 /// not retain an ID after calling `remove`.
 #[derive(Debug)]
 pub struct Pool<T> {
-    /// Sparse storage; `pool[i]` holds `Some(element)` when slot `i` is live.
+    /// Sparse storage; `pool[i]` holds `Some(entry)` when slot `i` is live.
     /// The u64 ID handed to callers equals the Vec index as a `u64`.
-    pool: Vec<Option<T>>,
+    pool: Vec<Option<PoolEntry<T>>>,
 
     /// Dense list of currently-live indices into `pool`.  Used for O(len)
     /// dense iteration without scanning `None` slots.
@@ -64,7 +74,11 @@ impl<T> Pool<T> {
             }
         };
 
-        self.pool[idx] = Some(element);
+        let active_pos = self.active_indexes.len();
+        self.pool[idx] = Some(PoolEntry {
+            value: element,
+            active_pos,
+        });
         self.active_indexes.push(idx);
         trace!(pool_len = self.active_indexes.len(), "pool insert");
         idx as u64
@@ -83,50 +97,74 @@ impl<T> Pool<T> {
             self.pool.resize_with(idx + 1, || None);
         }
 
-        let was_empty = self.pool[idx].is_none();
-        self.pool[idx] = Some(element);
-
-        if was_empty {
-            self.active_indexes.push(idx);
+        match self.pool[idx].as_mut() {
+            Some(entry) => {
+                // Slot already live: replace value in-place, active_pos unchanged.
+                entry.value = element;
+            }
+            None => {
+                let active_pos = self.active_indexes.len();
+                self.pool[idx] = Some(PoolEntry {
+                    value: element,
+                    active_pos,
+                });
+                self.active_indexes.push(idx);
+            }
         }
     }
 
     /// Remove the element with the given `id`.  Returns `true` if an element
     /// was present, `false` if the slot was already empty.
+    ///
+    /// Runs in O(1): the `active_pos` back-pointer stored inside the entry
+    /// lets us jump directly to the right position in `active_indexes` instead
+    /// of scanning for it.
     pub fn remove(&mut self, id: u64) -> bool {
         let idx = id as usize;
+        let pos = match self.pool.get(idx).and_then(|e| e.as_ref()) {
+            Some(entry) => entry.active_pos,
+            None => return false,
+        };
 
-        if self.pool.get(idx).and_then(|x| x.as_ref()).is_none() {
-            return false;
+        self.active_indexes.swap_remove(pos);
+
+        // If swap_remove moved an element into `pos`, update its back-pointer.
+        if pos < self.active_indexes.len() {
+            let moved_slot = self.active_indexes[pos];
+            self.pool[moved_slot]
+                .as_mut()
+                .expect("active_indexes must point to live slots")
+                .active_pos = pos;
         }
 
         self.pool[idx] = None;
-
-        // Remove from active_indexes (swap_remove is O(1) after the scan).
-        if let Some(pos) = self.active_indexes.iter().position(|&i| i == idx) {
-            self.active_indexes.swap_remove(pos);
-        }
-
         self.free_slots.push(idx);
         true
     }
 
     /// Look up an element by its stable ID.
     pub fn get(&self, id: u64) -> Option<&T> {
-        self.pool.get(id as usize).and_then(|x| x.as_ref())
+        self.pool
+            .get(id as usize)
+            .and_then(|x| x.as_ref())
+            .map(|entry| &entry.value)
     }
 
     /// Mutably look up an element by its stable ID.
     pub fn get_mut(&mut self, id: u64) -> Option<&mut T> {
-        self.pool.get_mut(id as usize).and_then(|x| x.as_mut())
+        self.pool
+            .get_mut(id as usize)
+            .and_then(|x| x.as_mut())
+            .map(|entry| &mut entry.value)
     }
 
     /// Iterate over all live elements.  No empty slots are visited.
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.active_indexes.iter().map(|&i| {
-            self.pool[i]
+            &self.pool[i]
                 .as_ref()
                 .expect("active_indexes must point to live slots")
+                .value
         })
     }
 
@@ -135,9 +173,10 @@ impl<T> Pool<T> {
         self.active_indexes.iter().map(|&i| {
             (
                 i as u64,
-                self.pool[i]
+                &self.pool[i]
                     .as_ref()
-                    .expect("active_indexes must point to live slots"),
+                    .expect("active_indexes must point to live slots")
+                    .value,
             )
         })
     }
@@ -178,9 +217,10 @@ impl<T> Pool<T> {
         let pos = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
         let idx = self.active_indexes[pos];
         Some(
-            self.pool[idx]
+            &self.pool[idx]
                 .as_ref()
-                .expect("active_indexes must point to live slots"),
+                .expect("active_indexes must point to live slots")
+                .value,
         )
     }
 
@@ -403,6 +443,92 @@ mod tests {
         // The second cycle must repeat in the same order.
         let second: Vec<u32> = (0..3).map(|_| *pool.next_val().unwrap()).collect();
         assert_eq!(first, second);
+    }
+
+    /// Removing a middle element forces a `swap_remove` that relocates the
+    /// last active entry.  The back-pointer of the moved entry must be updated
+    /// so subsequent removes of *that* entry are still O(1) and correct.
+    #[test]
+    fn test_remove_is_consistent_after_swap() {
+        let mut pool = Pool::with_capacity(8);
+        let id0 = pool.insert(0u32); // active_indexes: [0]
+        let id1 = pool.insert(1u32); // active_indexes: [0, 1]
+        let id2 = pool.insert(2u32); // active_indexes: [0, 1, 2]
+        let id3 = pool.insert(3u32); // active_indexes: [0, 1, 2, 3]
+
+        // Remove id1 (middle).  swap_remove swaps id3 into position 1.
+        // active_indexes becomes [0, 3, 2].
+        assert!(pool.remove(id1));
+        assert_eq!(pool.len(), 3);
+        assert_eq!(pool.get(id1), None);
+
+        // All survivors still reachable.
+        assert_eq!(pool.get(id0), Some(&0));
+        assert_eq!(pool.get(id2), Some(&2));
+        assert_eq!(pool.get(id3), Some(&3));
+
+        // iter returns exactly the three surviving values.
+        let mut vals: Vec<u32> = pool.iter().copied().collect();
+        vals.sort();
+        assert_eq!(vals, vec![0, 2, 3]);
+
+        // Re-insert into the freed slot, then remove it again to verify
+        // active_pos is set correctly on the re-inserted entry.
+        pool.insert_at(99u32, id1);
+        assert_eq!(pool.len(), 4);
+        assert!(pool.remove(id1));
+        assert_eq!(pool.len(), 3);
+        assert_eq!(pool.get(id1), None);
+
+        // Remaining entries still intact.
+        assert_eq!(pool.get(id0), Some(&0));
+        assert_eq!(pool.get(id2), Some(&2));
+        assert_eq!(pool.get(id3), Some(&3));
+    }
+
+    /// Remove the very last element in `active_indexes`.  No back-pointer
+    /// fixup is needed (the swap_remove doesn't move anything).
+    #[test]
+    fn test_remove_last_active_no_fixup() {
+        let mut pool = Pool::with_capacity(4);
+        let id0 = pool.insert(10u32);
+        let id1 = pool.insert(20u32);
+        let id2 = pool.insert(30u32);
+
+        // id2 is at position 2 — the last entry; removing it needs no fixup.
+        assert!(pool.remove(id2));
+        assert_eq!(pool.len(), 2);
+        assert_eq!(pool.get(id2), None);
+        assert_eq!(pool.get(id0), Some(&10));
+        assert_eq!(pool.get(id1), Some(&20));
+
+        // Removing the now-last element (id1) must also work.
+        assert!(pool.remove(id1));
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.get(id1), None);
+        assert_eq!(pool.get(id0), Some(&10));
+    }
+
+    /// `insert_at` on an occupied slot must replace the value without touching
+    /// `active_pos`.  A subsequent `remove` must therefore still succeed in O(1).
+    #[test]
+    fn test_insert_at_replace_preserves_active_pos() {
+        let mut pool = Pool::with_capacity(4);
+        let id0 = pool.insert(1u32);
+        let id1 = pool.insert(2u32);
+        let id2 = pool.insert(3u32);
+
+        // Replace the value at id1 (occupied slot).
+        pool.insert_at(99u32, id1);
+        assert_eq!(pool.len(), 3);
+        assert_eq!(pool.get(id1), Some(&99));
+
+        // Now remove id1; active_pos must still point to the right position.
+        assert!(pool.remove(id1));
+        assert_eq!(pool.len(), 2);
+        assert_eq!(pool.get(id1), None);
+        assert_eq!(pool.get(id0), Some(&1));
+        assert_eq!(pool.get(id2), Some(&3));
     }
 
     #[test]

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -24,6 +24,11 @@ pub struct Pool<T> {
 
     /// Stack of recycled indices available for reuse by the next `insert`.
     free_slots: Vec<usize>,
+
+    /// Cursor for the persistent round-robin iterator (`next_id`).
+    /// Holds a position in `active_indexes`; wrapped on each call and
+    /// clamped on entry if elements have been removed since last use.
+    cursor: usize,
 }
 
 impl<T> Pool<T> {
@@ -33,6 +38,7 @@ impl<T> Pool<T> {
             pool: Vec::with_capacity(capacity),
             active_indexes: Vec::with_capacity(capacity),
             free_slots: Vec::new(),
+            cursor: 0,
         }
     }
 
@@ -138,6 +144,27 @@ impl<T> Pool<T> {
     /// borrow of the pool.
     pub fn ids(&self) -> impl Iterator<Item = u64> + '_ {
         self.active_indexes.iter().map(|&i| i as u64)
+    }
+
+    /// Persistent round-robin iterator: returns the ID of the next live
+    /// element on each call, cycling back to the first when the end is
+    /// reached.  Returns `None` if the pool is empty.
+    ///
+    /// The cursor survives across calls.  If elements are removed between
+    /// calls the cursor is clamped back into range automatically, so the
+    /// sequence remains valid even as the pool changes size.
+    pub fn next_id(&mut self) -> Option<u64> {
+        let n = self.active_indexes.len();
+        if n == 0 {
+            return None;
+        }
+        // Clamp in case removals shrank active_indexes since the last call.
+        if self.cursor >= n {
+            self.cursor = 0;
+        }
+        let id = self.active_indexes[self.cursor] as u64;
+        self.cursor = (self.cursor + 1) % n;
+        Some(id)
     }
 
     /// Number of elements currently in the pool.
@@ -311,5 +338,54 @@ mod tests {
         let mut pairs: Vec<(u64, u32)> = pool.iter_with_ids().map(|(id, &v)| (id, v)).collect();
         pairs.sort_by_key(|&(id, _)| id);
         assert_eq!(pairs, vec![(id0, 10), (id2, 30)]);
+    }
+
+    #[test]
+    fn test_next_id_round_robin() {
+        let mut pool = Pool::with_capacity(4);
+        let id0 = pool.insert(10u32);
+        let id1 = pool.insert(20u32);
+        let id2 = pool.insert(30u32);
+
+        // Collect the sequence emitted by the first full cycle.
+        let first: Vec<u64> = (0..3).map(|_| pool.next_id().unwrap()).collect();
+        assert_eq!(first.len(), 3);
+        // Every live ID must appear exactly once per cycle.
+        let mut sorted = first.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![id0, id1, id2]);
+
+        // The second cycle must repeat in the same order.
+        let second: Vec<u64> = (0..3).map(|_| pool.next_id().unwrap()).collect();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_next_id_empty() {
+        let mut pool: Pool<u32> = Pool::with_capacity(4);
+        assert_eq!(pool.next_id(), None);
+    }
+
+    #[test]
+    fn test_next_id_cursor_clamped_after_remove() {
+        let mut pool = Pool::with_capacity(4);
+        let id0 = pool.insert(10u32);
+        let id1 = pool.insert(20u32);
+        let id2 = pool.insert(30u32);
+
+        // Advance cursor to the last position.
+        assert_eq!(pool.next_id(), Some(id0));
+        assert_eq!(pool.next_id(), Some(id1));
+        assert_eq!(pool.next_id(), Some(id2));
+        // Cursor is now at position 0 (wrapped).
+
+        // Remove two elements so the pool has only one left; cursor must clamp.
+        pool.remove(id0);
+        pool.remove(id1);
+        assert_eq!(pool.len(), 1);
+
+        // next_id must still return the surviving element without panicking.
+        assert_eq!(pool.next_id(), Some(id2));
+        assert_eq!(pool.next_id(), Some(id2));
     }
 }

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -1,376 +1,204 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use bit_vec::BitVec;
+use std::collections::HashMap;
 
 use tracing::trace;
 
+/// A collection that assigns each inserted element a stable `u64` ID.
+///
+/// IDs are assigned by a monotonically-increasing counter and are never
+/// reused after removal, so a stale ID will never silently resolve to a
+/// different element.  Iteration is dense — there are no empty slots to
+/// skip.
 #[derive(Debug)]
 pub struct Pool<T> {
-    /// bitmap indicating if the pool contains an element
-    bitmap: BitVec,
+    /// elements keyed by their stable ID
+    map: HashMap<u64, T>,
 
-    /// the pool of elements
-    pool: Vec<Option<T>>,
-
-    /// the number of elements in the pool
-    len: usize,
-
-    /// the capacity of the pool
-    capacity: usize,
-
-    /// index of the bit sit with max pos
-    max_set: usize,
+    /// next ID to hand out on insert
+    next_id: u64,
 }
 
 impl<T> Pool<T> {
-    /// Create a new pool with a given capacity
+    /// Create a new pool, pre-allocating space for `capacity` elements.
     pub fn with_capacity(capacity: usize) -> Self {
-        let mut pool = Vec::with_capacity(capacity);
-        pool.resize_with(capacity, || None);
-
         Pool {
-            bitmap: BitVec::from_elem(capacity, false),
-            pool,
-            len: 0,
-            capacity,
-            max_set: 0,
+            map: HashMap::with_capacity(capacity),
+            next_id: 0,
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
-        Iter {
-            bit_vec_iter: self.bitmap.iter(),
-            pool: self,
-            current_index: 0,
+    /// Insert `element`, returning its stable ID.
+    pub fn insert(&mut self, element: T) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.map.insert(id, element);
+        trace!(pool_len = self.map.len(), "pool insert");
+        id
+    }
+
+    /// Insert `element` at a specific `id`.
+    ///
+    /// If `id` is already occupied the element is replaced (length
+    /// unchanged).  `next_id` is advanced past `id` so future calls to
+    /// [`insert`] never collide with it.
+    ///
+    /// Always returns `true`; the signature mirrors the old API for
+    /// compatibility with call-sites that check the return value.
+    pub fn insert_at(&mut self, element: T, id: u64) -> bool {
+        if id >= self.next_id {
+            self.next_id = id + 1;
         }
-    }
-
-    /// Get the number of elements in the pool
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    /// Get the capacity of the pool
-    pub fn capacity(&self) -> usize {
-        self.capacity
-    }
-
-    /// Get the max set index
-    pub fn max_set(&self) -> usize {
-        self.max_set
-    }
-
-    /// Check if the pool is empty
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    /// Get an element from the pool
-    pub fn get(&self, index: usize) -> Option<&T> {
-        self.pool.get(index).and_then(|slot| slot.as_ref())
-    }
-
-    /// Get a mutable reference to an element in the pool
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
-        self.pool.get_mut(index).and_then(|slot| slot.as_mut())
-    }
-
-    /// Insert an element into the pool
-    pub fn insert(&mut self, element: T) -> usize {
-        // If length is equal to capacity, resize the pool
-        if self.len == self.capacity {
-            // Resize the pool
-            self.pool.resize_with(2 * self.capacity, || None);
-            self.bitmap.grow(self.capacity, false);
-            self.capacity *= 2;
-
-            trace!(
-                pool_capacity = self.pool.capacity(),
-                bitmap_capacity = self.bitmap.capacity(),
-                "pool resized",
-            );
-
-            debug_assert!(self.len < self.capacity);
-            debug_assert!(self.pool.capacity() >= self.capacity);
-            debug_assert!(self.bitmap.capacity() >= self.capacity);
-        }
-
-        // Find the first unset bit and insert the element
-        if let Some(index) = self.bitmap.iter().position(|x| !x) {
-            self.insert_at(element, index)
-                .then_some(true)
-                .expect("insert_at failed");
-
-            index
-        } else {
-            // This should never happen
-            panic!("pool is full");
-        }
-    }
-
-    /// Insert the element in a given position
-    /// if the position does not exist the method fails
-    /// return true on success
-    pub fn insert_at(&mut self, element: T, index: usize) -> bool {
-        if self.capacity < index {
-            // position index cannot be accessed
-            return false;
-        }
-
-        if !self.bitmap.get(index).unwrap_or(false) {
-            // if the bit is not set, increase len
-            self.len += 1;
-        }
-
-        // Mark the bit as set
-        self.bitmap.set(index, true);
-
-        // Store the new element in the pool
-        self.pool[index] = Some(element);
-
-        // If the index is greater than the max_set, update max_set
-        if index > self.max_set {
-            self.max_set = index;
-        }
-
-        // Return success
+        self.map.insert(id, element);
         true
     }
 
-    /// Remove an element from the pool
-    pub fn remove(&mut self, index: usize) -> bool {
-        if self.bitmap.get(index).unwrap_or(false) {
-            self.bitmap.set(index, false);
+    /// Remove the element with the given `id`.  Returns `true` if an
+    /// element was present, `false` if the `id` was not found.
+    pub fn remove(&mut self, id: u64) -> bool {
+        self.map.remove(&id).is_some()
+    }
 
-            // Remove element from the pool
-            self.pool[index] = None;
+    /// Look up an element by its stable ID.
+    pub fn get(&self, id: u64) -> Option<&T> {
+        self.map.get(&id)
+    }
 
-            // Decrease the length of the pool
-            self.len -= 1;
+    /// Mutably look up an element by its stable ID.
+    pub fn get_mut(&mut self, id: u64) -> Option<&mut T> {
+        self.map.get_mut(&id)
+    }
 
-            if index == self.max_set {
-                // find the new max_set, including index - 1 as a candidate.
-                // If pool became empty, reset to 0.
-                let mut new_max = None;
-                for i in (0..index).rev() {
-                    if self.bitmap.get(i).unwrap_or(false) {
-                        new_max = Some(i);
-                        break;
-                    }
-                }
-                self.max_set = new_max.unwrap_or(0);
-            }
+    /// Iterate over all live elements.  No empty slots are visited.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.map.values()
+    }
 
-            true
-        } else {
-            false
-        }
+    /// Iterate over all `(id, element)` pairs.
+    pub fn iter_with_ids(&self) -> impl Iterator<Item = (u64, &T)> {
+        self.map.iter().map(|(&id, v)| (id, v))
+    }
+
+    /// Number of elements currently in the pool.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Current allocated capacity (elements storable without reallocation).
+    pub fn capacity(&self) -> usize {
+        self.map.capacity()
+    }
+
+    /// Returns `true` if the pool contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
     }
 }
 
-/// An iterator for the pool.
-#[derive(Clone)]
-pub struct Iter<'a, T> {
-    bit_vec_iter: bit_vec::Iter<'a>,
-    pool: &'a Pool<T>,
-    current_index: usize,
-}
-
-impl<'a, T> Iterator for Iter<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // only returns the elements that are set
-
-        // iterate until we find a true bit
-        // TODO: this can be optimized a lot by skipping the elements
-        // that are not set and returning the first element that is set
-        for index in self.bit_vec_iter.by_ref() {
-            if !index {
-                // if the bit is not set, continue
-                self.current_index += 1;
-                continue;
-            }
-
-            // if the bit is set, return the element
-            let ret = self.pool.get(self.current_index);
-
-            // debug assert that the element is not None
-            debug_assert!(ret.is_some(), "Element is None");
-
-            // increment the current index
-            self.current_index += 1;
-
-            // return the element
-            return ret;
-        }
-
-        None
-    }
-}
-
-// tests
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
 
     use super::*;
-    use rand::Rng;
 
     #[test]
     fn test_pool() {
         let mut pool = Pool::with_capacity(10);
         assert_eq!(pool.len(), 0);
-        assert_eq!(pool.capacity(), 10);
         assert!(pool.is_empty());
-        assert_eq!(pool.max_set(), 0);
 
-        let element = 42;
-        let index = pool.insert(element);
+        // Insert a few elements; IDs are assigned sequentially.
+        let id0 = pool.insert(42u32);
+        assert_eq!(id0, 0);
         assert_eq!(pool.len(), 1);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 42));
-        assert_eq!(pool.max_set(), 0);
+        assert_eq!(pool.get(id0), Some(&42));
+        assert_eq!(pool.get_mut(id0), Some(&mut 42));
 
-        let element = 43;
-        let index = pool.insert(element);
+        let id1 = pool.insert(43u32);
+        assert_eq!(id1, 1);
         assert_eq!(pool.len(), 2);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 43));
-        assert_eq!(pool.max_set(), 1);
+        assert_eq!(pool.get(id1), Some(&43));
 
-        let element = 44;
-        let index = pool.insert(element);
+        let id2 = pool.insert(44u32);
+        assert_eq!(id2, 2);
         assert_eq!(pool.len(), 3);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 44));
-        assert_eq!(pool.max_set(), 2);
 
-        let element = 45;
-        let index = pool.insert(element);
+        // insert_at with an occupied ID replaces the element.
+        assert!(pool.insert_at(99u32, id1));
+        assert_eq!(pool.len(), 3);
+        assert_eq!(pool.get(id1), Some(&99));
+
+        // insert_at with a fresh ID inserts a new element.
+        assert!(pool.insert_at(55u32, 50));
         assert_eq!(pool.len(), 4);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 45));
-        assert_eq!(pool.max_set(), 3);
+        assert_eq!(pool.get(50), Some(&55));
 
-        let element = 46;
-        let index = pool.insert(element);
-        assert_eq!(pool.len(), 5);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 46));
-        assert_eq!(pool.max_set(), 4);
+        // next_id is now at least 51 so inserts don't collide.
+        let id_next = pool.insert(77u32);
+        assert!(id_next >= 51);
+        assert_eq!(pool.get(id_next), Some(&77));
 
-        let element = 47;
-        let index = pool.insert(element);
-        assert_eq!(pool.len(), 6);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 47));
-        assert_eq!(pool.max_set(), 5);
+        // Remove an element; its ID no longer resolves.
+        assert!(pool.remove(id0));
+        assert_eq!(pool.get(id0), None);
+        assert_eq!(pool.len(), 4);
 
-        let element = 48;
-        let index = pool.insert(element);
+        // Removing a non-existent ID returns false.
+        assert!(!pool.remove(id0));
+
+        // After removing id0, get(id1) still resolves correctly.
+        assert_eq!(pool.get(id1), Some(&99));
+    }
+
+    #[test]
+    fn test_pool_ids_not_reused() {
+        let mut pool = Pool::with_capacity(4);
+        let a = pool.insert(1u32);
+        let b = pool.insert(2u32);
+        pool.remove(a);
+        // The next insert must not reuse `a`.
+        let c = pool.insert(3u32);
+        assert_ne!(c, a);
+        assert_eq!(pool.get(a), None);
+        assert_eq!(pool.get(b), Some(&2));
+        assert_eq!(pool.get(c), Some(&3));
+    }
+
+    #[test]
+    fn test_pool_iter() {
+        let mut pool = Pool::with_capacity(10);
+        let elements = [1u32, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let ids: Vec<u64> = elements.iter().map(|&e| pool.insert(e)).collect();
+
+        // All elements are reachable by ID.
+        for (&id, &elem) in ids.iter().zip(elements.iter()) {
+            assert_eq!(pool.get(id), Some(&elem));
+        }
+
+        // Iteration visits every live element exactly once (no gaps).
+        let mut collected: Vec<u32> = pool.iter().copied().collect();
+        collected.sort();
+        let mut expected = elements.to_vec();
+        expected.sort();
+        assert_eq!(collected, expected);
+
+        // Remove a few elements; iter still returns only live ones.
+        pool.remove(ids[2]); // was 3
+        pool.remove(ids[4]); // was 5
+        pool.remove(ids[6]); // was 7
+
+        let mut collected: Vec<u32> = pool.iter().copied().collect();
+        collected.sort();
+        let mut expected: Vec<u32> = elements
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != 2 && *i != 4 && *i != 6)
+            .map(|(_, &v)| v)
+            .collect();
+        expected.sort();
+        assert_eq!(collected, expected);
         assert_eq!(pool.len(), 7);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 48));
-        assert_eq!(pool.max_set(), 6);
-
-        let element = 49;
-        let index = pool.insert(element);
-        assert_eq!(pool.len(), 8);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 49));
-        assert_eq!(pool.max_set(), 7);
-
-        let element = 1;
-        let res = pool.insert_at(element, index);
-        assert!(res);
-        assert_eq!(pool.len(), 8);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 1));
-        assert_eq!(pool.max_set(), 7);
-
-        let element = 56898;
-        let res = pool.insert_at(element, index);
-        assert!(res);
-        assert_eq!(pool.len(), 8);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 56898));
-        assert_eq!(pool.max_set(), 7);
-
-        let element = 49;
-        let res = pool.insert_at(element, index);
-        assert!(res);
-        assert_eq!(pool.len(), 8);
-        assert_eq!(pool.get(index), Some(&element));
-        assert_eq!(pool.get_mut(index), Some(&mut 49));
-        assert_eq!(pool.max_set(), 7);
-
-        let element = 50;
-        let res = pool.insert_at(element, index + 1);
-        assert!(res);
-        assert_eq!(pool.len(), 9);
-        assert_eq!(pool.get(index + 1), Some(&element));
-        assert_eq!(pool.get_mut(index + 1), Some(&mut 50));
-        assert_eq!(pool.max_set(), 8);
-
-        let res = pool.insert_at(element, 100000000);
-        assert!(!res);
-
-        let current_len = pool.len();
-        let mut curr_max_set = pool.max_set();
-
-        // insert a very large number of elements in a loop to trigger resize
-        for mut i in 0..1000 {
-            let index = pool.insert(i);
-            assert_eq!(pool.get(index), Some(&i));
-            assert_eq!(pool.get_mut(index), Some(&mut i));
-            assert_eq!(pool.max_set(), curr_max_set + 1);
-            curr_max_set = pool.max_set();
-        }
-
-        assert_eq!(pool.len(), current_len + 1000);
-
-        let current_len = pool.len();
-        let mut curr_max_set = pool.max_set();
-
-        // Let's remove some random elements between 0 and 1000
-        let mut removed_indexes = Vec::new();
-
-        for i in 0..1000 {
-            let pivot = rand::rng().random_range(0..1000) as usize;
-            if i < pivot {
-                let ret = pool.remove(i);
-                assert!(ret);
-
-                if i == curr_max_set {
-                    assert_ne!(curr_max_set, pool.max_set());
-                } else {
-                    assert_eq!(curr_max_set, pool.max_set());
-                }
-                curr_max_set = pool.max_set();
-
-                removed_indexes.push(i);
-            }
-        }
-
-        assert_eq!(pool.len(), current_len - removed_indexes.len());
-
-        let mut curr_max_set = pool.max_set();
-
-        // Insert new elements in the pool and check whether they are inserted in the same indexes
-        for (mut i, idx) in removed_indexes.iter().enumerate() {
-            let index = pool.insert(i);
-            assert_eq!(index, *idx);
-            assert_eq!(pool.get(index), Some(&i));
-            assert_eq!(pool.get_mut(index), Some(&mut i));
-            if i > curr_max_set {
-                assert_eq!(i, pool.max_set());
-                curr_max_set = pool.max_set();
-            } else {
-                assert_eq!(curr_max_set, pool.max_set());
-            }
-        }
     }
 
     struct TestDropStruct<F: FnMut()> {
@@ -385,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_pool_drop() {
-        // check if the drop is called for all elements in the pool at the end
+        // All elements are dropped when the pool is dropped.
         let drop_count: RefCell<u32> = 0.into();
         let mut pool = Pool::with_capacity(10);
         (0..10).for_each(|_| {
@@ -395,51 +223,49 @@ mod tests {
                 },
             });
         });
-
         assert_eq!(*drop_count.borrow(), 0);
         drop(pool);
         assert_eq!(*drop_count.borrow(), 10);
 
-        // check if the drop is called when an element in the pool is removed
+        // The element is dropped immediately on remove.
         let drop_count: RefCell<u32> = 0.into();
         let mut pool = Pool::with_capacity(10);
-        let pos = pool.insert(TestDropStruct {
+        let id = pool.insert(TestDropStruct {
             drop_callback: || {
                 *drop_count.borrow_mut() += 1;
             },
         });
-
         assert_eq!(*drop_count.borrow(), 0);
-        pool.remove(pos);
+        pool.remove(id);
         assert_eq!(*drop_count.borrow(), 1);
     }
 
     #[test]
-    fn test_pool_iter() {
-        let mut pool = Pool::with_capacity(10);
-        let elements = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        for element in &elements {
-            pool.insert(*element);
+    fn test_pool_grow() {
+        // Start small and let the pool grow well past initial capacity.
+        let mut pool = Pool::with_capacity(4);
+        let ids: Vec<u64> = (0..1000u32).map(|i| pool.insert(i)).collect();
+        assert_eq!(pool.len(), 1000);
+        for (i, &id) in ids.iter().enumerate() {
+            assert_eq!(pool.get(id), Some(&(i as u32)));
         }
+    }
 
-        let mut iter = pool.iter();
-        for element in elements.iter() {
-            assert_eq!(iter.next(), Some(element));
-        }
-        assert_eq!(iter.next(), None);
+    #[test]
+    fn test_iter_with_ids() {
+        let mut pool = Pool::with_capacity(4);
+        let id0 = pool.insert(10u32);
+        let id1 = pool.insert(20u32);
+        let id2 = pool.insert(30u32);
 
-        // drop the iterator to be able to reuse the pool
-        drop(iter);
+        let mut pairs: Vec<(u64, u32)> = pool.iter_with_ids().map(|(id, &v)| (id, v)).collect();
+        pairs.sort_by_key(|&(id, _)| id);
+        assert_eq!(pairs, vec![(id0, 10), (id1, 20), (id2, 30)]);
 
-        // Check that the iterator skips unset bits
-        pool.remove(2);
-        pool.remove(4);
-        pool.remove(6);
-        let mut iter = pool.iter();
-        for element in elements.iter().filter(|&&x| x != 3 && x != 5 && x != 7) {
-            assert_eq!(iter.next(), Some(element));
-        }
-        assert_eq!(iter.next(), None);
+        pool.remove(id1);
+        let mut pairs: Vec<(u64, u32)> = pool.iter_with_ids().map(|(id, &v)| (id, v)).collect();
+        pairs.sort_by_key(|&(id, _)| id);
+        assert_eq!(pairs, vec![(id0, 10), (id2, 30)]);
     }
 
     #[test]

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -1,98 +1,153 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
 use tracing::trace;
 
 /// A collection that assigns each inserted element a stable `u64` ID.
 ///
-/// IDs are assigned by a monotonically-increasing counter and are never
-/// reused after removal, so a stale ID will never silently resolve to a
-/// different element.  Iteration is dense — there are no empty slots to
-/// skip.
+/// IDs map directly to Vec indices, giving O(1) `get()` with no hash
+/// computation.  Iteration is dense — only live elements are visited.
+/// Freed slots are recycled via a free-list stack so `insert` is O(1)
+/// amortised.
+///
+/// **Note:** IDs *are* reused after `remove` + `insert`.  Callers must
+/// not retain an ID after calling `remove`.
 #[derive(Debug)]
 pub struct Pool<T> {
-    /// elements keyed by their stable ID
-    map: HashMap<u64, T>,
+    /// Sparse storage; `pool[i]` holds `Some(element)` when slot `i` is live.
+    /// The u64 ID handed to callers equals the Vec index as a `u64`.
+    pool: Vec<Option<T>>,
 
-    /// next ID to hand out on insert
-    next_id: u64,
+    /// Dense list of currently-live indices into `pool`.  Used for O(len)
+    /// dense iteration without scanning `None` slots.
+    active_indexes: Vec<usize>,
+
+    /// Stack of recycled indices available for reuse by the next `insert`.
+    free_slots: Vec<usize>,
 }
 
 impl<T> Pool<T> {
     /// Create a new pool, pre-allocating space for `capacity` elements.
     pub fn with_capacity(capacity: usize) -> Self {
         Pool {
-            map: HashMap::with_capacity(capacity),
-            next_id: 0,
+            pool: Vec::with_capacity(capacity),
+            active_indexes: Vec::with_capacity(capacity),
+            free_slots: Vec::new(),
         }
     }
 
     /// Insert `element`, returning its stable ID.
+    ///
+    /// Reuses a freed slot when one is available; otherwise appends a new slot.
     pub fn insert(&mut self, element: T) -> u64 {
-        let id = self.next_id;
-        self.next_id += 1;
-        self.map.insert(id, element);
-        trace!(pool_len = self.map.len(), "pool insert");
-        id
+        // Pop from free_slots, skipping any stale entries (slot re-occupied
+        // by insert_at before this insert ran).
+        let idx = loop {
+            match self.free_slots.pop() {
+                Some(i) if self.pool[i].is_none() => break i,
+                Some(_) => continue, // stale entry; skip
+                None => {
+                    // No free slot — extend the pool.
+                    let i = self.pool.len();
+                    self.pool.push(None);
+                    break i;
+                }
+            }
+        };
+
+        self.pool[idx] = Some(element);
+        self.active_indexes.push(idx);
+        trace!(pool_len = self.active_indexes.len(), "pool insert");
+        idx as u64
     }
 
     /// Insert `element` at a specific `id`.
     ///
-    /// If `id` is already occupied the element is replaced (length
-    /// unchanged).  `next_id` is advanced past `id` so future calls to
-    /// [`insert`] never collide with it.
+    /// Grows `pool` if `id` is beyond the current length.  If the slot was
+    /// empty the index is added to `active_indexes`; if it was already
+    /// occupied the element is replaced (length unchanged).
     ///
-    /// Always returns `true`; the signature mirrors the old API for
+    /// Returns `true` always; the bool return mirrors the old API for
     /// compatibility with call-sites that check the return value.
     pub fn insert_at(&mut self, element: T, id: u64) -> bool {
-        if id >= self.next_id {
-            self.next_id = id + 1;
+        let idx = id as usize;
+
+        // Grow the pool with None slots until it covers `idx`.
+        if idx >= self.pool.len() {
+            self.pool.resize_with(idx + 1, || None);
         }
-        self.map.insert(id, element);
+
+        let was_empty = self.pool[idx].is_none();
+        self.pool[idx] = Some(element);
+
+        if was_empty {
+            self.active_indexes.push(idx);
+        }
         true
     }
 
-    /// Remove the element with the given `id`.  Returns `true` if an
-    /// element was present, `false` if the `id` was not found.
+    /// Remove the element with the given `id`.  Returns `true` if an element
+    /// was present, `false` if the slot was already empty.
     pub fn remove(&mut self, id: u64) -> bool {
-        self.map.remove(&id).is_some()
+        let idx = id as usize;
+
+        if self.pool.get(idx).and_then(|x| x.as_ref()).is_none() {
+            return false;
+        }
+
+        self.pool[idx] = None;
+
+        // Remove from active_indexes (swap_remove is O(1) after the scan).
+        if let Some(pos) = self.active_indexes.iter().position(|&i| i == idx) {
+            self.active_indexes.swap_remove(pos);
+        }
+
+        self.free_slots.push(idx);
+        true
     }
 
     /// Look up an element by its stable ID.
     pub fn get(&self, id: u64) -> Option<&T> {
-        self.map.get(&id)
+        self.pool.get(id as usize).and_then(|x| x.as_ref())
     }
 
     /// Mutably look up an element by its stable ID.
     pub fn get_mut(&mut self, id: u64) -> Option<&mut T> {
-        self.map.get_mut(&id)
+        self.pool.get_mut(id as usize).and_then(|x| x.as_mut())
     }
 
     /// Iterate over all live elements.  No empty slots are visited.
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.map.values()
+        self.active_indexes
+            .iter()
+            .map(|&i| self.pool[i].as_ref().expect("active_indexes must point to live slots"))
     }
 
     /// Iterate over all `(id, element)` pairs.
     pub fn iter_with_ids(&self) -> impl Iterator<Item = (u64, &T)> {
-        self.map.iter().map(|(&id, v)| (id, v))
+        self.active_indexes.iter().map(|&i| {
+            (
+                i as u64,
+                self.pool[i]
+                    .as_ref()
+                    .expect("active_indexes must point to live slots"),
+            )
+        })
     }
 
     /// Number of elements currently in the pool.
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.active_indexes.len()
     }
 
     /// Current allocated capacity (elements storable without reallocation).
     pub fn capacity(&self) -> usize {
-        self.map.capacity()
+        self.pool.capacity()
     }
 
     /// Returns `true` if the pool contains no elements.
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.active_indexes.is_empty()
     }
 }
 
@@ -134,9 +189,8 @@ mod tests {
         assert_eq!(pool.len(), 4);
         assert_eq!(pool.get(50), Some(&55));
 
-        // next_id is now at least 51 so inserts don't collide.
+        // insert returns a valid ID that resolves correctly.
         let id_next = pool.insert(77u32);
-        assert!(id_next >= 51);
         assert_eq!(pool.get(id_next), Some(&77));
 
         // Remove an element; its ID no longer resolves.
@@ -149,20 +203,6 @@ mod tests {
 
         // After removing id0, get(id1) still resolves correctly.
         assert_eq!(pool.get(id1), Some(&99));
-    }
-
-    #[test]
-    fn test_pool_ids_not_reused() {
-        let mut pool = Pool::with_capacity(4);
-        let a = pool.insert(1u32);
-        let b = pool.insert(2u32);
-        pool.remove(a);
-        // The next insert must not reuse `a`.
-        let c = pool.insert(3u32);
-        assert_ne!(c, a);
-        assert_eq!(pool.get(a), None);
-        assert_eq!(pool.get(b), Some(&2));
-        assert_eq!(pool.get(c), Some(&3));
     }
 
     #[test]

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -27,8 +27,8 @@ pub struct Pool<T> {
     /// Stack of recycled indices available for reuse by the next `insert`.
     free_slots: Vec<usize>,
 
-    /// Cursor for the persistent round-robin iterator (`next_id`).
-    /// Stored as an `AtomicUsize` so that `next_id` can advance it through
+    /// Cursor for the persistent round-robin iterators (`next_id`, `next_val`).
+    /// Stored as an `AtomicUsize` so that they can advance it through
     /// a shared `&self` reference — callers that hold only a read lock on
     /// an outer container are not forced to upgrade to a write lock.
     cursor: AtomicUsize,
@@ -165,6 +165,23 @@ impl<T> Pool<T> {
         }
         let pos = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
         Some(self.active_indexes[pos] as u64)
+    }
+
+    /// Round-robin iterator that returns a direct reference to the next live
+    /// element, advancing the shared cursor on each call.  Shares the same
+    /// cursor as `next_id`.  Returns `None` if the pool is empty.
+    pub fn next_val(&self) -> Option<&T> {
+        let n = self.active_indexes.len();
+        if n == 0 {
+            return None;
+        }
+        let pos = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
+        let idx = self.active_indexes[pos];
+        Some(
+            self.pool[idx]
+                .as_ref()
+                .expect("active_indexes must point to live slots"),
+        )
     }
 
     /// Number of elements currently in the pool.
@@ -363,8 +380,29 @@ mod tests {
 
     #[test]
     fn test_next_id_empty() {
-        let mut pool: Pool<u32> = Pool::with_capacity(4);
+        let pool: Pool<u32> = Pool::with_capacity(4);
         assert_eq!(pool.next_id(), None);
+    }
+
+    #[test]
+    fn test_next_val_round_robin() {
+        let mut pool = Pool::with_capacity(4);
+        pool.insert(10u32);
+        pool.insert(20u32);
+        pool.insert(30u32);
+        let pool = pool; // rebind as immutable — next_val only needs &self
+
+        // Collect the sequence emitted by the first full cycle.
+        let first: Vec<u32> = (0..3).map(|_| *pool.next_val().unwrap()).collect();
+        assert_eq!(first.len(), 3);
+        // Every live value must appear exactly once per cycle.
+        let mut sorted = first.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![10, 20, 30]);
+
+        // The second cycle must repeat in the same order.
+        let second: Vec<u32> = (0..3).map(|_| *pool.next_val().unwrap()).collect();
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -121,9 +121,8 @@ impl SubscriptionRefs {
 
 #[derive(Debug)]
 struct Connections {
-    // map from connection id to the position in the connections pool
-    // this is used in the insertion/remove
-    index: HashMap<u64, usize>,
+    // map from connection id to the pool ID returned on insert
+    index: HashMap<u64, u64>,
     // pool of all connections ids that can to be used in the match
     pool: Pool<ConnId>,
 }
@@ -190,21 +189,19 @@ impl Connections {
             }
         }
 
-        // we need to iterate and find a value starting from a random point in the pool
+        // Pick a random starting point in the (dense) pool and walk forward,
+        // looking for a connection that isn't except_conn.
+        let conn_ids: Vec<u64> = self.pool.iter().map(|c| c.conn_id).collect();
+        if conn_ids.is_empty() {
+            debug!("no output connection available");
+            return None;
+        }
         let mut rng = rand::rng();
-        let index = rng.random_range(0..self.pool.max_set() + 1);
-        let mut stop = false;
-        let mut i = index;
-        while !stop {
-            let opt = self.pool.get(i);
-            if let Some(opt) = opt
-                && opt.conn_id != except_conn
-            {
-                return Some(opt.conn_id);
-            }
-            i = (i + 1) % (self.pool.max_set() + 1);
-            if i == index {
-                stop = true;
+        let start = rng.random_range(0..conn_ids.len());
+        for i in 0..conn_ids.len() {
+            let conn_id = conn_ids[(start + i) % conn_ids.len()];
+            if conn_id != except_conn {
+                return Some(conn_id);
             }
         }
         debug!("no output connection available");

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -189,22 +189,22 @@ impl Connections {
             }
         }
 
-        // Pick a random starting point in the (dense) pool and walk forward,
-        // looking for a connection that isn't except_conn.
+        // Pick a random starting point and walk forward circularly, looking
+        // for a connection that isn't except_conn.
         let n = self.pool.len();
         if n == 0 {
             debug!("no output connection available");
             return None;
         }
         let start = rand::rng().random_range(0..n);
-        for i in 0..n {
-            let conn_id = self
-                .pool
-                .get_by_position((start + i) % n)
-                .expect("position within 0..len is always valid")
-                .conn_id;
-            if conn_id != except_conn {
-                return Some(conn_id);
+        for c in self
+            .pool
+            .iter()
+            .skip(start)
+            .chain(self.pool.iter().take(start))
+        {
+            if c.conn_id != except_conn {
+                return Some(c.conn_id);
             }
         }
         debug!("no output connection available");

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -191,15 +191,18 @@ impl Connections {
 
         // Pick a random starting point in the (dense) pool and walk forward,
         // looking for a connection that isn't except_conn.
-        let conn_ids: Vec<u64> = self.pool.iter().map(|c| c.conn_id).collect();
-        if conn_ids.is_empty() {
+        let n = self.pool.len();
+        if n == 0 {
             debug!("no output connection available");
             return None;
         }
-        let mut rng = rand::rng();
-        let start = rng.random_range(0..conn_ids.len());
-        for i in 0..conn_ids.len() {
-            let conn_id = conn_ids[(start + i) % conn_ids.len()];
+        let start = rand::rng().random_range(0..n);
+        for i in 0..n {
+            let conn_id = self
+                .pool
+                .get_by_position((start + i) % n)
+                .expect("position within 0..len is always valid")
+                .conn_id;
             if conn_id != except_conn {
                 return Some(conn_id);
             }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -189,22 +189,22 @@ impl Connections {
             }
         }
 
-        // Pick a random starting point and walk forward circularly, looking
-        // for a connection that isn't except_conn.
+        // Walk at most n steps from the current cursor position, looking for
+        // a connection that isn't except_conn.
         let n = self.pool.len();
         if n == 0 {
             debug!("no output connection available");
             return None;
         }
-        let start = rand::rng().random_range(0..n);
-        for c in self
-            .pool
-            .iter()
-            .skip(start)
-            .chain(self.pool.iter().take(start))
-        {
-            if c.conn_id != except_conn {
-                return Some(c.conn_id);
+        for _ in 0..n {
+            let id = self.pool.next_id().expect("pool is non-empty");
+            let conn_id = self
+                .pool
+                .get(id)
+                .expect("next_id returns a live ID")
+                .conn_id;
+            if conn_id != except_conn {
+                return Some(conn_id);
             }
         }
         debug!("no output connection available");

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -197,12 +197,7 @@ impl Connections {
             return None;
         }
         for _ in 0..n {
-            let id = self.pool.next_id().expect("pool is non-empty");
-            let conn_id = self
-                .pool
-                .get(id)
-                .expect("next_id returns a live ID")
-                .conn_id;
+            let conn_id = self.pool.next_val().expect("pool is non-empty").conn_id;
             if conn_id != except_conn {
                 return Some(conn_id);
             }

--- a/data-plane/core/datapath/tests/data_path_test.rs
+++ b/data-plane/core/datapath/tests/data_path_test.rs
@@ -192,7 +192,7 @@ mod tests {
         assert!(
             msg_processor
                 .connection_table()
-                .get(conn_index as usize)
+                .get(conn_index)
                 .is_some()
         );
 
@@ -208,7 +208,7 @@ mod tests {
         assert!(
             msg_processor
                 .connection_table()
-                .get(conn_index as usize)
+                .get(conn_index)
                 .is_none(),
             "connection should be removed after disconnect"
         );

--- a/data-plane/core/datapath/tests/data_path_test.rs
+++ b/data-plane/core/datapath/tests/data_path_test.rs
@@ -189,12 +189,7 @@ mod tests {
             .expect("error creating channel");
 
         // ensure connection exists before disconnect
-        assert!(
-            msg_processor
-                .connection_table()
-                .get(conn_index)
-                .is_some()
-        );
+        assert!(msg_processor.connection_table().get(conn_index).is_some());
 
         // disconnect (should cancel stream and eventually remove connection)
         let _returned_cfg = msg_processor
@@ -206,10 +201,7 @@ mod tests {
 
         // after disconnect the connection should be removed
         assert!(
-            msg_processor
-                .connection_table()
-                .get(conn_index)
-                .is_none(),
+            msg_processor.connection_table().get(conn_index).is_none(),
             "connection should be removed after disconnect"
         );
     }

--- a/data-plane/core/service/src/service.rs
+++ b/data-plane/core/service/src/service.rs
@@ -478,7 +478,7 @@ impl Service {
                 // Get connection details from the connection table
                 self.message_processor
                     .connection_table()
-                    .get(conn_id as usize)
+                    .get(conn_id)
                     .map(|conn| ConnectionInfo {
                         id: conn_id,
                         remote_addr: conn.remote_addr().copied(),
@@ -752,7 +752,7 @@ mod tests {
             service
                 .message_processor
                 .connection_table()
-                .get(conn_id as usize)
+                .get(conn_id)
                 .is_none(),
             "connection should be removed after disconnect"
         );


### PR DESCRIPTION
# Description

\`Pool<T>\` previously stored items in a \`Vec<Option<T>>\` with a \`BitVec\`
tracking occupied slots.  This created an inconsistency: \`iter()\` skipped
empty slots (logical indexing) while \`get(n)\` indexed raw storage positions
(physical indexing).  A stale ID could also silently resolve to a *different*
element after a remove+insert cycle because physical slots were reused.

This replaces the implementation with a purpose-built three-Vec design:

\`\`\`
pool:           Vec<Option<PoolEntry<T>>>  // sparse storage; Vec index == ID
active_indexes: Vec<usize>                // dense list of live indices
free_slots:     Vec<usize>                // recycled slot stack (free-list)
\`\`\`

- **O(1) \`get()\`** — direct Vec index, no hash computation.
- **Dense \`iter()\`** — \`active_indexes\` walk, no empty slots visited; \`iter()\` and \`get(id)\` are now semantically consistent.
- **O(1) amortised \`insert()\`** — free-list stack avoids the O(n²) bitmap scan.
- **O(1) \`remove()\`** — each entry carries an \`active_pos\` back-pointer into \`active_indexes\`, so removal jumps directly to the right position instead of scanning; \`swap_remove\` then fixes up the moved entry in a single indexed write.
- \`insert_at(element, id)\` still supported for state-sync scenarios.
- Adds \`iter_with_ids()\` for callers that need \`(id, &T)\` pairs.
- Removes the \`bit-vec\` crate dependency from the workspace entirely.
- All callers updated to use \`u64\` IDs directly, removing the \`as usize\` / \`as u64\` casts that papered over the semantic mismatch.

**Note:** IDs are reused after \`remove\` + \`insert\`.  Callers hold IDs only
for the lifetime of the element and call \`remove\` before any reuse, so this
is safe.

## Benchmarks

Criterion benchmarks vs \`main\` baseline (1024-element pool, Apple M-series):

| Benchmark | \`main\` | this PR | Change |
|---|---|---|---|
| pool lookup (1024 × \`get\` by ID) | 431 ns | 453 ns | within noise |
| pool insert (1024 inserts, pre-allocated) | 240 µs | 2.25 µs | **~107× faster** |
| pool grow (1024 inserts, start cap 16) | 240 µs | 3.36 µs | **~71× faster** |
| pool remove (1024 removes) | 243 µs | 4.91 µs | **~50× faster** |
| pool remove+insert cycle (1024 pairs) | 479 µs | 6.68 µs | **~72× faster** |
| pool next\_id (round-robin, 8-element pool) | — | 2.20 ns | new |
| pool next\_val (round-robin, 8-element pool) | — | 2.13 ns | new |

All significant results have p = 0.00.  The \`remove\` improvement breaks down across two commits: the three-Vec redesign (linear scan, ~2.9× vs main), then the \`active_pos\` back-pointer (O(1) scan-free, ~18× vs the three-Vec baseline — ~50× total vs main).

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass