### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-protoc-slimrpc-plugin"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-datapath",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.15"
+version = "0.9.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.15"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -43,17 +43,17 @@ resolver = "2"
 [workspace.dependencies]
 # Local dependencies
 agntcy-slim = { path = "core/slim", version = "2.0.0-alpha.0" }
-agntcy-slim-auth = { path = "core/auth", version = "0.8.0" }
+agntcy-slim-auth = { path = "core/auth", version = "0.9.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "2.0.0-alpha.0" }
-agntcy-slim-config = { path = "core/config", version = "0.9.3" }
-agntcy-slim-controller = { path = "core/controller", version = "0.6.2" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.13.2" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.18" }
-agntcy-slim-service = { path = "core/service", version = "0.8.15", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.1.15" }
+agntcy-slim-config = { path = "core/config", version = "0.10.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.7.0" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.14.0" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.19" }
+agntcy-slim-service = { path = "core/service", version = "0.9.0", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.2.0" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.12" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.3.13" }
 agntcy-slim-version = { path = "core/version", version = "2.0.0-alpha.0" }
 agntcy-slimctl = { path = "slimctl", version = "2.0.0-alpha.0" }
 

--- a/data-plane/bindings/rust/CHANGELOG.md
+++ b/data-plane/bindings/rust/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.4.0...slim-bindings-v2.0.0-alpha.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+
+### Fixed
+
+- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))
+
+### Other
+
+- publish alpha release 2.0.0-alpha.0 ([#1704](https://github.com/agntcy/slim/pull/1704))
+- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
+- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
+- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
+
 ## [1.4.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.3.0...slim-bindings-v1.4.0) - 2026-04-21
 
 ### Added

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/agntcy/slim/compare/slim-auth-v0.8.0...slim-auth-v0.9.0) - 2026-06-03
+
+### Added
+
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+
+### Other
+
+- Replace async-trait with trait-variant in auth module ([#1684](https://github.com/agntcy/slim/pull/1684))
+- *(auth)* cache HMAC key and claims, drop per-call allocations in SharedSecret ([#1671](https://github.com/agntcy/slim/pull/1671))
+
 ## [0.8.0](https://github.com/agntcy/slim/compare/slim-auth-v0.7.0...slim-auth-v0.8.0) - 2026-05-11
 
 ### Other

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.8.0"
+version = "0.9.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/agntcy/slim/compare/slim-config-v0.9.3...slim-config-v0.10.0) - 2026-06-03
+
+### Added
+
+- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+
+### Other
+
+- remove bindings dependecy from channel-manager ([#1697](https://github.com/agntcy/slim/pull/1697))
+- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
+
 ## [0.9.3](https://github.com/agntcy/slim/compare/slim-config-v0.9.2...slim-config-v0.9.3) - 2026-05-13
 
 ### Other

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.9.3"
+version = "0.10.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/agntcy/slim/compare/slim-controller-v0.6.2...slim-controller-v0.7.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
+
+### Other
+
+- *(datapath)* replace is_local bool with ConnType enum ([#1689](https://github.com/agntcy/slim/pull/1689))
+- remove unused code from controller service ([#1682](https://github.com/agntcy/slim/pull/1682))
+- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
+- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
+
 ## [0.6.2](https://github.com/agntcy/slim/compare/slim-controller-v0.6.1...slim-controller-v0.6.2) - 2026-05-13
 
 ### Other

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.6.2"
+version = "0.7.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.13.2...slim-datapath-v0.14.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
+- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))
+
+### Fixed
+
+- *(datapath)* update doctests to match current API ([#1686](https://github.com/agntcy/slim/pull/1686))
+- fix ws tests port collision on fallback ([#1688](https://github.com/agntcy/slim/pull/1688))
+
+### Other
+
+- *(datapath)* replace is_local bool with ConnType enum ([#1689](https://github.com/agntcy/slim/pull/1689))
+- remove bindings dependecy from channel-manager ([#1697](https://github.com/agntcy/slim/pull/1697))
+- *(datapath)* replace RwLock with ArcSwap on the connection table read path ([#1624](https://github.com/agntcy/slim/pull/1624))
+- *(datapath)* refactor SubscriptionTableImpl for cache efficiency ([#1611](https://github.com/agntcy/slim/pull/1611))
+- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
+- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
+- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
+- *(datapath)* eliminate allocations from publish routing hot path ([#1577](https://github.com/agntcy/slim/pull/1577))
+
 ## [0.13.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.13.1...slim-datapath-v0.13.2) - 2026-05-13
 
 ### Other

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.13.2"
+version = "0.14.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/agntcy/slim/compare/slim-mls-v0.1.18...slim-mls-v0.1.19) - 2026-06-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath
+
 ## [0.1.18](https://github.com/agntcy/slim/compare/slim-mls-v0.1.17...slim-mls-v0.1.18) - 2026-05-13
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.18"
+version = "0.1.19"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/agntcy/slim/compare/slim-service-v0.8.15...slim-service-v0.9.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))
+
+### Fixed
+
+- *(datapath)* update doctests to match current API ([#1686](https://github.com/agntcy/slim/pull/1686))
+
+### Other
+
+- *(session)* drop AppTransmitter, Transmitter trait, and MockTransmitter ([#1679](https://github.com/agntcy/slim/pull/1679))
+- *(session)* replace interceptor layer with direct identity handling ([#1676](https://github.com/agntcy/slim/pull/1676))
+- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
+- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
+
 ## [0.8.15](https://github.com/agntcy/slim/compare/slim-service-v0.8.14...slim-service-v0.8.15) - 2026-05-13
 
 ### Other

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.8.15"
+version = "0.9.0"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/slim/compare/slim-session-v0.1.15...slim-session-v0.2.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
+- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))
+
+### Fixed
+
+- *(session)* skip buffer clone in unreliable mode ([#1673](https://github.com/agntcy/slim/pull/1673))
+- *(session)* apply backpressure on outbound channel send ([#1669](https://github.com/agntcy/slim/pull/1669))
+- *(session)* fix need_drains with app direction set to None ([#1574](https://github.com/agntcy/slim/pull/1574))
+- *(session)* guard against late GroupAck after task completion ([#1628](https://github.com/agntcy/slim/pull/1628))
+
+### Other
+
+- Replace async-trait with trait-variant in auth module ([#1684](https://github.com/agntcy/slim/pull/1684))
+- *(auth)* cache HMAC key and claims, drop per-call allocations in SharedSecret ([#1671](https://github.com/agntcy/slim/pull/1671))
+- *(session)* drop AppTransmitter, Transmitter trait, and MockTransmitter ([#1679](https://github.com/agntcy/slim/pull/1679))
+- *(session)* replace interceptor layer with direct identity handling ([#1676](https://github.com/agntcy/slim/pull/1676))
+- *(session)* drop async_trait from MessageHandler and Transmitter ([#1667](https://github.com/agntcy/slim/pull/1667))
+- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
+
 ## [0.1.15](https://github.com/agntcy/slim/compare/slim-session-v0.1.14...slim-session-v0.1.15) - 2026-05-13
 
 ### Other

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.15"
+version = "0.2.0"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-v1.4.0...slim-v2.0.0-alpha.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+
+### Fixed
+
+- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))
+
 ## [1.4.0](https://github.com/agntcy/slim/compare/slim-v1.3.0...slim-v1.4.0) - 2026-04-21
 
 ### Other

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.13](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.12...slim-tracing-v0.3.13) - 2026-06-03
+
+### Added
+
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+
 ## [0.3.12](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.11...slim-tracing-v0.3.12) - 2026-05-13
 
 ### Other

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.12"
+version = "0.3.13"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimctl/CHANGELOG.md
+++ b/data-plane/slimctl/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slimctl-v1.4.0...slimctl-v2.0.0-alpha.0) - 2026-06-03
+
+### Added
+
+- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
+- *(slimctl)* add bench sub/pub and channel sub/pub commands ([#1602](https://github.com/agntcy/slim/pull/1602))
+- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
+- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
+- *(slimctl)* use channel manager to create groups ([#1589](https://github.com/agntcy/slim/pull/1589))
+- *(slimctl)* add commands for channel manager ([#1586](https://github.com/agntcy/slim/pull/1586))
+
+### Fixed
+
+- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))
+
+### Other
+
+- publish alpha release 2.0.0-alpha.0 ([#1704](https://github.com/agntcy/slim/pull/1704))
+- remove agntcy-slim-bindings dependency from slimctl ([#1700](https://github.com/agntcy/slim/pull/1700))
+- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
+- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
+
 ## [1.4.0](https://github.com/agntcy/slim/compare/slimctl-v1.3.0...slimctl-v1.4.0) - 2026-04-21
 
 ### Added

--- a/data-plane/slimrpc-compiler/CHANGELOG.md
+++ b/data-plane/slimrpc-compiler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.4.0...protoc-slimrpc-plugin-v1.4.1) - 2026-06-03
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.4.0](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.3.0...protoc-slimrpc-plugin-v1.4.0) - 2026-04-21
 
 ### Fixed

--- a/data-plane/slimrpc-compiler/Cargo.toml
+++ b/data-plane/slimrpc-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agntcy-protoc-slimrpc-plugin"
 description = "A protoc plugin for generating slimrpc code"
-version = "1.4.0"
+version = "1.4.1"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.9.3 -> 0.10.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.3.12 -> 0.3.13 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.13.2 -> 0.14.0 (⚠ API breaking changes)
* `agntcy-slim-session`: 0.1.15 -> 0.2.0 (⚠ API breaking changes)
* `agntcy-slim-controller`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.8.15 -> 0.9.0 (⚠ API breaking changes)
* `agntcy-slim`: 1.4.0 -> 2.0.0-alpha.0
* `agntcy-slim-bindings`: 1.4.0 -> 2.0.0-alpha.0
* `agntcy-slimctl`: 1.4.0 -> 2.0.0-alpha.0
* `agntcy-protoc-slimrpc-plugin`: 1.4.0 -> 1.4.1 (✓ API compatible changes)
* `agntcy-slim-mls`: 0.1.18 -> 0.1.19

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait slim_auth::traits::Verifier gained Send in file /tmp/.tmp69v9VS/slim/data-plane/core/auth/src/traits.rs:66
  trait slim_auth::traits::TokenProvider gained Send in file /tmp/.tmp69v9VS/slim/data-plane/core/auth/src/traits.rs:104

--- failure trait_no_longer_dyn_compatible: trait no longer dyn compatible ---

Description:
Trait is no longer dyn compatible, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_no_longer_dyn_compatible.ron

Failed in:
  trait TokenProvider in file /tmp/.tmp69v9VS/slim/data-plane/core/auth/src/traits.rs:104
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ClientConfig.require_header_mac in /tmp/.tmp69v9VS/slim/data-plane/core/config/src/client.rs:245
  field ServerConfig.require_header_mac in /tmp/.tmp69v9VS/slim/data-plane/core/config/src/server.rs:130
  field ServerConfig.link_hmac_timeout_secs in /tmp/.tmp69v9VS/slim/data-plane/core/config/src/server.rs:135
  field ServerConfig.link_hmac_poll_interval_ms in /tmp/.tmp69v9VS/slim/data-plane/core/config/src/server.rs:140

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum slim_config::grpc::errors::ConfigError, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/errors.rs:12

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigAuthError:IdentityProviderNotConfigured in /tmp/.tmp69v9VS/slim/data-plane/core/config/src/auth.rs:39
  variant ConfigAuthError:IdentityVerifierNotConfigured in /tmp/.tmp69v9VS/slim/data-plane/core/config/src/auth.rs:41

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ClientConfig::with_transport, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/client.rs:456
  ClientConfig::with_websocket_auth_query_param, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/client.rs:460
  SpireConfig::create_provider, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/auth/spire.rs:121
  ServerConfig::with_transport, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/server.rs:267

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_config::grpc::errors, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/errors.rs:4

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field transport of struct ClientConfig, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/client.rs:280
  field websocket_auth_query_param of struct ClientConfig, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/client.rs:284
  field transport of struct ServerConfig, previously in file /tmp/.tmpSDrv9r/agntcy-slim-config/src/grpc/server.rs:90
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SlimHeader.version in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:86
  field SlimHeader.header_mac in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:96
  field LinkNegotiationPayload.link_ecdh_public_key in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:385
  field JoinReplyPayload.participant in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:263

--- failure copy_impl_added: type now implements Copy ---

Description:
A public type now implements Copy, causing non-move closures to capture it by reference instead of moving it.
        ref: https://github.com/rust-lang/rust/issues/100905
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/copy_impl_added.ron

Failed in:
  slim_datapath::api::DiscoveryRequestPayload in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:230
  slim_datapath::api::LeaveRequestPayload in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:267

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MessageError::DestinationNotFound 2 -> 3 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:69
  variant MessageError::SessionHeaderNotFound 3 -> 5 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:73
  variant MessageError::MessageTypeNotFound 4 -> 6 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:75
  variant MessageError::IncomingConnectionNotFound 5 -> 7 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:77
  variant MessageError::ContentTypeNotSet 6 -> 8 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:79
  variant MessageError::NotApplicationPayload 7 -> 9 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:81
  variant MessageError::NotCommandPayload 8 -> 10 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:83
  variant MessageError::LinkTypeNotSet 9 -> 11 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:85
  variant MessageError::InvalidCommandPayloadType 10 -> 12 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:87
  variant MessageError::BuilderErrorSourceRequired 11 -> 13 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:94
  variant MessageError::BuilderErrorDestinationRequired 12 -> 14 in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:96

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant DataPathError:NegotiationError in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:24
  variant DataPathError:InvalidNameIdFormat in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:32
  variant DataPathError:InvalidNameFormat in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:34
  variant DataPathError:NoMatchEncoded in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:38
  variant DataPathError:HeaderIntegrity in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:86
  variant DataPathError:HeaderMacAwaitingLinkNegotiation in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:89
  variant DataPathError:LinkKeyGeneration in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/errors.rs:92
  variant MessageError:SourceEncodedNameNotFound in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:67
  variant MessageError:DestinationEncodedNameNotFound in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:71
  variant MessageError:ParticipantNameNotFound in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:98
  variant MessageError:ParticipantSettingsNotFound in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:100

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant DataPathError::NoMatch, previously in file /tmp/.tmpSDrv9r/agntcy-slim-datapath/src/errors.rs:29

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_datapath::messages::utils::ProtoMessageBuilder::build_link_negotiation now takes 4 parameters instead of 3, in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:1683
  slim_datapath::messages::utils::CommandPayloadBuilder::discovery_request now takes 0 parameters instead of 1, in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:1123
  slim_datapath::messages::utils::CommandPayloadBuilder::join_reply now takes 2 parameters instead of 1, in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:1170
  slim_datapath::messages::utils::CommandPayloadBuilder::leave_request now takes 0 parameters instead of 1, in /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/messages/utils.rs:1185

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  IS_MODERATOR in file /tmp/.tmpSDrv9r/agntcy-slim-datapath/src/messages/utils.rs:27

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_datapath::messages::encoder::Name, previously in file /tmp/.tmpSDrv9r/agntcy-slim-datapath/src/messages/encoder.rs:11
  struct slim_datapath::messages::Name, previously in file /tmp/.tmpSDrv9r/agntcy-slim-datapath/src/messages/encoder.rs:11

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field destination of struct DiscoveryRequestPayload, previously in file /tmp/.tmpSDrv9r/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:205
  field destination of struct LeaveRequestPayload, previously in file /tmp/.tmpSDrv9r/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:245

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  SubscriptionTable::match_one now takes 3 instead of 2 parameters, in file /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/tables.rs:124
  SubscriptionTable::match_all now takes 3 instead of 2 parameters, in file /tmp/.tmp69v9VS/slim/data-plane/core/datapath/src/tables.rs:131
```

### ⚠ `agntcy-slim-session` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionError:MalformedParticipant in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:51
  variant SessionError:MissingParticipantSettings in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:53
  variant SessionError:SessionReceiverShutdown in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:133
  variant SessionError:MissingParticipantNameOnTimer in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:135
  variant SessionError:MalformedParticipant in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:51
  variant SessionError:MissingParticipantSettings in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:53
  variant SessionError:SessionReceiverShutdown in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:133
  variant SessionError:MissingParticipantNameOnTimer in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/errors.rs:135

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_session::session_sender::SessionSender::new now takes 5 parameters instead of 6, in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_sender.rs:99
  slim_session::SessionLayer::new now takes 8 parameters instead of 9, in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_layer.rs:139
  slim_session::session_receiver::SessionReceiver::new now takes 6 parameters instead of 7, in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_receiver.rs:99

--- failure method_receiver_type_changed: method receiver changed type ---

Description:
A method's receiver changed to a different type.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_receiver_type_changed.ron

Failed in:
  slim_session::SessionLayer::handle_message_from_slim now takes &Arc<Self>, not &Self, in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_layer.rs:480

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_session::interceptor, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/interceptor.rs:5

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_session::interceptor::IdentityInterceptor, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/interceptor.rs:53
  struct slim_session::transmitter::AppTransmitter, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/transmitter.rs:102

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait slim_session::interceptor::SessionInterceptorProvider, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/interceptor.rs:23
  trait slim_session::SessionInterceptorProvider, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/interceptor.rs:23
  trait slim_session::traits::Transmitter, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/traits.rs:21
  trait slim_session::Transmitter, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/traits.rs:21
  trait slim_session::interceptor::SessionInterceptor, previously in file /tmp/.tmpSDrv9r/agntcy-slim-session/src/interceptor.rs:15

--- failure trait_no_longer_dyn_compatible: trait no longer dyn compatible ---

Description:
Trait is no longer dyn compatible, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_no_longer_dyn_compatible.ron

Failed in:
  trait MessageHandler in file /tmp/.tmp69v9VS/slim/data-plane/core/session/src/traits.rs:18
  trait MessageHandler in file /tmp/.tmp69v9VS/slim/data-plane/core/session/src/traits.rs:18

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait SessionTransmitter (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/transmitter.rs:22
  trait ControllerSender (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/controller_sender.rs:86
  trait SessionSender (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_sender.rs:42
  trait SessionReceiver (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_receiver.rs:57

--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct SessionLayer allows 3 -> 2 generic types in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_layer.rs:81

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct SessionTransmitter (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/transmitter.rs:22
  Struct ControllerSender (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/controller_sender.rs:86
  Struct SessionSender (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_sender.rs:42
  Struct SessionReceiver (0 -> 1 required generic types) in /tmp/.tmp69v9VS/slim/data-plane/core/session/src/session_receiver.rs:57
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RegisterNodeRequest.connections in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:184
  field RegisterNodeRequest.routes in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:187
  field RegisterNodeResponse.connections in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:197
  field RegisterNodeResponse.routes in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:199
  field Connection.link_id in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:43
  field ConnectionAck.link_id in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:50
  field ConfigurationCommand.routes_to_set in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:79
  field ConfigurationCommand.routes_to_delete in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:81
  field ConfigurationCommand.reconcile in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:85
  field ConfigurationCommandAck.routes_status in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:94
  field ConnectionDetails.external_endpoint in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:157
  field ConnectionDetails.spire_mtls in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:159
  field ConnectionListResponse.done in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:145

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type RegisterNodeResponse no longer derives Eq, in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:190
  type RegisterNodeResponse no longer derives Hash, in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:190

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Payload:RouteListRequest in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:21
  variant Payload:RouteListResponse in /tmp/.tmp69v9VS/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:23

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Payload::SubscriptionListRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:21
  variant Payload::SubscriptionListResponse, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:23
  variant Payload::CreateChannelRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:37
  variant Payload::DeleteChannelRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:39
  variant Payload::AddParticipantRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:41
  variant Payload::DeleteParticipantRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:43
  variant Payload::ListChannelRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:45
  variant Payload::ListChannelResponse, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:47
  variant Payload::ListParticipantsRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:49
  variant Payload::ListParticipantsResponse, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:51
  variant ControllerError::Auth, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/errors.rs:41

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ConnectionDetails::auth, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:180
  ConnectionDetails::tls, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:180
  Config::with_token_provider_auth, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/config.rs:67
  Config::with_token_verifier_auth, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/config.rs:75

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_controller::api::proto::api::v1::SubscriptionEntry, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:139
  struct slim_controller::api::proto::api::v1::Subscription, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:73
  struct slim_controller::api::proto::api::v1::CreateChannelRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:222
  struct slim_controller::api::proto::api::v1::DeleteChannelRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:231
  struct slim_controller::api::proto::api::v1::AddParticipantRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:240
  struct slim_controller::api::proto::api::v1::DeleteParticipantRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:252
  struct slim_controller::api::proto::api::v1::ListChannelsRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:264
  struct slim_controller::api::proto::api::v1::ListChannelsResponse, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:266
  struct slim_controller::api::proto::api::v1::ListParticipantsRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:274
  struct slim_controller::api::proto::api::v1::ListParticipantsResponse, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:280
  struct slim_controller::api::proto::api::v1::SubscriptionListRequest, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:130
  struct slim_controller::api::proto::api::v1::SubscriptionAck, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:92
  struct slim_controller::api::proto::api::v1::SubscriptionListResponse, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:132

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field mtls_required of struct ConnectionDetails, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:185
  field auth of struct ConnectionDetails, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:189
  field tls of struct ConnectionDetails, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:191
  field connection_id of struct Connection, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:59
  field connection_id of struct ConnectionAck, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:66
  field token_provider of struct Config, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/config.rs:33
  field token_verifier of struct Config, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/config.rs:37
  field subscriptions_status of struct ConfigurationCommandAck, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:118
  field subscriptions_to_set of struct ConfigurationCommand, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:105
  field subscriptions_to_delete of struct ConfigurationCommand, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:107
  field auth_provider of struct ControlPlaneSettings, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/service.rs:76
  field auth_verifier of struct ControlPlaneSettings, previously in file /tmp/.tmpSDrv9r/agntcy-slim-controller/src/service.rs:78
```

### ⚠ `agntcy-slim-service` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ServiceError:ConfigError in /tmp/.tmp69v9VS/slim/data-plane/core/service/src/errors.rs:20
  variant ServiceError:ConfigError in /tmp/.tmp69v9VS/slim/data-plane/core/service/src/errors.rs:20

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ServiceError::GrpcConfigError, previously in file /tmp/.tmpSDrv9r/agntcy-slim-service/src/errors.rs:20
  variant ServiceError::GrpcConfigError, previously in file /tmp/.tmpSDrv9r/agntcy-slim-service/src/errors.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.9.0](https://github.com/agntcy/slim/compare/slim-auth-v0.8.0...slim-auth-v0.9.0) - 2026-06-03

### Added

- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))

### Other

- Replace async-trait with trait-variant in auth module ([#1684](https://github.com/agntcy/slim/pull/1684))
- *(auth)* cache HMAC key and claims, drop per-call allocations in SharedSecret ([#1671](https://github.com/agntcy/slim/pull/1671))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.10.0](https://github.com/agntcy/slim/compare/slim-config-v0.9.3...slim-config-v0.10.0) - 2026-06-03

### Added

- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))

### Other

- remove bindings dependecy from channel-manager ([#1697](https://github.com/agntcy/slim/pull/1697))
- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.3.13](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.12...slim-tracing-v0.3.13) - 2026-06-03

### Added

- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.14.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.13.2...slim-datapath-v0.14.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))

### Fixed

- *(datapath)* update doctests to match current API ([#1686](https://github.com/agntcy/slim/pull/1686))
- fix ws tests port collision on fallback ([#1688](https://github.com/agntcy/slim/pull/1688))

### Other

- *(datapath)* replace is_local bool with ConnType enum ([#1689](https://github.com/agntcy/slim/pull/1689))
- remove bindings dependecy from channel-manager ([#1697](https://github.com/agntcy/slim/pull/1697))
- *(datapath)* replace RwLock with ArcSwap on the connection table read path ([#1624](https://github.com/agntcy/slim/pull/1624))
- *(datapath)* refactor SubscriptionTableImpl for cache efficiency ([#1611](https://github.com/agntcy/slim/pull/1611))
- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
- *(datapath)* eliminate allocations from publish routing hot path ([#1577](https://github.com/agntcy/slim/pull/1577))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.2.0](https://github.com/agntcy/slim/compare/slim-session-v0.1.15...slim-session-v0.2.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))

### Fixed

- *(session)* skip buffer clone in unreliable mode ([#1673](https://github.com/agntcy/slim/pull/1673))
- *(session)* apply backpressure on outbound channel send ([#1669](https://github.com/agntcy/slim/pull/1669))
- *(session)* fix need_drains with app direction set to None ([#1574](https://github.com/agntcy/slim/pull/1574))
- *(session)* guard against late GroupAck after task completion ([#1628](https://github.com/agntcy/slim/pull/1628))

### Other

- Replace async-trait with trait-variant in auth module ([#1684](https://github.com/agntcy/slim/pull/1684))
- *(auth)* cache HMAC key and claims, drop per-call allocations in SharedSecret ([#1671](https://github.com/agntcy/slim/pull/1671))
- *(session)* drop AppTransmitter, Transmitter trait, and MockTransmitter ([#1679](https://github.com/agntcy/slim/pull/1679))
- *(session)* replace interceptor layer with direct identity handling ([#1676](https://github.com/agntcy/slim/pull/1676))
- *(session)* drop async_trait from MessageHandler and Transmitter ([#1667](https://github.com/agntcy/slim/pull/1667))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.7.0](https://github.com/agntcy/slim/compare/slim-controller-v0.6.2...slim-controller-v0.7.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))

### Other

- *(datapath)* replace is_local bool with ConnType enum ([#1689](https://github.com/agntcy/slim/pull/1689))
- remove unused code from controller service ([#1682](https://github.com/agntcy/slim/pull/1682))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.9.0](https://github.com/agntcy/slim/compare/slim-service-v0.8.15...slim-service-v0.9.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))

### Fixed

- *(datapath)* update doctests to match current API ([#1686](https://github.com/agntcy/slim/pull/1686))

### Other

- *(session)* drop AppTransmitter, Transmitter trait, and MockTransmitter ([#1679](https://github.com/agntcy/slim/pull/1679))
- *(session)* replace interceptor layer with direct identity handling ([#1676](https://github.com/agntcy/slim/pull/1676))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-v1.4.0...slim-v2.0.0-alpha.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))

### Fixed

- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.4.0...slim-bindings-v2.0.0-alpha.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))

### Fixed

- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))

### Other

- publish alpha release 2.0.0-alpha.0 ([#1704](https://github.com/agntcy/slim/pull/1704))
- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slimctl-v1.4.0...slimctl-v2.0.0-alpha.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(slimctl)* add bench sub/pub and channel sub/pub commands ([#1602](https://github.com/agntcy/slim/pull/1602))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
- *(slimctl)* use channel manager to create groups ([#1589](https://github.com/agntcy/slim/pull/1589))
- *(slimctl)* add commands for channel manager ([#1586](https://github.com/agntcy/slim/pull/1586))

### Fixed

- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))

### Other

- publish alpha release 2.0.0-alpha.0 ([#1704](https://github.com/agntcy/slim/pull/1704))
- remove agntcy-slim-bindings dependency from slimctl ([#1700](https://github.com/agntcy/slim/pull/1700))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.4.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.4.0...protoc-slimrpc-plugin-v1.4.1) - 2026-06-03

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.19](https://github.com/agntcy/slim/compare/slim-mls-v0.1.18...slim-mls-v0.1.19) - 2026-06-03

### Other

- updated the following local packages: agntcy-slim-auth, agntcy-slim-datapath
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).