### PR TITLE
feat(datapath): add peer discovery module with static backend

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -308,6 +309,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-test",
+ "trait-variant",
  "twox-hash",
  "uuid",
 ]

--- a/data-plane/bindings/rust/src/client_config.rs
+++ b/data-plane/bindings/rust/src/client_config.rs
@@ -346,6 +346,7 @@ impl From<ClientConfig> for CoreClientConfig {
             require_header_mac: config
                 .require_header_mac
                 .unwrap_or(core_defaults.require_header_mac),
+            connection_type: core_defaults.connection_type,
         }
     }
 }

--- a/data-plane/core/config/src/client.rs
+++ b/data-plane/core/config/src/client.rs
@@ -28,6 +28,55 @@ use crate::auth::static_jwt::Config as BearerAuthenticationConfig;
 use crate::backoff::Strategy;
 use crate::backoff::exponential::Config as ExponentialBackoff;
 use crate::backoff::fixedinterval::Config as FixedIntervalBackoff;
+
+/// The type of connection a client establishes.
+///
+/// Determines how the datapath treats messages on this connection
+/// (routing rules, subscription forwarding, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ConnType {
+    /// Connection with a local application (agent).
+    /// Not exposed in configuration — only used internally.
+    #[serde(skip)]
+    Local,
+    /// Connection with a remote SLIM instance (other deployment, via controller).
+    #[default]
+    Remote,
+    /// Connection with a peer replica in the same deployment.
+    Peer,
+}
+
+impl ConnType {
+    /// All variants, for iteration.
+    pub const ALL: [ConnType; 3] = [ConnType::Local, ConnType::Remote, ConnType::Peer];
+
+    /// Number of ConnType variants (derived automatically).
+    pub const COUNT: usize = Self::ALL.len();
+
+    /// Index for array-based storage. Stable mapping.
+    pub const fn index(self) -> usize {
+        match self {
+            ConnType::Local => 0,
+            ConnType::Remote => 1,
+            ConnType::Peer => 2,
+        }
+    }
+
+    /// Converts from the legacy `is_local` boolean for backward compatibility.
+    pub fn from_is_local(is_local: bool) -> Self {
+        if is_local {
+            ConnType::Local
+        } else {
+            ConnType::Remote
+        }
+    }
+
+    /// Returns true if this is a local connection (app/agent).
+    pub fn is_local(self) -> bool {
+        matches!(self, ConnType::Local)
+    }
+}
 use crate::component::configuration::Configuration;
 use crate::errors::ConfigError;
 use crate::grpc::compression::CompressionType;
@@ -243,6 +292,11 @@ pub struct ClientConfig {
     /// Flag to enforce header integrity validation
     #[serde(default = "default_require_header_mac")]
     pub require_header_mac: bool,
+
+    /// The type of connection this client establishes.
+    /// Defaults to `remote`. Set to `peer` for intra-deployment peer connections.
+    #[serde(default)]
+    pub connection_type: ConnType,
 }
 
 /// Defaults for ClientConfig
@@ -266,6 +320,7 @@ impl Default for ClientConfig {
             metadata: None,
             link_id: default_link_id(),
             require_header_mac: true,
+            connection_type: ConnType::default(),
         }
     }
 }
@@ -291,7 +346,7 @@ impl std::fmt::Display for ClientConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ClientConfig {{ endpoint: {}, transport: {:?}, origin: {:?}, server_name: {:?}, compression: {:?}, rate_limit: {:?}, tls_setting: {:?}, keepalive: {:?}, proxy: {:?}, connect_timeout: {:?}, request_timeout: {:?}, buffer_size: {:?}, headers: {:?}, auth: {:?}, backoff: {:?}, metadata: {:?}, link_id: {:?} }}",
+            "ClientConfig {{ endpoint: {}, transport: {:?}, origin: {:?}, server_name: {:?}, compression: {:?}, rate_limit: {:?}, tls_setting: {:?}, keepalive: {:?}, proxy: {:?}, connect_timeout: {:?}, request_timeout: {:?}, buffer_size: {:?}, headers: {:?}, auth: {:?}, backoff: {:?}, metadata: {:?}, link_id: {:?}, connection_type: {:?} }}",
             self.endpoint,
             self.resolved_transport(),
             self.origin,
@@ -308,7 +363,8 @@ impl std::fmt::Display for ClientConfig {
             self.auth,
             self.backoff,
             self.metadata,
-            self.link_id
+            self.link_id,
+            self.connection_type
         )
     }
 }

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -38,6 +38,7 @@ tonic = { workspace = true }
 tonic-prost = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true, optional = true }
+trait-variant = { workspace = true }
 twox-hash = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
@@ -48,6 +49,7 @@ tonic-prost-build = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 criterion = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
 

--- a/data-plane/core/datapath/src/lib.rs
+++ b/data-plane/core/datapath/src/lib.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod errors;
 pub mod message_processing;
 pub mod messages;
+pub mod peer_discovery;
 pub mod tables;
 
 mod connection;

--- a/data-plane/core/datapath/src/peer_discovery.rs
+++ b/data-plane/core/datapath/src/peer_discovery.rs
@@ -1,0 +1,87 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Peer discovery abstraction for SLIM replicas.
+//!
+//! Provides a trait-based abstraction for discovering peer replicas within the
+//! same deployment. Implementations include:
+//! - [`StaticPeerDiscovery`]: Configuration-defined list of peer endpoints
+//! - (Future) Kubernetes API-based discovery
+
+mod config;
+mod static_list;
+
+pub use config::{PeerConfig, PeerDiscoveryConfig};
+pub use static_list::StaticPeerDiscovery;
+
+use std::fmt;
+
+/// Information about a discovered peer replica.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerInfo {
+    /// Unique peer identifier (e.g., pod name or configured ID).
+    pub id: String,
+    /// Network endpoint to reach the peer (e.g., "10.0.0.2:8080").
+    pub endpoint: String,
+}
+
+/// Events emitted by a peer discovery implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerEvent {
+    /// A new peer has been discovered and is available for connection.
+    Joined(PeerInfo),
+    /// A previously discovered peer is no longer available.
+    Left(PeerInfo),
+}
+
+/// Errors that can occur during peer discovery.
+#[derive(Debug)]
+pub enum PeerDiscoveryError {
+    /// Discovery backend failed to start or encountered an unrecoverable error.
+    Backend(String),
+    /// The discovery stream has been closed (clean shutdown).
+    Closed,
+}
+
+impl fmt::Display for PeerDiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(msg) => write!(f, "peer discovery error: {msg}"),
+            Self::Closed => write!(f, "peer discovery stream closed"),
+        }
+    }
+}
+
+impl std::error::Error for PeerDiscoveryError {}
+
+/// Trait for peer discovery backends.
+///
+/// Implementations are responsible for discovering peer replicas and emitting
+/// [`PeerEvent`]s as peers join or leave the deployment.
+///
+/// # Usage
+///
+/// ```ignore
+/// let mut discovery = StaticPeerDiscovery::new(config, "self-id");
+/// discovery.start().await?;
+/// while let Ok(event) = discovery.recv().await {
+///     match event {
+///         PeerEvent::Joined(info) => { /* connect to peer */ }
+///         PeerEvent::Left(info) => { /* disconnect from peer */ }
+///     }
+/// }
+/// ```
+#[trait_variant::make(Send)]
+pub trait PeerDiscovery {
+    /// Start the discovery process.
+    ///
+    /// This should return quickly. For static discovery, it emits all configured
+    /// peers. For dynamic backends (e.g., Kubernetes), it begins watching for changes.
+    async fn start(&mut self) -> Result<(), PeerDiscoveryError>;
+
+    /// Receive the next peer event.
+    ///
+    /// Blocks until an event is available. Returns an error if the discovery
+    /// backend encounters a failure or the stream is closed.
+    async fn recv(&mut self) -> Result<PeerEvent, PeerDiscoveryError>;
+}

--- a/data-plane/core/datapath/src/peer_discovery/config.rs
+++ b/data-plane/core/datapath/src/peer_discovery/config.rs
@@ -1,0 +1,104 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration types for peer discovery.
+
+use serde::Deserialize;
+
+/// Top-level peer configuration.
+///
+/// When present in the service configuration, enables peer-to-peer route
+/// synchronization between SLIM replicas.
+///
+/// For static peer discovery, peers are defined as `dataplane.clients` with
+/// `connection_type: peer`. No additional configuration is needed here.
+///
+/// For dynamic discovery (e.g., Kubernetes), set the `discovery` field.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PeerConfig {
+    /// Unique identifier for this replica within the peer group.
+    /// Used for self-filtering in dynamic discovery and leader election.
+    pub self_id: String,
+
+    /// Shared group identity for mutual peer authentication during link negotiation.
+    /// Peers must have the same `peer_group` to accept each other.
+    pub peer_group: String,
+
+    /// Optional dynamic discovery backend (e.g., Kubernetes).
+    /// When absent, peers are discovered statically from `dataplane.clients`
+    /// that have `connection_type: peer`.
+    #[serde(default)]
+    pub discovery: Option<PeerDiscoveryConfig>,
+}
+
+/// Dynamic discovery backend configuration.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum PeerDiscoveryConfig {
+    /// Kubernetes-based peer discovery (watches pods by label selector).
+    #[serde(rename = "kubernetes")]
+    Kubernetes {
+        /// Kubernetes namespace to watch.
+        namespace: String,
+        /// Label selector to filter peer pods (e.g., "app=slim").
+        label_selector: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_peer_config_no_discovery() {
+        let yaml = r#"
+            self_id: "slim-0"
+            peer_group: "my-deployment"
+        "#;
+
+        let config: PeerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.self_id, "slim-0");
+        assert_eq!(config.peer_group, "my-deployment");
+        assert!(config.discovery.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_kubernetes_config() {
+        let yaml = r#"
+            self_id: "slim-pod-abc"
+            peer_group: "slim-deployment"
+            discovery:
+              type: kubernetes
+              namespace: "default"
+              label_selector: "app=slim"
+        "#;
+
+        let config: PeerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.self_id, "slim-pod-abc");
+        assert_eq!(config.peer_group, "slim-deployment");
+
+        match &config.discovery {
+            Some(PeerDiscoveryConfig::Kubernetes {
+                namespace,
+                label_selector,
+            }) => {
+                assert_eq!(namespace, "default");
+                assert_eq!(label_selector, "app=slim");
+            }
+            None => panic!("expected kubernetes config"),
+        }
+    }
+
+    #[test]
+    fn test_reject_unknown_fields() {
+        let yaml = r#"
+            self_id: "slim-0"
+            peer_group: "group"
+            unknown_field: "oops"
+        "#;
+
+        let result: Result<PeerConfig, _> = serde_yaml::from_str(yaml);
+        assert!(result.is_err());
+    }
+}

--- a/data-plane/core/datapath/src/peer_discovery/static_list.rs
+++ b/data-plane/core/datapath/src/peer_discovery/static_list.rs
@@ -1,0 +1,128 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Static peer discovery implementation.
+//!
+//! Discovers peers from a pre-built list of [`PeerInfo`] entries (typically
+//! derived from `dataplane.clients` with `connection_type: peer`).
+//! Emits `Joined` events for all entries on startup. Never emits `Left`
+//! events since static peers are assumed to be always available.
+
+use std::collections::VecDeque;
+
+use super::{PeerDiscovery, PeerDiscoveryError, PeerEvent, PeerInfo};
+
+/// Static peer discovery: all peers are known at configuration time.
+pub struct StaticPeerDiscovery {
+    /// Pre-filtered peer entries ready for emission.
+    peers: Vec<PeerInfo>,
+    /// Events pending delivery.
+    pending: VecDeque<PeerEvent>,
+    /// Whether `start()` has been called.
+    started: bool,
+}
+
+impl StaticPeerDiscovery {
+    /// Create a new static discovery instance from a list of peer entries.
+    ///
+    /// The caller is responsible for filtering (e.g., excluding self).
+    pub fn new(peers: Vec<PeerInfo>) -> Self {
+        Self {
+            peers,
+            pending: VecDeque::new(),
+            started: false,
+        }
+    }
+}
+
+impl PeerDiscovery for StaticPeerDiscovery {
+    async fn start(&mut self) -> Result<(), PeerDiscoveryError> {
+        if self.started {
+            return Ok(());
+        }
+        self.started = true;
+
+        for peer in &self.peers {
+            self.pending.push_back(PeerEvent::Joined(peer.clone()));
+        }
+
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> Result<PeerEvent, PeerDiscoveryError> {
+        match self.pending.pop_front() {
+            Some(event) => Ok(event),
+            // Static discovery never produces more events after initial list.
+            // Block forever (the peer sync manager will drop the discovery on shutdown).
+            None => std::future::pending().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_peers() -> Vec<PeerInfo> {
+        vec![
+            PeerInfo {
+                id: "slim-1".to_string(),
+                endpoint: "slim-1:8080".to_string(),
+            },
+            PeerInfo {
+                id: "slim-2".to_string(),
+                endpoint: "slim-2:8080".to_string(),
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_emits_all_peers() {
+        let mut discovery = StaticPeerDiscovery::new(test_peers());
+        discovery.start().await.unwrap();
+
+        let event1 = discovery.recv().await.unwrap();
+        let event2 = discovery.recv().await.unwrap();
+
+        assert_eq!(
+            event1,
+            PeerEvent::Joined(PeerInfo {
+                id: "slim-1".to_string(),
+                endpoint: "slim-1:8080".to_string(),
+            })
+        );
+        assert_eq!(
+            event2,
+            PeerEvent::Joined(PeerInfo {
+                id: "slim-2".to_string(),
+                endpoint: "slim-2:8080".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_start_is_idempotent() {
+        let mut discovery = StaticPeerDiscovery::new(test_peers());
+        discovery.start().await.unwrap();
+        discovery.start().await.unwrap(); // second call is no-op
+
+        // Should still only have 2 events, not 4
+        let _event1 = discovery.recv().await.unwrap();
+        let _event2 = discovery.recv().await.unwrap();
+
+        // recv would block forever here (no more events)
+        let result =
+            tokio::time::timeout(std::time::Duration::from_millis(50), discovery.recv()).await;
+        assert!(result.is_err()); // timed out = no more events
+    }
+
+    #[tokio::test]
+    async fn test_empty_peer_list() {
+        let mut discovery = StaticPeerDiscovery::new(vec![]);
+        discovery.start().await.unwrap();
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_millis(50), discovery.recv()).await;
+        assert!(result.is_err()); // no events
+    }
+}

--- a/data-plane/core/datapath/src/tables.rs
+++ b/data-plane/core/datapath/src/tables.rs
@@ -14,52 +14,7 @@ pub mod pool;
 
 use crate::api::{EncodedName, ProtoName};
 
-/// Categorization of a connection for subscription table routing.
-///
-/// Determines which internal ConnList (local, remote, or peer) a subscription
-/// is stored in, and which lists are queried during publish-time matching.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ConnType {
-    /// Connection with a local application (agent)
-    Local,
-    /// Connection with a remote SLIM instance (other deployment, via controller)
-    #[default]
-    Remote,
-    /// Connection with a peer replica in the same deployment
-    Peer,
-}
-
-/// Number of ConnType variants.
-pub const CONN_TYPE_COUNT: usize = 3;
-
-impl ConnType {
-    /// All variants, for iteration.
-    pub const ALL: [ConnType; CONN_TYPE_COUNT] =
-        [ConnType::Local, ConnType::Remote, ConnType::Peer];
-
-    /// Index for array-based storage. Stable mapping.
-    pub const fn index(self) -> usize {
-        match self {
-            ConnType::Local => 0,
-            ConnType::Remote => 1,
-            ConnType::Peer => 2,
-        }
-    }
-
-    /// Converts from the legacy `is_local` boolean for backward compatibility.
-    pub fn from_is_local(is_local: bool) -> Self {
-        if is_local {
-            ConnType::Local
-        } else {
-            ConnType::Remote
-        }
-    }
-
-    /// Returns true if this is a local connection (app/agent).
-    pub fn is_local(self) -> bool {
-        matches!(self, ConnType::Local)
-    }
-}
+pub use slim_config::client::ConnType;
 
 /// Determines which connection categories to include when matching publish messages.
 ///
@@ -70,13 +25,13 @@ impl ConnType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MatchFilter {
     /// Indexed by `ConnType::index()`. True means include that category.
-    pub include: [bool; CONN_TYPE_COUNT],
+    pub include: [bool; ConnType::COUNT],
 }
 
 impl MatchFilter {
     /// Full routing: include all categories (used for Local and Remote sources)
     pub const ALL: Self = Self {
-        include: [true; CONN_TYPE_COUNT],
+        include: [true; ConnType::COUNT],
     };
 
     /// Exclude peers: used for Peer sources (1-hop rule)

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -11,7 +11,7 @@ use parking_lot::Mutex;
 use tracing::{debug, warn};
 
 use super::SubscriptionTable;
-use super::{CONN_TYPE_COUNT, ConnType, MatchFilter};
+use super::{ConnType, MatchFilter};
 use crate::api::{EncodedName, NameId, ProtoName};
 use crate::errors::DataPathError;
 
@@ -115,9 +115,9 @@ struct PrefixEntry {
     /// Dense u128 array for name IDs.
     ids: Vec<u128>,
     /// Per-slot connection lists, indexed by `ConnType::index()`.
-    slots: [Vec<ConnList>; CONN_TYPE_COUNT],
+    slots: [Vec<ConnList>; ConnType::COUNT],
     /// Deduplicated union of all per-slot connections, indexed by `ConnType::index()`.
-    aggregates: [Vec<u64>; CONN_TYPE_COUNT],
+    aggregates: [Vec<u64>; ConnType::COUNT],
     /// Round-robin cursor for NULL_COMPONENT slot selection.
     slot_cursor: AtomicUsize,
     /// Human-readable prefix strings for for_each / Display / ProtoName.

--- a/data-plane/core/datapath/src/tables/subscription_table.rs
+++ b/data-plane/core/datapath/src/tables/subscription_table.rs
@@ -447,6 +447,15 @@ impl Display for SubscriptionTableImpl {
                         }
                     }
                 }
+                let peer_slot = &prefix_entry.slots[ConnType::Peer.index()][i];
+                writeln!(f, "       Peer Connections:")?;
+                if peer_slot.is_empty() {
+                    writeln!(f, "         None")?;
+                } else {
+                    for c in peer_slot.iter() {
+                        writeln!(f, "         Connection: {}", c)?;
+                    }
+                }
             }
         }
         Ok(())

--- a/data-plane/core/service/src/service.rs
+++ b/data-plane/core/service/src/service.rs
@@ -21,6 +21,7 @@ use slim_controller::config::Config as ControllerConfig;
 use slim_controller::config::Config as DataplaneConfig;
 use slim_controller::service::ControlPlane;
 use slim_datapath::message_processing::MessageProcessor;
+use slim_datapath::peer_discovery::PeerConfig;
 
 // Local crate
 use crate::errors::ServiceError;
@@ -75,6 +76,11 @@ pub struct ServiceConfiguration {
     /// Controller API configuration
     #[serde(default)]
     pub controller: ControllerConfig,
+
+    /// Peer replica configuration for intra-deployment route sync.
+    /// When present, enables peer-to-peer subscription synchronization.
+    #[serde(default)]
+    pub peers: Option<PeerConfig>,
 }
 
 impl ServiceConfiguration {


### PR DESCRIPTION
# Description

Add the peer discovery abstraction for SLIM replica route synchronization:

- PeerDiscovery trait (start/recv) with #[trait_variant::make(Send)]
- PeerEvent enum (Joined/Left) and PeerInfo struct
- PeerConfig with peer_group and optional dynamic discovery config
- StaticPeerDiscovery implementation (emits Joined for provided peers)
- Add ConnectionType (remote/peer) to ClientConfig in core/config
- Add peers: Option<PeerConfig> to ServiceConfiguration
- Static peers are configured as dataplane.clients with connection_type: peer

Part of: #1553 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
