### PR TITLE
refactor: drop transport field from the config

### DIFF
--- a/data-plane/bindings/rust/src/client_config.rs
+++ b/data-plane/bindings/rust/src/client_config.rs
@@ -433,8 +433,6 @@ mod tests {
     use super::*;
     use crate::common_config::{CaSource, TlsSource};
     use crate::errors::SlimError;
-    #[allow(unused_imports)]
-    use slim_config::component::configuration::Configuration as _;
     use slim_config::transport::TransportProtocol as CoreTransportProtocol;
     use std::collections::HashMap;
 

--- a/data-plane/bindings/rust/src/client_config.rs
+++ b/data-plane/bindings/rust/src/client_config.rs
@@ -17,7 +17,6 @@ use slim_config::grpc::client::{
 
 use crate::common_config::{ClientAuthenticationConfig, TlsClientConfig};
 use crate::errors::SlimError;
-use crate::transport_protocol::TransportProtocol;
 
 use slim_config::component::configuration::Configuration;
 
@@ -261,11 +260,11 @@ impl From<CoreBackoffConfig> for BackoffConfig {
 /// Client configuration for connecting to a SLIM server
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct ClientConfig {
-    /// The target endpoint the client will connect to
+    /// The target endpoint the client will connect to.
+    ///
+    /// The transport protocol is inferred from the endpoint scheme:
+    /// `ws://`/`wss://` → WebSocket, otherwise gRPC.
     pub endpoint: String,
-
-    /// Transport protocol to use (defaults to gRPC in core config when omitted)
-    pub transport: Option<TransportProtocol>,
 
     /// TLS client configuration
     pub tls: TlsClientConfig,
@@ -315,10 +314,6 @@ impl From<ClientConfig> for CoreClientConfig {
         let core_defaults = CoreClientConfig::default();
         CoreClientConfig {
             endpoint: config.endpoint,
-            transport: config
-                .transport
-                .map(Into::into)
-                .unwrap_or(core_defaults.transport),
             origin: config.origin,
             server_name: config.server_name,
             compression: config.compression.map(Into::into),
@@ -353,7 +348,6 @@ impl From<CoreClientConfig> for ClientConfig {
     fn from(config: CoreClientConfig) -> Self {
         ClientConfig {
             endpoint: config.endpoint,
-            transport: Some(config.transport.into()),
             origin: config.origin,
             server_name: config.server_name,
             compression: config.compression.map(Into::into),
@@ -377,7 +371,6 @@ impl Default for ClientConfig {
         let core_defaults = CoreClientConfig::default();
         Self {
             endpoint: core_defaults.endpoint,
-            transport: None,
             origin: None,
             server_name: None,
             compression: None,
@@ -440,6 +433,8 @@ mod tests {
     use super::*;
     use crate::common_config::{CaSource, TlsSource};
     use crate::errors::SlimError;
+    #[allow(unused_imports)]
+    use slim_config::component::configuration::Configuration as _;
     use slim_config::transport::TransportProtocol as CoreTransportProtocol;
     use std::collections::HashMap;
 
@@ -447,7 +442,6 @@ mod tests {
     fn test_client_config_creation() {
         let config = ClientConfig {
             endpoint: "example.com:443".to_string(),
-            transport: None,
             origin: None,
             server_name: None,
             compression: None,
@@ -484,7 +478,6 @@ mod tests {
 
         // Verify defaults are all None (core defaults applied during conversion)
         assert_eq!(config.endpoint, "");
-        assert_eq!(config.transport, None);
         assert_eq!(config.origin, None);
         assert_eq!(config.server_name, None);
         assert_eq!(config.compression, None);
@@ -568,8 +561,7 @@ mod tests {
         headers.insert("x-api-key".to_string(), "test-key".to_string());
 
         let ffi_config = ClientConfig {
-            endpoint: "api.example.com:443".to_string(),
-            transport: Some(TransportProtocol::Websocket),
+            endpoint: "ws://api.example.com:443".to_string(),
             origin: Some("example.com".to_string()),
             server_name: Some("sni.example.com".to_string()),
             compression: Some(CompressionType::Gzip),
@@ -598,8 +590,11 @@ mod tests {
 
         let core_config: CoreClientConfig = ffi_config.into();
 
-        assert_eq!(core_config.endpoint, "api.example.com:443");
-        assert_eq!(core_config.transport, CoreTransportProtocol::Websocket);
+        assert_eq!(core_config.endpoint, "ws://api.example.com:443");
+        assert_eq!(
+            core_config.resolved_transport(),
+            CoreTransportProtocol::Websocket
+        );
         assert_eq!(core_config.origin, Some("example.com".to_string()));
         assert_eq!(core_config.server_name, Some("sni.example.com".to_string()));
         assert!(core_config.compression.is_some());
@@ -619,7 +614,6 @@ mod tests {
         let ffi_config: ClientConfig = core_config.clone().into();
 
         assert_eq!(ffi_config.endpoint, core_config.endpoint);
-        assert_eq!(ffi_config.transport, Some(core_config.transport.into()));
         assert_eq!(ffi_config.origin, core_config.origin);
         assert_eq!(ffi_config.server_name, core_config.server_name);
         assert_eq!(ffi_config.rate_limit, core_config.rate_limit);
@@ -637,7 +631,6 @@ mod tests {
     fn test_client_config_roundtrip_conversion() {
         let original = ClientConfig {
             endpoint: "localhost:8080".to_string(),
-            transport: Some(TransportProtocol::Grpc),
             origin: Some("test.local".to_string()),
             server_name: None,
             compression: Some(CompressionType::Zstd),
@@ -661,7 +654,6 @@ mod tests {
         let roundtrip: ClientConfig = core.into();
 
         assert_eq!(roundtrip.endpoint, original.endpoint);
-        assert_eq!(roundtrip.transport, original.transport);
         assert_eq!(roundtrip.origin, original.origin);
         assert_eq!(roundtrip.rate_limit, original.rate_limit);
         assert_eq!(roundtrip.buffer_size, original.buffer_size);

--- a/data-plane/bindings/rust/src/server_config.rs
+++ b/data-plane/bindings/rust/src/server_config.rs
@@ -8,7 +8,6 @@ use slim_config::grpc::server::KeepaliveServerParameters as CoreKeepaliveServerP
 use slim_config::grpc::server::ServerConfig as CoreServerConfig;
 
 use crate::common_config::{ServerAuthenticationConfig, TlsServerConfig, TlsSource};
-use crate::transport_protocol::TransportProtocol;
 
 /// Keepalive configuration for the server
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
@@ -69,11 +68,11 @@ impl From<CoreKeepaliveServerParameters> for KeepaliveServerParameters {
 /// Server configuration for running a SLIM server
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct ServerConfig {
-    /// Endpoint address to listen on (e.g., "0.0.0.0:50051" or "[::]:50051")
+    /// Endpoint address to listen on (e.g., "0.0.0.0:50051" or "[::]:50051").
+    ///
+    /// The transport protocol is inferred from the endpoint scheme:
+    /// `ws://`/`wss://` → WebSocket, otherwise gRPC.
     pub endpoint: String,
-
-    /// Transport protocol to use (defaults to gRPC in core config when omitted)
-    pub transport: Option<TransportProtocol>,
 
     /// TLS server configuration
     pub tls: TlsServerConfig,
@@ -111,7 +110,6 @@ impl Default for ServerConfig {
         let core_defaults = CoreServerConfig::default();
         ServerConfig {
             endpoint: core_defaults.endpoint,
-            transport: None,
             tls: core_defaults.tls_setting.into(),
             http2_only: None,
             max_frame_size: None,
@@ -131,10 +129,6 @@ impl From<ServerConfig> for CoreServerConfig {
         let core_defaults = CoreServerConfig::default();
         CoreServerConfig {
             endpoint: config.endpoint,
-            transport: config
-                .transport
-                .map(Into::into)
-                .unwrap_or(core_defaults.transport),
             tls_setting: config.tls.into(),
             http2_only: config.http2_only.unwrap_or(core_defaults.http2_only),
             max_frame_size: config.max_frame_size.or(core_defaults.max_frame_size),
@@ -168,7 +162,6 @@ impl From<CoreServerConfig> for ServerConfig {
     fn from(config: CoreServerConfig) -> Self {
         ServerConfig {
             endpoint: config.endpoint,
-            transport: Some(config.transport.into()),
             tls: config.tls_setting.into(),
             http2_only: Some(config.http2_only),
             max_frame_size: config.max_frame_size,
@@ -256,7 +249,6 @@ mod tests {
 
         // Verify defaults are all None (core defaults applied during conversion)
         assert_eq!(config.endpoint, "");
-        assert_eq!(config.transport, None);
         assert_eq!(config.http2_only, None);
         assert_eq!(config.max_frame_size, None);
         assert_eq!(config.max_concurrent_streams, None);
@@ -330,8 +322,7 @@ mod tests {
     #[test]
     fn test_server_config_to_core_conversion() {
         let ffi_config = ServerConfig {
-            endpoint: "127.0.0.1:8080".to_string(),
-            transport: Some(TransportProtocol::Websocket),
+            endpoint: "ws://127.0.0.1:8080".to_string(),
             tls: TlsServerConfig::default(),
             http2_only: Some(false),
             max_frame_size: Some(8),
@@ -346,8 +337,11 @@ mod tests {
 
         let core_config: CoreServerConfig = ffi_config.into();
 
-        assert_eq!(core_config.endpoint, "127.0.0.1:8080");
-        assert_eq!(core_config.transport, CoreTransportProtocol::Websocket);
+        assert_eq!(core_config.endpoint, "ws://127.0.0.1:8080");
+        assert_eq!(
+            core_config.resolved_transport(),
+            CoreTransportProtocol::Websocket
+        );
         assert!(!core_config.http2_only);
         assert_eq!(core_config.max_frame_size, Some(8));
         assert_eq!(core_config.max_concurrent_streams, Some(200));
@@ -366,7 +360,6 @@ mod tests {
         let ffi_config: ServerConfig = core_config.clone().into();
 
         assert_eq!(ffi_config.endpoint, core_config.endpoint);
-        assert_eq!(ffi_config.transport, Some(core_config.transport.into()));
         assert_eq!(ffi_config.http2_only, Some(core_config.http2_only));
         assert_eq!(ffi_config.max_frame_size, core_config.max_frame_size);
         assert_eq!(
@@ -383,7 +376,6 @@ mod tests {
     fn test_server_config_roundtrip_conversion() {
         let original = ServerConfig {
             endpoint: "localhost:9090".to_string(),
-            transport: Some(TransportProtocol::Grpc),
             tls: TlsServerConfig::default(),
             http2_only: Some(true),
             max_frame_size: Some(16),
@@ -401,7 +393,6 @@ mod tests {
         let roundtrip: ServerConfig = core.into();
 
         assert_eq!(roundtrip.endpoint, original.endpoint);
-        assert_eq!(roundtrip.transport, original.transport);
         assert_eq!(roundtrip.http2_only, original.http2_only);
         assert_eq!(roundtrip.max_frame_size, original.max_frame_size);
         assert_eq!(

--- a/data-plane/channel-manager/README.md
+++ b/data-plane/channel-manager/README.md
@@ -22,10 +22,11 @@ Create a YAML configuration file (see [example-channel-manager-config.yaml](exam
 ```yaml
 channel-manager:
   # Connection configuration for the SLIM data-plane node.
-  # transport can be "grpc" (http/https endpoint) or "websocket" (ws/wss endpoint).
+  # Transport is inferred from the endpoint scheme:
+  #   ws://, wss://      → websocket (TLS when wss)
+  #   http://, https://, bare host:port → grpc
   slim-connection:
     endpoint: "http://127.0.0.1:46357"
-    transport: "grpc"
     tls:
       insecure: true
 

--- a/data-plane/channel-manager/base-config.yaml
+++ b/data-plane/channel-manager/base-config.yaml
@@ -4,7 +4,6 @@
 channel-manager:
   slim-connection:
     endpoint: "http://127.0.0.1:46357"
-    transport: "grpc"
     tls:
       insecure: true
 

--- a/data-plane/channel-manager/example-channel-manager-config.yaml
+++ b/data-plane/channel-manager/example-channel-manager-config.yaml
@@ -7,13 +7,11 @@ channel-manager:
   # transport (grpc/websocket), TLS, authentication, keepalive, proxy, backoff, headers, etc.
   slim-connection:
     endpoint: "http://127.0.0.1:46357"
-    transport: "grpc"
     tls:
       insecure: true
-    # For websocket transport, use:
+    # For websocket transport, change the endpoint scheme to ws:// or wss://, e.g.:
     # endpoint: "ws://127.0.0.1:46357"
-    # transport: "websocket"
-    # Uncomment below for TLS-secured connections:
+    # Uncomment below for TLS-secured connections (or use https://, wss://):
     # tls:
     #   insecure: false
     #   ca_file: "/path/to/ca.pem"

--- a/data-plane/channel-manager/src/config.rs
+++ b/data-plane/channel-manager/src/config.rs
@@ -9,7 +9,6 @@
 //! channel-manager:
 //!   slim-connection:
 //!     endpoint: "http://127.0.0.1:46357"
-//!     transport: "grpc"
 //!     tls:
 //!       insecure: true
 //!   api-server:
@@ -285,7 +284,6 @@ channel-manager:
 channel-manager:
   slim-connection:
     endpoint: "ws://127.0.0.1:46357"
-    transport: "websocket"
     tls:
       insecure: true
   api-server:
@@ -300,7 +298,7 @@ channel-manager:
         let cfg: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(cfg.validate().is_ok());
         assert_eq!(
-            cfg.manager.slim_connection.transport,
+            cfg.manager.slim_connection.resolved_transport(),
             TransportProtocol::Websocket
         );
     }

--- a/data-plane/config/reference/config.yaml
+++ b/data-plane/config/reference/config.yaml
@@ -59,10 +59,9 @@ services:
         # No default, this must be specified.
         - endpoint: "0.0.0.0:46357"
 
-          # Dataplane transport protocol.
-          # Available options: grpc, websocket
-          # Default: grpc
-          # transport: grpc
+          # Transport protocol is inferred from the endpoint scheme:
+          #   ws://, wss://  → websocket (TLS when wss)
+          #   http://, https://, bare host:port, unix://  → grpc
 
           # Authentication configuration
           auth:
@@ -217,13 +216,12 @@ services:
         # No default, this must be specified.
         - endpoint: "1.2.3.4:54321"
 
-          # Dataplane transport protocol.
-          # Available options: grpc, websocket
-          # Default: grpc
-          # transport: grpc
+          # Transport protocol is inferred from the endpoint scheme:
+          #   ws://, wss://  → websocket (TLS when wss)
+          #   http://, https://, bare host:port, unix://  → grpc
 
           # Optional websocket auth query parameter key.
-          # Used only when transport=websocket.
+          # Used only when endpoint scheme is ws:// or wss://.
           # websocket_auth_query_param: token
 
           # Authentication configuration

--- a/data-plane/config/websocket/client-config-wss.yaml
+++ b/data-plane/config/websocket/client-config-wss.yaml
@@ -16,7 +16,6 @@ services:
     dataplane:
       clients:
         - endpoint: "wss://localhost:46357"
-          transport: websocket
           server_name: "localhost"
           tls:
             ca_source:

--- a/data-plane/config/websocket/client-config.yaml
+++ b/data-plane/config/websocket/client-config.yaml
@@ -16,7 +16,6 @@ services:
     dataplane:
       clients:
         - endpoint: "ws://localhost:46357"
-          transport: websocket
           websocket_auth_query_param: token
           tls:
             insecure: true

--- a/data-plane/config/websocket/server-config-wss.yaml
+++ b/data-plane/config/websocket/server-config-wss.yaml
@@ -16,7 +16,6 @@ services:
     dataplane:
       servers:
         - endpoint: "wss://0.0.0.0:46357"
-          transport: websocket
           tls:
             source:
               type: file

--- a/data-plane/config/websocket/server-config.yaml
+++ b/data-plane/config/websocket/server-config.yaml
@@ -15,7 +15,6 @@ services:
     dataplane:
       servers:
         - endpoint: "ws://0.0.0.0:46357"
-          transport: websocket
           tls:
             insecure: true
       clients: []

--- a/data-plane/core/config/src/client.rs
+++ b/data-plane/core/config/src/client.rs
@@ -12,7 +12,7 @@
 //! * `crate::websocket::client` — WebSocket channel building
 
 use duration_string::DurationString;
-use std::{collections::HashMap, str::FromStr, time::Duration};
+use std::{collections::HashMap, time::Duration};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/data-plane/core/config/src/client.rs
+++ b/data-plane/core/config/src/client.rs
@@ -178,11 +178,11 @@ impl Strategy for BackoffConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct ClientConfig {
     /// The target the client will connect to.
+    ///
+    /// The transport protocol is inferred from the endpoint scheme:
+    /// * `ws://`, `wss://`  → WebSocket (TLS when `wss`)
+    /// * `http://`, `https://`, `unix://`, bare `host:port` → gRPC
     pub endpoint: String,
-
-    /// Transport protocol to use for dataplane communication.
-    #[serde(default)]
-    pub transport: TransportProtocol,
 
     /// Origin (HTTP Host authority override) for the client.
     pub origin: Option<String>,
@@ -247,7 +247,6 @@ impl Default for ClientConfig {
     fn default() -> Self {
         ClientConfig {
             endpoint: String::new(),
-            transport: TransportProtocol::default(),
             origin: None,
             server_name: None,
             compression: None,
@@ -286,7 +285,7 @@ impl std::fmt::Display for ClientConfig {
             f,
             "ClientConfig {{ endpoint: {}, transport: {:?}, origin: {:?}, server_name: {:?}, compression: {:?}, rate_limit: {:?}, tls_setting: {:?}, keepalive: {:?}, proxy: {:?}, connect_timeout: {:?}, request_timeout: {:?}, buffer_size: {:?}, headers: {:?}, auth: {:?}, backoff: {:?}, metadata: {:?}, link_id: {:?} }}",
             self.endpoint,
-            self.transport,
+            self.resolved_transport(),
             self.origin,
             self.server_name,
             self.compression,
@@ -328,7 +327,7 @@ impl Configuration for ClientConfig {
 
         // Validate the client configuration
         self.tls_setting.validate()?;
-        self.validate_websocket_endpoint()?;
+        self.validate_endpoint_scheme()?;
 
         Ok(())
     }
@@ -350,10 +349,6 @@ impl ClientConfig {
             origin: Some(origin.to_string()),
             ..self
         }
-    }
-
-    pub fn with_transport(self, transport: TransportProtocol) -> Self {
-        Self { transport, ..self }
     }
 
     pub fn with_server_name(self, server_name: &str) -> Self {
@@ -488,7 +483,7 @@ impl ClientConfig {
         >,
         ConfigError,
     > {
-        match self.transport {
+        match self.resolved_transport() {
             TransportProtocol::Grpc => Ok(TransportChannel::Grpc(self.to_grpc_channel().await?)),
             TransportProtocol::Websocket => Ok(TransportChannel::Websocket(
                 self.to_websocket_channel().await?,
@@ -496,18 +491,23 @@ impl ClientConfig {
         }
     }
 
-    /// Validates that the endpoint scheme matches the transport when set to
-    /// WebSocket. For gRPC transports the scheme is checked at channel-build
-    /// time by `grpc::client`.
-    fn validate_websocket_endpoint(&self) -> Result<(), ConfigError> {
-        if self.transport != TransportProtocol::Websocket {
+    /// Resolve the transport protocol for this configuration by inspecting
+    /// the endpoint URI scheme. See [`TransportProtocol::from_endpoint`].
+    pub fn resolved_transport(&self) -> TransportProtocol {
+        TransportProtocol::from_endpoint(&self.endpoint)
+    }
+
+    /// Validates that the endpoint scheme is one of the recognized values.
+    /// gRPC builders additionally check the scheme at channel-build time.
+    fn validate_endpoint_scheme(&self) -> Result<(), ConfigError> {
+        // Bare `host:port` (no scheme) is accepted and resolves to gRPC.
+        if !self.endpoint.contains("://") {
             return Ok(());
         }
-
         let endpoint = Uri::from_str(self.endpoint.as_str())?;
         match endpoint.scheme_str() {
-            Some("ws") | Some("wss") => Ok(()),
-            _ => Err(ConfigError::InvalidWebSocketEndpointScheme),
+            Some("ws") | Some("wss") | Some("http") | Some("https") | Some("unix") => Ok(()),
+            _ => Err(ConfigError::InvalidEndpointScheme),
         }
     }
 }
@@ -546,7 +546,7 @@ mod tests {
     fn test_default_client_config() {
         let client = ClientConfig::default();
         assert_eq!(client.endpoint, String::new());
-        assert_eq!(client.transport, TransportProtocol::Grpc);
+        assert_eq!(client.resolved_transport(), TransportProtocol::Grpc);
         assert_eq!(client.origin, None);
         assert_eq!(client.compression, None);
         assert_eq!(client.rate_limit, None);
@@ -560,21 +560,34 @@ mod tests {
     }
 
     #[test]
-    fn test_websocket_transport_endpoint_validation() {
-        let ws_config = ClientConfig::with_endpoint("ws://localhost:46357")
-            .with_transport(TransportProtocol::Websocket);
-        assert!(ws_config.validate().is_ok());
+    fn test_transport_inferred_from_endpoint_scheme() {
+        assert_eq!(
+            ClientConfig::with_endpoint("ws://localhost:46357").resolved_transport(),
+            TransportProtocol::Websocket
+        );
+        assert_eq!(
+            ClientConfig::with_endpoint("wss://localhost:46357").resolved_transport(),
+            TransportProtocol::Websocket
+        );
+        assert_eq!(
+            ClientConfig::with_endpoint("http://localhost:46357").resolved_transport(),
+            TransportProtocol::Grpc
+        );
+        assert_eq!(
+            ClientConfig::with_endpoint("https://localhost:46357").resolved_transport(),
+            TransportProtocol::Grpc
+        );
+        assert_eq!(
+            ClientConfig::with_endpoint("127.0.0.1:46357").resolved_transport(),
+            TransportProtocol::Grpc
+        );
 
-        let wss_config = ClientConfig::with_endpoint("wss://localhost:46357")
-            .with_transport(TransportProtocol::Websocket);
-        assert!(wss_config.validate().is_ok());
-
-        let invalid = ClientConfig::with_endpoint("http://localhost:46357")
-            .with_transport(TransportProtocol::Websocket);
-        let err = invalid
-            .validate()
-            .expect_err("expected invalid websocket scheme");
-        assert!(matches!(err, ConfigError::InvalidWebSocketEndpointScheme));
+        // Validation rejects unknown schemes.
+        let invalid = ClientConfig::with_endpoint("ftp://localhost:46357");
+        assert!(matches!(
+            invalid.validate(),
+            Err(ConfigError::InvalidEndpointScheme)
+        ));
     }
 
     #[test]

--- a/data-plane/core/config/src/client.rs
+++ b/data-plane/core/config/src/client.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, str::FromStr, time::Duration};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tonic::codegen::{Body, Bytes, StdError};
-use tonic::transport::Uri;
 
 use slim_auth::metadata::MetadataMap;
 
@@ -498,15 +497,17 @@ impl ClientConfig {
     }
 
     /// Validates that the endpoint scheme is one of the recognized values.
-    /// gRPC builders additionally check the scheme at channel-build time.
     fn validate_endpoint_scheme(&self) -> Result<(), ConfigError> {
         // Bare `host:port` (no scheme) is accepted and resolves to gRPC.
-        if !self.endpoint.contains("://") {
+        let Some((scheme, _rest)) = self.endpoint.split_once("://") else {
             return Ok(());
-        }
-        let endpoint = Uri::from_str(self.endpoint.as_str())?;
-        match endpoint.scheme_str() {
-            Some("ws") | Some("wss") | Some("http") | Some("https") | Some("unix") => Ok(()),
+        };
+        // Match the scheme by prefix only. Parsing the full URI via `http::Uri`
+        // here would reject otherwise-valid endpoints such as
+        // `unix:///tmp/slim.sock` (no authority), which gRPC handles via its
+        // own URI builder in `parse_endpoint_uri`.
+        match scheme {
+            "ws" | "wss" | "http" | "https" | "unix" => Ok(()),
             _ => Err(ConfigError::InvalidEndpointScheme),
         }
     }
@@ -532,6 +533,33 @@ mod metadata_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_accepts_supported_schemes() {
+        // Includes `unix://` with no authority — must not be rejected by the
+        // scheme validator even though `http::Uri::from_str` would fail on it.
+        for endpoint in [
+            "host:1234",
+            "http://host:1234",
+            "https://host:1234",
+            "ws://host:1234",
+            "wss://host:1234",
+            "unix:///tmp/slim.sock",
+        ] {
+            let cfg = ClientConfig::with_endpoint(endpoint);
+            cfg.validate_endpoint_scheme()
+                .unwrap_or_else(|e| panic!("endpoint {endpoint} rejected: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_unknown_scheme() {
+        let cfg = ClientConfig::with_endpoint("ftp://host:21");
+        assert!(matches!(
+            cfg.validate_endpoint_scheme(),
+            Err(ConfigError::InvalidEndpointScheme)
+        ));
+    }
 
     #[test]
     fn test_default_keepalive_config() {

--- a/data-plane/core/config/src/client.rs
+++ b/data-plane/core/config/src/client.rs
@@ -33,7 +33,7 @@ use crate::errors::ConfigError;
 use crate::grpc::compression::CompressionType;
 use crate::grpc::proxy::ProxyConfig;
 use crate::tls::client::TlsClientConfig as TLSSetting;
-use crate::transport::TransportProtocol;
+use crate::transport::{TransportProtocol, validate_endpoint_scheme};
 use crate::websocket::client::WebSocketClientChannel;
 
 /// Result of [`ClientConfig::to_channel`]: either a gRPC channel (the generic
@@ -326,7 +326,7 @@ impl Configuration for ClientConfig {
 
         // Validate the client configuration
         self.tls_setting.validate()?;
-        self.validate_endpoint_scheme()?;
+        validate_endpoint_scheme(&self.endpoint)?;
 
         Ok(())
     }
@@ -495,22 +495,6 @@ impl ClientConfig {
     pub fn resolved_transport(&self) -> TransportProtocol {
         TransportProtocol::from_endpoint(&self.endpoint)
     }
-
-    /// Validates that the endpoint scheme is one of the recognized values.
-    fn validate_endpoint_scheme(&self) -> Result<(), ConfigError> {
-        // Bare `host:port` (no scheme) is accepted and resolves to gRPC.
-        let Some((scheme, _rest)) = self.endpoint.split_once("://") else {
-            return Ok(());
-        };
-        // Match the scheme by prefix only. Parsing the full URI via `http::Uri`
-        // here would reject otherwise-valid endpoints such as
-        // `unix:///tmp/slim.sock` (no authority), which gRPC handles via its
-        // own URI builder in `parse_endpoint_uri`.
-        match scheme {
-            "ws" | "wss" | "http" | "https" | "unix" => Ok(()),
-            _ => Err(ConfigError::InvalidEndpointScheme),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -533,33 +517,6 @@ mod metadata_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_validate_accepts_supported_schemes() {
-        // Includes `unix://` with no authority — must not be rejected by the
-        // scheme validator even though `http::Uri::from_str` would fail on it.
-        for endpoint in [
-            "host:1234",
-            "http://host:1234",
-            "https://host:1234",
-            "ws://host:1234",
-            "wss://host:1234",
-            "unix:///tmp/slim.sock",
-        ] {
-            let cfg = ClientConfig::with_endpoint(endpoint);
-            cfg.validate_endpoint_scheme()
-                .unwrap_or_else(|e| panic!("endpoint {endpoint} rejected: {e}"));
-        }
-    }
-
-    #[test]
-    fn test_validate_rejects_unknown_scheme() {
-        let cfg = ClientConfig::with_endpoint("ftp://host:21");
-        assert!(matches!(
-            cfg.validate_endpoint_scheme(),
-            Err(ConfigError::InvalidEndpointScheme)
-        ));
-    }
 
     #[test]
     fn test_default_keepalive_config() {

--- a/data-plane/core/config/src/grpc/client.rs
+++ b/data-plane/core/config/src/grpc/client.rs
@@ -177,7 +177,7 @@ impl ClientConfig {
         + use<>,
         ConfigError,
     > {
-        if self.transport == TransportProtocol::Websocket {
+        if self.resolved_transport() == TransportProtocol::Websocket {
             return Err(ConfigError::GrpcChannelUnsupportedTransport);
         }
 
@@ -749,8 +749,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_to_grpc_channel_rejects_websocket_transport() {
-        let client = ClientConfig::with_endpoint("ws://localhost:46357")
-            .with_transport(TransportProtocol::Websocket);
+        let client = ClientConfig::with_endpoint("ws://localhost:46357");
         let channel = client.to_grpc_channel_lazy().await;
         assert!(matches!(
             channel,

--- a/data-plane/core/config/src/grpc/server.rs
+++ b/data-plane/core/config/src/grpc/server.rs
@@ -86,7 +86,7 @@ impl ServerConfig {
         &self,
         routes: Routes,
     ) -> Result<ServerFuture, ConfigError> {
-        if self.transport == TransportProtocol::Websocket {
+        if self.resolved_transport() == TransportProtocol::Websocket {
             return Err(ConfigError::GrpcServerUnsupportedTransport);
         }
 
@@ -357,8 +357,7 @@ mod tests {
     #[tokio::test]
     async fn test_to_server_future_rejects_websocket_transport() {
         let empty_service = Arc::new(Empty::new());
-        let server_config = ServerConfig::with_endpoint("0.0.0.0:12345")
-            .with_transport(TransportProtocol::Websocket);
+        let server_config = ServerConfig::with_endpoint("ws://0.0.0.0:12345");
         let ret = server_config
             .to_server_future(&[GreeterServer::from_arc(empty_service)])
             .await;

--- a/data-plane/core/config/src/schema/client-config.schema.json
+++ b/data-plane/core/config/src/schema/client-config.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ClientConfig",
-  "description": "Struct for the client configuration.\nThis struct contains the endpoint, origin, compression type, rate limit,\nTLS settings, keepalive settings, proxy settings, timeout settings, buffer size settings,\nheaders, and auth settings.\nThe client configuration can be converted to a tonic channel.",
+  "description": "Struct for the client configuration.\nThis struct contains the endpoint, origin, compression type, rate limit,\nTLS settings, keepalive settings, proxy settings, timeout settings, buffer size settings,\nheaders, and auth settings.\nThe client configuration can be converted to a transport channel via\n[`ClientConfig::to_channel`].",
   "type": "object",
   "properties": {
     "auth": {
@@ -49,7 +49,7 @@
       "default": "0y"
     },
     "endpoint": {
-      "description": "The target the client will connect to.",
+      "description": "The target the client will connect to.\n\nThe transport protocol is inferred from the endpoint scheme:\n* `ws://`, `wss://`  → WebSocket (TLS when `wss`)\n* `http://`, `https://`, `unix://`, bare `host:port` → gRPC",
       "type": "string"
     },
     "headers": {
@@ -70,6 +70,11 @@
           "type": "null"
         }
       ]
+    },
+    "link_id": {
+      "description": "Link identifier for this connection, used during link negotiation.\nMust be a valid UUID v4. Defaults to a randomly generated UUID v4.",
+      "type": "string",
+      "default": "5809da77-44e1-4b56-b221-de07c3b641e9"
     },
     "metadata": {
       "description": "Arbitrary user-provided metadata.",
@@ -147,18 +152,6 @@
         },
         "tls_version": "tls1.3"
       }
-    },
-    "transport": {
-      "description": "Transport protocol to use for dataplane communication.",
-      "$ref": "#/$defs/TransportProtocol",
-      "default": "grpc"
-    },
-    "websocket_auth_query_param": {
-      "description": "Optional websocket authentication query parameter key.\nThis is only used when `transport=websocket`.",
-      "type": [
-        "string",
-        "null"
-      ]
     }
   },
   "required": [
@@ -224,6 +217,20 @@
             }
           },
           "$ref": "#/$defs/Config3",
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "description": "SPIRE/SPIFFE authentication configuration.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "spire"
+            }
+          },
+          "$ref": "#/$defs/SpireConfig",
           "required": [
             "type"
           ]
@@ -687,10 +694,13 @@
       }
     },
     "MetadataValue": {
-      "description": "A generic metadata value.\n\nSupported variants:\n- String\n- Number (serde_json::Number – can represent integer & floating point)\n- List (Vec<MetadataValue>)\n- Map (nested MetadataMap)",
+      "description": "A generic metadata value.\n\nSupported variants:\n- String\n- Bool\n- Number (serde_json::Number – can represent integer & floating point)\n- List (Vec<MetadataValue>)\n- Map (nested MetadataMap)",
       "anyOf": [
         {
           "type": "string"
+        },
+        {
+          "type": "boolean"
         },
         {
           "type": "number"
@@ -757,6 +767,44 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "SpireConfig": {
+      "description": "SPIRE authentication configuration",
+      "type": "object",
+      "properties": {
+        "jwt_audiences": {
+          "description": "Audiences to request / verify for JWT SVIDs",
+          "type": "array",
+          "default": [
+            "slim"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "socket_path": {
+          "description": "Path to the SPIFFE Workload API socket (None => use SPIFFE_ENDPOINT_SOCKET env var)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_spiffe_id": {
+          "description": "Optional target SPIFFE ID when requesting JWT SVIDs",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trust_domains": {
+          "description": "Optional trust domains override for X.509 bundle retrieval. If set,\n`get_x509_bundle()` uses this instead of deriving from the current SVID.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -904,21 +952,6 @@
           "required": [
             "type"
           ]
-        }
-      ]
-    },
-    "TransportProtocol": {
-      "description": "Transport protocol used by client and server dataplane configuration.",
-      "oneOf": [
-        {
-          "description": "gRPC transport (default).",
-          "type": "string",
-          "const": "grpc"
-        },
-        {
-          "description": "Native websocket transport.",
-          "type": "string",
-          "const": "websocket"
         }
       ]
     }

--- a/data-plane/core/config/src/schema/server-config.schema.json
+++ b/data-plane/core/config/src/schema/server-config.schema.json
@@ -11,7 +11,7 @@
       }
     },
     "endpoint": {
-      "description": "Endpoint is the address to listen on.",
+      "description": "Endpoint is the address to listen on.\n\nThe transport protocol is inferred from the endpoint scheme:\n* `ws://`, `wss://`  → WebSocket (TLS when `wss`)\n* `http://`, `https://`, bare `host:port` → gRPC",
       "type": "string"
     },
     "http2_only": {
@@ -97,11 +97,6 @@
         "tls_version": "tls1.3"
       }
     },
-    "transport": {
-      "description": "Transport protocol to use for dataplane communication.",
-      "$ref": "#/$defs/TransportProtocol",
-      "default": "grpc"
-    },
     "write_buffer_size": {
       "description": "WriteBufferSize for gRPC server.",
       "type": [
@@ -135,7 +130,7 @@
       ]
     },
     "AuthenticationConfig": {
-      "description": "Enum holding one configuration for the client.",
+      "description": "Enum holding one configuration for the server.",
       "oneOf": [
         {
           "description": "Basic authentication configuration.",
@@ -161,6 +156,20 @@
             }
           },
           "$ref": "#/$defs/Config2",
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "description": "SPIRE/SPIFFE authentication configuration.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "spire"
+            }
+          },
+          "$ref": "#/$defs/SpireConfig",
           "required": [
             "type"
           ]
@@ -518,10 +527,13 @@
       }
     },
     "MetadataValue": {
-      "description": "A generic metadata value.\n\nSupported variants:\n- String\n- Number (serde_json::Number – can represent integer & floating point)\n- List (Vec<MetadataValue>)\n- Map (nested MetadataMap)",
+      "description": "A generic metadata value.\n\nSupported variants:\n- String\n- Bool\n- Number (serde_json::Number – can represent integer & floating point)\n- List (Vec<MetadataValue>)\n- Map (nested MetadataMap)",
       "anyOf": [
         {
           "type": "string"
+        },
+        {
+          "type": "boolean"
         },
         {
           "type": "number"
@@ -539,6 +551,44 @@
     },
     "OpaqueString": {
       "type": "string"
+    },
+    "SpireConfig": {
+      "description": "SPIRE authentication configuration",
+      "type": "object",
+      "properties": {
+        "jwt_audiences": {
+          "description": "Audiences to request / verify for JWT SVIDs",
+          "type": "array",
+          "default": [
+            "slim"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "socket_path": {
+          "description": "Path to the SPIFFE Workload API socket (None => use SPIFFE_ENDPOINT_SOCKET env var)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_spiffe_id": {
+          "description": "Optional target SPIFFE ID when requesting JWT SVIDs",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trust_domains": {
+          "description": "Optional trust domains override for X.509 bundle retrieval. If set,\n`get_x509_bundle()` uses this instead of deriving from the current SVID.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "TlsServerConfig": {
       "type": "object",
@@ -691,21 +741,6 @@
           "required": [
             "type"
           ]
-        }
-      ]
-    },
-    "TransportProtocol": {
-      "description": "Transport protocol used by client and server dataplane configuration.",
-      "oneOf": [
-        {
-          "description": "gRPC transport (default).",
-          "type": "string",
-          "const": "grpc"
-        },
-        {
-          "description": "Native websocket transport.",
-          "type": "string",
-          "const": "websocket"
         }
       ]
     }

--- a/data-plane/core/config/src/server.rs
+++ b/data-plane/core/config/src/server.rs
@@ -82,11 +82,11 @@ pub enum AuthenticationConfig {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
 pub struct ServerConfig {
     /// Endpoint is the address to listen on.
+    ///
+    /// The transport protocol is inferred from the endpoint scheme:
+    /// * `ws://`, `wss://`  → WebSocket (TLS when `wss`)
+    /// * `http://`, `https://`, bare `host:port` → gRPC
     pub endpoint: String,
-
-    /// Transport protocol to use for dataplane communication.
-    #[serde(default)]
-    pub transport: TransportProtocol,
 
     /// Configures the protocol to use TLS.
     #[serde(default, rename = "tls")]
@@ -163,7 +163,6 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             endpoint: String::new(),
-            transport: TransportProtocol::default(),
             tls_setting: TLSSetting::default(),
             http2_only: default_http2_only(),
             max_frame_size: Some(4),
@@ -189,7 +188,7 @@ impl std::fmt::Display for ServerConfig {
             f,
             "ServerConfig {{ endpoint: {}, transport: {:?}, tls_setting: {}, http2_only: {}, max_frame_size: {:?}, max_concurrent_streams: {:?}, max_header_list_size: {:?}, read_buffer_size: {:?}, write_buffer_size: {:?}, keepalive: {:?}, auth: {:?}, metadata: {:?} }}",
             self.endpoint,
-            self.transport,
+            self.resolved_transport(),
             self.tls_setting,
             self.http2_only,
             self.max_frame_size,
@@ -226,10 +225,6 @@ impl ServerConfig {
             tls_setting,
             ..self
         }
-    }
-
-    pub fn with_transport(self, transport: TransportProtocol) -> Self {
-        Self { transport, ..self }
     }
 
     pub fn with_http2_only(self, http2_only: bool) -> Self {
@@ -290,7 +285,7 @@ impl ServerConfig {
         watch: drain::Watch,
         handler: Arc<H>,
     ) -> Result<CancellationToken, ConfigError> {
-        match self.transport {
+        match self.resolved_transport() {
             TransportProtocol::Grpc => {
                 let routes = handler
                     .grpc_routes()
@@ -304,6 +299,12 @@ impl ServerConfig {
                 self.run_websocket_server(watch, on_accepted).await
             }
         }
+    }
+
+    /// Resolve the transport protocol for this configuration by inspecting
+    /// the endpoint URI scheme. See [`TransportProtocol::from_endpoint`].
+    pub fn resolved_transport(&self) -> TransportProtocol {
+        TransportProtocol::from_endpoint(&self.endpoint)
     }
 }
 
@@ -353,7 +354,7 @@ mod tests {
     fn test_default_server_config() {
         let server_config = ServerConfig::default();
         assert_eq!(server_config.endpoint, String::new());
-        assert_eq!(server_config.transport, TransportProtocol::Grpc);
+        assert_eq!(server_config.resolved_transport(), TransportProtocol::Grpc);
         assert_eq!(server_config.tls_setting, TLSSetting::default());
         assert_eq!(server_config.http2_only, default_http2_only());
         assert_eq!(server_config.max_frame_size, Some(4));

--- a/data-plane/core/config/src/server.rs
+++ b/data-plane/core/config/src/server.rs
@@ -32,7 +32,7 @@ use crate::auth::spire::SpireConfig as SpireAuthConfig;
 use crate::component::configuration::Configuration;
 use crate::errors::ConfigError;
 use crate::tls::server::TlsServerConfig as TLSSetting;
-use crate::transport::TransportProtocol;
+use crate::transport::{TransportProtocol, validate_endpoint_scheme};
 use slim_auth::metadata::MetadataMap;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
@@ -85,7 +85,7 @@ pub struct ServerConfig {
     ///
     /// The transport protocol is inferred from the endpoint scheme:
     /// * `ws://`, `wss://`  → WebSocket (TLS when `wss`)
-    /// * `http://`, `https://`, bare `host:port` → gRPC
+    /// * `http://`, `https://`, `unix://`, bare `host:port` → gRPC
     pub endpoint: String,
 
     /// Configures the protocol to use TLS.
@@ -208,6 +208,7 @@ impl Configuration for ServerConfig {
 
     fn validate(&self) -> Result<(), Self::Error> {
         self.tls_setting.validate()?;
+        validate_endpoint_scheme(&self.endpoint)?;
         Ok(())
     }
 }
@@ -336,6 +337,31 @@ mod metadata_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_rejects_unknown_scheme() {
+        let cfg = ServerConfig::with_endpoint("ftp://0.0.0.0:46357");
+        assert!(matches!(
+            cfg.validate(),
+            Err(ConfigError::InvalidEndpointScheme)
+        ));
+    }
+
+    #[test]
+    fn test_validate_accepts_supported_schemes() {
+        for endpoint in [
+            "0.0.0.0:46357",
+            "http://0.0.0.0:46357",
+            "https://0.0.0.0:46357",
+            "ws://0.0.0.0:46357",
+            "wss://0.0.0.0:46357",
+            "unix:///tmp/slim.sock",
+        ] {
+            let cfg = ServerConfig::with_endpoint(endpoint);
+            cfg.validate()
+                .unwrap_or_else(|e| panic!("endpoint {endpoint} rejected: {e}"));
+        }
+    }
 
     #[test]
     fn test_default_keepalive_server_parameters() {

--- a/data-plane/core/config/src/transport.rs
+++ b/data-plane/core/config/src/transport.rs
@@ -4,6 +4,35 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::errors::ConfigError;
+
+/// Endpoint URI schemes recognized by `ClientConfig` and `ServerConfig`.
+///
+/// Kept in sync with the dispatch in [`TransportProtocol::from_endpoint`] and
+/// the role-specific handling in `grpc/{client,server}.rs` and
+/// `websocket/{client,server}.rs`.
+const ALLOWED_ENDPOINT_SCHEMES: &[&str] = &["ws", "wss", "http", "https", "unix"];
+
+/// Validates that an endpoint string carries a recognized URI scheme (or no
+/// scheme, in which case it is treated as a bare `host:port` gRPC endpoint).
+///
+/// Shared by `ClientConfig::validate` and `ServerConfig::validate` so both
+/// sides reject unknown schemes consistently.
+///
+/// The scheme is matched as a literal prefix rather than via `http::Uri`
+/// parsing because authority-less endpoints such as `unix:///tmp/slim.sock`
+/// are valid for gRPC but rejected by `http::Uri::from_str`.
+pub fn validate_endpoint_scheme(endpoint: &str) -> Result<(), ConfigError> {
+    let Some((scheme, _rest)) = endpoint.split_once("://") else {
+        return Ok(());
+    };
+    if ALLOWED_ENDPOINT_SCHEMES.contains(&scheme) {
+        Ok(())
+    } else {
+        Err(ConfigError::InvalidEndpointScheme)
+    }
+}
+
 /// Transport protocol used by client and server dataplane configuration.
 #[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -73,5 +102,28 @@ mod tests {
             TransportProtocol::from_endpoint("unix:///tmp/slim.sock"),
             TransportProtocol::Grpc
         );
+    }
+
+    #[test]
+    fn validate_endpoint_scheme_accepts_known_schemes() {
+        for endpoint in [
+            "host:1234",
+            "http://host:1234",
+            "https://host:1234",
+            "ws://host:1234",
+            "wss://host:1234",
+            "unix:///tmp/slim.sock",
+        ] {
+            validate_endpoint_scheme(endpoint)
+                .unwrap_or_else(|e| panic!("endpoint {endpoint} rejected: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_endpoint_scheme_rejects_unknown_scheme() {
+        assert!(matches!(
+            validate_endpoint_scheme("ftp://host:21"),
+            Err(ConfigError::InvalidEndpointScheme)
+        ));
     }
 }

--- a/data-plane/core/config/src/transport.rs
+++ b/data-plane/core/config/src/transport.rs
@@ -14,3 +14,64 @@ pub enum TransportProtocol {
     /// Native websocket transport.
     Websocket,
 }
+
+impl TransportProtocol {
+    /// Infer the transport protocol from an endpoint string by inspecting
+    /// its URI scheme.
+    ///
+    /// Mapping:
+    /// * `ws://`, `wss://`  → [`TransportProtocol::Websocket`]
+    /// * everything else (`http://`, `https://`, `unix://`, bare `host:port`)
+    ///   → [`TransportProtocol::Grpc`]
+    pub fn from_endpoint(endpoint: &str) -> Self {
+        match endpoint.split_once("://").map(|(s, _)| s) {
+            Some("ws") | Some("wss") => TransportProtocol::Websocket,
+            _ => TransportProtocol::Grpc,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_grpc_from_http() {
+        assert_eq!(
+            TransportProtocol::from_endpoint("http://localhost:1234"),
+            TransportProtocol::Grpc
+        );
+        assert_eq!(
+            TransportProtocol::from_endpoint("https://localhost:1234"),
+            TransportProtocol::Grpc
+        );
+    }
+
+    #[test]
+    fn infer_websocket_from_ws() {
+        assert_eq!(
+            TransportProtocol::from_endpoint("ws://localhost:1234"),
+            TransportProtocol::Websocket
+        );
+        assert_eq!(
+            TransportProtocol::from_endpoint("wss://localhost:1234"),
+            TransportProtocol::Websocket
+        );
+    }
+
+    #[test]
+    fn infer_grpc_from_bare_host_port() {
+        assert_eq!(
+            TransportProtocol::from_endpoint("a.b.c.d:12345"),
+            TransportProtocol::Grpc
+        );
+    }
+
+    #[test]
+    fn infer_grpc_from_unix() {
+        assert_eq!(
+            TransportProtocol::from_endpoint("unix:///tmp/slim.sock"),
+            TransportProtocol::Grpc
+        );
+    }
+}

--- a/data-plane/core/config/src/websocket/client.rs
+++ b/data-plane/core/config/src/websocket/client.rs
@@ -84,7 +84,7 @@ impl ClientConfig {
     /// Build a WebSocket channel. Crate-private; external callers should use
     /// [`ClientConfig::to_channel`].
     pub(crate) async fn to_websocket_channel(&self) -> Result<WebSocketClientChannel, ConfigError> {
-        if self.transport != TransportProtocol::Websocket {
+        if self.resolved_transport() != TransportProtocol::Websocket {
             return Err(ConfigError::WebSocketClientUnsupportedTransport);
         }
 
@@ -417,7 +417,6 @@ mod tests {
     use super::*;
 
     use crate::tls::client::TlsClientConfig;
-    use crate::transport::TransportProtocol;
     use std::net::TcpListener;
     use std::time::Duration;
 
@@ -443,7 +442,6 @@ mod tests {
     #[tokio::test]
     async fn test_websocket_client_invalid_endpoint_scheme() {
         let cfg = ClientConfig::with_endpoint("http://127.0.0.1:80")
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure());
         let result = cfg.to_websocket_channel().await;
         assert!(result.is_err(), "non-ws scheme must be rejected");
@@ -454,7 +452,6 @@ mod tests {
         // Bind to grab a port, then drop the listener to guarantee it's closed.
         let port = available_port();
         let cfg = ClientConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure())
             .with_backoff(crate::client::BackoffConfig::new_fixed_interval(
                 Duration::from_millis(0),
@@ -469,7 +466,6 @@ mod tests {
     async fn test_websocket_client_connect_timeout() {
         // RFC 5737 TEST-NET-1: guaranteed unroutable.
         let cfg = ClientConfig::with_endpoint("ws://192.0.2.1:9")
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure())
             .with_connect_timeout(Duration::from_millis(200))
             .with_backoff(crate::client::BackoffConfig::new_fixed_interval(
@@ -570,8 +566,7 @@ mod tests {
 
     #[test]
     fn test_handshake_request_sets_required_headers() {
-        let cfg = ClientConfig::with_endpoint("ws://example.com:8080/p")
-            .with_transport(TransportProtocol::Websocket);
+        let cfg = ClientConfig::with_endpoint("ws://example.com:8080/p");
         let req = handshake_request_for(&cfg);
         let h = req.headers();
         assert_eq!(h.get(HOST).unwrap(), "example.com:8080");
@@ -590,32 +585,28 @@ mod tests {
 
     #[test]
     fn test_handshake_request_host_omits_default_ws_port() {
-        let cfg = ClientConfig::with_endpoint("ws://api.example.com/p")
-            .with_transport(TransportProtocol::Websocket);
+        let cfg = ClientConfig::with_endpoint("ws://api.example.com/p");
         let req = handshake_request_for(&cfg);
         assert_eq!(req.headers().get(HOST).unwrap(), "api.example.com");
     }
 
     #[test]
     fn test_handshake_request_host_omits_default_wss_port() {
-        let cfg = ClientConfig::with_endpoint("wss://api.example.com/p")
-            .with_transport(TransportProtocol::Websocket);
+        let cfg = ClientConfig::with_endpoint("wss://api.example.com/p");
         let req = handshake_request_for(&cfg);
         assert_eq!(req.headers().get(HOST).unwrap(), "api.example.com");
     }
 
     #[test]
     fn test_handshake_request_host_preserves_explicit_port() {
-        let cfg = ClientConfig::with_endpoint("ws://api.example.com:80/p")
-            .with_transport(TransportProtocol::Websocket);
+        let cfg = ClientConfig::with_endpoint("ws://api.example.com:80/p");
         let req = handshake_request_for(&cfg);
         assert_eq!(req.headers().get(HOST).unwrap(), "api.example.com:80");
     }
 
     #[test]
     fn test_handshake_request_host_excludes_userinfo() {
-        let cfg = ClientConfig::with_endpoint("ws://user:pw@example.com:8080/p")
-            .with_transport(TransportProtocol::Websocket);
+        let cfg = ClientConfig::with_endpoint("ws://user:pw@example.com:8080/p");
         let req = handshake_request_for(&cfg);
         let host = req.headers().get(HOST).unwrap().to_str().unwrap();
         assert!(
@@ -627,8 +618,7 @@ mod tests {
 
     #[test]
     fn test_handshake_request_host_for_ipv6() {
-        let cfg = ClientConfig::with_endpoint("ws://[::1]:9000/p")
-            .with_transport(TransportProtocol::Websocket);
+        let cfg = ClientConfig::with_endpoint("ws://[::1]:9000/p");
         let req = handshake_request_for(&cfg);
         assert_eq!(req.headers().get(HOST).unwrap(), "[::1]:9000");
     }
@@ -653,9 +643,7 @@ mod tests {
         );
         headers.insert("Sec-WebSocket-Version".to_string(), "8".to_string());
         headers.insert("Host".to_string(), "attacker.example".to_string());
-        let cfg = ClientConfig::with_endpoint("ws://example.com:8080/p")
-            .with_transport(TransportProtocol::Websocket)
-            .with_headers(headers);
+        let cfg = ClientConfig::with_endpoint("ws://example.com:8080/p").with_headers(headers);
         let req = handshake_request_for(&cfg);
         let h = req.headers();
         assert_eq!(h.get(UPGRADE).unwrap(), "websocket");
@@ -670,9 +658,7 @@ mod tests {
     fn test_handshake_request_allows_user_supplied_non_reserved_headers() {
         let mut headers = std::collections::HashMap::new();
         headers.insert("X-Trace-Id".to_string(), "abc-123".to_string());
-        let cfg = ClientConfig::with_endpoint("ws://example.com:8080/p")
-            .with_transport(TransportProtocol::Websocket)
-            .with_headers(headers);
+        let cfg = ClientConfig::with_endpoint("ws://example.com:8080/p").with_headers(headers);
         let req = handshake_request_for(&cfg);
         assert_eq!(req.headers().get("X-Trace-Id").unwrap(), "abc-123");
     }

--- a/data-plane/core/config/src/websocket/client.rs
+++ b/data-plane/core/config/src/websocket/client.rs
@@ -429,17 +429,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_websocket_client_wrong_transport() {
-        // Default transport is gRPC, not websocket -> must error.
-        let cfg = ClientConfig::with_endpoint("ws://127.0.0.1:1");
-        let result = cfg.to_websocket_channel().await;
-        assert!(matches!(
-            result,
-            Err(ConfigError::WebSocketClientUnsupportedTransport)
-        ));
-    }
-
-    #[tokio::test]
     async fn test_websocket_client_invalid_endpoint_scheme() {
         let cfg = ClientConfig::with_endpoint("http://127.0.0.1:80")
             .with_tls_setting(TlsClientConfig::insecure());

--- a/data-plane/core/config/src/websocket/server.rs
+++ b/data-plane/core/config/src/websocket/server.rs
@@ -173,7 +173,7 @@ impl ServerConfig {
         drain_rx: drain::Watch,
         on_accepted: OnAcceptedWebSocket,
     ) -> Result<CancellationToken, ConfigError> {
-        if self.transport != TransportProtocol::Websocket {
+        if self.resolved_transport() != TransportProtocol::Websocket {
             return Err(ConfigError::WebSocketServerUnsupportedTransport);
         }
 
@@ -522,7 +522,6 @@ mod tests {
     async fn test_websocket_server_starts() {
         let port = available_port();
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
 
         let token = start_ws_server(cfg).await;
@@ -546,7 +545,6 @@ mod tests {
     #[tokio::test]
     async fn test_websocket_server_rejects_invalid_endpoint() {
         let cfg = ServerConfig::with_endpoint("not-a-ws-uri")
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
         let (signal, watch) = drain::channel();
         std::mem::forget(signal);
@@ -585,7 +583,6 @@ mod tests {
     async fn test_websocket_server_404_on_unknown_path() {
         let port = available_port();
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
         let token = start_ws_server(cfg).await;
 
@@ -611,7 +608,6 @@ mod tests {
     async fn test_websocket_server_400_when_not_upgrade() {
         let port = available_port();
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
         let token = start_ws_server(cfg).await;
 
@@ -632,7 +628,6 @@ mod tests {
         let test_user = format!("user-{}", std::process::id());
         let test_pass = format!("pw-{}-{}", std::process::id(), port);
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure())
             .with_auth(ServerAuthConfig::Basic(BasicConfig::new(
                 &test_user, &test_pass,
@@ -692,7 +687,6 @@ mod tests {
         let server_jwt = JwtConfig::new(claims, Duration::from_secs(3600), decoding_key);
 
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure())
             .with_auth(ServerAuthConfig::Jwt(server_jwt));
         let token = start_ws_server(cfg).await;
@@ -771,7 +765,6 @@ mod tests {
         let server_jwt = JwtConfig::new(claims, Duration::from_secs(3600), decoding_key);
 
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure())
             .with_auth(ServerAuthConfig::Jwt(server_jwt));
         let token = start_ws_server(cfg).await;
@@ -825,12 +818,10 @@ mod tests {
     async fn test_websocket_server_full_handshake_via_client() {
         let port = available_port();
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
         let token = start_ws_server(cfg).await;
 
         let client_cfg = ClientConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure());
 
         let channel =
@@ -851,7 +842,6 @@ mod tests {
     async fn test_websocket_server_cancellation_stops_listener() {
         let port = available_port();
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
         let token = start_ws_server(cfg).await;
 
@@ -874,7 +864,6 @@ mod tests {
     async fn test_websocket_server_enforces_max_connections() {
         let port = available_port();
         let cfg = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure())
             .with_max_concurrent_streams(Some(1));
 
@@ -892,7 +881,6 @@ mod tests {
             .expect("server start");
 
         let client_cfg = ClientConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure())
             .with_connect_timeout(Duration::from_secs(5))
             .with_backoff(crate::client::BackoffConfig::new_fixed_interval(

--- a/data-plane/core/datapath/src/websocket/stream.rs
+++ b/data-plane/core/datapath/src/websocket/stream.rs
@@ -230,7 +230,6 @@ mod tests {
     use slim_config::server::ServerConfig;
     use slim_config::tls::client::TlsClientConfig;
     use slim_config::tls::server::TlsServerConfig;
-    use slim_config::transport::TransportProtocol;
     use slim_config::websocket::common::UpgradedWebSocket;
     use slim_config::websocket::server::OnAcceptedWebSocket;
     use std::net::TcpListener as StdTcpListener;
@@ -260,9 +259,8 @@ mod tests {
 
     async fn start_server_with_transport_tasks(port: u16) -> CancellationToken {
         let endpoint = format!("ws://127.0.0.1:{port}");
-        let server_conf = ServerConfig::with_endpoint(&endpoint)
-            .with_transport(TransportProtocol::Websocket)
-            .with_tls_settings(TlsServerConfig::insecure());
+        let server_conf =
+            ServerConfig::with_endpoint(&endpoint).with_tls_settings(TlsServerConfig::insecure());
 
         let cancel = CancellationToken::new();
         let cancel_for_cb = cancel.clone();
@@ -296,9 +294,8 @@ mod tests {
 
     async fn connect_ws_client(port: u16) -> UpgradedWebSocket {
         let endpoint = format!("ws://127.0.0.1:{port}");
-        let cfg = ClientConfig::with_endpoint(&endpoint)
-            .with_transport(TransportProtocol::Websocket)
-            .with_tls_setting(TlsClientConfig::insecure());
+        let cfg =
+            ClientConfig::with_endpoint(&endpoint).with_tls_setting(TlsClientConfig::insecure());
         match cfg.to_channel().await.expect("connect") {
             TransportChannel::Websocket(ws) => {
                 ws.take_websocket().expect("websocket already taken")
@@ -412,7 +409,6 @@ mod tests {
 
         let endpoint = format!("ws://127.0.0.1:{port}");
         let cfg = ClientConfig::with_endpoint(&endpoint)
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure())
             .with_backoff(slim_config::client::BackoffConfig::new_fixed_interval(
                 Duration::from_millis(0),

--- a/data-plane/core/datapath/tests/data_path_test.rs
+++ b/data-plane/core/datapath/tests/data_path_test.rs
@@ -11,7 +11,6 @@ mod tests {
 
     use slim_config::tls::client::TlsClientConfig;
     use slim_config::tls::server::TlsServerConfig;
-    use slim_config::transport::TransportProtocol;
     use slim_config::{client::ClientConfig, server::ServerConfig};
     use slim_datapath::api::{DataPlaneServiceServer, ProtoMessage as Message};
     use slim_datapath::errors::DataPathError;
@@ -308,11 +307,9 @@ mod tests {
     #[traced_test]
     async fn test_websocket_connection_ws() {
         let server_conf = ServerConfig::with_endpoint("ws://127.0.0.1:51061")
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_settings(TlsServerConfig::insecure());
 
         let client_conf = ClientConfig::with_endpoint("ws://127.0.0.1:51061")
-            .with_transport(TransportProtocol::Websocket)
             .with_tls_setting(TlsClientConfig::insecure());
         let conn_index =
             run_transport_roundtrip(server_conf, client_conf, None, "websocket ws").await;
@@ -334,15 +331,13 @@ mod tests {
             &format!("{}/server.key", grpc_tls_testdata),
         );
 
-        let server_conf = ServerConfig::with_endpoint("wss://127.0.0.1:51062")
-            .with_transport(TransportProtocol::Websocket)
-            .with_tls_settings(server_tls);
+        let server_conf =
+            ServerConfig::with_endpoint("wss://127.0.0.1:51062").with_tls_settings(server_tls);
 
         let client_tls =
             TlsClientConfig::new().with_ca_file(&format!("{}/ca.crt", grpc_tls_testdata));
 
         let client_conf = ClientConfig::with_endpoint("wss://127.0.0.1:51062")
-            .with_transport(TransportProtocol::Websocket)
             .with_server_name("example1")
             .with_tls_setting(client_tls);
         let conn_index =

--- a/tests/integration/config_startup_test.go
+++ b/tests/integration/config_startup_test.go
@@ -36,7 +36,13 @@ func fileUsesWebsocketTransport(path string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(content), "transport: websocket")
+	// Transport is inferred from the endpoint scheme: ws:// or wss:// means
+	// websocket. Match both quoted and unquoted endpoint forms.
+	s := string(content)
+	return strings.Contains(s, "endpoint: \"ws://") ||
+		strings.Contains(s, "endpoint: \"wss://") ||
+		strings.Contains(s, "endpoint: ws://") ||
+		strings.Contains(s, "endpoint: wss://")
 }
 
 func resolveConfigCases() []configCase {


### PR DESCRIPTION
# Description

Remove the transport: attribute from server and connection configuration and
use the protocol in the url (e.g. `https://`, `wss://`, `ws://`, `unix://` etc.)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
