### PR TITLE
perf(datapath): replace RwLock with ArcSwap on the connection table read path

### DIFF
--- a/data-plane/core/datapath/src/tables/connection_table.rs
+++ b/data-plane/core/datapath/src/tables/connection_table.rs
@@ -3,17 +3,32 @@
 
 use std::sync::Arc;
 
-use parking_lot::RwLock;
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
 
 use super::pool::Pool;
 
+/// A connection table that provides lock-free reads via `ArcSwap`.
+///
+/// Concurrency design:
+///   - Hot read path (`get`, `for_each`, `len`, `is_empty`): lock-free via
+///     `ArcSwap::load()`.  A single atomic pointer load gives callers an
+///     immutable snapshot of the pool.
+///   - Write path (`insert`, `insert_at`, `remove`): serialised by
+///     `write_lock`.  Writers load the current snapshot, clone the pool,
+///     apply the change, then atomically store the new `Arc`.  No write
+///     lock is ever held during reads.
+///
+/// Connections are stored as `Arc<T>` so that pool clones (made on every
+/// write) only bump refcounts rather than deep-copying each connection.
+/// `get()` returns `Option<Arc<T>>`; callers can auto-deref into `T`.
 #[derive(Debug)]
 pub struct ConnectionTable<T>
 where
     T: Clone,
 {
-    /// Connection pool
-    pool: RwLock<Pool<Arc<T>>>,
+    pool: ArcSwap<Pool<Arc<T>>>,
+    write_lock: Mutex<()>,
 }
 
 impl<T> ConnectionTable<T>
@@ -23,53 +38,58 @@ where
     /// Create a new connection table with a given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         ConnectionTable {
-            pool: RwLock::new(Pool::with_capacity(capacity)),
+            pool: ArcSwap::from_pointee(Pool::with_capacity(capacity)),
+            write_lock: Mutex::new(()),
         }
     }
 
     /// Add a connection to the table, returning its stable ID.
     pub fn insert(&self, connection: T) -> u64 {
-        let mut pool = self.pool.write();
-        pool.insert(Arc::new(connection))
+        let _guard = self.write_lock.lock();
+        let mut pool = (**self.pool.load()).clone();
+        let id = pool.insert(Arc::new(connection));
+        self.pool.store(Arc::new(pool));
+        id
     }
 
     /// Add a connection at a specific ID.
     pub fn insert_at(&self, connection: T, id: u64) {
-        let mut pool = self.pool.write();
-        pool.insert_at(Arc::new(connection), id)
+        let _guard = self.write_lock.lock();
+        let mut pool = (**self.pool.load()).clone();
+        pool.insert_at(Arc::new(connection), id);
+        self.pool.store(Arc::new(pool));
     }
 
     /// Remove the connection with the given ID.
     pub fn remove(&self, id: u64) -> bool {
-        let mut pool = self.pool.write();
-        pool.remove(id)
+        let _guard = self.write_lock.lock();
+        let mut pool = (**self.pool.load()).clone();
+        let existed = pool.remove(id);
+        self.pool.store(Arc::new(pool));
+        existed
     }
 
     /// Number of connections in the table.
     #[allow(dead_code)]
     pub fn len(&self) -> usize {
-        let pool = self.pool.read();
-        pool.len()
+        self.pool.load().len()
     }
 
     /// Current allocated capacity.
     #[allow(dead_code)]
     pub fn capacity(&self) -> usize {
-        let pool = self.pool.read();
-        pool.capacity()
+        self.pool.load().capacity()
     }
 
     /// Returns `true` if the table contains no connections.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
-        let pool = self.pool.read();
-        pool.is_empty()
+        self.pool.load().is_empty()
     }
 
     /// Look up a connection by its stable ID.
     pub fn get(&self, id: u64) -> Option<Arc<T>> {
-        let pool = self.pool.read();
-        pool.get(id).cloned()
+        self.pool.load().get(id).cloned()
     }
 
     /// Call `f(id, connection)` for every live connection.
@@ -77,9 +97,9 @@ where
     where
         F: FnMut(u64, Arc<T>),
     {
-        let pool = self.pool.read();
-        for (id, conn_arc) in pool.iter_with_ids() {
-            f(id, Arc::clone(conn_arc));
+        let pool = self.pool.load();
+        for (id, conn) in pool.iter_with_ids() {
+            f(id, conn.clone());
         }
     }
 }

--- a/data-plane/core/datapath/src/tables/pool.rs
+++ b/data-plane/core/datapath/src/tables/pool.rs
@@ -15,6 +15,15 @@ struct PoolEntry<T> {
     active_pos: usize,
 }
 
+impl<T: Clone> Clone for PoolEntry<T> {
+    fn clone(&self) -> Self {
+        PoolEntry {
+            value: self.value.clone(),
+            active_pos: self.active_pos,
+        }
+    }
+}
+
 /// A collection that assigns each inserted element a stable `u64` ID.
 ///
 /// IDs map directly to Vec indices, giving O(1) `get()` with no hash
@@ -237,6 +246,17 @@ impl<T> Pool<T> {
     /// Returns `true` if the pool contains no elements.
     pub fn is_empty(&self) -> bool {
         self.active_indexes.is_empty()
+    }
+}
+
+impl<T: Clone> Clone for Pool<T> {
+    fn clone(&self) -> Self {
+        Pool {
+            pool: self.pool.clone(),
+            active_indexes: self.active_indexes.clone(),
+            free_slots: self.free_slots.clone(),
+            cursor: AtomicUsize::new(self.cursor.load(Ordering::Relaxed)),
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Follow-up to #1611. Flame-graph profiling showed that `ConnectionTable::get()` on the hot publish path was dominated by `RwLock::read()` acquisition, the same issue already fixed in `SubscriptionTableImpl`.

This PR makes the same change for `ConnectionTable<T>`:

- **Read path** (`get`, `for_each`, `len`, `is_empty`): completely lock-free via `ArcSwap::load()` — a single atomic pointer load, no CAS loop, no mutex.
- **Write path** (`insert`, `insert_at`, `remove`): serialised by a `Mutex<()>` (`write_lock`) to prevent lost-update races in the load → clone → modify → store sequence. No write lock is held during reads.
- **`Arc<T>` preserved**: connections are stored as `Arc<T>` so pool clones (performed on every write) only bump refcounts rather than deep-copying each `Connection`. `get()` returns `Option<Arc<T>>`; callers auto-deref into `T` unchanged.

`Pool<T>` and `PoolEntry<T>` gained manual `Clone` impls (`AtomicUsize` does not implement `Clone`) that snapshot cursor values with `Ordering::Relaxed`.

Fixes: #1383

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass