### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -41,15 +41,15 @@ resolver = "2"
 agntcy-slim = { path = "core/slim", version = "1.4.0-rc.3" }
 agntcy-slim-auth = { path = "core/auth", version = "0.8.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "1.4.0-rc.3" }
-agntcy-slim-config = { path = "core/config", version = "0.9.1" }
-agntcy-slim-controller = { path = "core/controller", version = "0.6.0" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.13.0" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.16" }
-agntcy-slim-service = { path = "core/service", version = "0.8.13", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.13" }
+agntcy-slim-config = { path = "core/config", version = "0.9.2" }
+agntcy-slim-controller = { path = "core/controller", version = "0.6.1" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.13.1" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.17" }
+agntcy-slim-service = { path = "core/service", version = "0.8.14", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.1.14" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.10" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.11" }
 agntcy-slim-version = { path = "core/version", version = "1.4.0-rc.3" }
 agntcy-slimctl = { path = "slimctl", version = "1.4.0-rc.3" }
 

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/agntcy/slim/compare/slim-config-v0.9.1...slim-config-v0.9.2) - 2026-05-12
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.9.1](https://github.com/agntcy/slim/compare/slim-config-v0.9.0...slim-config-v0.9.1) - 2026-05-11
 
 ### Other

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.9.1"
+version = "0.9.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/agntcy/slim/compare/slim-controller-v0.6.0...slim-controller-v0.6.1) - 2026-05-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session
+
 ## [0.6.0](https://github.com/agntcy/slim/compare/slim-controller-v0.5.0...slim-controller-v0.6.0) - 2026-05-11
 
 ### Added

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.6.0"
+version = "0.6.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.13.0...slim-datapath-v0.13.1) - 2026-05-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing
+
 ## [0.13.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.12.3...slim-datapath-v0.13.0) - 2026-05-11
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.13.0"
+version = "0.13.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/agntcy/slim/compare/slim-mls-v0.1.16...slim-mls-v0.1.17) - 2026-05-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-datapath
+
 ## [0.1.16](https://github.com/agntcy/slim/compare/slim-mls-v0.1.15...slim-mls-v0.1.16) - 2026-05-11
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.16"
+version = "0.1.17"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.14](https://github.com/agntcy/slim/compare/slim-service-v0.8.13...slim-service-v0.8.14) - 2026-05-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.8.13](https://github.com/agntcy/slim/compare/slim-service-v0.8.12...slim-service-v0.8.13) - 2026-05-11
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.13"
+version = "0.8.14"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/agntcy/slim/compare/slim-session-v0.1.13...slim-session-v0.1.14) - 2026-05-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.1.13](https://github.com/agntcy/slim/compare/slim-session-v0.1.12...slim-session-v0.1.13) - 2026-05-11
 
 ### Added

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.13"
+version = "0.1.14"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.10...slim-tracing-v0.3.11) - 2026-05-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-config
+
 ## [0.3.10](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.9...slim-tracing-v0.3.10) - 2026-05-11
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.10"
+version = "0.3.11"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-config`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `agntcy-slim`: 1.4.0-rc.2 -> 1.4.0-rc.3
* `agntcy-slim-bindings`: 1.4.0-rc.2 -> 1.4.0-rc.3
* `agntcy-slimctl`: 1.4.0-rc.2 -> 1.4.0-rc.3
* `agntcy-protoc-slimrpc-plugin`: 1.4.0-rc.2 -> 1.4.0-rc.3
* `agntcy-slim-tracing`: 0.3.10 -> 0.3.11
* `agntcy-slim-datapath`: 0.13.0 -> 0.13.1
* `agntcy-slim-mls`: 0.1.16 -> 0.1.17
* `agntcy-slim-session`: 0.1.13 -> 0.1.14
* `agntcy-slim-controller`: 0.6.0 -> 0.6.1
* `agntcy-slim-service`: 0.8.13 -> 0.8.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-config`

<blockquote>

## [0.9.2](https://github.com/agntcy/slim/compare/slim-config-v0.9.1...slim-config-v0.9.2) - 2026-05-12

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim`

<blockquote>

## [1.4.0-rc.3](https://github.com/agntcy/slim/compare/slim-v1.3.0...slim-v1.4.0-rc.3) - 2026-04-21

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [1.4.0-rc.3](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0...slim-bindings-v1.4.0-rc.3) - 2026-04-21

### Added

- add tower auth middleware using spire ([#1452](https://github.com/agntcy/slim/pull/1452))

### Fixed

- adding linters to Golang, Java and Kotlin bindings and generaliz… ([#1502](https://github.com/agntcy/slim/pull/1502))

### Other

- prepare 1.4.0-rc.3 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [1.4.0-rc.3](https://github.com/agntcy/slim/compare/slimctl-v1.3.0...slimctl-v1.4.0-rc.3) - 2026-04-21

### Added

- update controller connection ([#1485](https://github.com/agntcy/slim/pull/1485))

### Fixed

- *(slimctl)* correct test name spelling (writable) ([#1464](https://github.com/agntcy/slim/pull/1464))

### Other

- prepare 1.4.0-rc.3 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.4.0-rc.3](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.3.0...protoc-slimrpc-plugin-v1.4.0-rc.3) - 2026-04-21

### Fixed

- *(bindings/go)* use ChannelInterface and ServerInterface in generated stubs ([#1426](https://github.com/agntcy/slim/pull/1426))

### Other

- prepare 1.4.0-rc.3 ([#1530](https://github.com/agntcy/slim/pull/1530))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.11](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.10...slim-tracing-v0.3.11) - 2026-05-12

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.13.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.13.0...slim-datapath-v0.13.1) - 2026-05-12

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.17](https://github.com/agntcy/slim/compare/slim-mls-v0.1.16...slim-mls-v0.1.17) - 2026-05-12

### Other

- updated the following local packages: agntcy-slim-datapath
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.1.14](https://github.com/agntcy/slim/compare/slim-session-v0.1.13...slim-session-v0.1.14) - 2026-05-12

### Other

- updated the following local packages: agntcy-slim-datapath, agntcy-slim-mls
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.6.1](https://github.com/agntcy/slim/compare/slim-controller-v0.6.0...slim-controller-v0.6.1) - 2026-05-12

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.8.14](https://github.com/agntcy/slim/compare/slim-service-v0.8.13...slim-service-v0.8.14) - 2026-05-12

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).