### PR TITLE
fix(ci): remove duplicate library rename and strip Python/Node libs

### DIFF
--- a/.github/workflows/release-bindings.yaml
+++ b/.github/workflows/release-bindings.yaml
@@ -333,6 +333,21 @@ jobs:
           find . -maxdepth 4 -ls 2>/dev/null | head -80
           exit 1
 
+      - name: Install LLVM
+        run: |
+          curl -L https://apt.llvm.org/llvm.sh -o /tmp/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 19
+
+      - name: Strip dynamic library
+        run: |
+          RELEASE_DIR="data-plane/target/${{ matrix.target }}/release"
+          echo "✂️  Stripping dynamic libraries in $RELEASE_DIR using llvm-strip-19..."
+          find "$RELEASE_DIR" -maxdepth 1 -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib; do
+            echo "  Stripping: $lib"
+            llvm-strip-19 --strip-unneeded "$lib"
+          done
+
       - name: Pack Node platform package
         working-directory: ./data-plane/bindings/node
         run: |

--- a/.github/workflows/reusable-bindings-build-and-test.yaml
+++ b/.github/workflows/reusable-bindings-build-and-test.yaml
@@ -165,59 +165,19 @@ jobs:
           PLATFORM_TARGET: ${{ matrix.platform.target }}
         run: |
           task bindings:build:all TARGET="$PLATFORM_TARGET" PROFILE=release
-      - name: Strip and rename artifacts
+      - name: Normalize cargo output path
         run: |
-          # Cargo output path: zigbuild uses versioned target (e.g. .2.28) for linux-gnu;
-          # native build with --target uses unversioned path. Detect which exists.
+          # zigbuild uses a versioned target dir (e.g. .2.28) for linux-gnu; native
+          # build with --target uses the unversioned path. Move libs to the
+          # unversioned path the rest of the workflow expects.
           TARGET="${{ matrix.platform.target }}"
-          if [[ "$TARGET" == *"-linux-gnu" ]]; then
-            if [ -d "../../target/${TARGET}.2.28/release" ]; then
-              CARGO_TARGET="${TARGET}.2.28"
-            else
-              CARGO_TARGET="$TARGET"
-            fi
-          else
-            CARGO_TARGET="$TARGET"
-          fi
-
-          RELEASE_DIR="../../target/${CARGO_TARGET}/release"
-          ls -lah "$RELEASE_DIR/"
-
-          # Split target (logical name) for library filename
-          ARCH=$(echo "$TARGET" | cut -d'-' -f1)
-          OS=$(echo "$TARGET" | cut -d'-' -f3)
-          ABI=$(echo "$TARGET" | cut -d'-' -f4)
-
-          echo "Architecture: $ARCH"
-          echo "OS: $OS"
-          echo "ABI: $ABI"
-
-          # Build the library name with arch_os_abi if ABI is present, otherwise arch_os
-          if [ -n "$ABI" ] && [ "$ABI" != "" ]; then
-            LIB_NAME="slim_bindings_${ARCH}_${OS}_${ABI}"
-          else
-            LIB_NAME="slim_bindings_${ARCH}_${OS}"
-          fi
-
-          # Rename in place in the cargo output directory
-          for file in "$RELEASE_DIR"/libslim_bindings* "$RELEASE_DIR"/slim_bindings.*; do
-            if [ -f "$file" ]; then
-              filename=$(basename "$file")
-              new_filename="${filename/slim_bindings/${LIB_NAME}}"
-              if [ "$filename" != "$new_filename" ]; then
-                mv "$file" "$RELEASE_DIR/${new_filename}"
-              fi
-            fi
-          done
-
-          # If cargo used a versioned target, move renamed files to the path the rest of the workflow expects
-          if [ "$CARGO_TARGET" != "$TARGET" ]; then
+          if [[ "$TARGET" == *"-linux-gnu" ]] && [ -d "../../target/${TARGET}.2.28/release" ]; then
             mkdir -p "../../target/${TARGET}/release"
-            mv "$RELEASE_DIR"/*slim_bindings* "../../target/${TARGET}/release/"
+            mv "../../target/${TARGET}.2.28/release"/*slim_bindings* "../../target/${TARGET}/release/"
           fi
-
-          echo "📁 Renamed files:"
+          echo "📁 Library files:"
           ls -lah ../../target/${{ matrix.platform.target }}/release/*slim_bindings*
+        working-directory: ./data-plane/bindings/rust
       - name: Upload libs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -499,14 +459,9 @@ jobs:
           node-version: '20'
           package-manager-cache: false
 
-      - name: Install Task
-        run: |
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-
       - name: Install uniffi-bindgen-node
         run: |
-          rustup install stable --no-self-update 2>/dev/null || true
-          rustup run stable cargo install --git https://github.com/livekit/uniffi-bindgen-node.git --tag uniffi-bindgen-node@0.1.4
+          cargo install --git https://github.com/livekit/uniffi-bindgen-node.git --tag uniffi-bindgen-node@0.1.4
 
       - name: Download libraries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/data-plane/bindings/node/Taskfile.yaml
+++ b/data-plane/bindings/node/Taskfile.yaml
@@ -43,12 +43,16 @@ tasks:
       - task -l
 
   install-uniffi-bindgen-node:
-    desc: Install uniffi-bindgen-node
+    desc: Install uniffi-bindgen-node (>= 0.1.4)
     status:
-      - which uniffi-bindgen-node
+      - |
+        command -v uniffi-bindgen-node >/dev/null || exit 1
+        v=$(uniffi-bindgen-node --version 2>/dev/null | awk '{print $2}')
+        [ -n "$v" ] || exit 1
+        printf '0.1.4\n%s\n' "$v" | sort -V -C
     cmds:
-      - echo "📦 Installing uniffi-bindgen-node..."
-      - cargo install --git https://github.com/livekit/uniffi-bindgen-node.git --tag uniffi-bindgen-node@0.1.4
+      - echo "📦 Installing uniffi-bindgen-node 0.1.4..."
+      - cargo install --force --git https://github.com/livekit/uniffi-bindgen-node.git --tag uniffi-bindgen-node@0.1.4
 
   # Only builds when library is missing (CI places it from artifact; local dev builds).
   ensure-bindings-lib:
@@ -86,30 +90,16 @@ tasks:
           *)               DYLIB_EXT="so";    DYLIB_PREFIX="lib" ;;
         esac
 
-        ARCH=$(echo "$TARGET" | cut -d'-' -f1)
-        OS=$(echo "$TARGET" | cut -d'-' -f3)
-        ABI=$(echo "$TARGET" | cut -d'-' -f4)
-
-        if [ -n "$ABI" ] && [ "$ABI" != "" ]; then
-          RENAMED_LIB="${DYLIB_PREFIX}${LIB_NAME}_${ARCH}_${OS}_${ABI}.${DYLIB_EXT}"
-        else
-          RENAMED_LIB="${DYLIB_PREFIX}${LIB_NAME}_${ARCH}_${OS}.${DYLIB_EXT}"
-        fi
         DEFAULT_LIB="${DYLIB_PREFIX}${LIB_NAME}.${DYLIB_EXT}"
 
         # Try target/TARGET/release first; when TARGET equals host, Cargo may use target/release/
         HOST_RELEASE_DIR="${TASKFILE_DIR}/../../target/${PROFILE}"
         if [ -f "${RELEASE_DIR}/${DEFAULT_LIB}" ]; then
           DYLIB_PATH="${RELEASE_DIR}/${DEFAULT_LIB}"
-        elif [ -f "${RELEASE_DIR}/${RENAMED_LIB}" ]; then
-          DYLIB_PATH="${RELEASE_DIR}/${RENAMED_LIB}"
         elif [ -f "${HOST_RELEASE_DIR}/${DEFAULT_LIB}" ]; then
           DYLIB_PATH="${HOST_RELEASE_DIR}/${DEFAULT_LIB}"
-        elif [ -f "${HOST_RELEASE_DIR}/${RENAMED_LIB}" ]; then
-          DYLIB_PATH="${HOST_RELEASE_DIR}/${RENAMED_LIB}"
         else
-          echo "❌ Error: Library not found in ${RELEASE_DIR} or ${HOST_RELEASE_DIR}"
-          echo "   Tried: ${RENAMED_LIB}, ${DEFAULT_LIB}"
+          echo "❌ Error: Library ${DEFAULT_LIB} not found in ${RELEASE_DIR} or ${HOST_RELEASE_DIR}"
           ls -la "${RELEASE_DIR}/" 2>/dev/null | grep slim || true
           ls -la "${HOST_RELEASE_DIR}/" 2>/dev/null | grep slim || true
           exit 1
@@ -232,20 +222,8 @@ tasks:
           *)               DYLIB_EXT="so";    DYLIB_PREFIX="lib" ;;
         esac
         CANONICAL="${DYLIB_PREFIX}${LIB_NAME}.${DYLIB_EXT}"
-        # Match reusable-bindings-build-and-test strip/rename: libslim_bindings_<arch>_<os>[_<abi>].<ext>
-        ARCH=$(echo "$TARGET" | cut -d'-' -f1)
-        OS=$(echo "$TARGET" | cut -d'-' -f3)
-        ABI=$(echo "$TARGET" | cut -d'-' -f4)
-        if [ -n "$ABI" ] && [ "$ABI" != "" ]; then
-          STEM="slim_bindings_${ARCH}_${OS}_${ABI}"
-        else
-          STEM="slim_bindings_${ARCH}_${OS}"
-        fi
-        VERSIONED="${DYLIB_PREFIX}${STEM}.${DYLIB_EXT}"
         SRC=""
-        if [ -f "$RELEASE_DIR/$VERSIONED" ]; then
-          SRC="$RELEASE_DIR/$VERSIONED"
-        elif [ -f "$RELEASE_DIR/$CANONICAL" ]; then
+        if [ -f "$RELEASE_DIR/$CANONICAL" ]; then
           SRC="$RELEASE_DIR/$CANONICAL"
         else
           count=0
@@ -270,7 +248,7 @@ tasks:
           fi
         fi
         if [ -z "$SRC" ] || [ ! -f "$SRC" ]; then
-          echo "No dynamic library found for $TARGET (expected $VERSIONED or $CANONICAL) in $RELEASE_DIR"
+          echo "No dynamic library found for $TARGET (expected $CANONICAL) in $RELEASE_DIR"
           ls -la "$RELEASE_DIR/" 2>/dev/null || true
           exit 1
         fi

--- a/data-plane/bindings/python/Taskfile.yaml
+++ b/data-plane/bindings/python/Taskfile.yaml
@@ -98,6 +98,7 @@ tasks:
           --out dist
           --target {{.TARGET}}
           --frozen
+          --strip
           -i {{.INTERPRETERS}}
         )
 


### PR DESCRIPTION
# Description
The "Strip and rename artifacts" step in reusable-bindings-build-and-test
already produced platform-suffixed library names (e.g.
libslim_bindings_aarch64_darwin.dylib), and release-libraries then renamed
them again — yielding doubled suffixes like
libslim_bindings_aarch64_darwin_aarch64_darwin.dylib in the released zips.

Drop the upstream rename so artifacts carry cargo's canonical names. The
release-libraries job's own rename produces the correct suffixed names for
the GitHub Release zips, and the Go / Node packaging tasks already derive
the suffixed name themselves from TARGET when copying the library into
their package layout — neither needs the artifact to be pre-renamed.

The upstream step was also misnamed: it didn't actually strip anything.
While here, add real stripping for the consumers that were shipping
unstripped dynamic libs to end users:

- Python wheels: pass `--strip` to maturin so the embedded dylib/so/dll
  is stripped in-place during the wheel build.
- Node platform packages: add an llvm-strip-19 step in build-node-packages
  after the lib is placed for the target, before pack-platform.ts runs.
  Only `.so/.dylib/.dll` are stripped — never `.a` (Go cgo and RN iOS
  both consume static libs and need their symbols intact).

Java, Kotlin, and .NET already strip in their reusable workflows after
the per-language layout is assembled, so they're unchanged.

Also clean up the Node Taskfile:
- Remove now-dead RENAMED_LIB / VERSIONED fallbacks in `generate` and
  `pack:platform:from-artifacts` (no caller produces those names anymore).
- Make `install-uniffi-bindgen-node` actually verify the installed version
  is >= 0.1.4 (the `generate` subcommand was added in 0.1.4); previously
  the status check only tested for presence, so a stale 0.1.3 install
  would silently break `task generate`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
