### PR TITLE
fix(datapath): update doctests to match current API

### DIFF
--- a/data-plane/core/datapath/src/messages/utils.rs
+++ b/data-plane/core/datapath/src/messages/utils.rs
@@ -1074,10 +1074,8 @@ impl AsRef<ProtoPublish> for ProtoMessage {
 /// ## Discovery Request
 /// ```
 /// use slim_datapath::api::CommandPayload;
-/// use slim_datapath::api::ProtoName;
 ///
-/// let dest = ProtoName::from_strings(["org", "namespace", "service"]);
-/// let payload = CommandPayload::builder().discovery_request(Some(dest));
+/// let payload = CommandPayload::builder().discovery_request();
 /// ```
 ///
 /// ## Join Request with Timer Settings
@@ -1097,13 +1095,13 @@ impl AsRef<ProtoPublish> for ProtoMessage {
 ///
 /// ## Group Operations
 /// ```
-/// use slim_datapath::api::CommandPayload;
+/// use slim_datapath::api::{CommandPayload, Participant};
 /// use slim_datapath::api::ProtoName;
 ///
-/// let participant = ProtoName::from_strings(["org", "ns", "user1"]);
+/// let participant = Participant { name: Some(ProtoName::from_strings(["org", "ns", "user1"])), settings: None };
 /// let participants = vec![
-///     ProtoName::from_strings(["org", "ns", "user2"]),
-///     ProtoName::from_strings(["org", "ns", "user3"]),
+///     Participant { name: Some(ProtoName::from_strings(["org", "ns", "user2"])), settings: None },
+///     Participant { name: Some(ProtoName::from_strings(["org", "ns", "user3"])), settings: None },
 /// ];
 ///
 /// // Add participant
@@ -1336,7 +1334,7 @@ impl CommandPayload {
 /// let source = ProtoName::from_strings(["org", "ns", "app"]);
 /// let dest = ProtoName::from_strings(["org", "ns", "service"]);
 ///
-/// let cmd = CommandPayload::builder().discovery_request(Some(dest.clone()));
+/// let cmd = CommandPayload::builder().discovery_request();
 ///
 /// let msg = ProtoMessage::builder()
 ///     .source(source)

--- a/data-plane/core/service/src/lib.rs
+++ b/data-plane/core/service/src/lib.rs
@@ -17,18 +17,18 @@
 //! use slim_service::Service;
 //! use slim_config::component::ComponentBuilder;
 //! use slim_auth::shared_secret::SharedSecret;
-//! use slim_auth::testutils::TEST_VALID_SECRET;
 //! use slim_datapath::api::ProtoName;
 //!
 //! // Create service instance (handles message processing)
 //! let service = Service::builder().build("svc-0".to_string()).expect("Failed to create service");
 //!
 //! // Create authentication components
-//! let provider = SharedSecret::new("myapp", TEST_VALID_SECRET)?;
-//! let verifier = SharedSecret::new("myapp", TEST_VALID_SECRET)?;
+//! let secret = "test-shared-secret-value-0123456789abcdef";
+//! let provider = SharedSecret::new("myapp", secret).unwrap();
+//! let verifier = SharedSecret::new("myapp", secret).unwrap();
 //!
 //! // Create an app for messaging
-//! let app_name = Name::from_strings(["org", "ns", "app"]);
+//! let app_name = ProtoName::from_strings(["org", "ns", "app"]);
 //! let (app, rx) = service.create_app(&app_name, provider, verifier).expect("Failed to create app");
 //! # })
 //! ```


### PR DESCRIPTION
## Description

Several code examples in doc comments had drifted out of sync with the
current API and failed to compile as doctests:

- `CommandPayloadBuilder::discovery_request()` previously accepted an
  `Option<ProtoName>` argument but now takes no arguments; three callers
  in the `utils.rs` doc examples were updated.
- `CommandPayloadBuilder::group_add()` now takes `Vec<Participant>`
  instead of `Vec<ProtoName>`; the example was updated to construct
  `Participant` values.
- The `slim_service` crate-level doc example referenced a non-existent
  `slim_auth::testutils` module, used `Name` instead of `ProtoName`, and
  used `?` in an `async {}` block returning `()`; all three issues are
  fixed.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass