### PR TITLE
chore: update node version for release

### DIFF
--- a/.github/workflows/release-bindings.yaml
+++ b/.github/workflows/release-bindings.yaml
@@ -361,11 +361,11 @@ jobs:
           path: ./node-packages
           pattern: node-platform-*
 
-      # Trusted publishing: Node >= 22.14 + npm >= 11.5.1; registry-url enables OIDC for npm publish.
+      # Trusted publishing requires npm CLI >= 11.5.1 (Node 22.14 still ships npm 10.x); registry-url enables OIDC.
       - name: Setup Node (npm OIDC)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.14'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
@@ -403,7 +403,7 @@ jobs:
       - name: Setup Node (npm OIDC)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.14'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
@@ -474,7 +474,7 @@ jobs:
       - name: Setup Node (npm OIDC)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.14'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 


### PR DESCRIPTION
# Description

Update node version so the runner gets an npm 11.5.1+ line by default.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
