### PR TITLE
refactor: remove unused code from controller service

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -257,7 +257,6 @@ dependencies = [
  "prost",
  "prost-types",
  "protoc-bin-vendored",
- "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -25,7 +25,6 @@ h2 = { workspace = true }
 parking_lot = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -33,7 +33,6 @@ use crate::errors::ControllerError;
 use prost_types::Struct;
 use slim_config::client::{ClientConfig, TransportChannel};
 use slim_datapath::api::ProtoName;
-use slim_datapath::api::ProtoName as Name;
 use slim_datapath::api::{
     MessageType::Subscribe, MessageType::SubscriptionAck as SubscriptionAckType,
     MessageType::Unsubscribe, ProtoMessage as DataPlaneMessage,
@@ -45,8 +44,6 @@ use slim_datapath::tables::SubscriptionTable;
 type TxChannel = mpsc::Sender<Result<ControlMessage, Status>>;
 type TxChannels = HashMap<String, TxChannel>;
 
-// Controller component
-const CONTROLLER_COMPONENT: &str = "controller";
 /// Maximum number of queued subscription notifications
 const MAX_QUEUED_NOTIFICATIONS: usize = 1000;
 
@@ -79,9 +76,6 @@ struct ControllerServiceInternal {
     /// ID of this SLIM instance
     id: ID,
 
-    /// controller name
-    controller_name: ProtoName,
-
     /// optional group name
     group_name: Option<String>,
 
@@ -110,7 +104,7 @@ struct ControllerServiceInternal {
     connection_details: Vec<ConnectionDetails>,
 
     /// Maps (subscription_name, link_id) → subscription_id for route tracking
-    route_subscription_ids: parking_lot::Mutex<HashMap<(Name, u64), u64>>,
+    route_subscription_ids: parking_lot::Mutex<HashMap<(ProtoName, u64), u64>>,
 
     /// Reverse index: link_id → conn_id for O(1) lookup.
     /// Populated lazily on first resolve and eagerly on connection create/delete.
@@ -248,13 +242,6 @@ impl ControlPlane {
             .unwrap();
 
         let (signal, watch) = drain::channel();
-        let controller_name = ProtoName::from_strings([
-            CONTROLLER_COMPONENT,
-            CONTROLLER_COMPONENT,
-            CONTROLLER_COMPONENT,
-        ])
-        .with_id(rand::random::<u64>());
-        debug!("create controller with name: {}", controller_name);
 
         ControlPlane {
             servers: config.servers,
@@ -262,7 +249,6 @@ impl ControlPlane {
             controller: ControllerService {
                 inner: Arc::new(ControllerServiceInternal {
                     id: config.id,
-                    controller_name,
                     group_name: config.group_name,
                     message_processor: config.message_processor,
                     subscription_manager: SubscriptionManager::new(tx_slim.clone()),
@@ -393,29 +379,10 @@ impl ControlPlane {
         let clients = self.clients.clone();
         let controller = self.controller.clone();
 
-        // Send subscription to data-plane to receive messages for the controller source name
-        let controller_name = self.controller.inner.controller_name.clone();
-        let subscribe_msg = DataPlaneMessage::builder()
-            .source(controller_name.clone())
-            .destination(controller_name.clone())
-            .identity(controller_name.to_string())
-            .build_subscribe()
-            .unwrap();
-
-        controller
-            .inner
-            .tx_slim
-            .send(Ok(subscribe_msg))
-            .await
-            .map_err(|e| {
-                error!(error = %e.chain(), "failed to send subscribe message to data plane");
-                ControllerError::DatapathSendError(e.to_string())
-            })?;
-
         // Get a drain watch clone
         let watch = self.controller.drain_watch()?;
 
-        debug!("Starting data plane listener: {}", controller_name);
+        debug!("Starting data plane listener");
         tokio::spawn(async move {
             let mut drain_fut = std::pin::pin!(watch.signaled());
             loop {
@@ -425,7 +392,7 @@ impl ControlPlane {
                             Some(res) => {
                                 match res {
                                     Ok(msg) => {
-                                        debug!("Send sub/unsub/ack to control plane for message: {:?}", msg);
+                                        debug!("Send sub/unsub to control plane for message: {:?}", msg);
                                         match msg.get_type() {
                                             Subscribe(_) => {
                                                 controller.handle_subscribe_message(msg.get_dst(), &clients).await;
@@ -758,20 +725,20 @@ impl ControllerService {
     fn resolve_desired_routes<'a>(
         &self,
         desired_routes: &'a [v1::Route],
-    ) -> (HashMap<(Name, u64), &'a v1::Route>, Vec<v1::RouteAck>) {
-        type SubKey = (Name, u64);
+    ) -> (HashMap<(ProtoName, u64), &'a v1::Route>, Vec<v1::RouteAck>) {
+        type SubKey = (ProtoName, u64);
         let mut desired_subs: HashMap<SubKey, &v1::Route> = HashMap::new();
         let mut failures: Vec<v1::RouteAck> = Vec::new();
 
         for sub in desired_routes {
             match self.resolve_route_connection(sub) {
                 Ok(Some(conn_id)) => {
-                    let name = Name::from_strings([
+                    let name = ProtoName::from_strings([
                         sub.component_0.as_str(),
                         sub.component_1.as_str(),
                         sub.component_2.as_str(),
                     ])
-                    .with_id(sub.id.unwrap_or(Name::NULL_COMPONENT));
+                    .with_id(sub.id.unwrap_or(ProtoName::NULL_COMPONENT));
                     desired_subs.insert((name, conn_id), sub);
                 }
                 Ok(None) => {
@@ -796,9 +763,9 @@ impl ControllerService {
 
     async fn delete_stale_subscriptions(
         &self,
-        desired_subs: &HashMap<(Name, u64), &v1::Route>,
+        desired_subs: &HashMap<(ProtoName, u64), &v1::Route>,
     ) -> Vec<v1::RouteAck> {
-        let active_subs: Vec<((Name, u64), u64)> = self
+        let active_subs: Vec<((ProtoName, u64), u64)> = self
             .inner
             .route_subscription_ids
             .lock()
@@ -879,11 +846,11 @@ impl ControllerService {
 
     async fn create_new_subscriptions(
         &self,
-        desired_subs: &HashMap<(Name, u64), &v1::Route>,
+        desired_subs: &HashMap<(ProtoName, u64), &v1::Route>,
     ) -> Vec<v1::RouteAck> {
         let mut routes_status = Vec::new();
 
-        let to_create: Vec<((Name, u64), v1::Route)> = desired_subs
+        let to_create: Vec<((ProtoName, u64), v1::Route)> = desired_subs
             .iter()
             .filter(|((name, conn_id), _)| {
                 !self
@@ -1088,18 +1055,18 @@ impl ControllerService {
                                 let conn = self.resolve_route_connection(route);
 
                                 if let Ok(Some(conn)) = conn {
-                                    let source = Name::from_strings([
+                                    let source = ProtoName::from_strings([
                                         route.component_0.as_str(),
                                         route.component_1.as_str(),
                                         route.component_2.as_str(),
                                     ])
                                     .with_id(0);
-                                    let name = Name::from_strings([
+                                    let name = ProtoName::from_strings([
                                         route.component_0.as_str(),
                                         route.component_1.as_str(),
                                         route.component_2.as_str(),
                                     ])
-                                    .with_id(route.id.unwrap_or(Name::NULL_COMPONENT));
+                                    .with_id(route.id.unwrap_or(ProtoName::NULL_COMPONENT));
 
                                     let msg = DataPlaneMessage::builder()
                                         .source(source.clone())
@@ -1154,18 +1121,18 @@ impl ControllerService {
                                 let conn = self.resolve_route_connection(route);
 
                                 if let Ok(Some(conn)) = conn {
-                                    let source = Name::from_strings([
+                                    let source = ProtoName::from_strings([
                                         route.component_0.as_str(),
                                         route.component_1.as_str(),
                                         route.component_2.as_str(),
                                     ])
                                     .with_id(0);
-                                    let name = Name::from_strings([
+                                    let name = ProtoName::from_strings([
                                         route.component_0.as_str(),
                                         route.component_1.as_str(),
                                         route.component_2.as_str(),
                                     ])
-                                    .with_id(route.id.unwrap_or(Name::NULL_COMPONENT));
+                                    .with_id(route.id.unwrap_or(ProtoName::NULL_COMPONENT));
 
                                     let msg = DataPlaneMessage::builder()
                                         .source(source.clone())
@@ -1431,29 +1398,15 @@ impl ControllerService {
                             }
                         }
                     }
-                    Payload::Ack(_ack) => {
-                        // received an ack, do nothing - this should not happen
-                    }
-                    Payload::ConfigCommandAck(_) => {
-                        // received a config command ack, do nothing - this should not happen
-                    }
-                    Payload::RouteListResponse(_) => {
-                        // received a route list response, do nothing - this should not happen
-                    }
-                    Payload::ConnectionListResponse(_) => {
-                        // received a connection list response, do nothing - this should not happen
-                    }
                     Payload::RegisterNodeRequest(_) => {
                         error!("received a register node request");
-                    }
-                    Payload::RegisterNodeResponse(_) => {
-                        // received a register node response, do nothing
                     }
                     Payload::DeregisterNodeRequest(_) => {
                         error!("received a deregister node request");
                     }
-                    Payload::DeregisterNodeResponse(_) => {
-                        // received a deregister node response, do nothing
+                    _ => {
+                        // received unsupported message type, do nothing
+                        debug!("received unsupported message type from control - ignoring");
                     }
                 }
             }
@@ -1749,7 +1702,7 @@ impl ControllerService {
                             component_0: c0.to_string(),
                             component_1: c1.to_string(),
                             component_2: c2.to_string(),
-                            id: if id != Name::NULL_COMPONENT {
+                            id: if id != ProtoName::NULL_COMPONENT {
                                 Some(id)
                             } else {
                                 None

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -6,12 +6,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use std::time::Duration;
-use std::vec;
 
 use display_error_chain::ErrorChainExt;
 use slim_config::component::id::ID;
 use slim_config::server::ServerConfig;
-use slim_session::SessionMessage;
 use slim_session::subscription_manager::SubscriptionManager;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -27,7 +25,7 @@ use crate::api::proto::api::v1::{
     RouteListResponse,
 };
 use crate::api::proto::api::v1::{
-    Ack, ConnectionEntry, ControlMessage, RouteEntry,
+    ConnectionEntry, ControlMessage, RouteEntry,
     controller_service_client::ControllerServiceClient,
     controller_service_server::ControllerService as GrpcControllerService,
 };
@@ -36,18 +34,13 @@ use prost_types::Struct;
 use slim_config::client::{ClientConfig, TransportChannel};
 use slim_datapath::api::ProtoName;
 use slim_datapath::api::ProtoName as Name;
-use slim_datapath::api::ProtoSessionMessageType;
 use slim_datapath::api::{
-    MessageType::Link as LinkType, MessageType::Publish, MessageType::Subscribe,
-    MessageType::SubscriptionAck as SubscriptionAckType, MessageType::Unsubscribe,
-    ProtoMessage as DataPlaneMessage,
+    MessageType::Subscribe, MessageType::SubscriptionAck as SubscriptionAckType,
+    MessageType::Unsubscribe, ProtoMessage as DataPlaneMessage,
 };
 use slim_datapath::message_processing::MessageProcessor;
 use slim_datapath::messages::utils::SlimHeaderFlags;
 use slim_datapath::tables::SubscriptionTable;
-
-use slim_session::timer::{Timer, TimerType};
-use slim_session::timer_factory::{TimerFactory, TimerSettings};
 
 type TxChannel = mpsc::Sender<Result<ControlMessage, Status>>;
 type TxChannels = HashMap<String, TxChannel>;
@@ -112,17 +105,6 @@ struct ControllerServiceInternal {
 
     /// Manages pending subscription ack tracking (id generation, registration, resolution).
     subscription_manager: SubscriptionManager,
-
-    /// Maps generated u32 keys to original string message IDs and their associated timers.
-    /// u32 keys have a ~0.01% collision probability at ~650 concurrent entries (birthday bound).
-    /// Entries are short-lived (removed on ack or timeout), so practical risk is negligible.
-    message_id_map: Arc<parking_lot::RwLock<HashMap<u32, (String, Option<Timer>)>>>,
-
-    /// timer factory for controller messages
-    /// used to create timers for messages that require timeouts
-    /// the lock is needed to set the timer factory after initialization
-    /// because it requires a channel to send session messages
-    timer_factory: parking_lot::RwLock<Option<TimerFactory>>,
 
     /// connection details used by control plane to store connection settings
     connection_details: Vec<ConnectionDetails>,
@@ -289,8 +271,6 @@ impl ControlPlane {
                     cancellation_tokens: parking_lot::RwLock::new(HashMap::new()),
                     drain_watch: parking_lot::RwLock::new(Some(watch)),
                     pending_notifications: Arc::new(parking_lot::Mutex::new(VecDeque::new())),
-                    message_id_map: Arc::new(parking_lot::RwLock::new(HashMap::new())),
-                    timer_factory: parking_lot::RwLock::new(None),
                     connection_details: config.connection_details,
                     route_subscription_ids: parking_lot::Mutex::new(HashMap::new()),
                     link_id_to_conn_id: parking_lot::RwLock::new(HashMap::new()),
@@ -453,18 +433,11 @@ impl ControlPlane {
                                             Unsubscribe(_) => {
                                                 controller.handle_unsubscribe_message(msg.get_dst(), &clients).await;
                                             }
-                                            Publish(_) => {
-                                                if msg.get_session_message_type() == ProtoSessionMessageType::GroupAck {
-                                                    controller.send_ack_message(msg.get_id(), true, &clients).await;
-                                                } else {
-                                                    debug!("Ignoring publish message with session type: {:?}", msg.get_session_message_type());
-                                                }
-                                            }
-                                            LinkType(_) => {
-                                                debug!("received link message from dataplane - this should not happen");
-                                            }
                                             SubscriptionAckType(_) => {
                                                 controller.inner.subscription_manager.resolve_ack(msg.get_subscription_ack());
+                                            }
+                                            _ => {
+                                                debug!("Ignoring unexpected message type from dataplane: {:?}", msg.get_type());
                                             }
                                         }
                                     }
@@ -1605,37 +1578,6 @@ impl ControllerService {
         }
     }
 
-    // send an ack back to the control plane. the success field indicates whether the original
-    // operation was successfully delivered/processed or not.
-    async fn send_ack_message(&self, msg_id: u32, success: bool, clients: &[ClientConfig]) {
-        let original_message_id = self.inner.message_id_map.write().remove(&msg_id);
-        match original_message_id {
-            Some(entry) => {
-                debug!("Received GroupAck for message ID: {}", entry.0);
-                // stop timer and send ack
-                if let Some(mut timer) = entry.1 {
-                    timer.stop();
-                }
-
-                let ack = Ack {
-                    original_message_id: entry.0,
-                    success,
-                    messages: vec![msg_id.to_string()],
-                };
-
-                let reply = ControlMessage {
-                    message_id: uuid::Uuid::new_v4().to_string(),
-                    payload: Some(Payload::Ack(ack)),
-                };
-
-                self.send_or_queue_notification(reply, clients).await;
-            }
-            None => {
-                debug!("Received GroupAck for unknown message ID: {}", msg_id);
-            }
-        }
-    }
-
     /// Send a control message to SLIM.
     async fn send_control_message(&self, msg: DataPlaneMessage) -> Result<(), ControllerError> {
         self.inner.tx_slim.send(Ok(msg)).await.map_err(|e| {
@@ -1749,13 +1691,11 @@ impl ControllerService {
         &self,
         config: Option<ClientConfig>,
         mut stream: impl Stream<Item = Result<ControlMessage, Status>> + Unpin + Send + 'static,
-        mut timer_rx: Option<mpsc::Receiver<SessionMessage>>,
         tx: mpsc::Sender<Result<ControlMessage, Status>>,
         cancellation_token: CancellationToken,
     ) -> Result<JoinHandle<()>, ControllerError> {
         let this = self.clone();
         let watch = self.drain_watch()?;
-        let clients = config.clone();
 
         let handle = tokio::spawn(async move {
             // Send a register message to the control plane
@@ -1947,25 +1887,6 @@ impl ControllerService {
                             }
                         }
                     }
-                    Some(session_msg) = async {
-                        match &mut timer_rx {
-                            Some(rx) => rx.recv().await,
-                            None => std::future::pending().await,
-                        }
-                    } => {
-                        match session_msg {
-                            SessionMessage::TimerFailure { message_id, message_type: _, name: _, timeouts: _} => {
-                                tracing::info!("got a failure for message id: {}", message_id);
-                                // if there's a timer the clientconfig is always set
-                                if let Some(clients) = &clients {
-                                    this.send_ack_message(message_id, false, std::slice::from_ref(clients)).await;
-                                }
-                            }
-                            _ => {
-                                error!("unexpected session message received in controller");
-                            }
-                        }
-                    }
                     _ = cancellation_token.cancelled() => {
                         debug!("shutting down stream on cancellation token");
                         break;
@@ -2012,30 +1933,6 @@ impl ControllerService {
     ) -> Result<mpsc::Sender<Result<ControlMessage, Status>>, ControllerError> {
         info!(%config.endpoint, "connecting to control plane");
 
-        // On reconnect, drain message_id_map entries from the previous session.
-        // Their timers reference the old channel, so stop each one and send a
-        // failure ack to unblock waiters.
-        {
-            let prev_entries: Vec<(u32, (String, Option<Timer>))> =
-                self.inner.message_id_map.write().drain().collect();
-            for (msg_id, (original_id, timer)) in prev_entries {
-                if let Some(mut t) = timer {
-                    t.stop();
-                }
-                let ack = Ack {
-                    original_message_id: original_id,
-                    success: false,
-                    messages: vec![msg_id.to_string()],
-                };
-                let reply = ControlMessage {
-                    message_id: uuid::Uuid::new_v4().to_string(),
-                    payload: Some(Payload::Ack(ack)),
-                };
-                self.send_or_queue_notification(reply, std::slice::from_ref(&config))
-                    .await;
-            }
-        }
-
         // Reset connection state before establishing a new session. The CP
         // will send fresh ConfigCommands after re-registration to rebuild
         // these maps.
@@ -2064,22 +1961,11 @@ impl ControllerService {
             .open_control_channel(Request::new(out_stream))
             .await?;
 
-        let timer_settings = TimerSettings::new(
-            Duration::from_millis(2000),
-            None,
-            Some(0),
-            TimerType::Constant,
-        );
-        let (timer_tx, timer_rx) = mpsc::channel::<SessionMessage>(128);
-        let timer_factory = TimerFactory::new(timer_settings, timer_tx.clone());
-        self.inner.timer_factory.write().replace(timer_factory);
-
         // start processing the incoming stream
         let endpoint_key = config.endpoint.clone();
         let handle = self.process_control_message_stream(
             Some(config),
             stream.into_inner(),
-            Some(timer_rx),
             tx.clone(),
             cancellation_token.clone(),
         )?;
@@ -2135,13 +2021,7 @@ impl GrpcControllerService for ControllerService {
 
         // Server-side connections don't initiate operations requiring acks, so no timer channel needed
         let handle = self
-            .process_control_message_stream(
-                None,
-                stream,
-                None,
-                tx.clone(),
-                cancellation_token.clone(),
-            )
+            .process_control_message_stream(None, stream, tx.clone(), cancellation_token.clone())
             .map_err(|e| {
                 error!(error = %e.chain(), "error processing control message stream");
                 Status::unavailable("failed to process control message stream")


### PR DESCRIPTION
# Description

Remove unused group-ack code from the data plane controller that was accidentally reintroduced.

In PR #1594 (`4449651`), group creation logic was removed from the controller. However, PR #1581 (`55b27b6` — *refactor: control plane in rust*), which was developed in parallel, partially reintroduced some of that code. This PR cleans up the remnants.

### Removed

- **`send_ack_message`** function — handled `GroupAck` messages no longer produced
- **`message_id_map`** field — tracked group ack message IDs and timers
- **`timer_factory`** field — created timers for group-ack timeouts
- **`GroupAck` handling branch** in the datapath listener loop (replaced with catch-all)
- **`TimerFailure` handler** in the control-plane stream processing loop
- **`message_id_map` drain** on reconnect
- **Timer setup** (`TimerSettings`, `TimerFactory`) in the `connect` flow
- **`timer_rx` parameter** from `process_control_message_stream`
- **Unused imports**: `SessionMessage`, `ProtoSessionMessageType`, `Publish`, `LinkType`, `Timer`, `TimerType`, `TimerFactory`, `TimerSettings`, `Ack`, `std::vec`

ref: #1681 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
