### PR TITLE
fix: flaky kotlin test

### DIFF
--- a/data-plane/bindings/kotlin/src/test/kotlin/io/agntcy/slim/bindings/BindingsTest.kt
+++ b/data-plane/bindings/kotlin/src/test/kotlin/io/agntcy/slim/bindings/BindingsTest.kt
@@ -195,7 +195,7 @@ class BindingsTest {
             SessionConfig(
                 sessionType = SessionType.POINT_TO_POINT,
                 enableMls = false,
-                maxRetries = 5u,
+                maxRetries = 30u,
                 interval = Duration.ofSeconds(1),
                 metadata = emptyMap()
             ),


### PR DESCRIPTION
# Description

Fix flaky kotlin tests, which fails from time to time for not enough reconnection retries.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
