### PR TITLE
fix: increase file descriptor limit in parallel test run

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -214,11 +214,13 @@ dependencies = [
  "drain",
  "duration-string",
  "futures",
+ "libc",
  "libsqlite3-sys",
  "parking_lot",
  "prost",
  "prost-types",
  "protoc-bin-vendored",
+ "rlimit",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3445,6 +3447,15 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -120,6 +120,7 @@ rand = "0.9.0"
 regex = "1.11.1"
 
 reqwest = { version = "0.12", features = ["json", "rustls-tls-no-provider", "charset", "http2", "system-proxy", "blocking"], default-features = false }
+rlimit = "0.11.0"
 rustls = { version = "0.23.31" }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1.10.0"

--- a/data-plane/control-plane/Cargo.toml
+++ b/data-plane/control-plane/Cargo.toml
@@ -38,6 +38,7 @@ libsqlite3-sys = { workspace = true }
 parking_lot = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+rlimit = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -63,6 +64,7 @@ agntcy-slim-service = { workspace = true, features = ["session"] }
 agntcy-slim-testing = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
 drain = { workspace = true }
+libc = "0.2"
 tempfile = { workspace = true }
 tokio-test = { workspace = true }
 tonic = { workspace = true }

--- a/data-plane/control-plane/tests/integration_test.rs
+++ b/data-plane/control-plane/tests/integration_test.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use rlimit::increase_nofile_limit;
 use std::net::TcpListener;
 use std::time::Duration;
 use uuid::Uuid;
@@ -29,7 +30,15 @@ use tracing_subscriber::EnvFilter;
 
 // --- Helpers ---
 
+fn raise_fd_limit() {
+    static INIT_FD_LIMIT: std::sync::Once = std::sync::Once::new();
+    INIT_FD_LIMIT.call_once(|| {
+        let _ = increase_nofile_limit(4096).expect("unable to raise open file descriptor limit");
+    });
+}
+
 fn reserve_port() -> u16 {
+    raise_fd_limit();
     let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test port");
     let port = listener.local_addr().expect("failed to read port").port();
     drop(listener);

--- a/tasks/rust.yaml
+++ b/tasks/rust.yaml
@@ -186,14 +186,14 @@ tasks:
     deps:
       - task: install-target
     cmds:
-      - cargo test --no-run {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}}
+      - ulimit -n 4096 2>/dev/null || true; cargo test --no-run {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}}
     vars:
       ARGS: '{{.ARGS | default "--all-targets --locked --all-features"}}'
 
   test:
     desc: "Run the tests"
     cmds:
-      - cargo test {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}}
+      - ulimit -n 4096 2>/dev/null || true; cargo test {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}}
       - task: bindings:test
       - task: core:test
     vars:
@@ -206,7 +206,7 @@ tasks:
         vars:
           COMPONENTS: "cargo-llvm-cov"
     cmds:
-      - cargo llvm-cov --lcov --output-path lcov.info {{.GLOBAL_ARGS}} {{.ARGS}}
+      - ulimit -n 4096 2>/dev/null || true; cargo llvm-cov --lcov --output-path lcov.info {{.GLOBAL_ARGS}} {{.ARGS}}
     vars:
       ARGS: '{{.ARGS | default "--all-targets --locked --all-features"}}'
 


### PR DESCRIPTION
# Description

Local data-plane tests can fail because of exceeding the concurrent file descriptor limit of the process (on MacOS it is 256 by default).


# Actions
- setting  fd limit to 4096 (`ulimit -n 4096`)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
