### PR TITLE
perf(session): drop async_trait from MessageHandler and Transmitter

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-test",
+ "trait-variant",
 ]
 
 [[package]]
@@ -4577,6 +4578,17 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -151,6 +151,7 @@ tracing = "0.1.41"
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = "0.3.19"
 tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
+trait-variant = "0.1"
 twox-hash = "2.1.1"
 uniffi = { version = "0.31.1", features = ["cli"] }
 url = "2.5.0"

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+trait-variant = { workspace = true }
 
 [dev-dependencies]
 agntcy-slim-testing = { workspace = true }

--- a/data-plane/core/session/src/session.rs
+++ b/data-plane/core/session/src/session.rs
@@ -1,7 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
 use slim_datapath::api::{
     EncodedName, Participant, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
 };
@@ -297,7 +296,6 @@ impl Session {
 
 /// Implementation of MessageHandler trait for Session
 /// This allows Session to be used as a layer in the generic layer system
-#[async_trait]
 impl MessageHandler for Session {
     async fn init(&mut self) -> Result<(), SessionError> {
         // Session is the innermost layer, no initialization needed

--- a/data-plane/core/session/src/session_controller.rs
+++ b/data-plane/core/session/src/session_controller.rs
@@ -1740,7 +1740,6 @@ mod tests {
             }
         }
 
-        #[async_trait::async_trait]
         impl MessageHandler for InternalDrainHandler {
             async fn init(&mut self) -> Result<(), SessionError> {
                 Ok(())
@@ -1919,7 +1918,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl MessageHandler for DrainableHandler {
         async fn init(&mut self) -> Result<(), SessionError> {
             Ok(())

--- a/data-plane/core/session/src/session_moderator.rs
+++ b/data-plane/core/session/src/session_moderator.rs
@@ -6,8 +6,8 @@ use std::{
     time::Duration,
 };
 
-use async_trait::async_trait;
 use display_error_chain::ErrorChainExt;
+
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
     api::{
@@ -98,7 +98,6 @@ where
 
 /// Implementation of MessageHandler trait for SessionModerator
 /// This allows the moderator to be used as a layer in the generic layer system
-#[async_trait]
 impl<P, V, I, M> MessageHandler for SessionModerator<P, V, I, M>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
@@ -1130,17 +1129,22 @@ where
             }
         };
 
-        debug!("Process a new task from the todo list");
-        // Process the control message by calling on_message
-        // Since this is a control message coming from our internal queue,
-        // we use MessageDirection::North (coming from network/control plane)
-        // The ack_tx that was stored with the task is now used
-        self.on_message(SessionMessage::OnMessage {
-            message: msg,
-            direction: MessageDirection::North,
-            ack_tx,
-        })
-        .await
+        debug!("Re-enqueue a task from the todo list onto the processing loop");
+        // Send the task back to the processing loop instead of recursing into
+        // `on_message`. Recursive async calls would otherwise require a boxed
+        // future (and `async_trait` was hiding that cost before).
+        self.common
+            .settings
+            .tx_session
+            .send(SessionMessage::OnMessage {
+                message: msg,
+                direction: MessageDirection::North,
+                ack_tx,
+            })
+            .await
+            .map_err(|_| SessionError::SlimMessageSendFailed)?;
+
+        Ok(())
     }
 
     async fn join(&mut self, remote: ProtoName, conn: u64) -> Result<(), SessionError> {

--- a/data-plane/core/session/src/session_participant.rs
+++ b/data-plane/core/session/src/session_participant.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use async_trait::async_trait;
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
     api::{
@@ -78,7 +77,6 @@ where
 
 /// Implementation of MessageHandler trait for SessionParticipant
 /// This allows the participant to be used as a layer in the generic layer system
-#[async_trait]
 impl<P, V, I, M> MessageHandler for SessionParticipant<P, V, I, M>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,

--- a/data-plane/core/session/src/test_utils.rs
+++ b/data-plane/core/session/src/test_utils.rs
@@ -91,7 +91,6 @@ impl SessionInterceptorProvider for MockTransmitter {
     }
 }
 
-#[async_trait::async_trait]
 impl Transmitter for MockTransmitter {
     async fn send_to_slim(&self, message: Result<Message, Status>) -> Result<(), SessionError> {
         self.slim_tx
@@ -142,7 +141,6 @@ impl Default for MockInnerHandler {
     }
 }
 
-#[async_trait::async_trait]
 impl MessageHandler for MockInnerHandler {
     async fn init(&mut self) -> Result<(), SessionError> {
         Ok(())

--- a/data-plane/core/session/src/traits.rs
+++ b/data-plane/core/session/src/traits.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Third-party crates
-use async_trait::async_trait;
 use slim_datapath::Status;
 use slim_datapath::api::ProtoMessage as Message;
 
@@ -17,7 +16,7 @@ pub enum ProcessingState {
 }
 
 /// Session transmitter trait
-#[async_trait]
+#[trait_variant::make(Send)]
 pub trait Transmitter: SessionInterceptorProvider {
     async fn send_to_slim(&self, message: Result<Message, Status>) -> Result<(), SessionError>;
 
@@ -29,8 +28,8 @@ pub trait Transmitter: SessionInterceptorProvider {
 ///
 /// Each layer implements this trait and can hold an inner layer.
 /// The layer decides whether to pass messages to its inner layer or handle them itself (or both).
-#[async_trait]
-pub trait MessageHandler: Send + Sync {
+#[trait_variant::make(Send)]
+pub trait MessageHandler {
     /// Init the layer.
     async fn init(&mut self) -> Result<(), SessionError>;
 
@@ -51,7 +50,7 @@ pub trait MessageHandler: Send + Sync {
         &mut self,
         _endpoint: &slim_datapath::api::Participant,
     ) -> Result<(), SessionError> {
-        Ok(())
+        async { Ok(()) }
     }
 
     /// Remove an endpoint from the session.
@@ -75,7 +74,7 @@ pub trait MessageHandler: Send + Sync {
     /// Optional hook for periodic ops (e.g. MLS key rotation)
     #[allow(dead_code)]
     async fn on_tick(&mut self) -> Result<(), SessionError> {
-        Ok(())
+        async { Ok(()) }
     }
 
     /// Get the current participants list (participants in the session)

--- a/data-plane/core/session/src/transmitter.rs
+++ b/data-plane/core/session/src/transmitter.rs
@@ -52,7 +52,6 @@ impl SessionInterceptorProvider for SessionTransmitter {
     }
 }
 
-#[async_trait::async_trait]
 impl Transmitter for SessionTransmitter {
     async fn send_to_app(
         &self,
@@ -70,12 +69,11 @@ impl Transmitter for SessionTransmitter {
             }
         }
 
-        let ret = self
-            .app_tx
+        self.app_tx
             .send(message)
             .map_err(|_e| SessionError::ApplicationMessageSendFailed)?;
 
-        Ok(ret)
+        Ok(())
     }
 
     async fn send_to_slim(&self, mut message: Result<Message, Status>) -> Result<(), SessionError> {
@@ -120,7 +118,6 @@ impl SessionInterceptorProvider for AppTransmitter {
     }
 }
 
-#[async_trait::async_trait]
 impl Transmitter for AppTransmitter {
     async fn send_to_app(
         &self,


### PR DESCRIPTION
# Description

Replace #[async_trait] with native RPITIT (`fn ... -> impl Future + Send`)
on both traits. async_trait rewrites every async method into
`fn(...) -> Pin<Box<dyn Future + Send>>`, allocating on every call.
These traits sit on the per-message hot path of the session processing
loop, so the allocation is real overhead.

No dyn MessageHandler / dyn Transmitter exists in the codebase, so
giving up object safety costs nothing. Recursive async in
session_moderator::pop_task is now bridged explicitly with Box::pin
at the recursion edge (previously hidden by async_trait's blanket
boxing).

Also fixes a clippy::let_unit_value in SessionTransmitter::send_to_app
that async_trait's desugaring had been masking.

Fixes: #1665 

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
