### PR TITLE
fix(session): apply backpressure on outbound channel send

### DIFF
--- a/data-plane/core/session/src/transmitter.rs
+++ b/data-plane/core/session/src/transmitter.rs
@@ -92,7 +92,8 @@ impl Transmitter for SessionTransmitter {
         }
 
         self.slim_tx
-            .try_send(message)
+            .send(message)
+            .await
             .map_err(|_e| SessionError::SlimMessageSendFailed)
     }
 }
@@ -158,7 +159,8 @@ impl Transmitter for AppTransmitter {
         }
 
         self.slim_tx
-            .try_send(message)
+            .send(message)
+            .await
             .map_err(|_e| SessionError::SlimMessageSendFailed)
     }
 }


### PR DESCRIPTION
# Description

`SessionTransmitter` and `AppTransmitter` both used `try_send` when forwarding messages to the outbound SLIM channel. `try_send` returns an error immediately when the bounded channel is full, which caused silent message drops whenever a sender produced messages faster than the SLIM internals could forward them.

This fix replaces `try_send` with `send().await` so that a full channel blocks the sending task instead of dropping the message. The sending task yields until capacity is available, providing natural backpressure through Tokio's async scheduler without any packet loss.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass