### PR TITLE
fix(bindings): deadlock when using single thread runtime

### DIFF
--- a/data-plane/bindings/rust/src/app.rs
+++ b/data-plane/bindings/rust/src/app.rs
@@ -349,9 +349,8 @@ impl App {
         let runtime = get_runtime();
 
         // Spawn on the runtime's handle to ensure tokio context is available
-        let handle = runtime
-            .handle()
-            .spawn(async move { app.create_session(slim_config, slim_dest, None).await });
+        let handle =
+            runtime.spawn(async move { app.create_session(slim_config, slim_dest, None).await });
 
         let (session_ctx, completion) = handle.await.map_err(|e| SlimError::SessionError {
             message: format!("Failed to create session: {}", e),

--- a/data-plane/bindings/rust/src/config.rs
+++ b/data-plane/bindings/rust/src/config.rs
@@ -627,7 +627,6 @@ mod tests {
     }
 
     #[test_fork::fork]
-    #[test_fork::fork]
     #[test]
     fn test_single_thread_runtime_drives_io() {
         // With n_cores=1 the runtime is built as `current_thread` on a

--- a/data-plane/bindings/rust/src/config.rs
+++ b/data-plane/bindings/rust/src/config.rs
@@ -13,7 +13,7 @@ use futures_timer::Delay;
 use tracing::{debug, info};
 
 use slim::config::ConfigLoader;
-use slim::runtime::RuntimeConfiguration as CoreRuntimeConfiguration;
+use slim::runtime::{RuntimeConfiguration as CoreRuntimeConfiguration, SlimRuntime};
 use slim_config::tls::provider;
 use slim_service::ServiceConfiguration as CoreServiceConfiguration;
 use slim_tracing::TracingConfiguration as CoreTracingConfiguration;
@@ -40,8 +40,10 @@ struct GlobalState {
     /// Service configuration
     service_config: Vec<CoreServiceConfiguration>,
 
-    /// Global Tokio runtime
-    runtime: tokio::runtime::Runtime,
+    /// Global Tokio runtime. Built via `slim::runtime::build`, which picks a
+    /// multi-threaded runtime or a `current_thread` runtime on a dedicated
+    /// driver thread based on the effective core count.
+    runtime: SlimRuntime,
 
     /// Global service instances (all services)
     services: Vec<Arc<crate::service::Service>>,
@@ -237,8 +239,12 @@ fn initialize_internal(
     // Initialize crypto provider (must be done before any TLS operations)
     provider::initialize_crypto_provider();
 
-    // Build runtime from configuration
-    let runtime = slim::runtime::build(&runtime_config).runtime;
+    // Build runtime from configuration. `build_for_embedding` picks a
+    // dedicated-thread `current_thread` runtime when the effective core count
+    // is 1, so the I/O reactor stays driven even when the host language's
+    // event loop owns the calling thread; otherwise it falls back to the
+    // standard multi-threaded runtime.
+    let runtime = slim::runtime::build_for_embedding(&runtime_config);
 
     // Setup tracing subscriber (may fail if already set, which is OK)
     let guard = match tracing_conf.setup_tracing_subscriber() {
@@ -256,35 +262,22 @@ fn initialize_internal(
         }
     };
 
-    // Initialize the global service with config and start it
-    // If we're already in an async tokio context, we need to spawn a separate thread
-    // to avoid "Cannot start a runtime from within a runtime" panic.
-    // Even though we created a new runtime, calling block_on on it will still panic
-    // if the current thread is being used by another runtime to drive async tasks.
-    let (runtime, services) = if tokio::runtime::Handle::try_current().is_ok() {
-        // We're in an async context - spawn a separate OS thread to run block_on
-        // Wrap the runtime in Arc to safely share it across thread boundaries
-        let runtime_arc = Arc::new(runtime);
-        let runtime_clone = Arc::clone(&runtime_arc);
-        let service_config_clone = service_configs.to_vec();
-
-        let services = std::thread::spawn(move || {
-            runtime_clone.block_on(async move {
-                initialize_and_start_global_services(&service_config_clone).await
-            })
-        })
-        .join()
-        .expect("Thread panicked while initializing services")?;
-
-        // Extract the runtime back from Arc (will succeed since we have the only reference)
-        let runtime = Arc::try_unwrap(runtime_arc).expect("Failed to unwrap runtime from Arc");
-
-        (runtime, services)
-    } else {
-        // Not in an async context, safe to use block_on directly
-        let services = runtime
-            .block_on(async { initialize_and_start_global_services(service_configs).await })?;
-        (runtime, services)
+    // Initialize the global service with config and start it.
+    // If we're already in an async tokio context (e.g. #[tokio::test]),
+    // delegate the block_on to a fresh OS thread so we don't get "Cannot
+    // start a runtime from within a runtime". `Handle` is Clone, so we just
+    // hand a copy to the worker thread.
+    let services = {
+        let handle = runtime.handle();
+        let configs = service_configs.to_vec();
+        let work = move || handle.block_on(initialize_and_start_global_services(&configs));
+        if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::spawn(work)
+                .join()
+                .expect("Thread panicked while initializing services")?
+        } else {
+            work()?
+        }
     };
 
     // Get first service for backward compatibility
@@ -315,15 +308,23 @@ pub fn is_initialized() -> bool {
     GLOBAL_STATE.get().is_some()
 }
 
-/// Get the global runtime
+/// Get a handle to the global Tokio runtime.
 ///
-/// Returns a reference to the runtime, or initializes with defaults if not yet initialized.
-pub fn get_runtime() -> &'static tokio::runtime::Runtime {
+/// The returned `Handle` is cheap to clone and is safe to call `block_on` /
+/// `spawn` on from any thread (including foreign-language threads driven by
+/// UniFFI). When the runtime was built in single-threaded mode the actual
+/// scheduler runs on a dedicated background OS thread; the `Handle` simply
+/// routes work onto it.
+///
+/// If the bindings have not been initialized yet, this initializes them with
+/// defaults first.
+pub fn get_runtime() -> tokio::runtime::Handle {
     initialize_with_defaults();
-    &GLOBAL_STATE
+    GLOBAL_STATE
         .get()
         .expect("Global runtime not initialized")
         .runtime
+        .handle()
 }
 
 /// Returns references to all global services.
@@ -523,8 +524,7 @@ pub async fn shutdown() -> Result<(), SlimError> {
 /// * `Err(SlimError)` - If shutdown fails
 #[uniffi::export]
 pub fn shutdown_blocking() -> Result<(), SlimError> {
-    let runtime = get_runtime();
-    runtime.block_on(shutdown())
+    get_runtime().block_on(shutdown())
 }
 
 #[cfg(test)]
@@ -543,8 +543,7 @@ mod tests {
     #[test]
     fn test_runtime_always_accessible() {
         // The runtime can always be accessed (either from init or get_runtime fallback)
-        let runtime = get_runtime();
-        let _handle = runtime.handle();
+        let _handle = get_runtime();
     }
 
     #[test]
@@ -616,8 +615,7 @@ mod tests {
         initialize_with_defaults();
 
         // Verify we can access the runtime
-        let runtime = get_runtime();
-        let _handle = runtime.handle();
+        let _handle = get_runtime();
 
         // Verify we can access configs
         let _ = get_runtime_config();
@@ -629,6 +627,35 @@ mod tests {
     }
 
     #[test_fork::fork]
+    #[test_fork::fork]
+    #[test]
+    fn test_single_thread_runtime_drives_io() {
+        // With n_cores=1 the runtime is built as `current_thread` on a
+        // dedicated OS thread. Verify it actually drives timers and spawned
+        // tasks — this is the property that prevents the UniFFI/asyncio
+        // deadlock from issue #1648.
+        use crate::init_config::{new_runtime_config_with, new_service_config, new_tracing_config};
+        use std::time::Duration;
+
+        let runtime_config =
+            new_runtime_config_with(1, "slim-single".to_string(), Duration::from_secs(1));
+        let result = initialize_with_configs(
+            runtime_config,
+            new_tracing_config(),
+            &[new_service_config()],
+        );
+        assert!(result.is_ok());
+
+        // Schedule work on the global handle from a non-async thread. If the
+        // bg driver thread isn't actually polling, this will hang forever.
+        let handle = get_runtime();
+        let value = handle.block_on(async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            42_u32
+        });
+        assert_eq!(value, 42);
+    }
+
     #[test]
     fn test_initialize_with_configs() {
         // Test initializing with custom config structs using wrapper types

--- a/data-plane/bindings/rust/src/service.rs
+++ b/data-plane/bindings/rust/src/service.rs
@@ -204,7 +204,7 @@ impl Service {
         let inner = self.inner.clone();
 
         // Spawn on the runtime's handle to ensure tokio context is available
-        let handle: JoinHandle<Result<(), SlimError>> = runtime.handle().spawn(async move {
+        let handle: JoinHandle<Result<(), SlimError>> = runtime.spawn(async move {
             inner.run_server(&core_config).await?;
             Ok(())
         });

--- a/data-plane/bindings/rust/src/session.rs
+++ b/data-plane/bindings/rust/src/session.rs
@@ -111,7 +111,7 @@ impl Session {
     }
 
     /// Get the runtime (for internal use)
-    pub fn runtime(&self) -> &'static tokio::runtime::Runtime {
+    pub fn runtime(&self) -> tokio::runtime::Handle {
         crate::config::get_runtime()
     }
 }

--- a/data-plane/bindings/rust/src/slimrpc/channel.rs
+++ b/data-plane/bindings/rust/src/slimrpc/channel.rs
@@ -283,7 +283,7 @@ impl Channel {
             ));
         }
 
-        let runtime = crate::get_runtime().handle().clone();
+        let runtime = crate::get_runtime();
 
         let members_set: HashSet<Name> = members.into_iter().collect();
 

--- a/data-plane/bindings/rust/src/slimrpc/server.rs
+++ b/data-plane/bindings/rust/src/slimrpc/server.rs
@@ -1230,7 +1230,7 @@ impl Server {
             base_name.as_ref().into(),
             connection_id,
             rx,
-            Some(crate::get_runtime().handle().clone()),
+            Some(crate::get_runtime()),
         )
     }
 

--- a/data-plane/channel-manager/tests/integration_test.rs
+++ b/data-plane/channel-manager/tests/integration_test.rs
@@ -90,7 +90,7 @@ services:
 
             let runtime =
                 slim::runtime::build(config.runtime().expect("invalid runtime configuration"));
-            let _ = runtime.runtime.block_on(slim::runner::run_services(config));
+            let _ = runtime.block_on(slim::runner::run_services(config));
         })
         .expect("failed to spawn slim runtime thread")
 }

--- a/data-plane/core/slim/src/runner.rs
+++ b/data-plane/core/slim/src/runner.rs
@@ -86,5 +86,5 @@ pub fn run(config_file: &str) -> Result<()> {
     provider::initialize_crypto_provider();
 
     let slim_runtime = runtime::build(config.runtime().context("invalid runtime configuration")?);
-    slim_runtime.runtime.block_on(run_services(config))
+    slim_runtime.block_on(run_services(config))
 }

--- a/data-plane/core/slim/src/runtime.rs
+++ b/data-plane/core/slim/src/runtime.rs
@@ -3,8 +3,9 @@
 
 use duration_string::DurationString;
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 use std::time;
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::{Builder, Handle, Runtime};
 use tracing::{info, warn};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -86,20 +87,155 @@ impl RuntimeConfiguration {
 }
 
 pub struct SlimRuntime {
-    // Configuration field
+    /// Configuration this runtime was built from.
     pub config: RuntimeConfiguration,
 
-    // The actual runtime
-    pub runtime: Runtime,
+    /// The underlying driver — either a runtime owned and driven inline by
+    /// the caller, or a `current_thread` runtime owned by a dedicated OS
+    /// thread (see [`RuntimeDriver`] and [`build_for_embedding`]).
+    driver: RuntimeDriver,
 }
 
+/// Backing flavor for [`SlimRuntime`].
+///
+/// SLIM is embeddable in two distinct ways:
+///
+/// * As a standalone daemon, where the caller (`runner::run`, `slimctl`,
+///   integration tests) drives the runtime itself by calling `block_on` on
+///   the main thread. This is the [`Inline`] variant — it works for both
+///   `multi_thread` and `current_thread` runtimes.
+///
+/// * Through language bindings, where Rust `async fn`s are exposed to a host
+///   language (Python, Kotlin, Swift, …) and the host language's own event
+///   loop polls the outer future. In that mode Tokio's I/O reactor and timer
+///   wheel only advance while some thread is inside a Tokio runtime context;
+///   if every worker is idle because the host loop is the active driver,
+///   socket readiness events and timers never fire and I/O-bound futures
+///   hang indefinitely.
+///
+///   With a multi-worker runtime the embedded case is usually masked: at
+///   least one worker stays parked on the reactor while another services
+///   spawned tasks, so I/O keeps flowing. With a single worker the runtime
+///   collapses to one thread that has to alternate between reactor polling
+///   and task execution, and once the host loop takes over polling the
+///   chain breaks. The worker count is itself environment-dependent —
+///   auto-detection follows the process's CPU quota, so a container with a
+///   fractional CPU limit, a pinned cpuset, or a small machine can silently
+///   drop to one worker.
+///
+///   To make the single-worker embedded case behave consistently, use
+///   [`build_for_embedding`]. It returns the [`Dedicated`] variant: a
+///   `current_thread` runtime owned by a dedicated OS thread sitting in
+///   `rt.block_on(...)`. That thread is always inside the runtime context,
+///   so readiness and timer events are processed continuously regardless of
+///   how the host language drives outer futures. External callers interact
+///   with the runtime only through a [`Handle`], which routes work onto
+///   that thread.
+///
+/// [`Inline`]: RuntimeDriver::Inline
+/// [`Dedicated`]: RuntimeDriver::Dedicated
+enum RuntimeDriver {
+    /// Runtime owned directly. The caller drives it via `block_on` on
+    /// whatever thread it likes (its own thread for `current_thread`, or
+    /// any thread for `multi_thread`).
+    Inline(Runtime),
+    /// `current_thread` runtime owned by a dedicated OS thread that sits in
+    /// `rt.block_on(...)` for its entire lifetime.
+    Dedicated {
+        handle: Handle,
+        /// Sent on `Drop` to wake the driver thread out of `block_on`.
+        shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        /// The OS thread that owns and drives the runtime.
+        thread: Option<std::thread::JoinHandle<()>>,
+    },
+}
+
+impl SlimRuntime {
+    /// Return a clonable handle to this runtime. Cheap; safe to call from any
+    /// thread.
+    pub fn handle(&self) -> Handle {
+        match &self.driver {
+            RuntimeDriver::Inline(rt) => rt.handle().clone(),
+            RuntimeDriver::Dedicated { handle, .. } => handle.clone(),
+        }
+    }
+
+    /// Run a future to completion on this runtime, blocking the calling
+    /// thread. Must not be called from inside an existing Tokio context.
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        match &self.driver {
+            RuntimeDriver::Inline(rt) => rt.block_on(future),
+            RuntimeDriver::Dedicated { handle, .. } => handle.block_on(future),
+        }
+    }
+}
+
+impl Drop for SlimRuntime {
+    fn drop(&mut self) {
+        if let RuntimeDriver::Dedicated {
+            shutdown_tx,
+            thread,
+            ..
+        } = &mut self.driver
+        {
+            if let Some(tx) = shutdown_tx.take() {
+                let _ = tx.send(());
+            }
+            if let Some(handle) = thread.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+/// Build a runtime owned and driven inline by the caller.
+///
+/// At `n_cores > 1` this gives you a standard multi-thread runtime. At
+/// `n_cores == 1` it gives you a `current_thread` runtime — the calling
+/// thread will own it for the duration of `block_on`. This is the right
+/// shape for the daemon entry points.
+///
+/// Embedders whose calling thread is owned by a foreign event loop (e.g.
+/// language bindings driven by Python `asyncio`) should use
+/// [`build_for_embedding`] instead.
 pub fn build(config: &RuntimeConfiguration) -> SlimRuntime {
+    let cores = resolve_cores(config);
+    let runtime = build_inline_runtime(config, cores);
+    SlimRuntime {
+        config: config.clone(),
+        driver: RuntimeDriver::Inline(runtime),
+    }
+}
+
+/// Build a runtime suitable for embedding inside a host language.
+///
+/// Identical to [`build`] except that at `n_cores == 1` it dedicates a
+/// background OS thread to driving a `current_thread` runtime. See
+/// [`RuntimeDriver`] for the motivation. At `n_cores > 1` this is identical
+/// to [`build`] — a multi-thread runtime already keeps the I/O reactor
+/// alive without help.
+pub fn build_for_embedding(config: &RuntimeConfiguration) -> SlimRuntime {
+    let cores = resolve_cores(config);
+    let driver = if cores == 1 {
+        build_dedicated_driver(config)
+    } else {
+        RuntimeDriver::Inline(build_inline_runtime(config, cores))
+    };
+    SlimRuntime {
+        config: config.clone(),
+        driver,
+    }
+}
+
+/// Resolve the effective worker count, matching the historical semantics:
+/// `0` means "all available", and oversubscription is clamped with a warning.
+fn resolve_cores(config: &RuntimeConfiguration) -> usize {
     let n_cpu = num_cpus::get();
     debug_assert!(n_cpu > 0, "failed to get number of CPUs");
 
     tracing::debug!(%n_cpu, "Number of available CPU cores");
 
-    let cores = if config.n_cores > n_cpu {
+    if config.n_cores > n_cpu {
         warn!(
             requested = %config.n_cores,
             available = %n_cpu,
@@ -107,39 +243,69 @@ pub fn build(config: &RuntimeConfiguration) -> SlimRuntime {
         );
         n_cpu
     } else if config.n_cores == 0 {
-        info!(
-            %n_cpu,
-            "Using all available cores",
-        );
+        info!(%n_cpu, "Using all available cores");
         n_cpu
     } else {
         config.n_cores
-    };
+    }
+}
 
-    let runtime = match cores {
-        1 => {
-            info!("Using single-threaded runtime");
-            Builder::new_current_thread()
-                .enable_all()
-                .thread_name(config.thread_name.as_str())
-                .build()
-                .expect("failed to build single-thread runtime!")
-        }
-        _ => {
-            info!(%cores, "Using multi-threaded runtime");
-            Builder::new_multi_thread()
-                .enable_all()
-                .thread_name(config.thread_name.as_str())
-                .worker_threads(cores)
-                .max_blocking_threads(cores)
-                .build()
-                .expect("failed to build threaded runtime!")
-        }
-    };
+fn build_inline_runtime(config: &RuntimeConfiguration, cores: usize) -> Runtime {
+    if cores == 1 {
+        info!("Using single-threaded (current_thread) runtime");
+        Builder::new_current_thread()
+            .enable_all()
+            .thread_name(config.thread_name.as_str())
+            .build()
+            .expect("failed to build current_thread runtime!")
+    } else {
+        info!(%cores, "Using multi-threaded runtime");
+        Builder::new_multi_thread()
+            .enable_all()
+            .thread_name(config.thread_name.as_str())
+            .worker_threads(cores)
+            .build()
+            .expect("failed to build threaded runtime!")
+    }
+}
 
-    SlimRuntime {
-        config: config.clone(),
-        runtime,
+fn build_dedicated_driver(config: &RuntimeConfiguration) -> RuntimeDriver {
+    info!("Using single-threaded runtime driven on a dedicated OS thread");
+
+    let (handle_tx, handle_rx) = std::sync::mpsc::channel();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let thread_name = config.thread_name.clone();
+
+    let thread = std::thread::Builder::new()
+        .name(thread_name.clone())
+        .spawn(move || {
+            let rt = Builder::new_current_thread()
+                .enable_all()
+                .thread_name(thread_name)
+                .build()
+                .expect("failed to build current_thread runtime!");
+
+            // Publish the handle before parking the thread inside block_on.
+            handle_tx
+                .send(rt.handle().clone())
+                .expect("failed to publish Tokio handle to initializer");
+
+            // Drive the reactor until shutdown is signaled. The oneshot
+            // doubles as a heartbeat that never completes on its own, so
+            // I/O and timers keep being polled for the lifetime of the
+            // runtime.
+            let _ = rt.block_on(shutdown_rx);
+        })
+        .expect("failed to spawn Tokio driver thread");
+
+    let handle = handle_rx
+        .recv()
+        .expect("Tokio driver thread panicked during initialization");
+
+    RuntimeDriver::Dedicated {
+        handle,
+        shutdown_tx: Some(shutdown_tx),
+        thread: Some(thread),
     }
 }
 
@@ -171,6 +337,48 @@ mod tests {
         let config = RuntimeConfiguration::default();
         let runtime = build(&config);
         assert_eq!(runtime.config.n_cores, 0);
+    }
+
+    #[test]
+    fn test_single_thread_runtime_drives_io() {
+        // Inline `current_thread` runtime — the calling thread drives it via
+        // block_on. Verify timers and async work actually progress.
+        let config = RuntimeConfiguration {
+            n_cores: 1,
+            thread_name: "slim-single".to_string(),
+            drain_timeout: time::Duration::from_secs(1).into(),
+        };
+        let runtime = build(&config);
+
+        let value = runtime.block_on(async {
+            tokio::time::sleep(time::Duration::from_millis(20)).await;
+            42_u32
+        });
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn test_build_for_embedding_dedicates_thread() {
+        // With `build_for_embedding` and cores == 1, the runtime runs on a
+        // dedicated OS thread. The calling thread is *not* the one driving
+        // it, which is the property bindings rely on when the host
+        // language's event loop owns the calling thread. Spawning a task
+        // and awaiting it via the handle proves the dedicated thread is
+        // alive and polling.
+        let config = RuntimeConfiguration {
+            n_cores: 1,
+            thread_name: "slim-embed".to_string(),
+            drain_timeout: time::Duration::from_secs(1).into(),
+        };
+        let runtime = build_for_embedding(&config);
+        let handle = runtime.handle();
+
+        let join = handle.spawn(async {
+            tokio::time::sleep(time::Duration::from_millis(20)).await;
+            7_u32
+        });
+        let value = runtime.block_on(async move { join.await.unwrap() });
+        assert_eq!(value, 7);
     }
 
     #[test]

--- a/data-plane/core/slim/src/runtime.rs
+++ b/data-plane/core/slim/src/runtime.rs
@@ -151,7 +151,7 @@ enum RuntimeDriver {
 }
 
 impl SlimRuntime {
-    /// Return a clonable handle to this runtime. Cheap; safe to call from any
+    /// Return a cloneable handle to this runtime. Cheap; safe to call from any
     /// thread.
     pub fn handle(&self) -> Handle {
         match &self.driver {

--- a/data-plane/slimctl/src/commands/slim_cmd.rs
+++ b/data-plane/slimctl/src/commands/slim_cmd.rs
@@ -99,7 +99,7 @@ fn run_slim_in_thread(config_file: &str) -> Result<()> {
     slim_config::tls::provider::initialize_crypto_provider();
 
     let runtime = slim::runtime::build(config.runtime().context("invalid runtime configuration")?);
-    runtime.runtime.block_on(slim::runner::run_services(config))
+    runtime.block_on(slim::runner::run_services(config))
 }
 
 async fn start_slim_instance(config_file: &str) -> Result<()> {


### PR DESCRIPTION
# Description

When the bindings are loaded into a host language
(Python `asyncio`, Kotlin coroutines, Swift async, …),
the host loop — not Tokio — drives the outer future.

Tokio's I/O reactor and timer wheel only advance while
some thread is inside a Tokio runtime context. With a
multi-worker runtime one worker stays parked on the
reactor, so I/O keeps flowing. With a single worker
(which the process's CPU quota can silently force in
containers with fractional CPU limits, cpusets, or small
machines), reactor polling and task execution share one thread;
once the host loop takes over polling, sockets registered
with the reactor never see their readiness.

This PR:
 - Introduce slim::runtime::build_for_embedding,
    a runtime variant that, when the effective core
    count is 1, runs a `current_thread` Tokio runtime
    on a dedicated OS thread sitting in `block_on`.
    External callers schedule work via the `Handle`.
  
- Keep `slim::runtime::build` as the daemon entry point:
   inline `current_thread` at `cores == 1`, multi-thread
   otherwise. `runner`, `slimctl`, and `channel-manager`
   integration tests are unchanged in behavior.

- Switch `slim_bindings` over to `build_for_embedding`
   and expose the runtime through a `tokio::runtime::Handle`
   instead of a `&'static Runtime`..

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
