### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -39,17 +39,17 @@ resolver = "2"
 [workspace.dependencies]
 # Local dependencies
 agntcy-slim = { path = "core/slim", version = "1.4.0-rc.2" }
-agntcy-slim-auth = { path = "core/auth", version = "0.7.0" }
+agntcy-slim-auth = { path = "core/auth", version = "0.8.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.4.0-rc.2" }
-agntcy-slim-config = { path = "core/config", version = "0.9.0" }
-agntcy-slim-controller = { path = "core/controller", version = "0.5.0" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.12.3" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.15" }
-agntcy-slim-service = { path = "core/service", version = "0.8.12", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.12" }
+agntcy-slim-config = { path = "core/config", version = "0.9.1" }
+agntcy-slim-controller = { path = "core/controller", version = "0.6.0" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.13.0" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.16" }
+agntcy-slim-service = { path = "core/service", version = "0.8.13", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.13" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.9" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.10" }
 agntcy-slim-version = { path = "core/version", version = "1.4.0-rc.2" }
 agntcy-slimctl = { path = "slimctl", version = "1.4.0-rc.2" }
 

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/agntcy/slim/compare/slim-auth-v0.7.0...slim-auth-v0.8.0) - 2026-05-11
+
+### Other
+
+- *(deps)* upgrade to spire 0.12 ([#1557](https://github.com/agntcy/slim/pull/1557))
+
 ## [0.7.0](https://github.com/agntcy/slim/compare/slim-auth-v0.6.2...slim-auth-v0.7.0) - 2026-04-21
 
 ### Added

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.7.0"
+version = "0.8.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/agntcy/slim/compare/slim-config-v0.9.0...slim-config-v0.9.1) - 2026-05-11
+
+### Other
+
+- *(deps)* upgrade to spire 0.12 ([#1557](https://github.com/agntcy/slim/pull/1557))
+
 ## [0.9.0](https://github.com/agntcy/slim/compare/slim-config-v0.8.2...slim-config-v0.9.0) - 2026-04-21
 
 ### Added

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.9.0"
+version = "0.9.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/agntcy/slim/compare/slim-controller-v0.5.0...slim-controller-v0.6.0) - 2026-05-11
+
+### Added
+
+- recover subscriptions sent from slim server ([#1566](https://github.com/agntcy/slim/pull/1566))
+
+### Other
+
+- *(datapath)* replace Pool bitmap/vec with three-vec design ([#1496](https://github.com/agntcy/slim/pull/1496))
+
 ## [0.5.0](https://github.com/agntcy/slim/compare/slim-controller-v0.4.12...slim-controller-v0.5.0) - 2026-04-21
 
 ### Added

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.5.0"
+version = "0.6.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.3...slim-datapath-v0.13.0) - 2026-05-11
+
+### Added
+
+- recover subscriptions sent from slim server ([#1566](https://github.com/agntcy/slim/pull/1566))
+
+### Fixed
+
+- *(datapath)* break recursive span nesting on reconnection ([#1585](https://github.com/agntcy/slim/pull/1585))
+- implement correct matching behavior ([#1438](https://github.com/agntcy/slim/pull/1438))
+
+### Other
+
+- *(datapath)* gate message OTEL propagation on OTLP config ([#1503](https://github.com/agntcy/slim/pull/1503))
+- *(datapath)* replace Pool bitmap/vec with three-vec design ([#1496](https://github.com/agntcy/slim/pull/1496))
+- *(datapath)* add pool remove and remove+insert cycle benchmarks ([#1529](https://github.com/agntcy/slim/pull/1529))
+
 ## [0.12.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.2...slim-datapath-v0.12.3) - 2026-04-21
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.12.3"
+version = "0.13.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/agntcy/slim/compare/slim-mls-v0.1.15...slim-mls-v0.1.16) - 2026-05-11
+
+### Other
+
+- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath
+
 ## [0.1.15](https://github.com/agntcy/slim/compare/slim-mls-v0.1.14...slim-mls-v0.1.15) - 2026-04-21
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.15"
+version = "0.1.16"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.13](https://github.com/agntcy/slim/compare/slim-service-v0.8.12...slim-service-v0.8.13) - 2026-05-11
+
+### Added
+
+- recover subscriptions sent from slim server ([#1566](https://github.com/agntcy/slim/pull/1566))
+
+### Fixed
+
+- implement correct matching behavior ([#1438](https://github.com/agntcy/slim/pull/1438))
+
+### Other
+
+- *(datapath)* replace Pool bitmap/vec with three-vec design ([#1496](https://github.com/agntcy/slim/pull/1496))
+
 ## [0.8.12](https://github.com/agntcy/slim/compare/slim-service-v0.8.11...slim-service-v0.8.12) - 2026-04-21
 
 ### Other

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.12"
+version = "0.8.13"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/agntcy/slim/compare/slim-session-v0.1.12...slim-session-v0.1.13) - 2026-05-11
+
+### Added
+
+- Bindings uniffi version updates ([#1590](https://github.com/agntcy/slim/pull/1590))
+
 ## [0.1.12](https://github.com/agntcy/slim/compare/slim-session-v0.1.11...slim-session-v0.1.12) - 2026-04-21
 
 ### Other

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.12"
+version = "0.1.13"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.9...slim-tracing-v0.3.10) - 2026-05-11
+
+### Other
+
+- *(datapath)* gate message OTEL propagation on OTLP config ([#1503](https://github.com/agntcy/slim/pull/1503))
+
 ## [0.3.9](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.8...slim-tracing-v0.3.9) - 2026-04-21
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.9"
+version = "0.3.10"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `agntcy-slim-tracing`: 0.3.9 -> 0.3.10 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.12.3 -> 0.13.0 (⚠ API breaking changes)
* `agntcy-slim-session`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.8.12 -> 0.8.13 (✓ API compatible changes)
* `agntcy-slim`: 1.4.0-rc.0 -> 1.4.0-rc.2
* `agntcy-slim-bindings`: 1.4.0-rc.0 -> 1.4.0-rc.2
* `agntcy-slimctl`: 1.4.0-rc.0 -> 1.4.0-rc.2
* `agntcy-protoc-slimrpc-plugin`: 1.4.0-rc.0 -> 1.4.0-rc.2
* `agntcy-slim-mls`: 0.1.15 -> 0.1.16

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthError:SpiffeJwtSourceError in /tmp/.tmpDt3RQ9/slim/data-plane/core/auth/src/errors.rs:130

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AuthError::SpiffeX509SvidFetch, previously in file /tmp/.tmpze57Ru/agntcy-slim-auth/src/errors.rs:152
  variant AuthError::SpiffeX509BundleFetch, previously in file /tmp/.tmpze57Ru/agntcy-slim-auth/src/errors.rs:157
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Pool::max_set, previously in file /tmp/.tmpze57Ru/agntcy-slim-datapath/src/tables/pool.rs:60

--- failure inherent_method_now_returns_unit: inherent method now returns unit ---

Description:
A publicly-visible method that used to return a value now returns `()`.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_now_returns_unit.ron
Failed in:
  slim_datapath::tables::connection_table::ConnectionTable::insert_at in /tmp/.tmpDt3RQ9/slim/data-plane/core/datapath/src/tables/connection_table.rs:37
  slim_datapath::tables::pool::Pool::insert_at in /tmp/.tmpDt3RQ9/slim/data-plane/core/datapath/src/tables/pool.rs:92

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_datapath::tables::pool::Iter, previously in file /tmp/.tmpze57Ru/agntcy-slim-datapath/src/tables/pool.rs:174
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.recovery_ttl in /tmp/.tmpDt3RQ9/slim/data-plane/core/controller/src/config.rs:43
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.8.0](https://github.com/agntcy/slim/compare/slim-auth-v0.7.0...slim-auth-v0.8.0) - 2026-05-11

### Other

- *(deps)* upgrade to spire 0.12 ([#1557](https://github.com/agntcy/slim/pull/1557))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.9.1](https://github.com/agntcy/slim/compare/slim-config-v0.9.0...slim-config-v0.9.1) - 2026-05-11

### Other

- *(deps)* upgrade to spire 0.12 ([#1557](https://github.com/agntcy/slim/pull/1557))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.10](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.9...slim-tracing-v0.3.10) - 2026-05-11

### Other

- *(datapath)* gate message OTEL propagation on OTLP config ([#1503](https://github.com/agntcy/slim/pull/1503))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.13.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.3...slim-datapath-v0.13.0) - 2026-05-11

### Added

- recover subscriptions sent from slim server ([#1566](https://github.com/agntcy/slim/pull/1566))

### Fixed

- *(datapath)* break recursive span nesting on reconnection ([#1585](https://github.com/agntcy/slim/pull/1585))
- implement correct matching behavior ([#1438](https://github.com/agntcy/slim/pull/1438))

### Other

- *(datapath)* gate message OTEL propagation on OTLP config ([#1503](https://github.com/agntcy/slim/pull/1503))
- *(datapath)* replace Pool bitmap/vec with three-vec design ([#1496](https://github.com/agntcy/slim/pull/1496))
- *(datapath)* add pool remove and remove+insert cycle benchmarks ([#1529](https://github.com/agntcy/slim/pull/1529))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.13](https://github.com/agntcy/slim/compare/slim-session-v0.1.12...slim-session-v0.1.13) - 2026-05-11

### Added

- Bindings uniffi version updates ([#1590](https://github.com/agntcy/slim/pull/1590))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.6.0](https://github.com/agntcy/slim/compare/slim-controller-v0.5.0...slim-controller-v0.6.0) - 2026-05-11

### Added

- recover subscriptions sent from slim server ([#1566](https://github.com/agntcy/slim/pull/1566))

### Other

- *(datapath)* replace Pool bitmap/vec with three-vec design ([#1496](https://github.com/agntcy/slim/pull/1496))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.13](https://github.com/agntcy/slim/compare/slim-service-v0.8.12...slim-service-v0.8.13) - 2026-05-11

### Added

- recover subscriptions sent from slim server ([#1566](https://github.com/agntcy/slim/pull/1566))

### Fixed

- implement correct matching behavior ([#1438](https://github.com/agntcy/slim/pull/1438))

### Other

- *(datapath)* replace Pool bitmap/vec with three-vec design ([#1496](https://github.com/agntcy/slim/pull/1496))
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.4.0-rc.2](https://github.com/agntcy/slim/compare/slim-v1.3.0...slim-v1.4.0-rc.2) - 2026-04-21

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.4.0-rc.2](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0...slim-bindings-v1.4.0-rc.2) - 2026-04-21

### Added

- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))

### Fixed

- adding linters to Golang, Java and Kotlin bindings and generaliz… ([#1502](https://github.com/agntcy/slim/pull/1502))

### Other

- prepare 1.4.0-rc.2 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [1.4.0-rc.2](https://github.com/agntcy/slim/compare/slimctl-v1.3.0...slimctl-v1.4.0-rc.2) - 2026-04-21

### Added

- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))

### Fixed

- *(slimctl)* correct test name spelling (writable) ([#1464](https://github.com/agntcy/slim/pull/1464))

### Other

- prepare 1.4.0-rc.2 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.4.0-rc.2](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.3.0...protoc-slimrpc-plugin-v1.4.0-rc.2) - 2026-04-21

### Fixed

- *(bindings/go)* use ChannelInterface and ServerInterface in generated stubs ([#1426](https://github.com/agntcy/slim/pull/1426))

### Other

- prepare 1.4.0-rc.2 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.16](https://github.com/agntcy/slim/compare/slim-mls-v0.1.15...slim-mls-v0.1.16) - 2026-05-11

### Other

- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).