### PR TITLE
ci(strip-libraries): resolve path from repo root, not caller's working-directory

### DIFF
--- a/.github/actions/strip-libraries/action.yaml
+++ b/.github/actions/strip-libraries/action.yaml
@@ -41,6 +41,10 @@ runs:
         STRIP_PATH: ${{ inputs.path }}
         MAX_DEPTH: ${{ inputs.max-depth }}
       run: |
+        if [ ! -d "$STRIP_PATH" ]; then
+          echo "strip-libraries: path does not exist, nothing to strip: $STRIP_PATH"
+          exit 0
+        fi
         depth_args=()
         if [ -n "$MAX_DEPTH" ]; then
           depth_args=(-maxdepth "$MAX_DEPTH")
@@ -48,7 +52,7 @@ runs:
         echo "✂️  Stripping shared libraries in $STRIP_PATH using llvm-strip-19..."
         find "$STRIP_PATH" "${depth_args[@]}" -type f \
           \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" -o -name "*.lib" \) \
-          2>/dev/null | while read -r lib; do
+          | while read -r lib; do
           echo "  Stripping: $lib"
           case "$lib" in
             *.dylib) llvm-strip-19 -x "$lib" ;;

--- a/.github/workflows/reusable-dotnet-build-and-test.yaml
+++ b/.github/workflows/reusable-dotnet-build-and-test.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Strip native libraries
         uses: ./.github/actions/strip-libraries
         with:
-          path: ./runtimes
+          path: ${{ inputs.dotnet-bindings-dir }}/runtimes
 
       - name: Build, test and pack
         env:

--- a/.github/workflows/reusable-java-build-and-test.yaml
+++ b/.github/workflows/reusable-java-build-and-test.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Strip native libraries
         uses: ./.github/actions/strip-libraries
         with:
-          path: ./generated/native
+          path: ${{ inputs.working-directory }}/generated/native
 
       - name: Upload generated Java code and native libraries
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/reusable-kotlin-build-and-test.yaml
+++ b/.github/workflows/reusable-kotlin-build-and-test.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Strip native libraries
         uses: ./.github/actions/strip-libraries
         with:
-          path: ./generated/jniLibs
+          path: ${{ inputs.working-directory }}/generated/jniLibs
 
       - name: Upload generated Kotlin code and JNI libraries
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
# Description

Composite action steps run from $GITHUB_WORKSPACE and do not inherit
defaults.run.working-directory from the calling workflow. The reusable
java/kotlin/dotnet workflows set a job-level working-directory (e.g.
./data-plane/bindings/kotlin), so passing ./generated/jniLibs to the action
resolved against repo root and the directory was missing — find then failed
under set -eo pipefail.

Pass repo-root-relative paths from each call site
(${{ inputs.working-directory }}/generated/...) and add a directory-existence
guard in the action so a missing path is a clean no-op. Also simplify the
strip loop back to find | while read now that the guard prevents find from
erroring.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
