### PR TITLE
refactor(session): drop AppTransmitter, Transmitter trait, and MockTransmitter

### DIFF
--- a/data-plane/core/service/src/app.rs
+++ b/data-plane/core/service/src/app.rs
@@ -26,7 +26,7 @@ use crate::ServiceError;
 use slim_session::SlimChannelSender;
 use slim_session::notification::Notification;
 use slim_session::subscription_manager::{SubscriptionManager, SubscriptionOps};
-use slim_session::transmitter::AppTransmitter;
+
 use slim_session::{SessionError, SessionLayer, context::SessionContext};
 
 pub struct App<P, V>
@@ -134,10 +134,6 @@ where
             }
         };
 
-        // Create the transmitter
-        let transmitter =
-            AppTransmitter::new(tx_slim.clone(), tx_app.clone(), identity_provider.clone());
-
         // Create the session layer
         let service_id_clone = service_id.clone();
         let session_layer = Arc::new(SessionLayer::new(
@@ -147,7 +143,6 @@ where
             conn_id,
             tx_slim,
             tx_app,
-            transmitter,
             direction,
             service_id,
         ));

--- a/data-plane/core/session/src/controller_sender.rs
+++ b/data-plane/core/session/src/controller_sender.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::Sender;
 use tracing::debug;
 
 use crate::{
-    SessionError, Transmitter,
+    SessionError,
     common::SessionMessage,
     timer::Timer,
     timer_factory::{TimerFactory, TimerSettings},

--- a/data-plane/core/session/src/lib.rs
+++ b/data-plane/core/session/src/lib.rs
@@ -33,7 +33,7 @@ pub mod transmitter;
 pub mod test_utils;
 
 // Traits
-pub use traits::{MessageHandler, Transmitter};
+pub use traits::MessageHandler;
 
 // Re-export the unified builder for convenience
 pub use session_builder::{ForController, ForModerator, ForParticipant, SessionBuilder};

--- a/data-plane/core/session/src/session_controller.rs
+++ b/data-plane/core/session/src/session_controller.rs
@@ -22,7 +22,7 @@ use slim_datapath::{
 
 // Local crate
 use crate::{
-    MessageDirection, SessionError, Transmitter,
+    MessageDirection, SessionError,
     common::SessionMessage,
     completion_handle::CompletionHandle,
     controller_sender::{ControllerSender, PING_INTERVAL},

--- a/data-plane/core/session/src/session_layer.rs
+++ b/data-plane/core/session/src/session_layer.rs
@@ -27,15 +27,13 @@ use crate::session_config::SessionConfig;
 use crate::session_controller::SessionController;
 use crate::subscription_manager::SubscriptionManager;
 
-use crate::transmitter::{AppTransmitter, SessionTransmitter};
+use crate::transmitter::SessionTransmitter;
 
 // Local crate
 use super::context::SessionContext;
 
 use super::{SESSION_RANGE, SlimChannelSender};
 use super::{SessionError, session_controller::handle_channel_discovery_message};
-use crate::traits::Transmitter;
-
 /// Direction enum for session creation
 /// Indicates whether the session can send, receive, both, or neither data messages.
 #[derive(Clone, Copy, Debug)]
@@ -107,9 +105,6 @@ where
     tx_slim: SlimChannelSender,
     tx_app: Sender<Result<Notification, SessionError>>,
 
-    // Transmitter to bypass sessions
-    transmitter: AppTransmitter<P>,
-
     /// Channel to clone on session creation
     tx_session: tokio::sync::mpsc::Sender<Result<SessionMessage, SessionError>>,
 
@@ -148,7 +143,6 @@ where
         conn_id: u64,
         tx_slim: SlimChannelSender,
         tx_app: Sender<Result<Notification, SessionError>>,
-        transmitter: AppTransmitter<P>,
         direction: Direction,
         service_id: String,
     ) -> Self {
@@ -166,7 +160,6 @@ where
             conn_id,
             tx_slim,
             tx_app,
-            transmitter,
             tx_session,
             to_notify: SyncRwLock::new(HashMap::new()),
             direction,
@@ -580,7 +573,7 @@ where
                     }
                 };
 
-            let reply =
+            let mut reply =
                 match handle_channel_discovery_message(&message, &local_name, id, session_type) {
                     Ok(r) => r,
                     Err(e) => {
@@ -589,7 +582,15 @@ where
                     }
                 };
 
-            if let Err(e) = layer.transmitter.send_to_slim(Ok(reply)).await {
+            let identity = match layer.identity_provider.get_token() {
+                Ok(t) => t,
+                Err(e) => {
+                    debug!(error = %e.chain(), "error getting identity token for discovery reply");
+                    return;
+                }
+            };
+            reply.get_slim_header_mut().set_identity(identity);
+            if let Err(e) = layer.tx_slim.send(Ok(reply)).await {
                 debug!(error = %e.chain(), "error sending discovery reply");
             }
         });
@@ -690,14 +691,8 @@ mod tests {
     type TestSessionLayer = Arc<SessionLayer<MockTokenProvider, MockVerifier>>;
     type SlimReceiver = mpsc::Receiver<Result<Message, Status>>;
     type AppReceiver = mpsc::Receiver<Result<Notification, SessionError>>;
-    type TransmitterReceiver = mpsc::Receiver<Result<Message, Status>>;
 
-    fn setup_session_layer() -> (
-        TestSessionLayer,
-        SlimReceiver,
-        AppReceiver,
-        TransmitterReceiver,
-    ) {
+    fn setup_session_layer() -> (TestSessionLayer, SlimReceiver, AppReceiver) {
         let app_name = make_name(&["test", "app", "v1"]);
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;
@@ -705,9 +700,6 @@ mod tests {
 
         let (tx_slim, rx_slim) = mpsc::channel(16);
         let (tx_app, rx_app) = mpsc::channel(16);
-        let (tx_transmitter, rx_transmitter) = mpsc::channel(16);
-
-        let transmitter = AppTransmitter::new(tx_transmitter, tx_app.clone(), MockTokenProvider);
 
         let session_layer = Arc::new(SessionLayer::new(
             app_name,
@@ -716,17 +708,16 @@ mod tests {
             conn_id,
             tx_slim,
             tx_app,
-            transmitter,
             Direction::Bidirectional,
             "test-service".to_string(),
         ));
 
-        (session_layer, rx_slim, rx_app, rx_transmitter)
+        (session_layer, rx_slim, rx_app)
     }
 
     #[tokio::test]
     async fn test_new_session_layer() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         assert_eq!(session_layer.app_id(), 0);
         assert_eq!(session_layer.conn_id(), 12345);
@@ -735,7 +726,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_and_remove_app_name() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let name1 = make_name(&["service", "v1", "api"]);
         let name2 = make_name(&["service", "v2", "api"]);
@@ -755,7 +746,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_identity_token() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let token = session_layer.get_identity_token();
         assert!(token.is_ok());
@@ -764,7 +755,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_session_with_auto_id() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         let destination = make_name(&["remote", "app", "v1"]);
@@ -785,7 +776,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_session_with_specific_id() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         let destination = make_name(&["remote", "app", "v1"]);
@@ -815,7 +806,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_session_with_invalid_id() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         let destination = make_name(&["remote", "app", "v1"]);
@@ -846,7 +837,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_session_with_duplicate_id() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         let destination = make_name(&["remote", "app", "v1"]);
@@ -887,7 +878,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_session() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         let destination = make_name(&["remote", "app", "v1"]);
@@ -921,7 +912,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_local_name_for_session() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let name = make_name(&["service", "api", "v1"]);
         session_layer.add_app_name(name.clone(), 0);
@@ -936,7 +927,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_local_name_for_session_not_found() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let unknown_name = make_name(&["unknown", "service", "v1"]);
         let result = session_layer.get_local_name_for_session(unknown_name);
@@ -950,7 +941,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tx_slim_and_tx_app_cloning() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let tx_slim = session_layer.tx_slim();
         let tx_app = session_layer.tx_app();
@@ -962,7 +953,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_discovery_request_without_session() {
-        let (session_layer, _rx_slim, _rx_app, mut rx_transmitter) = setup_session_layer();
+        let (session_layer, mut rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         session_layer.add_app_name(local_name.clone(), 0);
@@ -987,11 +978,11 @@ mod tests {
             .await
             .unwrap();
 
-        let sent = tokio::time::timeout(std::time::Duration::from_secs(1), rx_transmitter.recv())
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(1), rx_slim.recv())
             .await
             .expect("expected a discovery reply")
-            .expect("transmitter channel closed")
-            .expect("transmitter delivered an error");
+            .expect("slim channel closed")
+            .expect("slim delivered an error");
 
         assert_eq!(
             sent.get_session_header().session_message_type(),
@@ -1001,7 +992,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pre_session_unknown_message_is_dropped() {
-        let (session_layer, _rx_slim, _rx_app, mut rx_transmitter) = setup_session_layer();
+        let (session_layer, mut rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         session_layer.add_app_name(local_name.clone(), 0);
@@ -1024,12 +1015,12 @@ mod tests {
             .unwrap();
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert!(rx_transmitter.try_recv().is_err());
+        assert!(rx_slim.try_recv().is_err());
     }
 
     #[tokio::test]
     async fn test_multiple_sessions_in_pool() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let local_name = make_name(&["local", "app", "v1"]);
         let config = SessionConfig {
@@ -1077,7 +1068,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_app_name_with_null_component() {
-        let (session_layer, _rx_slim, _rx_app, _rx_transmitter) = setup_session_layer();
+        let (session_layer, _rx_slim, _rx_app) = setup_session_layer();
 
         let name = make_name(&["service", "v1", "api"]).with_id(123);
         session_layer.add_app_name(name.clone(), 0);

--- a/data-plane/core/session/src/session_receiver.rs
+++ b/data-plane/core/session/src/session_receiver.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 
 use crate::transmitter::SessionTransmitter;
 use crate::{
-    SessionError, Transmitter,
+    SessionError,
     common::SessionMessage,
     receiver_buffer::ReceiverBuffer,
     timer::Timer,

--- a/data-plane/core/session/src/session_sender.rs
+++ b/data-plane/core/session/src/session_sender.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 
 use crate::transmitter::SessionTransmitter;
 use crate::{
-    SessionError, Transmitter,
+    SessionError,
     common::SessionMessage,
     producer_buffer::ProducerBuffer,
     timer::Timer,

--- a/data-plane/core/session/src/test_utils.rs
+++ b/data-plane/core/session/src/test_utils.rs
@@ -8,14 +8,12 @@
 
 use slim_auth::errors::AuthError;
 use slim_auth::traits::{TokenProvider, Verifier};
-use slim_datapath::Status;
-use slim_datapath::api::{Participant, ProtoMessage as Message, ProtoName};
+use slim_datapath::api::{Participant, ProtoName};
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 use crate::SessionError;
 use crate::common::SessionMessage;
-use crate::traits::{MessageHandler, Transmitter};
+use crate::traits::MessageHandler;
 
 /// Mock token provider for testing.
 #[derive(Clone, Default)]
@@ -69,27 +67,6 @@ impl Verifier for MockVerifier {
         Claims: serde::de::DeserializeOwned,
     {
         Err(AuthError::TokenInvalid)
-    }
-}
-
-/// Mock transmitter for testing.
-#[derive(Clone)]
-pub struct MockTransmitter {
-    pub slim_tx: mpsc::UnboundedSender<Result<Message, Status>>,
-}
-
-impl Transmitter for MockTransmitter {
-    async fn send_to_slim(&self, message: Result<Message, Status>) -> Result<(), SessionError> {
-        self.slim_tx
-            .send(message)
-            .map_err(|_| SessionError::SlimMessageSendFailed)
-    }
-
-    async fn send_to_app(
-        &self,
-        _message: Result<Message, SessionError>,
-    ) -> Result<(), SessionError> {
-        Ok(())
     }
 }
 

--- a/data-plane/core/session/src/traits.rs
+++ b/data-plane/core/session/src/traits.rs
@@ -1,10 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-// Third-party crates
-use slim_datapath::Status;
-use slim_datapath::api::ProtoMessage as Message;
-
 // Local crate
 use crate::{common::SessionMessage, errors::SessionError};
 
@@ -12,15 +8,6 @@ use crate::{common::SessionMessage, errors::SessionError};
 pub enum ProcessingState {
     Active,
     Draining,
-}
-
-/// Session transmitter trait
-#[trait_variant::make(Send)]
-pub trait Transmitter {
-    async fn send_to_slim(&self, message: Result<Message, Status>) -> Result<(), SessionError>;
-
-    async fn send_to_app(&self, message: Result<Message, SessionError>)
-    -> Result<(), SessionError>;
 }
 
 /// Core trait for message handling at any layer.

--- a/data-plane/core/session/src/transmitter.rs
+++ b/data-plane/core/session/src/transmitter.rs
@@ -5,10 +5,7 @@ use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::Status;
 use slim_datapath::api::ProtoMessage as Message;
 
-use crate::{
-    SessionError, SlimChannelSender, Transmitter, common::AppChannelSender,
-    notification::Notification,
-};
+use crate::{SessionError, SlimChannelSender, common::AppChannelSender};
 
 pub(crate) async fn verify_identity<V>(msg: &Message, verifier: &V) -> Result<(), SessionError>
 where
@@ -44,11 +41,11 @@ where
     }
 }
 
-impl<P> Transmitter for SessionTransmitter<P>
+impl<P> SessionTransmitter<P>
 where
     P: TokenProvider + Send + Sync + Clone + 'static,
 {
-    async fn send_to_app(
+    pub async fn send_to_app(
         &self,
         message: Result<Message, SessionError>,
     ) -> Result<(), SessionError> {
@@ -57,61 +54,10 @@ where
             .map_err(|_e| SessionError::ApplicationMessageSendFailed)
     }
 
-    async fn send_to_slim(&self, mut message: Result<Message, Status>) -> Result<(), SessionError> {
-        if let Ok(msg) = message.as_mut() {
-            let identity = self.identity_provider.get_token()?;
-            msg.get_slim_header_mut().set_identity(identity);
-        }
-
-        self.slim_tx
-            .send(message)
-            .await
-            .map_err(|_e| SessionError::SlimMessageSendFailed)
-    }
-}
-
-#[derive(Clone)]
-pub struct AppTransmitter<P>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-{
-    pub slim_tx: SlimChannelSender,
-    pub app_tx: tokio::sync::mpsc::Sender<Result<Notification, SessionError>>,
-    pub identity_provider: P,
-}
-
-impl<P> AppTransmitter<P>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-{
-    pub fn new(
-        slim_tx: SlimChannelSender,
-        app_tx: tokio::sync::mpsc::Sender<Result<Notification, SessionError>>,
-        identity_provider: P,
-    ) -> Self {
-        AppTransmitter {
-            slim_tx,
-            app_tx,
-            identity_provider,
-        }
-    }
-}
-
-impl<P> Transmitter for AppTransmitter<P>
-where
-    P: TokenProvider + Send + Sync + Clone + 'static,
-{
-    async fn send_to_app(
+    pub async fn send_to_slim(
         &self,
-        message: Result<Message, SessionError>,
+        mut message: Result<Message, Status>,
     ) -> Result<(), SessionError> {
-        self.app_tx
-            .send(message.map(|msg| Notification::NewMessage(Box::new(msg))))
-            .await
-            .map_err(|_e| SessionError::ApplicationMessageSendFailed)
-    }
-
-    async fn send_to_slim(&self, mut message: Result<Message, Status>) -> Result<(), SessionError> {
         if let Ok(msg) = message.as_mut() {
             let identity = self.identity_provider.get_token()?;
             msg.get_slim_header_mut().set_identity(identity);
@@ -128,7 +74,6 @@ where
 mod tests {
     use super::*;
     use crate::SessionError;
-    use crate::notification::Notification;
     use crate::test_utils::{MockTokenProvider, MockVerifier};
     use slim_datapath::Status;
     use slim_datapath::api::ProtoMessage as Message;
@@ -162,18 +107,5 @@ mod tests {
     async fn verify_identity_accepts_mock() {
         let msg = make_message();
         verify_identity(&msg, &MockVerifier).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn app_transmitter_wraps_notification() {
-        let (slim_tx, _slim_rx) = mpsc::channel::<Result<Message, Status>>(4);
-        let (app_tx, mut app_rx) = mpsc::channel::<Result<Notification, SessionError>>(4);
-        let tx = AppTransmitter::new(slim_tx, app_tx, MockTokenProvider);
-
-        tx.send_to_app(Ok(make_message())).await.unwrap();
-        match app_rx.recv().await.unwrap().unwrap() {
-            Notification::NewMessage(_) => {}
-            _ => panic!("expected NewMessage"),
-        }
     }
 }


### PR DESCRIPTION
# Description

Follow-up cleanup to the session refactor. Removes three abstractions that were providing no value:

- **`AppTransmitter`** — a wrapper struct on `SessionLayer` that bundled fields the layer already held directly. Its single production call site (`handle_discovery_request`) is inlined with equivalent logic.
- **`Transmitter` trait** — had no dynamic dispatch (`dyn Transmitter`) and no generic bounds (`T: Transmitter`) anywhere in the codebase. It was imported in five files purely to bring inherent-style methods into scope. The methods are now inherent on `SessionTransmitter<P>`.
- **`MockTransmitter`** — dead code; every test in the crate was already using `SessionTransmitter<MockTokenProvider>` directly.

Net result: −164 lines, all tests pass, clippy clean.

## Type of Change

- [x] Refactor

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass