### PR TITLE
fix: replace `cp -af` with `cp -Rf` in zig install task

### DIFF
--- a/tasks/tools.yaml
+++ b/tasks/tools.yaml
@@ -290,7 +290,7 @@ tasks:
         fi
 
         # Install
-        cp -af zig-{{.DETECTED_ARCH}}-{{.DETECTED_OS}}-{{.ZIG_VERSION}}/* "{{.TOOLS_INSTALL_DIR}}"
+        cp -Rf zig-{{.DETECTED_ARCH}}-{{.DETECTED_OS}}-{{.ZIG_VERSION}}/* "{{.TOOLS_INSTALL_DIR}}"
         rm -rf zig-{{.DETECTED_ARCH}}-{{.DETECTED_OS}}-{{.ZIG_VERSION}}
         rm -f "$FILENAME" "$SIGFILE" mirrors.txt
         echo "Zig installed to {{.TOOLS_INSTALL_DIR}}"


### PR DESCRIPTION
# Description

go-task's built-in coreutils on Windows does not support the `-a` flag

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
