### PR TITLE
fix(ci): exclude .lib when stripping libs

### DIFF
--- a/.github/actions/strip-libraries/action.yaml
+++ b/.github/actions/strip-libraries/action.yaml
@@ -51,7 +51,7 @@ runs:
         fi
         echo "✂️  Stripping shared libraries in $STRIP_PATH using llvm-strip-19..."
         find "$STRIP_PATH" "${depth_args[@]}" -type f \
-          \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" -o -name "*.lib" \) \
+          \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) \
           | while read -r lib; do
           echo "  Stripping: $lib"
           case "$lib" in


### PR DESCRIPTION
# Description

Exclude .lib libraries when stripping.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
