### PR TITLE
fix(session): guard against late GroupAck after task completion

### DIFF
--- a/data-plane/core/session/src/session_moderator.rs
+++ b/data-plane/core/session/src/session_moderator.rs
@@ -2134,4 +2134,41 @@ mod tests {
             "Participant2 should still be in group (task queued, not processed)"
         );
     }
+
+    /// A late or retransmitted GroupAck arriving when `current_task` is `None`
+    /// must be silently discarded instead of panicking.
+    #[tokio::test]
+    async fn test_group_ack_ignored_when_no_current_task() {
+        let (mut moderator, _rx_slim, _rx_session_layer) = setup_moderator();
+        moderator.init().await.unwrap();
+
+        // Sanity-check: no task is active.
+        assert!(moderator.current_task.is_none());
+
+        let source = make_name(&["participant", "app", "v1"]).with_id(300);
+        let destination = moderator.common.settings.source.clone();
+
+        // Build a GroupAck whose message_id was never registered with the sender,
+        // so `is_still_pending` returns false and the guard is exercised.
+        let group_ack = Message::builder()
+            .source(source)
+            .destination(destination)
+            .identity("")
+            .forward_to(0)
+            .incoming_conn(12345)
+            .session_type(ProtoSessionType::Multicast)
+            .session_message_type(ProtoSessionMessageType::GroupAck)
+            .session_id(1)
+            .message_id(999)
+            .payload(CommandPayload::builder().group_ack().as_content())
+            .build_publish()
+            .unwrap();
+
+        // Must not panic; the stale ACK is discarded and Ok(()) is returned.
+        let result = moderator.process_control_message(group_ack, None).await;
+        assert!(result.is_ok());
+
+        // State is unchanged.
+        assert!(moderator.current_task.is_none());
+    }
 }

--- a/data-plane/core/session/src/session_moderator.rs
+++ b/data-plane/core/session/src/session_moderator.rs
@@ -1167,12 +1167,21 @@ where
                 id = %msg_id,
                 "process group ack. try to close task",
             );
+            // `is_still_pending` returns false for any ID that is not actively
+            // tracked — including IDs that were already cleaned up when a task
+            // completed or failed.  Guard against a late / retransmitted GroupAck
+            // arriving after the task has been cleared; such an ACK is harmless
+            // and should be silently discarded rather than causing a panic.
+            let Some(task) = self.current_task.as_mut() else {
+                debug!(
+                    id = %msg_id,
+                    "received group ack for completed/unknown task, ignoring",
+                );
+                return Ok(());
+            };
             // we received all the messages related to this timer
             // check if we are done and move on
-            self.current_task
-                .as_mut()
-                .unwrap()
-                .update_phase_completed(msg_id)?;
+            task.update_phase_completed(msg_id)?;
 
             // check if the task is finished.
             if !self.current_task.as_mut().unwrap().task_complete() {


### PR DESCRIPTION
# Description

Fixes a panic in `SessionModerator` that occurs when a late or
retransmitted `GroupAck` arrives after the current task has already
been cleaned up.

The existing code called `.unwrap()` on `self.current_task` unconditionally
when processing a `GroupAck`. Under high-throughput or lossy conditions a
retransmitted ACK can arrive after the task entry has been removed, producing
an unexpected `None` and a panic.

The fix replaces the unconditional unwrap with a `let Some(task) = ... else`
guard. If no task is active the stale ACK is silently discarded with a debug
log entry, matching the existing `is_still_pending` defensive pattern in the
same function.

This panic was surfaced during `slimctl bench` channel benchmarking runs.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass