### PR TITLE
perf(datapath): refactor SubscriptionTableImpl for cache efficiency

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
+ "arc-swap",
  "criterion",
  "display-error-chain",
  "drain",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -59,6 +59,8 @@ agntcy-slimctl = { path = "slimctl", version = "1.4.0" }
 
 anyhow = "1.0.98"
 
+arc-swap = "1"
+
 async-stream = "0.3"
 async-trait = "0.1.88"
 aws-lc-rs = { version = "1.16", features = ["bindgen"] }

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -55,3 +55,7 @@ harness = false
 [[bench]]
 name = "name_benchmark"
 harness = false
+
+[[bench]]
+name = "subscription_table_benchmark"
+harness = false

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -16,6 +16,7 @@ otel_tracing = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
 agntcy-slim-config = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
 agntcy-slim-version = { workspace = true }
+arc-swap = { workspace = true }
 display-error-chain = { workspace = true }
 drain = { workspace = true }
 fastwebsockets = { workspace = true }

--- a/data-plane/core/datapath/benches/subscription_table_benchmark.rs
+++ b/data-plane/core/datapath/benches/subscription_table_benchmark.rs
@@ -1,0 +1,148 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use slim_datapath::api::{EncodedName, ProtoName};
+use slim_datapath::tables::SubscriptionTable;
+use slim_datapath::tables::subscription_table::SubscriptionTableImpl;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn encoded(name: &ProtoName) -> EncodedName {
+    name.name.unwrap()
+}
+
+/// Build a table with `n` distinct specific IDs under one prefix.
+/// The target returned is the last-inserted ID — worst-case scan position.
+fn build_specific_ids(n: usize) -> (SubscriptionTableImpl, EncodedName) {
+    let base = ProtoName::from_strings(["org", "ns", "svc"]);
+    let table = SubscriptionTableImpl::default();
+    for i in 1..=n {
+        let name = base.clone().with_id(i as u64);
+        table
+            .add_subscription(name, (i + 100) as u64, false, i as u64)
+            .unwrap();
+    }
+    let target = base.with_id(n as u64);
+    (table, encoded(&target))
+}
+
+/// Build a table with `n` entries under one prefix: 1 NULL_COMPONENT entry
+/// (conn 1) plus n−1 specific IDs, each with 1 remote connection.
+/// Returns the encoded NULL_COMPONENT name for fan-out benchmarks.
+fn build_with_null(n: usize) -> (SubscriptionTableImpl, EncodedName) {
+    let base = ProtoName::from_strings(["org", "ns", "svc"]);
+    let table = SubscriptionTableImpl::default();
+    table.add_subscription(base.clone(), 1, false, 1).unwrap();
+    for i in 1..n {
+        let name = base.clone().with_id(i as u64);
+        table
+            .add_subscription(name, (i + 100) as u64, false, (i + 100) as u64)
+            .unwrap();
+    }
+    (table, encoded(&base))
+}
+
+/// Build a table with a single specific ID (42) having `n_conns` connections.
+/// The first half are local, the rest remote.
+fn build_one_id_n_conns(n_conns: usize) -> (SubscriptionTableImpl, EncodedName) {
+    let name = ProtoName::from_strings(["org", "ns", "svc"]).with_id(42);
+    let table = SubscriptionTableImpl::default();
+    let half = n_conns.div_ceil(2);
+    for i in 0..n_conns {
+        let is_local = i < half;
+        table
+            .add_subscription(name.clone(), (i + 10) as u64, is_local, i as u64)
+            .unwrap();
+    }
+    (table, encoded(&name))
+}
+
+// ── match_one benchmarks ──────────────────────────────────────────────────────
+
+/// Linear scan over `by_id` to find a specific component_3.
+/// `n` = number of distinct IDs in the prefix; target is last (worst case).
+fn bench_match_one_specific_id(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_one/specific_id");
+    for &n in &[1usize, 4, 8, 16] {
+        let (table, enc) = build_specific_ids(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
+            b.iter(|| black_box(table.match_one(black_box(e), u64::MAX)))
+        });
+    }
+    group.finish();
+}
+
+/// NULL_COMPONENT fan-out: aggregate unique locals/remotes across `n` IdEntries.
+/// `n` = total IdEntries (1 NULL_COMPONENT + n−1 specific IDs).
+fn bench_match_one_null_component(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_one/null_component");
+    for &n in &[1usize, 4, 8, 16] {
+        let (table, enc) = build_with_null(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
+            b.iter(|| black_box(table.match_one(black_box(e), u64::MAX)))
+        });
+    }
+    group.finish();
+}
+
+/// match_one with both local and remote connections present — verifies the
+/// local-preference fast path returns without scanning remotes.
+fn bench_match_one_local_preference(c: &mut Criterion) {
+    let name = ProtoName::from_strings(["org", "ns", "svc"]);
+    let table = SubscriptionTableImpl::default();
+    // 4 remote connections
+    for i in 0u64..4 {
+        table
+            .add_subscription(name.clone(), i, false, i)
+            .unwrap();
+    }
+    // 2 local connections (should be preferred)
+    for i in 10u64..12 {
+        table
+            .add_subscription(name.clone(), i, true, i)
+            .unwrap();
+    }
+    let enc = encoded(&name);
+    c.bench_function("match_one/local_preference", |b| {
+        b.iter(|| black_box(table.match_one(black_box(&enc), u64::MAX)))
+    });
+}
+
+// ── match_all benchmarks ──────────────────────────────────────────────────────
+
+/// Collect all connections for a specific ID.
+/// `n` = number of connections (first half local, rest remote).
+fn bench_match_all_specific_id(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_all/specific_id");
+    for &n in &[1usize, 4, 8, 16] {
+        let (table, enc) = build_one_id_n_conns(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
+            b.iter(|| black_box(table.match_all(black_box(e), u64::MAX)))
+        });
+    }
+    group.finish();
+}
+
+/// NULL_COMPONENT union: collect unique connections across `n` IdEntries.
+/// `n` = total IdEntries (1 NULL_COMPONENT + n−1 specific IDs, 1 conn each).
+fn bench_match_all_null_component(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_all/null_component");
+    for &n in &[1usize, 4, 8, 16] {
+        let (table, enc) = build_with_null(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
+            b.iter(|| black_box(table.match_all(black_box(e), u64::MAX)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_match_one_specific_id,
+    bench_match_one_null_component,
+    bench_match_one_local_preference,
+    bench_match_all_specific_id,
+    bench_match_all_null_component,
+);
+criterion_main!(benches);

--- a/data-plane/core/datapath/benches/subscription_table_benchmark.rs
+++ b/data-plane/core/datapath/benches/subscription_table_benchmark.rs
@@ -110,15 +110,11 @@ fn bench_match_one_local_preference(c: &mut Criterion) {
     let table = SubscriptionTableImpl::default();
     // 4 remote connections
     for i in 0u64..4 {
-        table
-            .add_subscription(name.clone(), i, false, i)
-            .unwrap();
+        table.add_subscription(name.clone(), i, false, i).unwrap();
     }
     // 2 local connections (should be preferred)
     for i in 10u64..12 {
-        table
-            .add_subscription(name.clone(), i, true, i)
-            .unwrap();
+        table.add_subscription(name.clone(), i, true, i).unwrap();
     }
     let enc = encoded(&name);
     c.bench_function("match_one/local_preference", |b| {

--- a/data-plane/core/datapath/benches/subscription_table_benchmark.rs
+++ b/data-plane/core/datapath/benches/subscription_table_benchmark.rs
@@ -13,7 +13,7 @@ fn encoded(name: &ProtoName) -> EncodedName {
 }
 
 /// Build a table with `n` distinct specific IDs under one prefix.
-/// The target returned is the last-inserted ID — worst-case scan position.
+/// The target is the last-inserted ID — worst-case scan position.
 fn build_specific_ids(n: usize) -> (SubscriptionTableImpl, EncodedName) {
     let base = ProtoName::from_strings(["org", "ns", "svc"]);
     let table = SubscriptionTableImpl::default();
@@ -58,13 +58,32 @@ fn build_one_id_n_conns(n_conns: usize) -> (SubscriptionTableImpl, EncodedName) 
     (table, encoded(&name))
 }
 
+/// Build a table with `n` distinct prefixes (org/ns/svcN), each with 1
+/// specific ID (id=1) and 1 remote connection.  The returned target is the
+/// last-inserted prefix — every lookup costs exactly one HashMap probe
+/// regardless of table size, so this group isolates HashMap / cache-miss
+/// overhead as the routing table grows.
+fn build_many_prefixes(n: usize) -> (SubscriptionTableImpl, EncodedName) {
+    let table = SubscriptionTableImpl::default();
+    for i in 0..n {
+        let svc = format!("svc{i}");
+        let name = ProtoName::from_strings(["org", "ns", svc.as_str()]).with_id(1);
+        table
+            .add_subscription(name, (i + 100) as u64, false, i as u64)
+            .unwrap();
+    }
+    let last_svc = format!("svc{}", n - 1);
+    let target = ProtoName::from_strings(["org", "ns", last_svc.as_str()]).with_id(1);
+    (table, encoded(&target))
+}
+
 // ── match_one benchmarks ──────────────────────────────────────────────────────
 
-/// Linear scan over `by_id` to find a specific component_3.
-/// `n` = number of distinct IDs in the prefix; target is last (worst case).
+/// Deep / single-prefix topology: `n` distinct IDs under one prefix.
+/// Target is last (worst-case linear scan over by_id).
 fn bench_match_one_specific_id(c: &mut Criterion) {
     let mut group = c.benchmark_group("match_one/specific_id");
-    for &n in &[1usize, 4, 8, 16] {
+    for &n in &[1usize, 4, 8, 16, 64, 256, 1024] {
         let (table, enc) = build_specific_ids(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
             b.iter(|| black_box(table.match_one(black_box(e), u64::MAX)))
@@ -73,11 +92,10 @@ fn bench_match_one_specific_id(c: &mut Criterion) {
     group.finish();
 }
 
-/// NULL_COMPONENT fan-out: aggregate unique locals/remotes across `n` IdEntries.
-/// `n` = total IdEntries (1 NULL_COMPONENT + n−1 specific IDs).
+/// Deep / single-prefix topology: NULL_COMPONENT over `n` IdEntries.
 fn bench_match_one_null_component(c: &mut Criterion) {
     let mut group = c.benchmark_group("match_one/null_component");
-    for &n in &[1usize, 4, 8, 16] {
+    for &n in &[1usize, 4, 8, 16, 64, 256] {
         let (table, enc) = build_with_null(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
             b.iter(|| black_box(table.match_one(black_box(e), u64::MAX)))
@@ -86,8 +104,7 @@ fn bench_match_one_null_component(c: &mut Criterion) {
     group.finish();
 }
 
-/// match_one with both local and remote connections present — verifies the
-/// local-preference fast path returns without scanning remotes.
+/// Local-preference fast path: single IdEntry, locals preferred over remotes.
 fn bench_match_one_local_preference(c: &mut Criterion) {
     let name = ProtoName::from_strings(["org", "ns", "svc"]);
     let table = SubscriptionTableImpl::default();
@@ -109,13 +126,26 @@ fn bench_match_one_local_preference(c: &mut Criterion) {
     });
 }
 
+/// Wide topology: `n` distinct prefixes in the routing table, each with
+/// 1 ID and 1 connection.  One specific prefix is targeted on every call.
+/// Per-prefix work is O(1); the variable is HashMap / cache-miss cost.
+fn bench_match_one_many_prefixes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_one/many_prefixes");
+    for &n in &[64usize, 256, 1024, 4096] {
+        let (table, enc) = build_many_prefixes(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
+            b.iter(|| black_box(table.match_one(black_box(e), u64::MAX)))
+        });
+    }
+    group.finish();
+}
+
 // ── match_all benchmarks ──────────────────────────────────────────────────────
 
-/// Collect all connections for a specific ID.
-/// `n` = number of connections (first half local, rest remote).
+/// Deep / single-prefix topology: one ID with `n` connections (half local).
 fn bench_match_all_specific_id(c: &mut Criterion) {
     let mut group = c.benchmark_group("match_all/specific_id");
-    for &n in &[1usize, 4, 8, 16] {
+    for &n in &[1usize, 4, 8, 16, 64, 256] {
         let (table, enc) = build_one_id_n_conns(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
             b.iter(|| black_box(table.match_all(black_box(e), u64::MAX)))
@@ -124,12 +154,24 @@ fn bench_match_all_specific_id(c: &mut Criterion) {
     group.finish();
 }
 
-/// NULL_COMPONENT union: collect unique connections across `n` IdEntries.
-/// `n` = total IdEntries (1 NULL_COMPONENT + n−1 specific IDs, 1 conn each).
+/// Deep / single-prefix topology: NULL_COMPONENT union across `n` IdEntries.
 fn bench_match_all_null_component(c: &mut Criterion) {
     let mut group = c.benchmark_group("match_all/null_component");
-    for &n in &[1usize, 4, 8, 16] {
+    for &n in &[1usize, 4, 8, 16, 64, 256] {
         let (table, enc) = build_with_null(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
+            b.iter(|| black_box(table.match_all(black_box(e), u64::MAX)))
+        });
+    }
+    group.finish();
+}
+
+/// Wide topology: `n` distinct prefixes, one targeted per call.
+/// Complements match_one/many_prefixes via the match_all code path.
+fn bench_match_all_many_prefixes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_all/many_prefixes");
+    for &n in &[64usize, 256, 1024, 4096] {
+        let (table, enc) = build_many_prefixes(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
             b.iter(|| black_box(table.match_all(black_box(e), u64::MAX)))
         });
@@ -142,7 +184,9 @@ criterion_group!(
     bench_match_one_specific_id,
     bench_match_one_null_component,
     bench_match_one_local_preference,
+    bench_match_one_many_prefixes,
     bench_match_all_specific_id,
     bench_match_all_null_component,
+    bench_match_all_many_prefixes,
 );
 criterion_main!(benches);

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -3,643 +3,211 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
-use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use parking_lot::{RawRwLock, RwLock, lock_api::RwLockWriteGuard};
+use parking_lot::RwLock;
 use rand::Rng;
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use super::SubscriptionTable;
-use super::pool::Pool;
 use crate::api::{EncodedName, ProtoName};
 use crate::errors::DataPathError;
 
-#[derive(Debug, Clone)]
-struct SubscriptionName([u64; 3]);
+// ──────────────────────────────────────────────────────────────────────────────
+// IdEntry – one entry per unique component_3 value registered under a prefix.
+//
+// `local` and `remote` are insertion-ordered Vecs (deduped).  The AtomicUsize
+// cursors advance under the read lock for round-robin selection.
+// ──────────────────────────────────────────────────────────────────────────────
 
-impl Hash for SubscriptionName {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0[0].hash(state);
-        self.0[1].hash(state);
-        self.0[2].hash(state);
-    }
+#[derive(Debug)]
+struct IdEntry {
+    id: u64,
+    local: Vec<u64>,
+    remote: Vec<u64>,
+    local_cursor: AtomicUsize,
+    remote_cursor: AtomicUsize,
 }
 
-impl PartialEq for SubscriptionName {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for SubscriptionName {}
-
-#[derive(Debug, Default, Clone)]
-struct ConnId {
-    conn_id: u64,   // connection id
-    counter: usize, // number of references
-}
-
-impl ConnId {
-    fn new(conn_id: u64) -> Self {
-        ConnId {
-            conn_id,
-            counter: 1,
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct SubscriptionRefs {
-    // map from connection id to set of subscription_ids
-    refs: HashMap<u64, HashSet<u64>>,
-}
-
-impl SubscriptionRefs {
-    fn new(conn: u64, subscription_id: u64) -> Self {
-        let mut set = HashSet::new();
-        set.insert(subscription_id);
-        let refs = HashMap::from([(conn, set)]);
-        SubscriptionRefs { refs }
-    }
-
-    /// Inserts a subscription_id for the given connection.
-    /// Returns true if the subscription_id was actually new (not a duplicate).
-    fn insert(&mut self, conn: u64, subscription_id: u64) -> bool {
-        self.refs.entry(conn).or_default().insert(subscription_id)
-    }
-
-    /// Removes a subscription_id for the given connection.
-    /// Returns `Ok(true)` if the connection has no remaining subscription_ids.
-    /// Returns `Ok(false)` if the connection still has other subscription_ids.
-    /// Returns `Err(SubscriptionIdNotFound)` if the subscription_id was not present.
-    /// Returns `Err(ConnectionIdNotFound)` if the connection was not found.
-    fn remove(&mut self, conn: u64, subscription_id: u64) -> Result<bool, DataPathError> {
-        match self.refs.get_mut(&conn) {
-            None => {
-                debug!(%conn, "connection not found in refs");
-                Err(DataPathError::ConnectionIdNotFound(conn))
-            }
-            Some(set) => {
-                if !set.remove(&subscription_id) {
-                    return Err(DataPathError::SubscriptionIdNotFound(subscription_id));
-                }
-                if set.is_empty() {
-                    self.refs.remove(&conn);
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
+impl IdEntry {
+    fn new(id: u64) -> Self {
+        IdEntry {
+            id,
+            local: Vec::new(),
+            remote: Vec::new(),
+            local_cursor: AtomicUsize::new(0),
+            remote_cursor: AtomicUsize::new(0),
         }
     }
 
-    fn force_remove(&mut self, conn: u64) -> Result<usize, DataPathError> {
-        // Returns the count that was removed
-        self.refs
-            .remove(&conn)
-            .map(|set| set.len())
-            .ok_or(DataPathError::ConnectionIdNotFound(conn))
+    /// Add `conn` to the appropriate list if not already present.
+    fn insert(&mut self, conn: u64, is_local: bool) {
+        let vec = if is_local {
+            &mut self.local
+        } else {
+            &mut self.remote
+        };
+        if !vec.contains(&conn) {
+            vec.push(conn);
+        }
+    }
+
+    /// Remove `conn` from the appropriate list (no-op if absent).
+    fn remove(&mut self, conn: u64, is_local: bool) {
+        let vec = if is_local {
+            &mut self.local
+        } else {
+            &mut self.remote
+        };
+        if let Some(pos) = vec.iter().position(|&c| c == conn) {
+            vec.swap_remove(pos);
+        }
     }
 
     fn is_empty(&self) -> bool {
-        self.refs.is_empty()
+        self.local.is_empty() && self.remote.is_empty()
     }
 
-    fn len(&self) -> usize {
-        self.refs.len()
-    }
-
-    fn keys(&self) -> impl Iterator<Item = &u64> {
-        self.refs.keys()
-    }
-
-    fn iter(&self) -> impl Iterator<Item = (&u64, usize)> + '_ {
-        self.refs.iter().map(|(k, v)| (k, v.len()))
-    }
-}
-
-#[derive(Debug)]
-struct Connections {
-    // map from connection id to the pool ID returned on insert
-    index: HashMap<u64, u64>,
-    // pool of all connections ids that can to be used in the match
-    pool: Pool<ConnId>,
-}
-
-impl Default for Connections {
-    fn default() -> Self {
-        Connections {
-            index: HashMap::new(),
-            pool: Pool::with_capacity(2),
-        }
-    }
-}
-
-impl Connections {
-    fn insert(&mut self, conn: u64) {
-        match self.index.get(&conn) {
-            None => {
-                let conn_id = ConnId::new(conn);
-                let pos = self.pool.insert(conn_id);
-                self.index.insert(conn, pos);
-            }
-            Some(pos) => match self.pool.get_mut(*pos) {
-                None => {
-                    error!(index = %*pos, "error retrieving the connection from the pool");
-                }
-                Some(conn_id) => {
-                    conn_id.counter += 1;
-                }
-            },
-        }
-    }
-
-    fn remove(&mut self, conn: u64) -> Result<(), DataPathError> {
-        let conn_index_opt = self.index.get(&conn);
-        if conn_index_opt.is_none() {
-            debug!(%conn, "cannot find the index for connection");
-            return Err(DataPathError::ConnectionIdNotFound(conn));
-        }
-        let conn_index = conn_index_opt.unwrap();
-        let conn_id_opt = self.pool.get_mut(*conn_index);
-        if conn_id_opt.is_none() {
-            debug!(%conn, "cannot find the connection in the pool");
-            return Err(DataPathError::ConnectionIdNotFound(conn));
-        }
-        let conn_id = conn_id_opt.unwrap();
-        if conn_id.counter == 1 {
-            // remove connection
-            self.pool.remove(*conn_index);
-            self.index.remove(&conn);
-        } else {
-            conn_id.counter -= 1;
-        }
-        Ok(())
-    }
-
-    fn get_one(&self, except_conn: u64) -> Option<u64> {
-        if self.index.len() == 1 {
-            if self.index.contains_key(&except_conn) {
-                debug!("the only available connection cannot be used");
-                return None;
-            } else {
-                let val = self.index.iter().next().unwrap();
-                return Some(*val.0);
-            }
-        }
-
-        // Walk at most n steps from the current cursor position, looking for
-        // a connection that isn't except_conn.
-        let n = self.pool.len();
+    /// Round-robin pick from `slice`, skipping `skip`.
+    fn pick_one(slice: &[u64], cursor: &AtomicUsize, skip: u64) -> Option<u64> {
+        let n = slice.len();
         if n == 0 {
-            debug!("no output connection available");
             return None;
         }
         for _ in 0..n {
-            let conn_id = self.pool.next_val().expect("pool is non-empty").conn_id;
-            if conn_id != except_conn {
-                return Some(conn_id);
+            let pos = cursor.fetch_add(1, Ordering::Relaxed) % n;
+            let c = slice[pos];
+            if c != skip {
+                return Some(c);
             }
         }
-        debug!("no output connection available");
         None
     }
 
-    fn get_all(&self, except_conn: u64) -> Option<Vec<u64>> {
-        if self.index.len() == 1 {
-            if self.index.contains_key(&except_conn) {
-                debug!("the only available connection cannot be used");
-                return None;
-            } else {
-                let val = self.index.iter().next().unwrap();
-                return Some(vec![*val.0]);
-            }
-        }
-        let mut out = Vec::new();
-        for val in self.index.iter() {
-            if *val.0 != except_conn {
-                out.push(*val.0);
-            }
-        }
-        if out.is_empty() { None } else { Some(out) }
+    /// Return one connection preferring local, round-robin, excluding `skip`.
+    fn get_one(&self, skip: u64) -> Option<u64> {
+        Self::pick_one(&self.local, &self.local_cursor, skip)
+            .or_else(|| Self::pick_one(&self.remote, &self.remote_cursor, skip))
+    }
+
+    /// Return all connections (local + remote) excluding `skip`.
+    fn get_all(&self, skip: u64) -> impl Iterator<Item = u64> + '_ {
+        self.local
+            .iter()
+            .chain(self.remote.iter())
+            .copied()
+            .filter(move |&c| c != skip)
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PrefixEntry – one allocation per unique [u64; 3] prefix.
+//
+// All IdEntries for a prefix share this heap object → a single cache miss
+// brings the whole routing context into L1/L2.
+// ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug)]
-struct NameState {
-    // map name -> [local connection refs, remote connection refs]
-    // the array contains the local connections at position 0 and the
-    // remote ones at position 1
-    // SubscriptionRefs tracks reference counts for each connection
-    ids: HashMap<u64, [SubscriptionRefs; 2]>,
-    // List of all the connections that are available for this name
-    // as for the ids map position 0 stores local connections and position
-    // 1 store remotes ones
-    connections: [Connections; 2],
-    // The human-readable name that this NameState represents in the subscription table.
-    representative_strings: [String; 3],
+struct PrefixEntry {
+    /// Linear scan only; n ≤ ~10 in any real deployment.
+    by_id: Vec<IdEntry>,
+    /// Human-readable prefix strings for for_each / Display / ProtoName.
+    strings: [String; 3],
 }
 
-impl NameState {
-    fn new(id: u64, conn: u64, is_local: bool, subscription_id: u64, name: ProtoName) -> Self {
-        let (s0, s1, s2) = name.str_components();
-        let mut type_state = NameState {
-            ids: HashMap::new(),
-            connections: [Connections::default(), Connections::default()],
-            representative_strings: [s0.to_string(), s1.to_string(), s2.to_string()],
-        };
-        let refs = SubscriptionRefs::new(conn, subscription_id);
-        if is_local {
-            type_state.connections[0].insert(conn);
-            type_state
-                .ids
-                .insert(id, [refs, SubscriptionRefs::default()]);
+impl PrefixEntry {
+    fn new(strings: [String; 3]) -> Self {
+        PrefixEntry {
+            by_id: Vec::new(),
+            strings,
+        }
+    }
+
+    /// Build a `ProtoName` from the stored strings and a component_3 value.
+    fn to_proto_name(&self, id: u64) -> ProtoName {
+        let base = ProtoName::from_strings([
+            self.strings[0].as_str(),
+            self.strings[1].as_str(),
+            self.strings[2].as_str(),
+        ]);
+        if id != ProtoName::NULL_COMPONENT {
+            base.with_id(id)
         } else {
-            type_state.connections[1].insert(conn);
-            type_state
-                .ids
-                .insert(id, [SubscriptionRefs::default(), refs]);
-        }
-        type_state
-    }
-
-    fn insert(&mut self, id: u64, conn: u64, is_local: bool, subscription_id: u64) {
-        let index = if is_local { 0 } else { 1 };
-
-        let actually_new = match self.ids.get_mut(&id) {
-            None => {
-                // the id does not exist
-                let mut connections = [SubscriptionRefs::default(), SubscriptionRefs::default()];
-                connections[index].insert(conn, subscription_id);
-                self.ids.insert(id, connections);
-                true
-            }
-            Some(v) => v[index].insert(conn, subscription_id),
-        };
-
-        // Only add to connections pool if this was actually a new subscription_id
-        if actually_new {
-            self.connections[index].insert(conn);
-        }
-    }
-
-    fn remove(
-        &mut self,
-        id: &u64,
-        conn: u64,
-        is_local: bool,
-        subscription_id: u64,
-    ) -> Result<bool, DataPathError> {
-        match self.ids.get_mut(id) {
-            None => {
-                warn!(%id, "not found");
-                Err(DataPathError::IdNotFound(*id))
-            }
-            Some(connection_refs) => {
-                let index = if is_local { 0 } else { 1 };
-
-                let conn_fully_removed = connection_refs[index].remove(conn, subscription_id)?;
-                // Decrement the Connections counter — it was incremented
-                // once per unique subscription_id in insert().
-                self.connections[index].remove(conn)?;
-
-                if conn_fully_removed
-                    && connection_refs[0].is_empty()
-                    && connection_refs[1].is_empty()
-                {
-                    self.ids.remove(id);
-                }
-
-                Ok(conn_fully_removed)
-            }
-        }
-    }
-
-    fn force_remove(&mut self, id: &u64, conn: u64, is_local: bool) -> Result<(), DataPathError> {
-        // Force remove regardless of counter - used when connection dies
-        match self.ids.get_mut(id) {
-            None => {
-                warn!(%id, "not found");
-                Err(DataPathError::IdNotFound(*id))
-            }
-            Some(connection_refs) => {
-                let index = if is_local { 0 } else { 1 };
-
-                let count = connection_refs[index].force_remove(conn)?;
-                // Remove from connections pool, decrementing by the full count
-                for _ in 0..count {
-                    self.connections[index].remove(conn)?;
-                }
-                // if both refs are empty remove the id from the tables
-                if connection_refs[0].is_empty() && connection_refs[1].is_empty() {
-                    self.ids.remove(id);
-                }
-                Ok(())
-            }
-        }
-    }
-
-    fn get_one_connection(
-        &self,
-        id: u64,
-        incoming_conn: u64,
-        get_local_connection: bool,
-    ) -> Option<u64> {
-        let mut index = 0;
-        if !get_local_connection {
-            index = 1;
-        }
-
-        if id == ProtoName::NULL_COMPONENT {
-            return self.connections[index].get_one(incoming_conn);
-        }
-
-        let val = self.ids.get(&id);
-        match val {
-            None => {
-                debug!(name = %id, "cannot find out connection, name does not exists");
-                None
-            }
-            Some(refs) => {
-                if refs[index].is_empty() {
-                    // no connections available
-                    return None;
-                }
-
-                if refs[index].len() == 1 {
-                    // Get the single connection id
-                    let conn_id = *refs[index].keys().next().unwrap();
-                    if conn_id == incoming_conn {
-                        // cannot return the incoming connection
-                        debug!("the only available connection cannot be used");
-                        return None;
-                    } else {
-                        return Some(conn_id);
-                    }
-                }
-
-                // we need to iterate and find a value starting from a random point
-                let conns: Vec<u64> = refs[index].keys().copied().collect();
-                let mut rng = rand::rng();
-                let pos = rng.random_range(0..conns.len());
-                let mut stop = false;
-                let mut i = pos;
-                while !stop {
-                    if conns[i] != incoming_conn {
-                        return Some(conns[i]);
-                    }
-                    i = (i + 1) % conns.len();
-                    if i == pos {
-                        stop = true;
-                    }
-                }
-                debug!("no output connection available");
-                None
-            }
-        }
-    }
-
-    fn get_all_connections(
-        &self,
-        id: u64,
-        incoming_conn: u64,
-        get_local_connection: bool,
-    ) -> Option<Vec<u64>> {
-        let mut index = 0;
-        if !get_local_connection {
-            index = 1;
-        }
-
-        if id == ProtoName::NULL_COMPONENT {
-            return self.connections[index].get_all(incoming_conn);
-        }
-
-        let val = self.ids.get(&id);
-        match val {
-            None => {
-                debug!(%id, "cannot find out connection, id does not exists");
-                None
-            }
-            Some(refs) => {
-                if refs[index].is_empty() {
-                    // should never happen
-                    return None;
-                }
-
-                if refs[index].len() == 1 {
-                    // Get the single connection id
-                    let conn_id = *refs[index].keys().next().unwrap();
-                    if conn_id == incoming_conn {
-                        // cannot return the incoming connection
-                        debug!("the only available connection cannot be used");
-                        return None;
-                    } else {
-                        return Some(vec![conn_id]);
-                    }
-                }
-
-                // we need to iterate over the refs and exclude the incoming connection
-                let mut out = Vec::new();
-                for conn_id in refs[index].keys() {
-                    if *conn_id != incoming_conn {
-                        out.push(*conn_id);
-                    }
-                }
-                if out.is_empty() { None } else { Some(out) }
-            }
+            base
         }
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SubRecord – flat write-path record stored per subscription_id.
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+struct SubRecord {
+    encoded: EncodedName,
+    conn_id: u64,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Inner
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Default)]
+struct Inner {
+    // ── HOT READ PATH ────────────────────────────────────────────────────────
+    // One HashMap lookup covers both specific-ID and NULL_COMPONENT cases.
+    routing: HashMap<[u64; 3], PrefixEntry>,
+
+    // ── COLD WRITE PATH ──────────────────────────────────────────────────────
+    // Flat: no nested HashMaps.
+    subscriptions: HashMap<u64, SubRecord>, // sub_id  → (name, conn_id)
+    conn_subs: HashMap<u64, Vec<u64>>,      // conn_id → sub_ids
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SubscriptionTableImpl
+// ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
 pub struct SubscriptionTableImpl {
-    // subscriptions table
-    // name -> name state
-    // if a subscription comes for a specific id, it is added
-    // to that specific id, otherwise the connection is added
-    // to the ProtoName::NULL_COMPONENT id
-    table: RwLock<HashMap<SubscriptionName, NameState>>,
-    // connections tables
-    // conn_index -> set(name)
-    connections: RwLock<HashMap<u64, HashSet<ProtoName>>>,
+    inner: RwLock<Inner>,
 }
 
 impl Display for SubscriptionTableImpl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // print main table
-        let table = self.table.read();
+        let inner = self.inner.read();
         writeln!(f, "Subscription Table")?;
-        for (_, v) in table.iter() {
-            let s = &v.representative_strings;
-            writeln!(f, "Type: {}/{}/{}", s[0], s[1], s[2])?;
+        for prefix_entry in inner.routing.values() {
+            writeln!(
+                f,
+                "Type: {}/{}/{}",
+                prefix_entry.strings[0], prefix_entry.strings[1], prefix_entry.strings[2]
+            )?;
             writeln!(f, "  Names:")?;
-            for (id, conn_refs) in v.ids.iter() {
-                writeln!(f, "    Id: {}", id)?;
-                if conn_refs[0].is_empty() {
+            for id_entry in &prefix_entry.by_id {
+                writeln!(f, "    Id: {}", id_entry.id)?;
+                if id_entry.local.is_empty() {
                     writeln!(f, "       Local Connections:")?;
                     writeln!(f, "         None")?;
                 } else {
                     writeln!(f, "       Local Connections:")?;
-                    for (c, count) in conn_refs[0].iter() {
-                        writeln!(f, "         Connection: {} (refs: {})", c, count)?;
+                    for c in &id_entry.local {
+                        writeln!(f, "         Connection: {}", c)?;
                     }
                 }
-                if conn_refs[1].is_empty() {
+                if id_entry.remote.is_empty() {
                     writeln!(f, "       Remote Connections:")?;
                     writeln!(f, "         None")?;
                 } else {
                     writeln!(f, "       Remote Connections:")?;
-                    for (c, count) in conn_refs[1].iter() {
-                        writeln!(f, "         Connection: {} (refs: {})", c, count)?;
+                    for c in &id_entry.remote {
+                        writeln!(f, "         Connection: {}", c)?;
                     }
                 }
             }
         }
-
         Ok(())
     }
-}
-
-fn add_subscription_to_sub_table(
-    name: ProtoName,
-    conn: u64,
-    is_local: bool,
-    subscription_id: u64,
-    mut table: RwLockWriteGuard<'_, RawRwLock, HashMap<SubscriptionName, NameState>>,
-) {
-    let uid = name.id();
-    let enc = name.name.as_ref().unwrap();
-    let key = SubscriptionName([enc.component_0, enc.component_1, enc.component_2]);
-
-    match table.get_mut(&key) {
-        None => {
-            debug!(
-                %name, %conn,
-                "subscription table: add first subscription",
-            );
-            let state = NameState::new(uid, conn, is_local, subscription_id, name);
-            table.insert(key, state);
-        }
-        Some(state) => {
-            state.insert(uid, conn, is_local, subscription_id);
-        }
-    }
-}
-
-fn add_subscription_to_connection(
-    name: ProtoName,
-    conn_index: u64,
-    mut map: RwLockWriteGuard<'_, RawRwLock, HashMap<u64, HashSet<ProtoName>>>,
-) -> Result<(), DataPathError> {
-    let name_str = name.to_string();
-
-    let set = map.get_mut(&conn_index);
-    match set {
-        None => {
-            debug!(
-                name = %name_str, %conn_index,
-                "add first subscription for name",
-            );
-            let mut set = HashSet::new();
-            set.insert(name);
-            map.insert(conn_index, set);
-        }
-        Some(s) => {
-            debug!(
-                name = %name_str, %conn_index, "add subscription",
-            );
-
-            if !s.insert(name) {
-                // Subscription already exists in the set - this is expected with refcounting
-                debug!(
-                    name = %name_str,
-                    %conn_index,
-                    "subscription already tracked in connections set (refcount incremented)",
-                );
-                return Ok(());
-            }
-        }
-    }
-    debug!(
-        name = %name_str, %conn_index,
-        "subscription successfully added on connection",
-    );
-    Ok(())
-}
-
-fn remove_subscription_from_sub_table(
-    name: &ProtoName,
-    conn_index: u64,
-    is_local: bool,
-    subscription_id: u64,
-    table: &mut RwLockWriteGuard<'_, RawRwLock, HashMap<SubscriptionName, NameState>>,
-) -> Result<bool, DataPathError> {
-    let enc = name.name.as_ref().unwrap();
-    let key = SubscriptionName([enc.component_0, enc.component_1, enc.component_2]);
-
-    if let Some(state) = table.get_mut(&key) {
-        let conn_fully_removed = state.remove(&name.id(), conn_index, is_local, subscription_id)?;
-
-        if state.ids.is_empty() {
-            table.remove(&key);
-        }
-        Ok(conn_fully_removed)
-    } else {
-        debug!("subscription not found {}", name);
-        Err(DataPathError::SubscriptionNotFound(name.clone()))
-    }
-}
-
-fn force_remove_subscription_from_sub_table(
-    name: &ProtoName,
-    conn_index: u64,
-    is_local: bool,
-    table: &mut RwLockWriteGuard<'_, RawRwLock, HashMap<SubscriptionName, NameState>>,
-) -> Result<(), DataPathError> {
-    let enc = name.name.as_ref().unwrap();
-    let key = SubscriptionName([enc.component_0, enc.component_1, enc.component_2]);
-
-    if let Some(state) = table.get_mut(&key) {
-        state.force_remove(&name.id(), conn_index, is_local)?;
-        if state.ids.is_empty() {
-            table.remove(&key);
-        }
-        Ok(())
-    } else {
-        debug!("subscription not found {}", name);
-        Err(DataPathError::SubscriptionNotFound(name.clone()))
-    }
-}
-
-fn remove_subscription_from_connection(
-    name: &ProtoName,
-    conn_index: u64,
-    mut map: RwLockWriteGuard<'_, RawRwLock, HashMap<u64, HashSet<ProtoName>>>,
-) -> Result<(), DataPathError> {
-    let set = map.get_mut(&conn_index);
-    match set {
-        None => {
-            warn!(%conn_index, "connection not found");
-            return Err(DataPathError::ConnectionIdNotFound(conn_index));
-        }
-        Some(s) => {
-            if !s.remove(name) {
-                warn!(
-                    %name, %conn_index,
-                    "subscription not found for connection",
-                );
-                return Err(DataPathError::SubscriptionNotFound(name.clone()));
-            }
-            if s.is_empty() {
-                map.remove(&conn_index);
-            }
-        }
-    }
-    debug!(
-        %name, %conn_index,
-        "subscription successfully removed",
-    );
-    Ok(())
 }
 
 impl SubscriptionTable for SubscriptionTableImpl {
@@ -649,16 +217,15 @@ impl SubscriptionTable for SubscriptionTableImpl {
     where
         F: FnMut(&ProtoName, u64, &[u64], &[u64]),
     {
-        let table = self.table.read();
-
-        for (_, v) in table.iter() {
-            let s = &v.representative_strings;
-            let name = ProtoName::from_strings([s[0].as_str(), s[1].as_str(), s[2].as_str()]);
-            for (id, conn_refs) in v.ids.iter() {
-                // Convert SubscriptionRefs keys to Vec for the callback
-                let local: Vec<u64> = conn_refs[0].keys().copied().collect();
-                let remote: Vec<u64> = conn_refs[1].keys().copied().collect();
-                f(&name, *id, local.as_ref(), remote.as_ref());
+        let inner = self.inner.read();
+        for prefix_entry in inner.routing.values() {
+            let base_name = ProtoName::from_strings([
+                prefix_entry.strings[0].as_str(),
+                prefix_entry.strings[1].as_str(),
+                prefix_entry.strings[2].as_str(),
+            ]);
+            for id_entry in &prefix_entry.by_id {
+                f(&base_name, id_entry.id, &id_entry.local, &id_entry.remote);
             }
         }
     }
@@ -670,14 +237,44 @@ impl SubscriptionTable for SubscriptionTableImpl {
         is_local: bool,
         subscription_id: u64,
     ) -> Result<(), Self::Error> {
-        {
-            let table = self.table.write();
-            add_subscription_to_sub_table(name.clone(), conn, is_local, subscription_id, table);
+        let enc = name.name.as_ref().unwrap();
+        let prefix = [enc.component_0, enc.component_1, enc.component_2];
+        let id = enc.component_3;
+        let encoded = *enc;
+
+        let mut inner = self.inner.write();
+
+        // 1. Ensure PrefixEntry exists; record strings on first insertion.
+        let prefix_entry = inner.routing.entry(prefix).or_insert_with(|| {
+            let (s0, s1, s2) = name.str_components();
+            PrefixEntry::new([s0.to_string(), s1.to_string(), s2.to_string()])
+        });
+
+        // 2. Ensure an IdEntry for this id exists within the prefix.
+        if !prefix_entry.by_id.iter().any(|e| e.id == id) {
+            prefix_entry.by_id.push(IdEntry::new(id));
         }
-        {
-            let conn_table = self.connections.write();
-            let _ = add_subscription_to_connection(name, conn, conn_table);
+
+        // 3. Insert conn into the right list (deduped).
+        let id_entry = prefix_entry.by_id.iter_mut().find(|e| e.id == id).unwrap();
+        id_entry.insert(conn, is_local);
+
+        // 4. Record the subscription (idempotent: same sub_id overwrites itself).
+        inner.subscriptions.insert(
+            subscription_id,
+            SubRecord {
+                encoded,
+                conn_id: conn,
+            },
+        );
+
+        // 5. Track sub_id → conn (deduped).
+        let subs = inner.conn_subs.entry(conn).or_default();
+        if !subs.contains(&subscription_id) {
+            subs.push(subscription_id);
         }
+
+        debug!(%name, %conn, "subscription table: add subscription");
         Ok(())
     }
 
@@ -688,14 +285,76 @@ impl SubscriptionTable for SubscriptionTableImpl {
         is_local: bool,
         subscription_id: u64,
     ) -> Result<(), Self::Error> {
-        let conn_fully_removed = {
-            let mut table = self.table.write();
-            remove_subscription_from_sub_table(name, conn, is_local, subscription_id, &mut table)?
-        };
-        if conn_fully_removed {
-            let conn_table = self.connections.write();
-            remove_subscription_from_connection(name, conn, conn_table)?;
+        let enc = name.name.as_ref().unwrap();
+        let prefix = [enc.component_0, enc.component_1, enc.component_2];
+        let id = enc.component_3;
+        let encoded = *enc;
+
+        let mut inner = self.inner.write();
+
+        // Error precedence: routing checks first.
+        if !inner.routing.contains_key(&prefix) {
+            debug!("subscription not found {}", name);
+            return Err(DataPathError::SubscriptionNotFound(name.clone()));
         }
+        if !inner.routing[&prefix].by_id.iter().any(|e| e.id == id) {
+            warn!(%id, "not found");
+            return Err(DataPathError::IdNotFound(id));
+        }
+
+        // Validate the subscription record.
+        let record = inner
+            .subscriptions
+            .get(&subscription_id)
+            .copied()
+            .ok_or(DataPathError::SubscriptionIdNotFound(subscription_id))?;
+
+        if record.conn_id != conn {
+            return Err(DataPathError::ConnectionIdNotFound(conn));
+        }
+        if record.encoded != encoded {
+            return Err(DataPathError::SubscriptionIdNotFound(subscription_id));
+        }
+
+        // Remove sub_id from the flat maps.
+        inner.subscriptions.remove(&subscription_id);
+        if let Some(subs) = inner.conn_subs.get_mut(&conn) {
+            subs.retain(|&s| s != subscription_id);
+        }
+
+        // Check whether conn still holds any subscription for this exact name.
+        // O(subs_per_conn) scan; typically < 20 entries.
+        let conn_still_subscribed = inner.conn_subs.get(&conn).is_some_and(|subs| {
+            subs.iter().any(|&s| {
+                inner
+                    .subscriptions
+                    .get(&s)
+                    .is_some_and(|r| r.encoded == encoded)
+            })
+        });
+
+        if !conn_still_subscribed {
+            // Remove conn from the routing entry; drop the mutable ref before
+            // potentially calling routing.remove().
+            let should_remove_prefix = if let Some(prefix_entry) = inner.routing.get_mut(&prefix) {
+                if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
+                    id_entry.remove(conn, is_local);
+                }
+                prefix_entry.by_id.retain(|e| !e.is_empty());
+                prefix_entry.by_id.is_empty()
+            } else {
+                false
+            };
+            if should_remove_prefix {
+                inner.routing.remove(&prefix);
+            }
+        }
+
+        // Clean up conn_subs if empty.
+        if inner.conn_subs.get(&conn).is_some_and(|s| s.is_empty()) {
+            inner.conn_subs.remove(&conn);
+        }
+
         Ok(())
     }
 
@@ -704,79 +363,152 @@ impl SubscriptionTable for SubscriptionTableImpl {
         conn: u64,
         is_local: bool,
     ) -> Result<HashMap<ProtoName, HashSet<u64>>, Self::Error> {
-        let removed_subscriptions = self
-            .connections
-            .write()
+        let mut inner = self.inner.write();
+
+        let sub_ids = inner
+            .conn_subs
             .remove(&conn)
             .ok_or(DataPathError::ConnectionIdNotFound(conn))?;
-        let mut table = self.table.write();
-        let idx = if is_local { 0 } else { 1 };
-        let mut result: HashMap<ProtoName, HashSet<u64>> =
-            HashMap::with_capacity(removed_subscriptions.len());
-        for name in removed_subscriptions {
-            debug!(%name, %conn, "remove subscription");
-            // Extract subscription IDs before removing so callers can restore exact state.
-            let enc = name.name.as_ref().unwrap();
-            let query_name = SubscriptionName([enc.component_0, enc.component_1, enc.component_2]);
-            if let Some(state) = table.get(&query_name)
-                && let Some(refs) = state.ids.get(&name.id())
-                && let Some(sub_ids) = refs[idx].refs.get(&conn)
-            {
-                result.insert(name.clone(), sub_ids.clone());
+
+        let mut result: HashMap<ProtoName, HashSet<u64>> = HashMap::with_capacity(sub_ids.len());
+
+        // Pass 1: remove each subscription record and build the result map.
+        // Track which encoded names need routing cleanup.
+        let mut encoded_names: Vec<EncodedName> = Vec::new();
+
+        for sub_id in sub_ids {
+            if let Some(record) = inner.subscriptions.remove(&sub_id) {
+                let prefix = [
+                    record.encoded.component_0,
+                    record.encoded.component_1,
+                    record.encoded.component_2,
+                ];
+                let proto_name = inner
+                    .routing
+                    .get(&prefix)
+                    .map(|pe| pe.to_proto_name(record.encoded.component_3))
+                    .unwrap_or(ProtoName {
+                        name: Some(record.encoded),
+                        str_name: None,
+                    });
+                result.entry(proto_name).or_default().insert(sub_id);
+
+                if !encoded_names.contains(&record.encoded) {
+                    encoded_names.push(record.encoded);
+                }
             }
-            force_remove_subscription_from_sub_table(&name, conn, is_local, &mut table)?;
         }
+
+        // Pass 2: remove conn from routing for every affected encoded name.
+        for encoded in &encoded_names {
+            debug!(%conn, ?encoded, "remove subscription");
+            let prefix = [
+                encoded.component_0,
+                encoded.component_1,
+                encoded.component_2,
+            ];
+            let id = encoded.component_3;
+
+            let should_remove_prefix = if let Some(prefix_entry) = inner.routing.get_mut(&prefix) {
+                if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
+                    id_entry.remove(conn, is_local);
+                }
+                prefix_entry.by_id.retain(|e| !e.is_empty());
+                prefix_entry.by_id.is_empty()
+            } else {
+                false
+            };
+
+            if should_remove_prefix {
+                inner.routing.remove(&prefix);
+            }
+        }
+
         Ok(result)
     }
 
     fn match_one(&self, encoded: &EncodedName, incoming_conn: u64) -> Result<u64, Self::Error> {
-        let key = SubscriptionName([
+        let prefix = [
             encoded.component_0,
             encoded.component_1,
             encoded.component_2,
-        ]);
-        let table = self.table.read();
+        ];
+        let id = encoded.component_3;
+        let inner = self.inner.read();
 
-        match table.get(&key) {
+        // ONE HashMap lookup — the same for any c3 value.
+        let prefix_entry = match inner.routing.get(&prefix) {
             None => {
                 debug!(
                     component_0 = encoded.component_0,
                     component_1 = encoded.component_1,
                     component_2 = encoded.component_2,
+                    component_3 = id,
                     "match not found for name"
                 );
-                Err(DataPathError::NoMatchEncoded([
+                return Err(DataPathError::NoMatchEncoded([
                     encoded.component_0,
                     encoded.component_1,
                     encoded.component_2,
-                    encoded.component_3,
-                ]))
+                    id,
+                ]));
             }
-            Some(state) => {
-                // first try to send the message to the local connections
-                // if no local connection exists or the message cannot
-                // be sent try on remote ones
-                let id = encoded.component_3;
-                let local_out = state.get_one_connection(id, incoming_conn, true);
-                if let Some(out) = local_out {
-                    return Ok(out);
+            Some(pe) => pe,
+        };
+
+        if id != ProtoName::NULL_COMPONENT {
+            // Specific ID: linear scan over by_id (n ≤ ~10, fits in cache).
+            match prefix_entry.by_id.iter().find(|e| e.id == id) {
+                None => {
+                    debug!(component_3 = id, "match not found for name");
+                    Err(DataPathError::NoMatchEncoded([
+                        encoded.component_0,
+                        encoded.component_1,
+                        encoded.component_2,
+                        id,
+                    ]))
                 }
-                let remote_out = state.get_one_connection(id, incoming_conn, false);
-                if let Some(out) = remote_out {
-                    return Ok(out);
+                Some(entry) => entry.get_one(incoming_conn).ok_or_else(|| {
+                    debug!("no output connection available");
+                    DataPathError::NoMatchEncoded([
+                        encoded.component_0,
+                        encoded.component_1,
+                        encoded.component_2,
+                        id,
+                    ])
+                }),
+            }
+        } else {
+            // NULL_COMPONENT: fan out over all registered IDs — data already hot
+            // from the single lookup above.
+            let mut local: Vec<u64> = Vec::new();
+            let mut remote: Vec<u64> = Vec::new();
+            for id_entry in &prefix_entry.by_id {
+                for &c in &id_entry.local {
+                    if c != incoming_conn && !local.contains(&c) {
+                        local.push(c);
+                    }
                 }
-                let s = &state.representative_strings;
-                debug!(
-                    name = format!("{}/{}/{}", s[0], s[1], s[2]),
-                    "no output connection available"
-                );
-                Err(DataPathError::NoMatchEncoded([
+                for &c in &id_entry.remote {
+                    if c != incoming_conn && !remote.contains(&c) {
+                        remote.push(c);
+                    }
+                }
+            }
+
+            let candidates = if !local.is_empty() { &local } else { &remote };
+            if candidates.is_empty() {
+                debug!("no output connection available");
+                return Err(DataPathError::NoMatchEncoded([
                     encoded.component_0,
                     encoded.component_1,
                     encoded.component_2,
-                    encoded.component_3,
-                ]))
+                    id,
+                ]));
             }
+            let mut rng = rand::rng();
+            let pos = rng.random_range(0..candidates.len());
+            Ok(candidates[pos])
         }
     }
 
@@ -785,59 +517,86 @@ impl SubscriptionTable for SubscriptionTableImpl {
         encoded: &EncodedName,
         incoming_conn: u64,
     ) -> Result<Vec<u64>, Self::Error> {
-        let key = SubscriptionName([
+        let prefix = [
             encoded.component_0,
             encoded.component_1,
             encoded.component_2,
-        ]);
-        let table = self.table.read();
+        ];
+        let id = encoded.component_3;
+        let inner = self.inner.read();
 
-        match table.get(&key) {
+        // ONE HashMap lookup — the same for any c3 value.
+        let prefix_entry = match inner.routing.get(&prefix) {
             None => {
                 debug!(
                     component_0 = encoded.component_0,
                     component_1 = encoded.component_1,
                     component_2 = encoded.component_2,
+                    component_3 = id,
                     "match not found for name"
                 );
-                Err(DataPathError::NoMatchEncoded([
+                return Err(DataPathError::NoMatchEncoded([
                     encoded.component_0,
                     encoded.component_1,
                     encoded.component_2,
-                    encoded.component_3,
-                ]))
+                    id,
+                ]));
             }
-            Some(state) => {
-                let id = encoded.component_3;
-                let mut all_connections = Vec::new();
+            Some(pe) => pe,
+        };
 
-                // Collect local connections
-                if let Some(local_out) = state.get_all_connections(id, incoming_conn, true) {
-                    debug!(?local_out, "found local connections");
-                    all_connections.extend(local_out);
-                }
-
-                // Collect remote connections
-                if let Some(remote_out) = state.get_all_connections(id, incoming_conn, false) {
-                    debug!(?remote_out, "found remote connections");
-                    all_connections.extend(remote_out);
-                }
-
-                if all_connections.is_empty() {
-                    let s = &state.representative_strings;
-                    debug!(
-                        name = format!("{}/{}/{}", s[0], s[1], s[2]),
-                        "no connection available (local/remote)"
-                    );
+        if id != ProtoName::NULL_COMPONENT {
+            // Specific ID: linear scan over by_id.
+            match prefix_entry.by_id.iter().find(|e| e.id == id) {
+                None => {
+                    debug!(component_3 = id, "match not found for name");
                     Err(DataPathError::NoMatchEncoded([
                         encoded.component_0,
                         encoded.component_1,
                         encoded.component_2,
-                        encoded.component_3,
+                        id,
                     ]))
-                } else {
-                    Ok(all_connections)
                 }
+                Some(entry) => {
+                    let out: Vec<u64> = entry.get_all(incoming_conn).collect();
+                    if out.is_empty() {
+                        debug!("no connection available (local/remote)");
+                        Err(DataPathError::NoMatchEncoded([
+                            encoded.component_0,
+                            encoded.component_1,
+                            encoded.component_2,
+                            id,
+                        ]))
+                    } else {
+                        debug!(?out, "found connections");
+                        Ok(out)
+                    }
+                }
+            }
+        } else {
+            // NULL_COMPONENT: union of all connections across all registered IDs;
+            // data already hot from the single lookup.
+            let mut seen: HashSet<u64> = HashSet::new();
+            let mut out: Vec<u64> = Vec::new();
+            for id_entry in &prefix_entry.by_id {
+                for c in id_entry.get_all(incoming_conn) {
+                    if seen.insert(c) {
+                        out.push(c);
+                    }
+                }
+            }
+
+            if out.is_empty() {
+                debug!("no connection available");
+                Err(DataPathError::NoMatchEncoded([
+                    encoded.component_0,
+                    encoded.component_1,
+                    encoded.component_2,
+                    id,
+                ]))
+            } else {
+                debug!(?out, "found connections");
+                Ok(out)
             }
         }
     }
@@ -911,7 +670,7 @@ mod tests {
         assert!(out.contains(&1));
         assert!(out.contains(&2));
 
-        // run multiple times for randomenes
+        // run multiple times for randomnes
         for _ in 0..20 {
             let out = t.match_one(&enc(&name1), 100).unwrap();
             if out != 1 && out != 2 {

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -3,9 +3,11 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use parking_lot::{Mutex, RwLock};
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
 use tracing::{debug, warn};
 
 use super::SubscriptionTable;
@@ -81,6 +83,15 @@ impl ConnList {
             }
         }
         None
+    }
+}
+
+impl Clone for ConnList {
+    fn clone(&self) -> Self {
+        ConnList {
+            conns: self.conns.clone(),
+            cursor: AtomicUsize::new(self.cursor.load(Ordering::Relaxed)),
+        }
     }
 }
 
@@ -294,6 +305,18 @@ impl PrefixEntry {
     }
 }
 
+impl Clone for PrefixEntry {
+    fn clone(&self) -> Self {
+        PrefixEntry {
+            ids: self.ids.clone(),
+            local: self.local.clone(),
+            remote: self.remote.clone(),
+            slot_cursor: AtomicUsize::new(self.slot_cursor.load(Ordering::Relaxed)),
+            strings: self.strings.clone(),
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // SubRecord – flat write-path record stored per subscription_id.
 // ──────────────────────────────────────────────────────────────────────────────
@@ -320,21 +343,33 @@ struct SubscriptionState {
 // ──────────────────────────────────────────────────────────────────────────────
 // SubscriptionTableImpl
 //
-// Lock ordering (must always be respected to prevent deadlock):
-//   1. subscription_state.lock() — acquired first by all writers
-//   2. routing.write()           — acquired second by all writers
-// Readers only ever acquire routing.read(); they never touch subscription_state.
+// Concurrency design:
+//   - Hot read path (match_one / match_all): lock-free via ArcSwap::load().
+//     Readers get an immutable snapshot with a single atomic pointer load.
+//   - Write path (add/remove subscription, remove connection):
+//       1. subscription_state.lock() — bookkeeping, always acquired first
+//       2. load current routing snapshot
+//       3. clone → modify → ArcSwap::store()  (no write lock held)
 // ──────────────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SubscriptionTableImpl {
-    routing: RwLock<HashMap<[u64; 3], PrefixEntry>>, // only lock held on the hot read path
-    subscription_state: Mutex<SubscriptionState>,    // never held by match_one / match_all
+    routing: ArcSwap<HashMap<[u64; 3], PrefixEntry>>, // lock-free on the hot read path
+    subscription_state: Mutex<SubscriptionState>,     // never held by match_one / match_all
+}
+
+impl Default for SubscriptionTableImpl {
+    fn default() -> Self {
+        SubscriptionTableImpl {
+            routing: ArcSwap::from_pointee(HashMap::new()),
+            subscription_state: Mutex::default(),
+        }
+    }
 }
 
 impl Display for SubscriptionTableImpl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let rs = self.routing.read();
+        let rs = self.routing.load();
         writeln!(f, "Subscription Table")?;
         for prefix_entry in rs.values() {
             writeln!(
@@ -376,7 +411,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
     where
         F: FnMut(&ProtoName, u64, &[u64], &[u64]),
     {
-        let rs = self.routing.read();
+        let rs = self.routing.load();
         for prefix_entry in rs.values() {
             let base_name = ProtoName::from_strings([
                 prefix_entry.strings[0].as_str(),
@@ -401,9 +436,9 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let id = enc.component_3;
         let encoded = *enc;
 
-        // Lock order: write_state first, routing second.
+        // subscription_state locked first; routing updated via clone-modify-store.
         let mut ss = self.subscription_state.lock();
-        let mut rs = self.routing.write();
+        let mut rs = (**self.routing.load()).clone();
 
         // 1. Ensure PrefixEntry exists; record strings on first insertion.
         let prefix_entry = rs.entry(prefix).or_insert_with(|| {
@@ -413,6 +448,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
 
         // 2 & 3. Ensure an ID slot exists and insert conn (deduped).
         prefix_entry.insert_conn_for_id(id, conn, is_local);
+        self.routing.store(Arc::new(rs));
 
         // 4. Record the subscription (idempotent: same sub_id overwrites itself).
         ss.subscriptions.insert(
@@ -445,18 +481,20 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let id = enc.component_3;
         let encoded = *enc;
 
-        // Lock order: write_state first, routing second.
+        // subscription_state locked first; routing validated then updated via clone-modify-store.
         let mut ss = self.subscription_state.lock();
-        let mut rs = self.routing.write();
 
-        // Error precedence: routing checks first.
-        if !rs.contains_key(&prefix) {
-            debug!("subscription not found {}", name);
-            return Err(DataPathError::SubscriptionNotFound(name.clone()));
-        }
-        if !rs[&prefix].has_id(id) {
-            warn!(%id, "not found");
-            return Err(DataPathError::IdNotFound(id));
+        // Error precedence: routing checks first (read snapshot, no clone yet).
+        {
+            let current = self.routing.load();
+            if !current.contains_key(&prefix) {
+                debug!("subscription not found {}", name);
+                return Err(DataPathError::SubscriptionNotFound(name.clone()));
+            }
+            if !current[&prefix].has_id(id) {
+                warn!(%id, "not found");
+                return Err(DataPathError::IdNotFound(id));
+            }
         }
 
         // Validate the subscription record.
@@ -490,8 +528,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         });
 
         if !conn_still_subscribed {
-            // Remove conn from the routing entry; drop the mutable ref before
-            // potentially calling routing.remove().
+            let mut rs = (**self.routing.load()).clone();
             let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
                 prefix_entry.remove_conn_for_id(id, conn, is_local);
                 prefix_entry.retain_non_empty();
@@ -502,6 +539,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             if should_remove_prefix {
                 rs.remove(&prefix);
             }
+            self.routing.store(Arc::new(rs));
         }
 
         // Clean up conn_subs if empty.
@@ -517,9 +555,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
         conn: u64,
         is_local: bool,
     ) -> Result<HashMap<ProtoName, HashSet<u64>>, Self::Error> {
-        // Lock order: write_state first, routing second.
+        // subscription_state locked first; routing updated via clone-modify-store.
         let mut ss = self.subscription_state.lock();
-        let mut rs = self.routing.write();
 
         let sub_ids = ss
             .conn_subs
@@ -529,9 +566,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let mut result: HashMap<ProtoName, HashSet<u64>> = HashMap::with_capacity(sub_ids.len());
 
         // Pass 1: remove each subscription record and build the result map.
-        // Track which encoded names need routing cleanup.
+        // Use a read snapshot (no clone yet) for proto_name lookups.
         let mut encoded_names: Vec<EncodedName> = Vec::new();
 
+        let current = self.routing.load();
         for sub_id in sub_ids {
             if let Some(record) = ss.subscriptions.remove(&sub_id) {
                 let prefix = [
@@ -539,7 +577,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                     record.encoded.component_1,
                     record.encoded.component_2,
                 ];
-                let proto_name = rs
+                let proto_name = current
                     .get(&prefix)
                     .map(|pe| pe.to_proto_name(record.encoded.component_3))
                     .unwrap_or(ProtoName {
@@ -554,7 +592,9 @@ impl SubscriptionTable for SubscriptionTableImpl {
             }
         }
 
-        // Pass 2: remove conn from routing for every affected encoded name.
+        // Pass 2: clone snapshot, remove conn from routing for every affected encoded name.
+        let mut rs = (**current).clone();
+        drop(current);
         for encoded in &encoded_names {
             debug!(%conn, ?encoded, "remove subscription");
             let prefix = [
@@ -576,6 +616,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 rs.remove(&prefix);
             }
         }
+        self.routing.store(Arc::new(rs));
 
         Ok(result)
     }
@@ -587,7 +628,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             encoded.component_2,
         ];
         let id = encoded.component_3;
-        let rs = self.routing.read();
+        let rs = self.routing.load();
 
         // ONE HashMap lookup — the same for any c3 value.
         let prefix_entry = match rs.get(&prefix) {
@@ -646,7 +687,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             encoded.component_2,
         ];
         let id = encoded.component_3;
-        let rs = self.routing.read();
+        let rs = self.routing.load();
 
         // ONE HashMap lookup — the same for any c3 value.
         let prefix_entry = match rs.get(&prefix) {

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -433,14 +433,14 @@ impl SubscriptionTable for SubscriptionTableImpl {
             return Err(DataPathError::SubscriptionIdNotFound(subscription_id));
         }
 
-        // Remove sub_id from the flat maps.
+        // Remove sub_id from the subscriptions map and the reverse conn_subs map.
         ss.subscriptions.remove(&subscription_id);
         if let Some(subs) = ss.conn_subs.get_mut(&conn) {
             subs.retain(|&s| s != subscription_id);
         }
 
-        // Check whether conn still holds any subscription for this exact name.
-        // O(subs_per_conn) scan; typically < 20 entries.
+        // Check whether the connection is still subscribed to the same encoded name via another
+        // subscription_id.
         let conn_still_subscribed = ss.conn_subs.get(&conn).is_some_and(|subs| {
             subs.iter().any(|&s| {
                 ss.subscriptions

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -13,24 +13,94 @@ use crate::api::{EncodedName, ProtoName};
 use crate::errors::DataPathError;
 
 // ──────────────────────────────────────────────────────────────────────────────
+// ConnList – a connection Vec with a built-in round-robin cursor.
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct ConnList {
+    conns: Vec<u64>,
+    cursor: AtomicUsize,
+}
+
+impl ConnList {
+    fn new() -> Self {
+        ConnList {
+            conns: Vec::new(),
+            cursor: AtomicUsize::new(0),
+        }
+    }
+
+    /// Add `conn` if not already present (deduped).
+    fn push(&mut self, conn: u64) {
+        if !self.conns.contains(&conn) {
+            self.conns.push(conn);
+        }
+    }
+
+    /// Remove `conn` (no-op if absent).
+    fn remove(&mut self, conn: u64) {
+        if let Some(pos) = self.conns.iter().position(|&c| c == conn) {
+            self.conns.swap_remove(pos);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.conns.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.conns.len()
+    }
+
+    fn as_slice(&self) -> &[u64] {
+        &self.conns
+    }
+
+    fn iter(&self) -> impl Iterator<Item = u64> + '_ {
+        self.conns.iter().copied()
+    }
+
+    /// Round-robin next connection, skipping `skip`.
+    fn next(&self, skip: u64) -> Option<u64> {
+        let n = self.conns.len();
+        if n == 0 {
+            return None;
+        }
+        if n == 1 {
+            return if self.conns[0] != skip {
+                Some(self.conns[0])
+            } else {
+                None
+            };
+        }
+        for _ in 0..n {
+            let pos = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
+            let c = self.conns[pos];
+            if c != skip {
+                return Some(c);
+            }
+        }
+        None
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // PrefixEntry – one allocation per unique [u64; 3] prefix.
 //
 // Struct-of-arrays layout: `ids` is a flat Vec<u64> so a scan for a matching
 // component_3 value reads 8 IDs per cache line instead of striding across
 // 72-byte AoS IdEntry objects.  Once the index is found the per-slot
-// connection Vecs are accessed by that index.
+// ConnLists are accessed by that index.
 //
-// Invariant: all five Vecs always have the same length.
+// Invariant: all three Vecs always have the same length.
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug)]
 struct PrefixEntry {
     /// Dense u64 array — 8 IDs per cache line.
     ids: Vec<u64>,
-    local_connections: Vec<Vec<u64>>,
-    remote_connections: Vec<Vec<u64>>,
-    local_cursors: Vec<AtomicUsize>,
-    remote_cursors: Vec<AtomicUsize>,
+    local: Vec<ConnList>,
+    remote: Vec<ConnList>,
     /// Round-robin cursor for NULL_COMPONENT slot selection.
     slot_cursor: AtomicUsize,
     /// Human-readable prefix strings for for_each / Display / ProtoName.
@@ -41,10 +111,8 @@ impl PrefixEntry {
     fn new(strings: [String; 3]) -> Self {
         PrefixEntry {
             ids: Vec::new(),
-            local_connections: Vec::new(),
-            remote_connections: Vec::new(),
-            local_cursors: Vec::new(),
-            remote_cursors: Vec::new(),
+            local: Vec::new(),
+            remote: Vec::new(),
             slot_cursor: AtomicUsize::new(0),
             strings,
         }
@@ -53,10 +121,8 @@ impl PrefixEntry {
     /// Append a new ID slot. Called only when `id` is not already present.
     fn push_id(&mut self, id: u64) {
         self.ids.push(id);
-        self.local_connections.push(Vec::new());
-        self.remote_connections.push(Vec::new());
-        self.local_cursors.push(AtomicUsize::new(0));
-        self.remote_cursors.push(AtomicUsize::new(0));
+        self.local.push(ConnList::new());
+        self.remote.push(ConnList::new());
     }
 
     fn len(&self) -> usize {
@@ -69,40 +135,34 @@ impl PrefixEntry {
 
     /// Add `conn` to the appropriate list for slot `idx` if not already present.
     fn insert_conn(&mut self, idx: usize, conn: u64, is_local: bool) {
-        let vec = if is_local {
-            &mut self.local_connections[idx]
+        let list = if is_local {
+            &mut self.local[idx]
         } else {
-            &mut self.remote_connections[idx]
+            &mut self.remote[idx]
         };
-        if !vec.contains(&conn) {
-            vec.push(conn);
-        }
+        list.push(conn);
     }
 
     /// Remove `conn` from the appropriate list for slot `idx` (no-op if absent).
     fn remove_conn(&mut self, idx: usize, conn: u64, is_local: bool) {
-        let vec = if is_local {
-            &mut self.local_connections[idx]
+        let list = if is_local {
+            &mut self.local[idx]
         } else {
-            &mut self.remote_connections[idx]
+            &mut self.remote[idx]
         };
-        if let Some(pos) = vec.iter().position(|&c| c == conn) {
-            vec.swap_remove(pos);
-        }
+        list.remove(conn);
     }
 
     /// True when both local and remote lists for slot `idx` are empty.
     fn is_slot_empty(&self, idx: usize) -> bool {
-        self.local_connections[idx].is_empty() && self.remote_connections[idx].is_empty()
+        self.local[idx].is_empty() && self.remote[idx].is_empty()
     }
 
     /// Remove slot `idx` using swap_remove on every parallel Vec.
     fn remove_slot(&mut self, idx: usize) {
         self.ids.swap_remove(idx);
-        self.local_connections.swap_remove(idx);
-        self.remote_connections.swap_remove(idx);
-        self.local_cursors.swap_remove(idx);
-        self.remote_cursors.swap_remove(idx);
+        self.local.swap_remove(idx);
+        self.remote.swap_remove(idx);
     }
 
     /// Remove all slots whose local and remote lists are both empty.
@@ -116,29 +176,6 @@ impl PrefixEntry {
                 i += 1;
             }
         }
-    }
-
-    /// Round-robin pick from `slice`, skipping `skip`.
-    fn pick_one(slice: &[u64], cursor: &AtomicUsize, skip: u64) -> Option<u64> {
-        let n = slice.len();
-        if n == 0 {
-            return None;
-        }
-        if n == 1 {
-            return if slice[0] != skip {
-                Some(slice[0])
-            } else {
-                None
-            };
-        }
-        for _ in 0..n {
-            let pos = cursor.fetch_add(1, Ordering::Relaxed) % n;
-            let c = slice[pos];
-            if c != skip {
-                return Some(c);
-            }
-        }
-        None
     }
 
     /// True when a slot for `id` exists.
@@ -166,13 +203,9 @@ impl PrefixEntry {
     /// Returns `None` if `id` has no slot or all connections equal `skip`.
     fn get_one(&self, id: u64, skip: u64) -> Option<u64> {
         let idx = self.ids.iter().position(|&i| i == id)?;
-        Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(|| {
-            Self::pick_one(
-                &self.remote_connections[idx],
-                &self.remote_cursors[idx],
-                skip,
-            )
-        })
+        self.local[idx]
+            .next(skip)
+            .or_else(|| self.remote[idx].next(skip))
     }
 
     /// Return all connections for `id` (local + remote) excluding `skip`.
@@ -180,14 +213,11 @@ impl PrefixEntry {
     /// `Some(empty)` means the slot exists but all connections equal `skip`.
     fn get_all(&self, id: u64, skip: u64) -> Option<Vec<u64>> {
         let idx = self.ids.iter().position(|&i| i == id)?;
-        let mut out = Vec::with_capacity(
-            self.local_connections[idx].len() + self.remote_connections[idx].len(),
-        );
+        let mut out = Vec::with_capacity(self.local[idx].len() + self.remote[idx].len());
         out.extend(
-            self.local_connections[idx]
+            self.local[idx]
                 .iter()
-                .chain(self.remote_connections[idx].iter())
-                .copied()
+                .chain(self.remote[idx].iter())
                 .filter(|&c| c != skip),
         );
         Some(out)
@@ -208,18 +238,14 @@ impl PrefixEntry {
         };
         // All locals first (starting from random slot, wrapping).
         for i in (start..n).chain(0..start) {
-            for &c in &self.local_connections[i] {
-                if c != skip {
-                    return Some(c);
-                }
+            if let Some(c) = self.local[i].next(skip) {
+                return Some(c);
             }
         }
         // Then all remotes (same wrapping start).
         for i in (start..n).chain(0..start) {
-            for &c in &self.remote_connections[i] {
-                if c != skip {
-                    return Some(c);
-                }
+            if let Some(c) = self.remote[i].next(skip) {
+                return Some(c);
             }
         }
         None
@@ -229,15 +255,15 @@ impl PrefixEntry {
     /// remotes, skipping `skip`.
     fn get_all_any(&self, skip: u64) -> Vec<u64> {
         let mut out: Vec<u64> = Vec::with_capacity(self.len());
-        for local in &self.local_connections {
-            for &c in local {
+        for local in &self.local {
+            for c in local.iter() {
                 if c != skip && !out.contains(&c) {
                     out.push(c);
                 }
             }
         }
-        for remote in &self.remote_connections {
-            for &c in remote {
+        for remote in &self.remote {
+            for c in remote.iter() {
                 if c != skip && !out.contains(&c) {
                     out.push(c);
                 }
@@ -249,7 +275,7 @@ impl PrefixEntry {
     /// Iterate all slots, yielding `(id, local, remote)` — used by `for_each`.
     fn for_each_slot<F: FnMut(u64, &[u64], &[u64])>(&self, mut f: F) {
         for (i, &id) in self.ids.iter().enumerate() {
-            f(id, &self.local_connections[i], &self.remote_connections[i]);
+            f(id, self.local[i].as_slice(), self.remote[i].as_slice());
         }
     }
 
@@ -319,21 +345,21 @@ impl Display for SubscriptionTableImpl {
             writeln!(f, "  Names:")?;
             for (i, &id) in prefix_entry.ids.iter().enumerate() {
                 writeln!(f, "    Id: {}", id)?;
-                if prefix_entry.local_connections[i].is_empty() {
+                if prefix_entry.local[i].is_empty() {
                     writeln!(f, "       Local Connections:")?;
                     writeln!(f, "         None")?;
                 } else {
                     writeln!(f, "       Local Connections:")?;
-                    for c in &prefix_entry.local_connections[i] {
+                    for c in prefix_entry.local[i].iter() {
                         writeln!(f, "         Connection: {}", c)?;
                     }
                 }
-                if prefix_entry.remote_connections[i].is_empty() {
+                if prefix_entry.remote[i].is_empty() {
                     writeln!(f, "       Remote Connections:")?;
                     writeln!(f, "         None")?;
                 } else {
                     writeln!(f, "       Remote Connections:")?;
-                    for c in &prefix_entry.remote_connections[i] {
+                    for c in prefix_entry.remote[i].iter() {
                         writeln!(f, "         Connection: {}", c)?;
                     }
                 }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rand::Rng;
 use tracing::{debug, warn};
 
@@ -149,35 +149,51 @@ struct SubRecord {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Inner
+// RoutingState — HOT read path.
+//
+// Protected by an RwLock so many readers can proceed concurrently without
+// ever being blocked by subscription bookkeeping (WriteState).
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
-struct Inner {
-    // ── HOT READ PATH ────────────────────────────────────────────────────────
+struct RoutingState {
     // One HashMap lookup covers both specific-ID and NULL_COMPONENT cases.
     routing: HashMap<[u64; 3], PrefixEntry>,
+}
 
-    // ── COLD WRITE PATH ──────────────────────────────────────────────────────
-    // Flat: no nested HashMaps.
-    subscriptions: HashMap<u64, SubRecord>, // sub_id  → (name, conn_id)
+// ──────────────────────────────────────────────────────────────────────────────
+// WriteState — COLD write path.
+//
+// Protected by a Mutex (exclusive access always required). Never held by
+// match_one / match_all, so subscription churn never blocks message routing.
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Default)]
+struct WriteState {
+    subscriptions: HashMap<u64, SubRecord>, // sub_id  → (encoded, conn_id)
     conn_subs: HashMap<u64, Vec<u64>>,      // conn_id → sub_ids
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
 // SubscriptionTableImpl
+//
+// Lock ordering (must always be respected to prevent deadlock):
+//   1. write_state.lock()   — acquired first by all writers
+//   2. routing.write()      — acquired second by all writers
+// Readers only ever acquire routing.read(); they never touch write_state.
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
 pub struct SubscriptionTableImpl {
-    inner: RwLock<Inner>,
+    routing: RwLock<RoutingState>,  // only lock held on the hot read path
+    write_state: Mutex<WriteState>, // never held by match_one / match_all
 }
 
 impl Display for SubscriptionTableImpl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let inner = self.inner.read();
+        let rs = self.routing.read();
         writeln!(f, "Subscription Table")?;
-        for prefix_entry in inner.routing.values() {
+        for prefix_entry in rs.routing.values() {
             writeln!(
                 f,
                 "Type: {}/{}/{}",
@@ -217,8 +233,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
     where
         F: FnMut(&ProtoName, u64, &[u64], &[u64]),
     {
-        let inner = self.inner.read();
-        for prefix_entry in inner.routing.values() {
+        let rs = self.routing.read();
+        for prefix_entry in rs.routing.values() {
             let base_name = ProtoName::from_strings([
                 prefix_entry.strings[0].as_str(),
                 prefix_entry.strings[1].as_str(),
@@ -242,10 +258,12 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let id = enc.component_3;
         let encoded = *enc;
 
-        let mut inner = self.inner.write();
+        // Lock order: write_state first, routing second.
+        let mut ws = self.write_state.lock();
+        let mut rs = self.routing.write();
 
         // 1. Ensure PrefixEntry exists; record strings on first insertion.
-        let prefix_entry = inner.routing.entry(prefix).or_insert_with(|| {
+        let prefix_entry = rs.routing.entry(prefix).or_insert_with(|| {
             let (s0, s1, s2) = name.str_components();
             PrefixEntry::new([s0.to_string(), s1.to_string(), s2.to_string()])
         });
@@ -260,7 +278,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         id_entry.insert(conn, is_local);
 
         // 4. Record the subscription (idempotent: same sub_id overwrites itself).
-        inner.subscriptions.insert(
+        ws.subscriptions.insert(
             subscription_id,
             SubRecord {
                 encoded,
@@ -269,7 +287,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         );
 
         // 5. Track sub_id → conn (deduped).
-        let subs = inner.conn_subs.entry(conn).or_default();
+        let subs = ws.conn_subs.entry(conn).or_default();
         if !subs.contains(&subscription_id) {
             subs.push(subscription_id);
         }
@@ -290,20 +308,22 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let id = enc.component_3;
         let encoded = *enc;
 
-        let mut inner = self.inner.write();
+        // Lock order: write_state first, routing second.
+        let mut ws = self.write_state.lock();
+        let mut rs = self.routing.write();
 
         // Error precedence: routing checks first.
-        if !inner.routing.contains_key(&prefix) {
+        if !rs.routing.contains_key(&prefix) {
             debug!("subscription not found {}", name);
             return Err(DataPathError::SubscriptionNotFound(name.clone()));
         }
-        if !inner.routing[&prefix].by_id.iter().any(|e| e.id == id) {
+        if !rs.routing[&prefix].by_id.iter().any(|e| e.id == id) {
             warn!(%id, "not found");
             return Err(DataPathError::IdNotFound(id));
         }
 
         // Validate the subscription record.
-        let record = inner
+        let record = ws
             .subscriptions
             .get(&subscription_id)
             .copied()
@@ -317,17 +337,16 @@ impl SubscriptionTable for SubscriptionTableImpl {
         }
 
         // Remove sub_id from the flat maps.
-        inner.subscriptions.remove(&subscription_id);
-        if let Some(subs) = inner.conn_subs.get_mut(&conn) {
+        ws.subscriptions.remove(&subscription_id);
+        if let Some(subs) = ws.conn_subs.get_mut(&conn) {
             subs.retain(|&s| s != subscription_id);
         }
 
         // Check whether conn still holds any subscription for this exact name.
         // O(subs_per_conn) scan; typically < 20 entries.
-        let conn_still_subscribed = inner.conn_subs.get(&conn).is_some_and(|subs| {
+        let conn_still_subscribed = ws.conn_subs.get(&conn).is_some_and(|subs| {
             subs.iter().any(|&s| {
-                inner
-                    .subscriptions
+                ws.subscriptions
                     .get(&s)
                     .is_some_and(|r| r.encoded == encoded)
             })
@@ -336,7 +355,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         if !conn_still_subscribed {
             // Remove conn from the routing entry; drop the mutable ref before
             // potentially calling routing.remove().
-            let should_remove_prefix = if let Some(prefix_entry) = inner.routing.get_mut(&prefix) {
+            let should_remove_prefix = if let Some(prefix_entry) = rs.routing.get_mut(&prefix) {
                 if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
                     id_entry.remove(conn, is_local);
                 }
@@ -346,13 +365,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 false
             };
             if should_remove_prefix {
-                inner.routing.remove(&prefix);
+                rs.routing.remove(&prefix);
             }
         }
 
         // Clean up conn_subs if empty.
-        if inner.conn_subs.get(&conn).is_some_and(|s| s.is_empty()) {
-            inner.conn_subs.remove(&conn);
+        if ws.conn_subs.get(&conn).is_some_and(|s| s.is_empty()) {
+            ws.conn_subs.remove(&conn);
         }
 
         Ok(())
@@ -363,9 +382,11 @@ impl SubscriptionTable for SubscriptionTableImpl {
         conn: u64,
         is_local: bool,
     ) -> Result<HashMap<ProtoName, HashSet<u64>>, Self::Error> {
-        let mut inner = self.inner.write();
+        // Lock order: write_state first, routing second.
+        let mut ws = self.write_state.lock();
+        let mut rs = self.routing.write();
 
-        let sub_ids = inner
+        let sub_ids = ws
             .conn_subs
             .remove(&conn)
             .ok_or(DataPathError::ConnectionIdNotFound(conn))?;
@@ -377,13 +398,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let mut encoded_names: Vec<EncodedName> = Vec::new();
 
         for sub_id in sub_ids {
-            if let Some(record) = inner.subscriptions.remove(&sub_id) {
+            if let Some(record) = ws.subscriptions.remove(&sub_id) {
                 let prefix = [
                     record.encoded.component_0,
                     record.encoded.component_1,
                     record.encoded.component_2,
                 ];
-                let proto_name = inner
+                let proto_name = rs
                     .routing
                     .get(&prefix)
                     .map(|pe| pe.to_proto_name(record.encoded.component_3))
@@ -409,7 +430,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             ];
             let id = encoded.component_3;
 
-            let should_remove_prefix = if let Some(prefix_entry) = inner.routing.get_mut(&prefix) {
+            let should_remove_prefix = if let Some(prefix_entry) = rs.routing.get_mut(&prefix) {
                 if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
                     id_entry.remove(conn, is_local);
                 }
@@ -420,7 +441,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             };
 
             if should_remove_prefix {
-                inner.routing.remove(&prefix);
+                rs.routing.remove(&prefix);
             }
         }
 
@@ -434,10 +455,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
             encoded.component_2,
         ];
         let id = encoded.component_3;
-        let inner = self.inner.read();
+        let rs = self.routing.read();
 
         // ONE HashMap lookup — the same for any c3 value.
-        let prefix_entry = match inner.routing.get(&prefix) {
+        let prefix_entry = match rs.routing.get(&prefix) {
             None => {
                 debug!(
                     component_0 = encoded.component_0,
@@ -528,10 +549,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
             encoded.component_2,
         ];
         let id = encoded.component_3;
-        let inner = self.inner.read();
+        let rs = self.routing.read();
 
         // ONE HashMap lookup — the same for any c3 value.
-        let prefix_entry = match inner.routing.get(&prefix) {
+        let prefix_entry = match rs.routing.get(&prefix) {
             None => {
                 debug!(
                     component_0 = encoded.component_0,

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -160,7 +160,9 @@ impl PrefixEntry {
     /// Returns `None` if `id` has no slot or all connections equal `skip`.
     fn get_one(&self, id: u64, skip: u64) -> Option<u64> {
         let idx = self.ids.iter().position(|&i| i == id)?;
-        self.get_one_at(idx, skip)
+        Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(
+            || Self::pick_one(&self.remote_connections[idx], &self.remote_cursors[idx], skip),
+        )
     }
 
     /// Return all connections for `id` (local + remote) excluding `skip`.
@@ -171,8 +173,63 @@ impl PrefixEntry {
         let mut out = Vec::with_capacity(
             self.local_connections[idx].len() + self.remote_connections[idx].len(),
         );
-        out.extend(self.get_all_at(idx, skip));
+        out.extend(
+            self.local_connections[idx]
+                .iter()
+                .chain(self.remote_connections[idx].iter())
+                .copied()
+                .filter(|&c| c != skip),
+        );
         Some(out)
+    }
+
+    /// NULL_COMPONENT `match_one`: pick one connection, all locals before any remote,
+    /// starting from a random slot, skipping `skip`.
+    fn pick_one_any(&self, skip: u64) -> Option<u64> {
+        let n = self.len();
+        if n == 0 {
+            return None;
+        }
+        // Skip the rng call when there is only one slot.
+        let start = if n == 1 { 0 } else { rand::rng().random_range(0..n) };
+        // All locals first (starting from random slot, wrapping).
+        for i in (start..n).chain(0..start) {
+            for &c in &self.local_connections[i] {
+                if c != skip {
+                    return Some(c);
+                }
+            }
+        }
+        // Then all remotes (same wrapping start).
+        for i in (start..n).chain(0..start) {
+            for &c in &self.remote_connections[i] {
+                if c != skip {
+                    return Some(c);
+                }
+            }
+        }
+        None
+    }
+
+    /// NULL_COMPONENT `match_all`: collect all distinct connections, locals before
+    /// remotes, skipping `skip`.
+    fn get_all_any(&self, skip: u64) -> Vec<u64> {
+        let mut out: Vec<u64> = Vec::with_capacity(self.len());
+        for local in &self.local_connections {
+            for &c in local {
+                if c != skip && !out.contains(&c) {
+                    out.push(c);
+                }
+            }
+        }
+        for remote in &self.remote_connections {
+            for &c in remote {
+                if c != skip && !out.contains(&c) {
+                    out.push(c);
+                }
+            }
+        }
+        out
     }
 
     /// Iterate all slots, yielding `(id, local, remote)` — used by `for_each`.
@@ -180,28 +237,6 @@ impl PrefixEntry {
         for (i, &id) in self.ids.iter().enumerate() {
             f(id, &self.local_connections[i], &self.remote_connections[i]);
         }
-    }
-
-    /// Return one connection for slot `idx`, preferring local, round-robin, excluding `skip`.
-    fn get_one_at(&self, idx: usize, skip: u64) -> Option<u64> {
-        Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(
-            || {
-                Self::pick_one(
-                    &self.remote_connections[idx],
-                    &self.remote_cursors[idx],
-                    skip,
-                )
-            },
-        )
-    }
-
-    /// Return all connections for slot `idx` (local + remote) excluding `skip`.
-    fn get_all_at(&self, idx: usize, skip: u64) -> impl Iterator<Item = u64> + '_ {
-        self.local_connections[idx]
-            .iter()
-            .chain(self.remote_connections[idx].iter())
-            .copied()
-            .filter(move |&c| c != skip)
     }
 
     /// Build a `ProtoName` from the stored strings and a component_3 value.
@@ -546,40 +581,17 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 ])
             })
         } else {
-            // NULL_COMPONENT: pick one connection across all registered IDs.
-            // Data is already hot from the single lookup above.
-
-            // Fast path: single slot — delegate to its round-robin picker,
-            // which already prefers locals and costs nothing to allocate.
-            if prefix_entry.len() == 1 {
-                return prefix_entry.get_one_at(0, incoming_conn).ok_or_else(|| {
-                    debug!("no output connection available");
-                    DataPathError::NoMatchEncoded([
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        id,
-                    ])
-                });
-            }
-
-            // General case: pick a random starting slot, then use its
-            // get_one_at (round-robin, local-preferred). A single
-            // random_range call keeps the hot path allocation-free.
-            let n = prefix_entry.len();
-            let start = rand::rng().random_range(0..n);
-            for i in (start..n).chain(0..start) {
-                if let Some(c) = prefix_entry.get_one_at(i, incoming_conn) {
-                    return Ok(c);
-                }
-            }
-            debug!("no output connection available");
-            Err(DataPathError::NoMatchEncoded([
-                encoded.component_0,
-                encoded.component_1,
-                encoded.component_2,
-                id,
-            ]))
+            // NULL_COMPONENT: pick one connection across all registered IDs,
+            // locals preferred.  Data is already hot from the single lookup above.
+            prefix_entry.pick_one_any(incoming_conn).ok_or_else(|| {
+                debug!("no output connection available");
+                DataPathError::NoMatchEncoded([
+                    encoded.component_0,
+                    encoded.component_1,
+                    encoded.component_2,
+                    id,
+                ])
+            })
         }
     }
 
@@ -643,20 +655,9 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 }
             }
         } else {
-            // NULL_COMPONENT: union of all connections across all registered IDs;
-            // data already hot from the single lookup.
-            // Use Vec::contains for dedup to avoid the HashSet allocation cost.
-            // O(n²) but n ≤ ~16 in practice, so linear scan beats HashSet overhead.
-            let n = prefix_entry.len();
-            let mut out: Vec<u64> = Vec::with_capacity(n);
-            for i in 0..n {
-                for c in prefix_entry.get_all_at(i, incoming_conn) {
-                    if !out.contains(&c) {
-                        out.push(c);
-                    }
-                }
-            }
-
+            // NULL_COMPONENT: union of all connections, locals before remotes.
+            // Data is already hot from the single lookup above.
+            let out = prefix_entry.get_all_any(incoming_conn);
             if out.is_empty() {
                 debug!("no connection available");
                 Err(DataPathError::NoMatchEncoded([

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -32,6 +32,8 @@ impl ConnList {
         }
     }
 
+    // Linear scan: acceptable for the expected connection counts (≤ 256).
+    // Switch to a HashSet if this ever grows significantly larger.
     /// Add `conn` if not already present (deduped).
     fn push(&mut self, conn: u64) {
         if !self.conns.contains(&conn) {
@@ -112,6 +114,10 @@ struct PrefixEntry {
     ids: Vec<u64>,
     local: Vec<ConnList>,
     remote: Vec<ConnList>,
+    /// Deduplicated union of all per-slot local connections.
+    all_local_conns: Vec<u64>,
+    /// Deduplicated union of all per-slot remote connections.
+    all_remote_conns: Vec<u64>,
     /// Round-robin cursor for NULL_COMPONENT slot selection.
     slot_cursor: AtomicUsize,
     /// Human-readable prefix strings for for_each / Display / ProtoName.
@@ -124,6 +130,8 @@ impl PrefixEntry {
             ids: Vec::new(),
             local: Vec::new(),
             remote: Vec::new(),
+            all_local_conns: Vec::new(),
+            all_remote_conns: Vec::new(),
             slot_cursor: AtomicUsize::new(0),
             strings,
         }
@@ -136,32 +144,66 @@ impl PrefixEntry {
         self.remote.push(ConnList::new());
     }
 
-    fn len(&self) -> usize {
-        self.ids.len()
-    }
-
     fn is_empty(&self) -> bool {
         self.ids.is_empty()
     }
 
     /// Add `conn` to the appropriate list for slot `idx` if not already present.
+    /// Also updates the aggregate deduped connection list.
     fn insert_conn(&mut self, idx: usize, conn: u64, is_local: bool) {
-        let list = if is_local {
-            &mut self.local[idx]
+        if is_local {
+            self.local[idx].push(conn);
+            if !self.all_local_conns.contains(&conn) {
+                self.all_local_conns.push(conn);
+            }
         } else {
-            &mut self.remote[idx]
-        };
-        list.push(conn);
+            self.remote[idx].push(conn);
+            if !self.all_remote_conns.contains(&conn) {
+                self.all_remote_conns.push(conn);
+            }
+        }
     }
 
     /// Remove `conn` from the appropriate list for slot `idx` (no-op if absent).
+    /// Evicts from the aggregate only when no other slot still holds the connection.
     fn remove_conn(&mut self, idx: usize, conn: u64, is_local: bool) {
-        let list = if is_local {
-            &mut self.local[idx]
+        if is_local {
+            self.local[idx].remove(conn);
+            let still_present = self.local.iter().any(|l| l.conns.contains(&conn));
+            if !still_present
+                && let Some(pos) = self.all_local_conns.iter().position(|&c| c == conn)
+            {
+                self.all_local_conns.swap_remove(pos);
+            }
         } else {
-            &mut self.remote[idx]
-        };
-        list.remove(conn);
+            self.remote[idx].remove(conn);
+            let still_present = self.remote.iter().any(|r| r.conns.contains(&conn));
+            if !still_present
+                && let Some(pos) = self.all_remote_conns.iter().position(|&c| c == conn)
+            {
+                self.all_remote_conns.swap_remove(pos);
+            }
+        }
+    }
+
+    /// Rebuild aggregate connection lists from scratch (called after a slot is removed).
+    fn rebuild_aggregates(&mut self) {
+        self.all_local_conns.clear();
+        for list in &self.local {
+            for &c in &list.conns {
+                if !self.all_local_conns.contains(&c) {
+                    self.all_local_conns.push(c);
+                }
+            }
+        }
+        self.all_remote_conns.clear();
+        for list in &self.remote {
+            for &c in &list.conns {
+                if !self.all_remote_conns.contains(&c) {
+                    self.all_remote_conns.push(c);
+                }
+            }
+        }
     }
 
     /// True when both local and remote lists for slot `idx` are empty.
@@ -174,6 +216,7 @@ impl PrefixEntry {
         self.ids.swap_remove(idx);
         self.local.swap_remove(idx);
         self.remote.swap_remove(idx);
+        self.rebuild_aggregates();
     }
 
     /// Remove all slots whose local and remote lists are both empty.
@@ -196,10 +239,13 @@ impl PrefixEntry {
 
     /// Ensure a slot for `id` exists, then insert `conn` (deduped).
     fn insert_conn_for_id(&mut self, id: u64, conn: u64, is_local: bool) {
-        if !self.ids.contains(&id) {
-            self.push_id(id);
-        }
-        let idx = self.ids.iter().position(|&i| i == id).unwrap();
+        let idx = match self.ids.iter().position(|&i| i == id) {
+            Some(i) => i,
+            None => {
+                self.push_id(id);
+                self.ids.len() - 1
+            }
+        };
         self.insert_conn(idx, conn, is_local);
     }
 
@@ -235,52 +281,38 @@ impl PrefixEntry {
     }
 
     /// NULL_COMPONENT `match_one`: pick one connection, all locals before any remote,
-    /// starting from a random slot, skipping `skip`.
+    /// round-robin across the pre-built aggregate lists, skipping `skip`.
     fn pick_one_any(&self, skip: u64) -> Option<u64> {
-        let n = self.len();
-        if n == 0 {
-            return None;
-        }
-        // Skip the atomic increment when there is only one slot.
-        let start = if n == 1 {
-            0
-        } else {
-            self.slot_cursor.fetch_add(1, Ordering::Relaxed) % n
-        };
-        // All locals first (starting from random slot, wrapping).
-        for i in (start..n).chain(0..start) {
-            if let Some(c) = self.local[i].next(skip) {
-                return Some(c);
+        let n = self.all_local_conns.len();
+        if n > 0 {
+            let start = self.slot_cursor.fetch_add(1, Ordering::Relaxed) % n;
+            for i in (start..n).chain(0..start) {
+                if self.all_local_conns[i] != skip {
+                    return Some(self.all_local_conns[i]);
+                }
             }
         }
-        // Then all remotes (same wrapping start).
-        for i in (start..n).chain(0..start) {
-            if let Some(c) = self.remote[i].next(skip) {
-                return Some(c);
+        let n = self.all_remote_conns.len();
+        if n > 0 {
+            let start = self.slot_cursor.fetch_add(1, Ordering::Relaxed) % n;
+            for i in (start..n).chain(0..start) {
+                if self.all_remote_conns[i] != skip {
+                    return Some(self.all_remote_conns[i]);
+                }
             }
         }
         None
     }
 
     /// NULL_COMPONENT `match_all`: collect all distinct connections, locals before
-    /// remotes, skipping `skip`.
+    /// remotes, skipping `skip`. Uses the pre-built aggregate lists (already deduped).
     fn get_all_any(&self, skip: u64) -> Vec<u64> {
-        let mut out: Vec<u64> = Vec::with_capacity(self.len());
-        for local in &self.local {
-            for c in local.iter() {
-                if c != skip && !out.contains(&c) {
-                    out.push(c);
-                }
-            }
-        }
-        for remote in &self.remote {
-            for c in remote.iter() {
-                if c != skip && !out.contains(&c) {
-                    out.push(c);
-                }
-            }
-        }
-        out
+        self.all_local_conns
+            .iter()
+            .chain(self.all_remote_conns.iter())
+            .copied()
+            .filter(|&c| c != skip)
+            .collect()
     }
 
     /// Iterate all slots, yielding `(id, local, remote)` — used by `for_each`.
@@ -311,6 +343,8 @@ impl Clone for PrefixEntry {
             ids: self.ids.clone(),
             local: self.local.clone(),
             remote: self.remote.clone(),
+            all_local_conns: self.all_local_conns.clone(),
+            all_remote_conns: self.all_remote_conns.clone(),
             slot_cursor: AtomicUsize::new(self.slot_cursor.load(Ordering::Relaxed)),
             strings: self.strings.clone(),
         }
@@ -337,7 +371,46 @@ struct SubRecord {
 #[derive(Debug, Default)]
 struct SubscriptionState {
     subscriptions: HashMap<u64, SubRecord>, // sub_id  → (encoded, conn_id)
-    conn_subs: HashMap<u64, Vec<u64>>,      // conn_id → sub_ids
+    conn_subs: HashMap<u64, HashSet<u64>>,  // conn_id → sub_ids
+}
+
+impl SubscriptionState {
+    /// Record a new subscription and update the reverse conn→sub_ids map.
+    fn add(&mut self, sub_id: u64, record: SubRecord) {
+        self.subscriptions.insert(sub_id, record);
+        self.conn_subs
+            .entry(record.conn_id)
+            .or_default()
+            .insert(sub_id);
+    }
+
+    /// Remove a subscription by `sub_id`, cleaning up `conn_subs` when empty.
+    /// Returns the removed record, or `None` if the `sub_id` was not present.
+    fn remove(&mut self, sub_id: u64) -> Option<SubRecord> {
+        let record = self.subscriptions.remove(&sub_id)?;
+        if let Some(set) = self.conn_subs.get_mut(&record.conn_id) {
+            set.remove(&sub_id);
+        }
+        if self
+            .conn_subs
+            .get(&record.conn_id)
+            .is_some_and(|s| s.is_empty())
+        {
+            self.conn_subs.remove(&record.conn_id);
+        }
+        Some(record)
+    }
+
+    /// True when `conn` still has at least one subscription for `encoded`.
+    fn conn_still_subscribed(&self, conn: u64, encoded: EncodedName) -> bool {
+        self.conn_subs.get(&conn).is_some_and(|subs| {
+            subs.iter().any(|&s| {
+                self.subscriptions
+                    .get(&s)
+                    .is_some_and(|r| r.encoded == encoded)
+            })
+        })
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -354,8 +427,8 @@ struct SubscriptionState {
 
 #[derive(Debug)]
 pub struct SubscriptionTableImpl {
-    routing: ArcSwap<HashMap<[u64; 3], PrefixEntry>>, // lock-free on the hot read path
-    subscription_state: Mutex<SubscriptionState>,     // never held by match_one / match_all
+    routing: ArcSwap<HashMap<[u64; 3], Arc<PrefixEntry>>>, // lock-free on the hot read path
+    subscription_state: Mutex<SubscriptionState>,          // never held by match_one / match_all
 }
 
 impl Default for SubscriptionTableImpl {
@@ -441,29 +514,28 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let mut rs = (**self.routing.load()).clone();
 
         // 1. Ensure PrefixEntry exists; record strings on first insertion.
-        let prefix_entry = rs.entry(prefix).or_insert_with(|| {
+        let entry = rs.entry(prefix).or_insert_with(|| {
             let (s0, s1, s2) = name.str_components();
-            PrefixEntry::new([s0.to_string(), s1.to_string(), s2.to_string()])
+            Arc::new(PrefixEntry::new([
+                s0.to_string(),
+                s1.to_string(),
+                s2.to_string(),
+            ]))
         });
 
         // 2 & 3. Ensure an ID slot exists and insert conn (deduped).
-        prefix_entry.insert_conn_for_id(id, conn, is_local);
+        // Arc::make_mut does COW: clones only this PrefixEntry if other refs exist.
+        Arc::make_mut(entry).insert_conn_for_id(id, conn, is_local);
         self.routing.store(Arc::new(rs));
 
-        // 4. Record the subscription (idempotent: same sub_id overwrites itself).
-        ss.subscriptions.insert(
+        // 4 & 5. Record subscription and update the reverse conn→sub_ids map.
+        ss.add(
             subscription_id,
             SubRecord {
                 encoded,
                 conn_id: conn,
             },
         );
-
-        // 5. Track sub_id → conn (deduped).
-        let subs = ss.conn_subs.entry(conn).or_default();
-        if !subs.contains(&subscription_id) {
-            subs.push(subscription_id);
-        }
 
         debug!(%name, %conn, "subscription table: add subscription");
         Ok(())
@@ -511,28 +583,20 @@ impl SubscriptionTable for SubscriptionTableImpl {
             return Err(DataPathError::SubscriptionIdNotFound(subscription_id));
         }
 
-        // Remove sub_id from the subscriptions map and the reverse conn_subs map.
-        ss.subscriptions.remove(&subscription_id);
-        if let Some(subs) = ss.conn_subs.get_mut(&conn) {
-            subs.retain(|&s| s != subscription_id);
-        }
+        // Remove sub_id from both maps (conn_subs is cleaned up when empty).
+        ss.remove(subscription_id);
 
         // Check whether the connection is still subscribed to the same encoded name via another
         // subscription_id.
-        let conn_still_subscribed = ss.conn_subs.get(&conn).is_some_and(|subs| {
-            subs.iter().any(|&s| {
-                ss.subscriptions
-                    .get(&s)
-                    .is_some_and(|r| r.encoded == encoded)
-            })
-        });
+        let conn_still_subscribed = ss.conn_still_subscribed(conn, encoded);
 
         if !conn_still_subscribed {
             let mut rs = (**self.routing.load()).clone();
-            let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
-                prefix_entry.remove_conn_for_id(id, conn, is_local);
-                prefix_entry.retain_non_empty();
-                prefix_entry.is_empty()
+            let should_remove_prefix = if let Some(entry) = rs.get_mut(&prefix) {
+                let pe = Arc::make_mut(entry);
+                pe.remove_conn_for_id(id, conn, is_local);
+                pe.retain_non_empty();
+                pe.is_empty()
             } else {
                 false
             };
@@ -540,11 +604,6 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 rs.remove(&prefix);
             }
             self.routing.store(Arc::new(rs));
-        }
-
-        // Clean up conn_subs if empty.
-        if ss.conn_subs.get(&conn).is_some_and(|s| s.is_empty()) {
-            ss.conn_subs.remove(&conn);
         }
 
         Ok(())
@@ -604,10 +663,11 @@ impl SubscriptionTable for SubscriptionTableImpl {
             ];
             let id = encoded.component_3;
 
-            let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
-                prefix_entry.remove_conn_for_id(id, conn, is_local);
-                prefix_entry.retain_non_empty();
-                prefix_entry.is_empty()
+            let should_remove_prefix = if let Some(entry) = rs.get_mut(&prefix) {
+                let pe = Arc::make_mut(entry);
+                pe.remove_conn_for_id(id, conn, is_local);
+                pe.retain_non_empty();
+                pe.is_empty()
             } else {
                 false
             };
@@ -823,7 +883,7 @@ mod tests {
         assert!(out.contains(&1));
         assert!(out.contains(&2));
 
-        // run multiple times for randomnes
+        // run multiple times for randomness
         for _ in 0..20 {
             let out = t.match_one(&enc(&name1), 100).unwrap();
             if out != 1 && out != 2 {

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -135,6 +135,53 @@ impl PrefixEntry {
         None
     }
 
+    /// True when a slot for `id` exists.
+    fn has_id(&self, id: u64) -> bool {
+        self.ids.contains(&id)
+    }
+
+    /// Ensure a slot for `id` exists, then insert `conn` (deduped).
+    fn insert_conn_for_id(&mut self, id: u64, conn: u64, is_local: bool) {
+        if !self.ids.contains(&id) {
+            self.push_id(id);
+        }
+        let idx = self.ids.iter().position(|&i| i == id).unwrap();
+        self.insert_conn(idx, conn, is_local);
+    }
+
+    /// Remove `conn` from the slot for `id` (no-op if slot absent).
+    fn remove_conn_for_id(&mut self, id: u64, conn: u64, is_local: bool) {
+        if let Some(idx) = self.ids.iter().position(|&i| i == id) {
+            self.remove_conn(idx, conn, is_local);
+        }
+    }
+
+    /// Return one connection for `id`, preferring local, round-robin, excluding `skip`.
+    /// Returns `None` if `id` has no slot or all connections equal `skip`.
+    fn get_one(&self, id: u64, skip: u64) -> Option<u64> {
+        let idx = self.ids.iter().position(|&i| i == id)?;
+        self.get_one_at(idx, skip)
+    }
+
+    /// Return all connections for `id` (local + remote) excluding `skip`.
+    /// `None` means the slot for `id` does not exist;
+    /// `Some(empty)` means the slot exists but all connections equal `skip`.
+    fn get_all(&self, id: u64, skip: u64) -> Option<Vec<u64>> {
+        let idx = self.ids.iter().position(|&i| i == id)?;
+        let mut out = Vec::with_capacity(
+            self.local_connections[idx].len() + self.remote_connections[idx].len(),
+        );
+        out.extend(self.get_all_at(idx, skip));
+        Some(out)
+    }
+
+    /// Iterate all slots, yielding `(id, local, remote)` — used by `for_each`.
+    fn for_each_slot<F: FnMut(u64, &[u64], &[u64])>(&self, mut f: F) {
+        for (i, &id) in self.ids.iter().enumerate() {
+            f(id, &self.local_connections[i], &self.remote_connections[i]);
+        }
+    }
+
     /// Return one connection for slot `idx`, preferring local, round-robin, excluding `skip`.
     fn get_one_at(&self, idx: usize, skip: u64) -> Option<u64> {
         Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(
@@ -261,14 +308,9 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 prefix_entry.strings[1].as_str(),
                 prefix_entry.strings[2].as_str(),
             ]);
-            for (i, &id) in prefix_entry.ids.iter().enumerate() {
-                f(
-                    &base_name,
-                    id,
-                    &prefix_entry.local_connections[i],
-                    &prefix_entry.remote_connections[i],
-                );
-            }
+            prefix_entry.for_each_slot(|id, local, remote| {
+                f(&base_name, id, local, remote);
+            });
         }
     }
 
@@ -294,14 +336,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
             PrefixEntry::new([s0.to_string(), s1.to_string(), s2.to_string()])
         });
 
-        // 2. Ensure an ID slot exists within the prefix.
-        if !prefix_entry.ids.contains(&id) {
-            prefix_entry.push_id(id);
-        }
-
-        // 3. Insert conn into the right list (deduped).
-        let idx = prefix_entry.ids.iter().position(|&i| i == id).unwrap();
-        prefix_entry.insert_conn(idx, conn, is_local);
+        // 2 & 3. Ensure an ID slot exists and insert conn (deduped).
+        prefix_entry.insert_conn_for_id(id, conn, is_local);
 
         // 4. Record the subscription (idempotent: same sub_id overwrites itself).
         ss.subscriptions.insert(
@@ -343,7 +379,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             debug!("subscription not found {}", name);
             return Err(DataPathError::SubscriptionNotFound(name.clone()));
         }
-        if !rs[&prefix].ids.contains(&id) {
+        if !rs[&prefix].has_id(id) {
             warn!(%id, "not found");
             return Err(DataPathError::IdNotFound(id));
         }
@@ -382,9 +418,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             // Remove conn from the routing entry; drop the mutable ref before
             // potentially calling routing.remove().
             let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
-                if let Some(idx) = prefix_entry.ids.iter().position(|&i| i == id) {
-                    prefix_entry.remove_conn(idx, conn, is_local);
-                }
+                prefix_entry.remove_conn_for_id(id, conn, is_local);
                 prefix_entry.retain_non_empty();
                 prefix_entry.is_empty()
             } else {
@@ -456,9 +490,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             let id = encoded.component_3;
 
             let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
-                if let Some(idx) = prefix_entry.ids.iter().position(|&i| i == id) {
-                    prefix_entry.remove_conn(idx, conn, is_local);
-                }
+                prefix_entry.remove_conn_for_id(id, conn, is_local);
                 prefix_entry.retain_non_empty();
                 prefix_entry.is_empty()
             } else {
@@ -504,26 +536,15 @@ impl SubscriptionTable for SubscriptionTableImpl {
 
         if id != ProtoName::NULL_COMPONENT {
             // Specific ID: linear scan over ids (8 per cache line).
-            match prefix_entry.ids.iter().position(|&i| i == id) {
-                None => {
-                    debug!(component_3 = id, "match not found for name");
-                    Err(DataPathError::NoMatchEncoded([
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        id,
-                    ]))
-                }
-                Some(idx) => prefix_entry.get_one_at(idx, incoming_conn).ok_or_else(|| {
-                    debug!("no output connection available");
-                    DataPathError::NoMatchEncoded([
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        id,
-                    ])
-                }),
-            }
+            prefix_entry.get_one(id, incoming_conn).ok_or_else(|| {
+                debug!(component_3 = id, "match not found for name");
+                DataPathError::NoMatchEncoded([
+                    encoded.component_0,
+                    encoded.component_1,
+                    encoded.component_2,
+                    id,
+                ])
+            })
         } else {
             // NULL_COMPONENT: pick one connection across all registered IDs.
             // Data is already hot from the single lookup above.
@@ -597,7 +618,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
 
         if id != ProtoName::NULL_COMPONENT {
             // Specific ID: linear scan over ids (8 per cache line).
-            match prefix_entry.ids.iter().position(|&i| i == id) {
+            match prefix_entry.get_all(id, incoming_conn) {
                 None => {
                     debug!(component_3 = id, "match not found for name");
                     Err(DataPathError::NoMatchEncoded([
@@ -607,24 +628,18 @@ impl SubscriptionTable for SubscriptionTableImpl {
                         id,
                     ]))
                 }
-                Some(idx) => {
-                    let mut out = Vec::with_capacity(
-                        prefix_entry.local_connections[idx].len()
-                            + prefix_entry.remote_connections[idx].len(),
-                    );
-                    out.extend(prefix_entry.get_all_at(idx, incoming_conn));
-                    if out.is_empty() {
-                        debug!("no connection available (local/remote)");
-                        Err(DataPathError::NoMatchEncoded([
-                            encoded.component_0,
-                            encoded.component_1,
-                            encoded.component_2,
-                            id,
-                        ]))
-                    } else {
-                        debug!(?out, "found connections");
-                        Ok(out)
-                    }
+                Some(out) if out.is_empty() => {
+                    debug!("no connection available (local/remote)");
+                    Err(DataPathError::NoMatchEncoded([
+                        encoded.component_0,
+                        encoded.component_1,
+                        encoded.component_2,
+                        id,
+                    ]))
+                }
+                Some(out) => {
+                    debug!(?out, "found connections");
+                    Ok(out)
                 }
             }
         } else {

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -14,58 +14,106 @@ use crate::api::{EncodedName, ProtoName};
 use crate::errors::DataPathError;
 
 // ──────────────────────────────────────────────────────────────────────────────
-// IdEntry – one entry per unique component_3 value registered under a prefix.
+// PrefixEntry – one allocation per unique [u64; 3] prefix.
 //
-// `local` and `remote` are insertion-ordered Vecs (deduped).  The AtomicUsize
-// cursors advance under the read lock for round-robin selection.
+// Struct-of-arrays layout: `ids` is a flat Vec<u64> so a scan for a matching
+// component_3 value reads 8 IDs per cache line instead of striding across
+// 72-byte AoS IdEntry objects.  Once the index is found the per-slot
+// connection Vecs are accessed by that index.
+//
+// Invariant: all five Vecs always have the same length.
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug)]
-struct IdEntry {
-    id: u64,
-    local: Vec<u64>,
-    remote: Vec<u64>,
-    local_cursor: AtomicUsize,
-    remote_cursor: AtomicUsize,
+struct PrefixEntry {
+    /// Dense u64 array — 8 IDs per cache line.
+    ids: Vec<u64>,
+    local_connections: Vec<Vec<u64>>,
+    remote_connections: Vec<Vec<u64>>,
+    local_cursors: Vec<AtomicUsize>,
+    remote_cursors: Vec<AtomicUsize>,
+    /// Human-readable prefix strings for for_each / Display / ProtoName.
+    strings: [String; 3],
 }
 
-impl IdEntry {
-    fn new(id: u64) -> Self {
-        IdEntry {
-            id,
-            local: Vec::new(),
-            remote: Vec::new(),
-            local_cursor: AtomicUsize::new(0),
-            remote_cursor: AtomicUsize::new(0),
+impl PrefixEntry {
+    fn new(strings: [String; 3]) -> Self {
+        PrefixEntry {
+            ids: Vec::new(),
+            local_connections: Vec::new(),
+            remote_connections: Vec::new(),
+            local_cursors: Vec::new(),
+            remote_cursors: Vec::new(),
+            strings,
         }
     }
 
-    /// Add `conn` to the appropriate list if not already present.
-    fn insert(&mut self, conn: u64, is_local: bool) {
+    /// Append a new ID slot. Called only when `id` is not already present.
+    fn push_id(&mut self, id: u64) {
+        self.ids.push(id);
+        self.local_connections.push(Vec::new());
+        self.remote_connections.push(Vec::new());
+        self.local_cursors.push(AtomicUsize::new(0));
+        self.remote_cursors.push(AtomicUsize::new(0));
+    }
+
+    fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    /// Add `conn` to the appropriate list for slot `idx` if not already present.
+    fn insert_conn(&mut self, idx: usize, conn: u64, is_local: bool) {
         let vec = if is_local {
-            &mut self.local
+            &mut self.local_connections[idx]
         } else {
-            &mut self.remote
+            &mut self.remote_connections[idx]
         };
         if !vec.contains(&conn) {
             vec.push(conn);
         }
     }
 
-    /// Remove `conn` from the appropriate list (no-op if absent).
-    fn remove(&mut self, conn: u64, is_local: bool) {
+    /// Remove `conn` from the appropriate list for slot `idx` (no-op if absent).
+    fn remove_conn(&mut self, idx: usize, conn: u64, is_local: bool) {
         let vec = if is_local {
-            &mut self.local
+            &mut self.local_connections[idx]
         } else {
-            &mut self.remote
+            &mut self.remote_connections[idx]
         };
         if let Some(pos) = vec.iter().position(|&c| c == conn) {
             vec.swap_remove(pos);
         }
     }
 
-    fn is_empty(&self) -> bool {
-        self.local.is_empty() && self.remote.is_empty()
+    /// True when both local and remote lists for slot `idx` are empty.
+    fn is_slot_empty(&self, idx: usize) -> bool {
+        self.local_connections[idx].is_empty() && self.remote_connections[idx].is_empty()
+    }
+
+    /// Remove slot `idx` using swap_remove on every parallel Vec.
+    fn remove_slot(&mut self, idx: usize) {
+        self.ids.swap_remove(idx);
+        self.local_connections.swap_remove(idx);
+        self.remote_connections.swap_remove(idx);
+        self.local_cursors.swap_remove(idx);
+        self.remote_cursors.swap_remove(idx);
+    }
+
+    /// Remove all slots whose local and remote lists are both empty.
+    /// Replaces `by_id.retain(|e| !e.is_empty())`.
+    fn retain_non_empty(&mut self) {
+        let mut i = 0;
+        while i < self.ids.len() {
+            if self.is_slot_empty(i) {
+                self.remove_slot(i); // swap_remove: don't advance i
+            } else {
+                i += 1;
+            }
+        }
     }
 
     /// Round-robin pick from `slice`, skipping `skip`.
@@ -87,43 +135,26 @@ impl IdEntry {
         None
     }
 
-    /// Return one connection preferring local, round-robin, excluding `skip`.
-    fn get_one(&self, skip: u64) -> Option<u64> {
-        Self::pick_one(&self.local, &self.local_cursor, skip)
-            .or_else(|| Self::pick_one(&self.remote, &self.remote_cursor, skip))
+    /// Return one connection for slot `idx`, preferring local, round-robin, excluding `skip`.
+    fn get_one_at(&self, idx: usize, skip: u64) -> Option<u64> {
+        Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(
+            || {
+                Self::pick_one(
+                    &self.remote_connections[idx],
+                    &self.remote_cursors[idx],
+                    skip,
+                )
+            },
+        )
     }
 
-    /// Return all connections (local + remote) excluding `skip`.
-    fn get_all(&self, skip: u64) -> impl Iterator<Item = u64> + '_ {
-        self.local
+    /// Return all connections for slot `idx` (local + remote) excluding `skip`.
+    fn get_all_at(&self, idx: usize, skip: u64) -> impl Iterator<Item = u64> + '_ {
+        self.local_connections[idx]
             .iter()
-            .chain(self.remote.iter())
+            .chain(self.remote_connections[idx].iter())
             .copied()
             .filter(move |&c| c != skip)
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// PrefixEntry – one allocation per unique [u64; 3] prefix.
-//
-// All IdEntries for a prefix share this heap object → a single cache miss
-// brings the whole routing context into L1/L2.
-// ──────────────────────────────────────────────────────────────────────────────
-
-#[derive(Debug)]
-struct PrefixEntry {
-    /// Linear scan only; n ≤ ~10 in any real deployment.
-    by_id: Vec<IdEntry>,
-    /// Human-readable prefix strings for for_each / Display / ProtoName.
-    strings: [String; 3],
-}
-
-impl PrefixEntry {
-    fn new(strings: [String; 3]) -> Self {
-        PrefixEntry {
-            by_id: Vec::new(),
-            strings,
-        }
     }
 
     /// Build a `ProtoName` from the stored strings and a component_3 value.
@@ -190,23 +221,23 @@ impl Display for SubscriptionTableImpl {
                 prefix_entry.strings[0], prefix_entry.strings[1], prefix_entry.strings[2]
             )?;
             writeln!(f, "  Names:")?;
-            for id_entry in &prefix_entry.by_id {
-                writeln!(f, "    Id: {}", id_entry.id)?;
-                if id_entry.local.is_empty() {
+            for (i, &id) in prefix_entry.ids.iter().enumerate() {
+                writeln!(f, "    Id: {}", id)?;
+                if prefix_entry.local_connections[i].is_empty() {
                     writeln!(f, "       Local Connections:")?;
                     writeln!(f, "         None")?;
                 } else {
                     writeln!(f, "       Local Connections:")?;
-                    for c in &id_entry.local {
+                    for c in &prefix_entry.local_connections[i] {
                         writeln!(f, "         Connection: {}", c)?;
                     }
                 }
-                if id_entry.remote.is_empty() {
+                if prefix_entry.remote_connections[i].is_empty() {
                     writeln!(f, "       Remote Connections:")?;
                     writeln!(f, "         None")?;
                 } else {
                     writeln!(f, "       Remote Connections:")?;
-                    for c in &id_entry.remote {
+                    for c in &prefix_entry.remote_connections[i] {
                         writeln!(f, "         Connection: {}", c)?;
                     }
                 }
@@ -230,8 +261,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 prefix_entry.strings[1].as_str(),
                 prefix_entry.strings[2].as_str(),
             ]);
-            for id_entry in &prefix_entry.by_id {
-                f(&base_name, id_entry.id, &id_entry.local, &id_entry.remote);
+            for (i, &id) in prefix_entry.ids.iter().enumerate() {
+                f(
+                    &base_name,
+                    id,
+                    &prefix_entry.local_connections[i],
+                    &prefix_entry.remote_connections[i],
+                );
             }
         }
     }
@@ -258,14 +294,14 @@ impl SubscriptionTable for SubscriptionTableImpl {
             PrefixEntry::new([s0.to_string(), s1.to_string(), s2.to_string()])
         });
 
-        // 2. Ensure an IdEntry for this id exists within the prefix.
-        if !prefix_entry.by_id.iter().any(|e| e.id == id) {
-            prefix_entry.by_id.push(IdEntry::new(id));
+        // 2. Ensure an ID slot exists within the prefix.
+        if !prefix_entry.ids.contains(&id) {
+            prefix_entry.push_id(id);
         }
 
         // 3. Insert conn into the right list (deduped).
-        let id_entry = prefix_entry.by_id.iter_mut().find(|e| e.id == id).unwrap();
-        id_entry.insert(conn, is_local);
+        let idx = prefix_entry.ids.iter().position(|&i| i == id).unwrap();
+        prefix_entry.insert_conn(idx, conn, is_local);
 
         // 4. Record the subscription (idempotent: same sub_id overwrites itself).
         ss.subscriptions.insert(
@@ -307,7 +343,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             debug!("subscription not found {}", name);
             return Err(DataPathError::SubscriptionNotFound(name.clone()));
         }
-        if !rs[&prefix].by_id.iter().any(|e| e.id == id) {
+        if !rs[&prefix].ids.contains(&id) {
             warn!(%id, "not found");
             return Err(DataPathError::IdNotFound(id));
         }
@@ -346,11 +382,11 @@ impl SubscriptionTable for SubscriptionTableImpl {
             // Remove conn from the routing entry; drop the mutable ref before
             // potentially calling routing.remove().
             let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
-                if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
-                    id_entry.remove(conn, is_local);
+                if let Some(idx) = prefix_entry.ids.iter().position(|&i| i == id) {
+                    prefix_entry.remove_conn(idx, conn, is_local);
                 }
-                prefix_entry.by_id.retain(|e| !e.is_empty());
-                prefix_entry.by_id.is_empty()
+                prefix_entry.retain_non_empty();
+                prefix_entry.is_empty()
             } else {
                 false
             };
@@ -420,11 +456,11 @@ impl SubscriptionTable for SubscriptionTableImpl {
             let id = encoded.component_3;
 
             let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
-                if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
-                    id_entry.remove(conn, is_local);
+                if let Some(idx) = prefix_entry.ids.iter().position(|&i| i == id) {
+                    prefix_entry.remove_conn(idx, conn, is_local);
                 }
-                prefix_entry.by_id.retain(|e| !e.is_empty());
-                prefix_entry.by_id.is_empty()
+                prefix_entry.retain_non_empty();
+                prefix_entry.is_empty()
             } else {
                 false
             };
@@ -467,8 +503,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
         };
 
         if id != ProtoName::NULL_COMPONENT {
-            // Specific ID: linear scan over by_id (n ≤ ~10, fits in cache).
-            match prefix_entry.by_id.iter().find(|e| e.id == id) {
+            // Specific ID: linear scan over ids (8 per cache line).
+            match prefix_entry.ids.iter().position(|&i| i == id) {
                 None => {
                     debug!(component_3 = id, "match not found for name");
                     Err(DataPathError::NoMatchEncoded([
@@ -478,7 +514,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                         id,
                     ]))
                 }
-                Some(entry) => entry.get_one(incoming_conn).ok_or_else(|| {
+                Some(idx) => prefix_entry.get_one_at(idx, incoming_conn).ok_or_else(|| {
                     debug!("no output connection available");
                     DataPathError::NoMatchEncoded([
                         encoded.component_0,
@@ -492,10 +528,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
             // NULL_COMPONENT: pick one connection across all registered IDs.
             // Data is already hot from the single lookup above.
 
-            // Fast path: single IdEntry — delegate to its round-robin picker,
+            // Fast path: single slot — delegate to its round-robin picker,
             // which already prefers locals and costs nothing to allocate.
-            if prefix_entry.by_id.len() == 1 {
-                return prefix_entry.by_id[0].get_one(incoming_conn).ok_or_else(|| {
+            if prefix_entry.len() == 1 {
+                return prefix_entry.get_one_at(0, incoming_conn).ok_or_else(|| {
                     debug!("no output connection available");
                     DataPathError::NoMatchEncoded([
                         encoded.component_0,
@@ -506,14 +542,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 });
             }
 
-            // General case: pick a random starting IdEntry, then use its
-            // existing get_one (round-robin, local-preferred). A single
+            // General case: pick a random starting slot, then use its
+            // get_one_at (round-robin, local-preferred). A single
             // random_range call keeps the hot path allocation-free.
-            let by_id = &prefix_entry.by_id;
-            let n = by_id.len();
+            let n = prefix_entry.len();
             let start = rand::rng().random_range(0..n);
-            for entry in by_id[start..].iter().chain(by_id[..start].iter()) {
-                if let Some(c) = entry.get_one(incoming_conn) {
+            for i in (start..n).chain(0..start) {
+                if let Some(c) = prefix_entry.get_one_at(i, incoming_conn) {
                     return Ok(c);
                 }
             }
@@ -561,8 +596,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
         };
 
         if id != ProtoName::NULL_COMPONENT {
-            // Specific ID: linear scan over by_id.
-            match prefix_entry.by_id.iter().find(|e| e.id == id) {
+            // Specific ID: linear scan over ids (8 per cache line).
+            match prefix_entry.ids.iter().position(|&i| i == id) {
                 None => {
                     debug!(component_3 = id, "match not found for name");
                     Err(DataPathError::NoMatchEncoded([
@@ -572,9 +607,12 @@ impl SubscriptionTable for SubscriptionTableImpl {
                         id,
                     ]))
                 }
-                Some(entry) => {
-                    let mut out = Vec::with_capacity(entry.local.len() + entry.remote.len());
-                    out.extend(entry.get_all(incoming_conn));
+                Some(idx) => {
+                    let mut out = Vec::with_capacity(
+                        prefix_entry.local_connections[idx].len()
+                            + prefix_entry.remote_connections[idx].len(),
+                    );
+                    out.extend(prefix_entry.get_all_at(idx, incoming_conn));
                     if out.is_empty() {
                         debug!("no connection available (local/remote)");
                         Err(DataPathError::NoMatchEncoded([
@@ -594,10 +632,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
             // data already hot from the single lookup.
             // Use Vec::contains for dedup to avoid the HashSet allocation cost.
             // O(n²) but n ≤ ~16 in practice, so linear scan beats HashSet overhead.
-            let n = prefix_entry.by_id.len();
+            let n = prefix_entry.len();
             let mut out: Vec<u64> = Vec::with_capacity(n);
-            for id_entry in &prefix_entry.by_id {
-                for c in id_entry.get_all(incoming_conn) {
+            for i in 0..n {
+                for c in prefix_entry.get_all_at(i, incoming_conn) {
                     if !out.contains(&c) {
                         out.push(c);
                     }

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -125,7 +125,11 @@ impl PrefixEntry {
             return None;
         }
         if n == 1 {
-            return if slice[0] != skip { Some(slice[0]) } else { None };
+            return if slice[0] != skip {
+                Some(slice[0])
+            } else {
+                None
+            };
         }
         for _ in 0..n {
             let pos = cursor.fetch_add(1, Ordering::Relaxed) % n;
@@ -162,9 +166,13 @@ impl PrefixEntry {
     /// Returns `None` if `id` has no slot or all connections equal `skip`.
     fn get_one(&self, id: u64, skip: u64) -> Option<u64> {
         let idx = self.ids.iter().position(|&i| i == id)?;
-        Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(
-            || Self::pick_one(&self.remote_connections[idx], &self.remote_cursors[idx], skip),
-        )
+        Self::pick_one(&self.local_connections[idx], &self.local_cursors[idx], skip).or_else(|| {
+            Self::pick_one(
+                &self.remote_connections[idx],
+                &self.remote_cursors[idx],
+                skip,
+            )
+        })
     }
 
     /// Return all connections for `id` (local + remote) excluding `skip`.

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -6,7 +6,6 @@ use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use parking_lot::{Mutex, RwLock};
-use rand::Rng;
 use tracing::{debug, warn};
 
 use super::SubscriptionTable;
@@ -32,6 +31,8 @@ struct PrefixEntry {
     remote_connections: Vec<Vec<u64>>,
     local_cursors: Vec<AtomicUsize>,
     remote_cursors: Vec<AtomicUsize>,
+    /// Round-robin cursor for NULL_COMPONENT slot selection.
+    slot_cursor: AtomicUsize,
     /// Human-readable prefix strings for for_each / Display / ProtoName.
     strings: [String; 3],
 }
@@ -44,6 +45,7 @@ impl PrefixEntry {
             remote_connections: Vec::new(),
             local_cursors: Vec::new(),
             remote_cursors: Vec::new(),
+            slot_cursor: AtomicUsize::new(0),
             strings,
         }
     }
@@ -190,8 +192,12 @@ impl PrefixEntry {
         if n == 0 {
             return None;
         }
-        // Skip the rng call when there is only one slot.
-        let start = if n == 1 { 0 } else { rand::rng().random_range(0..n) };
+        // Skip the atomic increment when there is only one slot.
+        let start = if n == 1 {
+            0
+        } else {
+            self.slot_cursor.fetch_add(1, Ordering::Relaxed) % n
+        };
         // All locals first (starting from random slot, wrapping).
         for i in (start..n).chain(0..start) {
             for &c in &self.local_connections[i] {

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -149,27 +149,14 @@ struct SubRecord {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// RoutingState — HOT read path.
-//
-// Protected by an RwLock so many readers can proceed concurrently without
-// ever being blocked by subscription bookkeeping (WriteState).
-// ──────────────────────────────────────────────────────────────────────────────
-
-#[derive(Debug, Default)]
-struct RoutingState {
-    // One HashMap lookup covers both specific-ID and NULL_COMPONENT cases.
-    routing: HashMap<[u64; 3], PrefixEntry>,
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// WriteState — COLD write path.
+// SubscriptionState — COLD write path.
 //
 // Protected by a Mutex (exclusive access always required). Never held by
 // match_one / match_all, so subscription churn never blocks message routing.
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
-struct WriteState {
+struct SubscriptionState {
     subscriptions: HashMap<u64, SubRecord>, // sub_id  → (encoded, conn_id)
     conn_subs: HashMap<u64, Vec<u64>>,      // conn_id → sub_ids
 }
@@ -178,22 +165,22 @@ struct WriteState {
 // SubscriptionTableImpl
 //
 // Lock ordering (must always be respected to prevent deadlock):
-//   1. write_state.lock()   — acquired first by all writers
-//   2. routing.write()      — acquired second by all writers
-// Readers only ever acquire routing.read(); they never touch write_state.
+//   1. subscription_state.lock() — acquired first by all writers
+//   2. routing.write()           — acquired second by all writers
+// Readers only ever acquire routing.read(); they never touch subscription_state.
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
 pub struct SubscriptionTableImpl {
-    routing: RwLock<RoutingState>,  // only lock held on the hot read path
-    write_state: Mutex<WriteState>, // never held by match_one / match_all
+    routing: RwLock<HashMap<[u64; 3], PrefixEntry>>, // only lock held on the hot read path
+    subscription_state: Mutex<SubscriptionState>,    // never held by match_one / match_all
 }
 
 impl Display for SubscriptionTableImpl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let rs = self.routing.read();
         writeln!(f, "Subscription Table")?;
-        for prefix_entry in rs.routing.values() {
+        for prefix_entry in rs.values() {
             writeln!(
                 f,
                 "Type: {}/{}/{}",
@@ -234,7 +221,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         F: FnMut(&ProtoName, u64, &[u64], &[u64]),
     {
         let rs = self.routing.read();
-        for prefix_entry in rs.routing.values() {
+        for prefix_entry in rs.values() {
             let base_name = ProtoName::from_strings([
                 prefix_entry.strings[0].as_str(),
                 prefix_entry.strings[1].as_str(),
@@ -259,11 +246,11 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let encoded = *enc;
 
         // Lock order: write_state first, routing second.
-        let mut ws = self.write_state.lock();
+        let mut ss = self.subscription_state.lock();
         let mut rs = self.routing.write();
 
         // 1. Ensure PrefixEntry exists; record strings on first insertion.
-        let prefix_entry = rs.routing.entry(prefix).or_insert_with(|| {
+        let prefix_entry = rs.entry(prefix).or_insert_with(|| {
             let (s0, s1, s2) = name.str_components();
             PrefixEntry::new([s0.to_string(), s1.to_string(), s2.to_string()])
         });
@@ -278,7 +265,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         id_entry.insert(conn, is_local);
 
         // 4. Record the subscription (idempotent: same sub_id overwrites itself).
-        ws.subscriptions.insert(
+        ss.subscriptions.insert(
             subscription_id,
             SubRecord {
                 encoded,
@@ -287,7 +274,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         );
 
         // 5. Track sub_id → conn (deduped).
-        let subs = ws.conn_subs.entry(conn).or_default();
+        let subs = ss.conn_subs.entry(conn).or_default();
         if !subs.contains(&subscription_id) {
             subs.push(subscription_id);
         }
@@ -309,21 +296,21 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let encoded = *enc;
 
         // Lock order: write_state first, routing second.
-        let mut ws = self.write_state.lock();
+        let mut ss = self.subscription_state.lock();
         let mut rs = self.routing.write();
 
         // Error precedence: routing checks first.
-        if !rs.routing.contains_key(&prefix) {
+        if !rs.contains_key(&prefix) {
             debug!("subscription not found {}", name);
             return Err(DataPathError::SubscriptionNotFound(name.clone()));
         }
-        if !rs.routing[&prefix].by_id.iter().any(|e| e.id == id) {
+        if !rs[&prefix].by_id.iter().any(|e| e.id == id) {
             warn!(%id, "not found");
             return Err(DataPathError::IdNotFound(id));
         }
 
         // Validate the subscription record.
-        let record = ws
+        let record = ss
             .subscriptions
             .get(&subscription_id)
             .copied()
@@ -337,16 +324,16 @@ impl SubscriptionTable for SubscriptionTableImpl {
         }
 
         // Remove sub_id from the flat maps.
-        ws.subscriptions.remove(&subscription_id);
-        if let Some(subs) = ws.conn_subs.get_mut(&conn) {
+        ss.subscriptions.remove(&subscription_id);
+        if let Some(subs) = ss.conn_subs.get_mut(&conn) {
             subs.retain(|&s| s != subscription_id);
         }
 
         // Check whether conn still holds any subscription for this exact name.
         // O(subs_per_conn) scan; typically < 20 entries.
-        let conn_still_subscribed = ws.conn_subs.get(&conn).is_some_and(|subs| {
+        let conn_still_subscribed = ss.conn_subs.get(&conn).is_some_and(|subs| {
             subs.iter().any(|&s| {
-                ws.subscriptions
+                ss.subscriptions
                     .get(&s)
                     .is_some_and(|r| r.encoded == encoded)
             })
@@ -355,7 +342,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         if !conn_still_subscribed {
             // Remove conn from the routing entry; drop the mutable ref before
             // potentially calling routing.remove().
-            let should_remove_prefix = if let Some(prefix_entry) = rs.routing.get_mut(&prefix) {
+            let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
                 if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
                     id_entry.remove(conn, is_local);
                 }
@@ -365,13 +352,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 false
             };
             if should_remove_prefix {
-                rs.routing.remove(&prefix);
+                rs.remove(&prefix);
             }
         }
 
         // Clean up conn_subs if empty.
-        if ws.conn_subs.get(&conn).is_some_and(|s| s.is_empty()) {
-            ws.conn_subs.remove(&conn);
+        if ss.conn_subs.get(&conn).is_some_and(|s| s.is_empty()) {
+            ss.conn_subs.remove(&conn);
         }
 
         Ok(())
@@ -383,10 +370,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
         is_local: bool,
     ) -> Result<HashMap<ProtoName, HashSet<u64>>, Self::Error> {
         // Lock order: write_state first, routing second.
-        let mut ws = self.write_state.lock();
+        let mut ss = self.subscription_state.lock();
         let mut rs = self.routing.write();
 
-        let sub_ids = ws
+        let sub_ids = ss
             .conn_subs
             .remove(&conn)
             .ok_or(DataPathError::ConnectionIdNotFound(conn))?;
@@ -398,14 +385,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let mut encoded_names: Vec<EncodedName> = Vec::new();
 
         for sub_id in sub_ids {
-            if let Some(record) = ws.subscriptions.remove(&sub_id) {
+            if let Some(record) = ss.subscriptions.remove(&sub_id) {
                 let prefix = [
                     record.encoded.component_0,
                     record.encoded.component_1,
                     record.encoded.component_2,
                 ];
                 let proto_name = rs
-                    .routing
                     .get(&prefix)
                     .map(|pe| pe.to_proto_name(record.encoded.component_3))
                     .unwrap_or(ProtoName {
@@ -430,7 +416,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             ];
             let id = encoded.component_3;
 
-            let should_remove_prefix = if let Some(prefix_entry) = rs.routing.get_mut(&prefix) {
+            let should_remove_prefix = if let Some(prefix_entry) = rs.get_mut(&prefix) {
                 if let Some(id_entry) = prefix_entry.by_id.iter_mut().find(|e| e.id == id) {
                     id_entry.remove(conn, is_local);
                 }
@@ -441,7 +427,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             };
 
             if should_remove_prefix {
-                rs.routing.remove(&prefix);
+                rs.remove(&prefix);
             }
         }
 
@@ -458,7 +444,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let rs = self.routing.read();
 
         // ONE HashMap lookup — the same for any c3 value.
-        let prefix_entry = match rs.routing.get(&prefix) {
+        let prefix_entry = match rs.get(&prefix) {
             None => {
                 debug!(
                     component_0 = encoded.component_0,
@@ -552,7 +538,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         let rs = self.routing.read();
 
         // ONE HashMap lookup — the same for any c3 value.
-        let prefix_entry = match rs.routing.get(&prefix) {
+        let prefix_entry = match rs.get(&prefix) {
             None => {
                 debug!(
                     component_0 = encoded.component_0,

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -74,6 +74,9 @@ impl IdEntry {
         if n == 0 {
             return None;
         }
+        if n == 1 {
+            return if slice[0] != skip { Some(slice[0]) } else { None };
+        }
         for _ in 0..n {
             let pos = cursor.fetch_add(1, Ordering::Relaxed) % n;
             let c = slice[pos];

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -479,36 +479,41 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 }),
             }
         } else {
-            // NULL_COMPONENT: fan out over all registered IDs — data already hot
-            // from the single lookup above.
-            let mut local: Vec<u64> = Vec::new();
-            let mut remote: Vec<u64> = Vec::new();
-            for id_entry in &prefix_entry.by_id {
-                for &c in &id_entry.local {
-                    if c != incoming_conn && !local.contains(&c) {
-                        local.push(c);
-                    }
-                }
-                for &c in &id_entry.remote {
-                    if c != incoming_conn && !remote.contains(&c) {
-                        remote.push(c);
-                    }
-                }
+            // NULL_COMPONENT: pick one connection across all registered IDs.
+            // Data is already hot from the single lookup above.
+
+            // Fast path: single IdEntry — delegate to its round-robin picker,
+            // which already prefers locals and costs nothing to allocate.
+            if prefix_entry.by_id.len() == 1 {
+                return prefix_entry.by_id[0].get_one(incoming_conn).ok_or_else(|| {
+                    debug!("no output connection available");
+                    DataPathError::NoMatchEncoded([
+                        encoded.component_0,
+                        encoded.component_1,
+                        encoded.component_2,
+                        id,
+                    ])
+                });
             }
 
-            let candidates = if !local.is_empty() { &local } else { &remote };
-            if candidates.is_empty() {
-                debug!("no output connection available");
-                return Err(DataPathError::NoMatchEncoded([
-                    encoded.component_0,
-                    encoded.component_1,
-                    encoded.component_2,
-                    id,
-                ]));
+            // General case: pick a random starting IdEntry, then use its
+            // existing get_one (round-robin, local-preferred). A single
+            // random_range call keeps the hot path allocation-free.
+            let by_id = &prefix_entry.by_id;
+            let n = by_id.len();
+            let start = rand::rng().random_range(0..n);
+            for entry in by_id[start..].iter().chain(by_id[..start].iter()) {
+                if let Some(c) = entry.get_one(incoming_conn) {
+                    return Ok(c);
+                }
             }
-            let mut rng = rand::rng();
-            let pos = rng.random_range(0..candidates.len());
-            Ok(candidates[pos])
+            debug!("no output connection available");
+            Err(DataPathError::NoMatchEncoded([
+                encoded.component_0,
+                encoded.component_1,
+                encoded.component_2,
+                id,
+            ]))
         }
     }
 
@@ -558,7 +563,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
                     ]))
                 }
                 Some(entry) => {
-                    let out: Vec<u64> = entry.get_all(incoming_conn).collect();
+                    let mut out = Vec::with_capacity(entry.local.len() + entry.remote.len());
+                    out.extend(entry.get_all(incoming_conn));
                     if out.is_empty() {
                         debug!("no connection available (local/remote)");
                         Err(DataPathError::NoMatchEncoded([
@@ -576,11 +582,13 @@ impl SubscriptionTable for SubscriptionTableImpl {
         } else {
             // NULL_COMPONENT: union of all connections across all registered IDs;
             // data already hot from the single lookup.
-            let mut seen: HashSet<u64> = HashSet::new();
-            let mut out: Vec<u64> = Vec::new();
+            // Use Vec::contains for dedup to avoid the HashSet allocation cost.
+            // O(n²) but n ≤ ~16 in practice, so linear scan beats HashSet overhead.
+            let n = prefix_entry.by_id.len();
+            let mut out: Vec<u64> = Vec::with_capacity(n);
             for id_entry in &prefix_entry.by_id {
                 for c in id_entry.get_all(incoming_conn) {
-                    if seen.insert(c) {
+                    if !out.contains(&c) {
                         out.push(c);
                     }
                 }


### PR DESCRIPTION
# Description

Redesigns \`SubscriptionTableImpl\` in the data-plane datapath for lower hot-path latency, motivated by flame-graph profiling of message routing under load.

**Data layout** — replaces the previous per-prefix state object with a \`PrefixEntry\` using a struct-of-arrays layout. A flat \`ids: Vec<u64>\` stores component_3 values densely (8 per cache line). Per-slot connection lists are held in two parallel \`Vec<ConnList>\` fields (\`local\` and \`remote\`). \`ConnList\` bundles a \`Vec<u64>\` with its own \`AtomicUsize\` round-robin cursor and exposes a \`next(skip)\` method, replacing the four separate Vecs that previously tracked connections and cursors independently.

**Lock design** — the routing table is stored in an \`ArcSwap<HashMap<[u64;3], PrefixEntry>>\`, making the read path entirely lock-free: \`match_one\`/\`match_all\` call \`load()\` (a single atomic pointer load) and never block. Subscription writes hold a \`Mutex<SubscriptionState>\` for bookkeeping, then clone the current routing snapshot, apply changes, and atomically store the new \`Arc\`. \`SubscriptionState\` is a separate cold structure that is never accessed by the read path.

**Routing logic** — a single \`HashMap.get(&prefix)\` covers all component_3 values under a prefix. For specific IDs, \`get_one\`/\`get_all\` scan the dense \`ids\` Vec and delegate to \`ConnList::next\` for round-robin selection. For \`NULL_COMPONENT\`, \`pick_one_any\`/\`get_all_any\` iterate all \`local\` ConnLists across every slot before touching any \`remote\` ConnLists, providing a true global local-over-remote preference. Slot rotation for \`NULL_COMPONENT\` uses an \`AtomicUsize slot_cursor\` on \`PrefixEntry\`, replacing the previous \`rand::rng\` call on the hot path.

**Criterion benchmarks** — \`subscription_table_benchmark\` covers \`match_one\` and \`match_all\` across deep (many IDs or connections per prefix) and wide (many distinct prefixes) topologies, with scale parameters up to 4096.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass