### PR TITLE
fix(session): skip buffer clone in unreliable mode

### DIFF
--- a/data-plane/core/session/src/session_sender.rs
+++ b/data-plane/core/session/src/session_sender.rs
@@ -215,11 +215,6 @@ where
         session_header.set_session_type(self.session_type);
         message.get_slim_header_mut().set_fanout(fanout);
 
-        // Buffer the message after setting the ID (only for non-publish_to messages)
-        if !is_publish_to {
-            self.buffer.push(message.clone());
-        }
-
         // Store the ack notifier if provided
         if let Some(tx) = ack_tx {
             // In unreliable mode (no timer_factory), signal success immediately
@@ -235,8 +230,19 @@ where
             debug!(
                 "there is no remote endopoint connected to the session, store the packet and send it later"
             );
+            // Buffer for flush-on-connect. set_timer_and_send is never reached from
+            // this path, so we can move the message without cloning.
+            if !is_publish_to {
+                self.buffer.push(message);
+            }
             self.to_flush = true;
             return Ok(());
+        }
+
+        // Endpoints are present. Buffer group messages for retransmission in reliable
+        // mode only. A clone is necessary because set_timer_and_send also needs message.
+        if self.timer_factory.is_some() && !is_publish_to {
+            self.buffer.push(message.clone());
         }
 
         self.set_timer_and_send(message).await


### PR DESCRIPTION
## Description

In unreliable mode (no `timer_factory`) there is no retransmission and acks are silently ignored, so cloning the message into `ProducerBuffer` on every send is pure overhead.

Additionally, the previous code had an inverted buffer condition (`timer_factory.is_none() || !is_publish_to`) introduced in a recent optimization attempt, which caused `publish_to` messages in reliable mode to also be buffered — a regression from the original behaviour.

This fix restructures the `on_publish_message` buffer logic so that:

1. The `endpoints_list.is_empty()` early-return path comes **before** the buffer push. Since `set_timer_and_send` is never reached from this path, the message can be **moved** into the buffer instead of cloned (no matter the reliability mode).
2. When endpoints are present, the buffer push is guarded by `timer_factory.is_some() && !is_publish_to` — only buffering group messages in reliable mode, where retransmission is actually needed.

| Condition | Before fix | After fix |
|-----------|-----------|-----------|
| Group + reliable, endpoints present | clone ✓ | clone ✓ |
| Group + unreliable, endpoints present | clone (unnecessary) | skip ✓ |
| publish_to + reliable, endpoints present | skip ✓ | skip ✓ |
| publish_to + unreliable, endpoints present | clone (regression) | skip ✓ |
| Any mode, no endpoints | clone + move | move only ✓ |

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass