### PR TITLE
refactor: remove bindings dependecy from channel-manager

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -136,7 +136,6 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-prost",

--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -122,9 +122,10 @@ name = "agntcy-slim-channel-manager"
 version = "0.1.0"
 dependencies = [
  "agntcy-slim",
- "agntcy-slim-bindings",
+ "agntcy-slim-auth",
  "agntcy-slim-config",
  "agntcy-slim-datapath",
+ "agntcy-slim-service",
  "agntcy-slim-session",
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
@@ -135,6 +136,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-prost",

--- a/data-plane/channel-manager/Cargo.toml
+++ b/data-plane/channel-manager/Cargo.toml
@@ -15,8 +15,10 @@ name = "cmctl"
 path = "src/bin/cmctl.rs"
 
 [dependencies]
-agntcy-slim-bindings = { workspace = true }
+agntcy-slim-auth = { workspace = true }
 agntcy-slim-config = { workspace = true }
+agntcy-slim-datapath = { workspace = true }
+agntcy-slim-service = { workspace = true, features = ["session"] }
 agntcy-slim-session = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
@@ -25,6 +27,7 @@ clap = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
@@ -36,7 +39,6 @@ tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
 agntcy-slim = { workspace = true }
-agntcy-slim-bindings = { workspace = true }
 agntcy-slim-config = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 tempfile = { workspace = true }

--- a/data-plane/channel-manager/Cargo.toml
+++ b/data-plane/channel-manager/Cargo.toml
@@ -27,7 +27,6 @@ clap = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }

--- a/data-plane/channel-manager/src/bin/channel_manager.rs
+++ b/data-plane/channel-manager/src/bin/channel_manager.rs
@@ -14,13 +14,16 @@ use agntcy_slim_channel_manager::config::Config;
 use agntcy_slim_channel_manager::proto::channel_manager_service_server::ChannelManagerServiceServer;
 use agntcy_slim_channel_manager::service::ChannelManagerServer;
 use agntcy_slim_channel_manager::sessions::SessionsList;
+use agntcy_slim_channel_manager::slim_adapter;
 
+use anyhow::Context;
 use clap::Parser;
-use slim_bindings::ClientConfig as BindingsClientConfig;
-use slim_bindings::{
-    IdentityProviderConfig, IdentityVerifierConfig, Name, SessionConfig, SessionType,
-    get_global_service, initialize_with_defaults, shutdown,
-};
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::traits::{TokenProvider, Verifier};
+use slim_config::component::ComponentBuilder;
+use slim_datapath::api::{ProtoName, ProtoSessionType};
+use slim_service::app::App;
+use slim_session::{Direction, SessionConfig};
 use slim_tracing::TracingConfiguration;
 use tracing::{error, info, warn};
 
@@ -36,35 +39,45 @@ struct Args {
 
 /// Create channels from the configuration file
 async fn create_channels_from_config(
-    app: &Arc<slim_bindings::App>,
+    app: &Arc<App<AuthProvider, AuthVerifier>>,
     conn_id: u64,
     sessions: &Arc<SessionsList>,
     config: &Config,
 ) -> anyhow::Result<()> {
     for channel_cfg in &config.manager.channels {
         let channel_name =
-            Name::from_string(channel_cfg.name.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+            ProtoName::parse_name(&channel_cfg.name).map_err(|e| anyhow::anyhow!("{e}"))?;
 
+        // Create a new session for the channel
         let session_config = SessionConfig {
-            session_type: SessionType::Group,
-            enable_mls: channel_cfg.mls_enabled,
+            session_type: ProtoSessionType::Multicast,
+            mls_enabled: channel_cfg.mls_enabled,
             max_retries: Some(10),
             interval: Some(Duration::from_millis(1000)),
+            initiator: true,
             metadata: std::collections::HashMap::new(),
         };
 
-        let session = app
-            .create_session_and_wait_async(session_config, Arc::new(channel_name))
+        let (session, completion) = app
+            .create_session(session_config, channel_name, None)
             .await
             .map_err(|e| {
                 anyhow::anyhow!("failed to create session for {}: {e}", channel_cfg.name)
             })?;
+        completion.await.map_err(|e| {
+            anyhow::anyhow!("session creation failed for {}: {e}", channel_cfg.name)
+        })?;
+
+        // Get the session controller for participant invitations
+        let controller = session.session_arc().ok_or_else(|| {
+            anyhow::anyhow!("session already closed for {}", channel_cfg.name)
+        })?;
 
         for participant in &channel_cfg.participants {
             let participant_name =
-                Name::from_string(participant.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+                ProtoName::parse_name(participant).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            app.set_route_async(Arc::new(participant_name.clone()), conn_id)
+            app.set_route(&participant_name, conn_id)
                 .await
                 .map_err(|e| {
                     anyhow::anyhow!(
@@ -74,8 +87,16 @@ async fn create_channels_from_config(
                     )
                 })?;
 
-            session
-                .invite_and_wait_async(Arc::new(participant_name))
+            controller
+                .invite_participant(&participant_name)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to invite {} to channel {}: {e}",
+                        participant,
+                        channel_cfg.name
+                    )
+                })?
                 .await
                 .map_err(|e| {
                     anyhow::anyhow!(
@@ -116,16 +137,20 @@ async fn main() -> anyhow::Result<()> {
     let config = Config::load(&args.config_file)?;
     info!(config_file = %args.config_file.display(), "Configuration loaded");
 
-    // Initialize SLIM (also sets up crypto provider; tracing subscriber already set so it reuses ours)
-    initialize_with_defaults();
-    let service = get_global_service();
+    // Initialize crypto provider (required before any TLS operations)
+    slim_config::tls::provider::initialize_crypto_provider();
 
-    // Connect to the SLIM node using the full ClientConfig
-    let client_config: BindingsClientConfig = config.manager.slim_connection.clone().into();
-    let conn_id = service
-        .connect_async(client_config)
+    // Create a SLIM service
+    let service = slim_service::ServiceBuilder::new()
+        .build("channel-manager-service".to_string())
+        .map_err(|e| anyhow::anyhow!("failed to create SLIM service: {e}"))?;
+
+    // Connect to the SLIM node
+    let conn_id  = service
+        .connect(&config.manager.slim_connection)
         .await
         .map_err(|e| anyhow::anyhow!("failed to connect to SLIM node: {e}"))?;
+    
     info!(
         endpoint = %config.manager.slim_connection.endpoint,
         conn_id,
@@ -133,47 +158,63 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Create the SLIM app with configured authentication
-    let app_name = Arc::new(
-        Name::from_string(config.manager.local_name.clone())
-            .map_err(|e| anyhow::anyhow!("invalid local-name: {e}"))?,
-    );
+    let app_name = ProtoName::parse_name(&config.manager.local_name)
+        .map_err(|e| anyhow::anyhow!("invalid local-name: {e}"))?;
     let (core_provider, core_verifier) = config
         .manager
         .auth
         .to_identity_configs(&config.manager.local_name);
-    let provider: IdentityProviderConfig = core_provider.into();
-    let verifier: IdentityVerifierConfig = core_verifier.into();
-    let app = service
-        .create_app_with_direction_async(
-            app_name.clone(),
-            provider,
-            verifier,
-            slim_bindings::Direction::None,
-        )
+    /*let app = slim_adapter::create_app(
+        &service,
+        &app_name,
+        core_provider,
+        core_verifier,
+        Direction::None,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to create SLIM app: {e}"))?;*/
+
+    let mut provider =  core_provider
+        .build_auth_provider()
+        .context("failed to build auth provider")?;
+    let mut verifier = core_verifier
+        .build_auth_verifier()
+        .context("failed to build auth verifier")?;
+
+    // Initialize auth (required before use)
+    provider
+        .initialize()
         .await
-        .map_err(|e| anyhow::anyhow!("failed to create SLIM app: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("failed to initialize identity provider: {e}"))?;
+    verifier
+        .initialize()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to initialize identity verifier: {e}"))?;
+
+    let (app, _rx) = service.create_app_with_direction(&app_name, provider, verifier, Direction::None)?;
 
     // Subscribe to the local name
-    app.subscribe_async(app.name(), Some(conn_id))
+    app.subscribe(app.app_name(), Some(conn_id))
         .await
         .map_err(|e| anyhow::anyhow!("failed to subscribe: {e}"))?;
 
     info!(
-        local_name = %app.name(),
+        local_name = %&app.app_name().to_string(),
         "SLIM app created"
     );
 
     // Create sessions list
     let sessions = Arc::new(SessionsList::new());
+    let arc_app = Arc::new(app);
 
     // Create channels from configuration
-    if let Err(e) = create_channels_from_config(&app, conn_id, &sessions, &config).await {
+    if let Err(e) = create_channels_from_config(&arc_app, conn_id, &sessions, &config).await {
         error!("Failed to create channels from config: {e}");
         return Err(e);
     }
 
     // Create gRPC server
-    let server = ChannelManagerServer::new(app.clone(), conn_id, sessions.clone());
+    let server = ChannelManagerServer::new(arc_app.clone(), conn_id, sessions.clone());
     let svc = ChannelManagerServiceServer::new(server);
 
     info!(
@@ -201,13 +242,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Cleanup with timeout to avoid hanging on shutdown
     info!("Shutting down...");
-    match tokio::time::timeout(Duration::from_secs(5), sessions.delete_all(&app)).await {
+    match tokio::time::timeout(Duration::from_secs(5), sessions.delete_all(&arc_app)).await {
         Ok(()) => info!("All sessions cleaned up"),
         Err(_) => warn!("Session cleanup timed out, forcing shutdown"),
     }
-    shutdown()
+       service
+        .shutdown()
         .await
-        .map_err(|e| anyhow::anyhow!("shutdown failed: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("service shutdown failed: {e}"))?;
     info!("Shutdown complete");
 
     Ok(())

--- a/data-plane/channel-manager/src/bin/channel_manager.rs
+++ b/data-plane/channel-manager/src/bin/channel_manager.rs
@@ -67,6 +67,11 @@ async fn create_channels_from_config(
             anyhow::anyhow!("session creation failed for {}: {e}", channel_cfg.name)
         })?;
 
+        // Get the session controller for participant invitations
+        let controller = session
+            .session_arc()
+            .ok_or_else(|| anyhow::anyhow!("session already closed for {}", channel_cfg.name))?;
+
         for participant in &channel_cfg.participants {
             let participant_name =
                 ProtoName::parse_name(participant).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -80,11 +85,6 @@ async fn create_channels_from_config(
                         channel_cfg.name
                     )
                 })?;
-
-            // Get the session controller for participant invitations
-            let controller = session.session_arc().ok_or_else(|| {
-                anyhow::anyhow!("session already closed for {}", channel_cfg.name)
-            })?;
 
             controller
                 .invite_participant(&participant_name)
@@ -190,7 +190,7 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("failed to subscribe: {e}"))?;
 
     info!(
-        local_name = %&app.app_name().to_string(),
+        local_name = %app.app_name(),
         "SLIM app created"
     );
 

--- a/data-plane/channel-manager/src/bin/channel_manager.rs
+++ b/data-plane/channel-manager/src/bin/channel_manager.rs
@@ -14,7 +14,6 @@ use agntcy_slim_channel_manager::config::Config;
 use agntcy_slim_channel_manager::proto::channel_manager_service_server::ChannelManagerServiceServer;
 use agntcy_slim_channel_manager::service::ChannelManagerServer;
 use agntcy_slim_channel_manager::sessions::SessionsList;
-use agntcy_slim_channel_manager::slim_adapter;
 
 use anyhow::Context;
 use clap::Parser;
@@ -68,11 +67,6 @@ async fn create_channels_from_config(
             anyhow::anyhow!("session creation failed for {}: {e}", channel_cfg.name)
         })?;
 
-        // Get the session controller for participant invitations
-        let controller = session.session_arc().ok_or_else(|| {
-            anyhow::anyhow!("session already closed for {}", channel_cfg.name)
-        })?;
-
         for participant in &channel_cfg.participants {
             let participant_name =
                 ProtoName::parse_name(participant).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -86,6 +80,11 @@ async fn create_channels_from_config(
                         channel_cfg.name
                     )
                 })?;
+
+            // Get the session controller for participant invitations
+            let controller = session.session_arc().ok_or_else(|| {
+                anyhow::anyhow!("session already closed for {}", channel_cfg.name)
+            })?;
 
             controller
                 .invite_participant(&participant_name)
@@ -146,11 +145,11 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("failed to create SLIM service: {e}"))?;
 
     // Connect to the SLIM node
-    let conn_id  = service
+    let conn_id = service
         .connect(&config.manager.slim_connection)
         .await
         .map_err(|e| anyhow::anyhow!("failed to connect to SLIM node: {e}"))?;
-    
+
     info!(
         endpoint = %config.manager.slim_connection.endpoint,
         conn_id,
@@ -164,17 +163,8 @@ async fn main() -> anyhow::Result<()> {
         .manager
         .auth
         .to_identity_configs(&config.manager.local_name);
-    /*let app = slim_adapter::create_app(
-        &service,
-        &app_name,
-        core_provider,
-        core_verifier,
-        Direction::None,
-    )
-    .await
-    .map_err(|e| anyhow::anyhow!("failed to create SLIM app: {e}"))?;*/
 
-    let mut provider =  core_provider
+    let mut provider = core_provider
         .build_auth_provider()
         .context("failed to build auth provider")?;
     let mut verifier = core_verifier
@@ -191,7 +181,8 @@ async fn main() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to initialize identity verifier: {e}"))?;
 
-    let (app, _rx) = service.create_app_with_direction(&app_name, provider, verifier, Direction::None)?;
+    let (app, _rx) =
+        service.create_app_with_direction(&app_name, provider, verifier, Direction::None)?;
 
     // Subscribe to the local name
     app.subscribe(app.app_name(), Some(conn_id))
@@ -246,7 +237,7 @@ async fn main() -> anyhow::Result<()> {
         Ok(()) => info!("All sessions cleaned up"),
         Err(_) => warn!("Session cleanup timed out, forcing shutdown"),
     }
-       service
+    service
         .shutdown()
         .await
         .map_err(|e| anyhow::anyhow!("service shutdown failed: {e}"))?;

--- a/data-plane/channel-manager/src/lib.rs
+++ b/data-plane/channel-manager/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod config;
 pub mod service;
 pub mod sessions;
+pub mod slim_adapter;
 
 pub mod proto {
     include!("gen/channel_manager.proto.v1.rs");

--- a/data-plane/channel-manager/src/lib.rs
+++ b/data-plane/channel-manager/src/lib.rs
@@ -10,7 +10,6 @@
 pub mod config;
 pub mod service;
 pub mod sessions;
-pub mod slim_adapter;
 
 pub mod proto {
     include!("gen/channel_manager.proto.v1.rs");

--- a/data-plane/channel-manager/src/service.rs
+++ b/data-plane/channel-manager/src/service.rs
@@ -9,9 +9,8 @@ use std::time::Duration;
 use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
 use slim_datapath::api::{ProtoName, ProtoSessionType};
 use slim_service::app::App;
-use slim_session::SessionConfig;
-use slim_session::context::SessionContext;
-use thiserror::Error;
+use slim_session::completion_handle::CompletionHandle;
+use slim_session::{SessionConfig, SessionError};
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
 
@@ -28,12 +27,6 @@ pub struct ChannelManagerServer {
     app: Arc<App<AuthProvider, AuthVerifier>>,
     conn_id: u64,
     sessions: Arc<SessionsList>,
-}
-
-#[derive(Error, Debug)]
-pub enum ServiceError {
-    #[error("session creation failed: {0}")]
-    SessionCreationFailed(String),
 }
 
 impl ChannelManagerServer {
@@ -64,20 +57,17 @@ impl ChannelManagerServer {
         }
     }
 
-    async fn create_session_and_wait(
-        &self,
-        config: SessionConfig,
-        destination: ProtoName,
-    ) -> Result<SessionContext, ServiceError> {
-        let (ctx, completion) = self
-            .app
-            .create_session(config, destination, None)
-            .await
-            .map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
-        completion
-            .await
-            .map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
-        Ok(ctx)
+    /// Await a two-step session operation (call + completion).
+    async fn await_session_op(
+        op: Result<CompletionHandle, SessionError>,
+        error_context: &str,
+    ) -> Result<(), String> {
+        match op {
+            Ok(completion) => completion
+                .await
+                .map_err(|e| format!("{error_context}: {e}")),
+            Err(e) => Err(format!("{error_context}: {e}")),
+        }
     }
 
     async fn handle_create_channel(&self, req: CreateChannelRequest) -> CommandResponse {
@@ -106,13 +96,19 @@ impl ChannelManagerServer {
             metadata: std::collections::HashMap::new(),
         };
 
-        let session = match self.create_session_and_wait(session_config, name).await {
+        let (session, completion) = match self.app.create_session(session_config, name, None).await
+        {
             Ok(s) => s,
             Err(e) => {
                 error!("Failed to create channel {channel_name}: {e}");
                 return self.error_response(format!("failed to create channel {channel_name}"));
             }
         };
+
+        if let Err(e) = completion.await {
+            error!("Failed to create channel {channel_name}: {e}");
+            return self.error_response(format!("failed to create channel {channel_name}"));
+        }
 
         // Keep a handle for cleanup in case of race condition
         let session_handle = session.session_arc();
@@ -175,19 +171,16 @@ impl ChannelManagerServer {
         }
 
         // Invite the participant
-        match session.invite_participant(&participant_name).await {
-            Ok(completion) => {
-                if let Err(e) = completion.await {
-                    return self.error_response(format!(
-                        "failed to invite participant {participant_name_str} to channel {channel_name}: {e}"
-                    ));
-                }
-            }
-            Err(e) => {
-                return self.error_response(format!(
-                    "failed to invite participant {participant_name_str} to channel {channel_name}: {e}"
-                ));
-            }
+        let op = session.invite_participant(&participant_name).await;
+        if let Err(msg) = Self::await_session_op(
+            op,
+            &format!(
+                "failed to invite participant {participant_name_str} to channel {channel_name}"
+            ),
+        )
+        .await
+        {
+            return self.error_response(msg);
         }
 
         info!("Added participant {participant_name_str} to channel {channel_name}");
@@ -212,23 +205,16 @@ impl ChannelManagerServer {
             }
         };
 
-        match session.remove_participant(&participant_name).await {
-            Ok(completion) => {
-                if let Err(e) = completion.await {
-                    return self.error_response(
-                        format!(
-                            "failed to remove participant {participant_name_str} from channel {channel_name}: {e}"
-                        ),
-                    );
-                }
-            }
-            Err(e) => {
-                return self.error_response(
-                    format!(
-                        "failed to remove participant {participant_name_str} from channel {channel_name}: {e}"
-                    ),
-                );
-            }
+        let op = session.remove_participant(&participant_name).await;
+        if let Err(msg) = Self::await_session_op(
+            op,
+            &format!(
+                "failed to remove participant {participant_name_str} from channel {channel_name}"
+            ),
+        )
+        .await
+        {
+            return self.error_response(msg);
         }
 
         info!("Removed participant {participant_name_str} from channel {channel_name}");

--- a/data-plane/channel-manager/src/service.rs
+++ b/data-plane/channel-manager/src/service.rs
@@ -6,9 +6,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use slim_bindings::{App, Name, SessionConfig, SessionType};
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::{ProtoName, ProtoSessionType};
+use slim_service::app::App;
+use slim_session::SessionConfig;
+use slim_session::context::SessionContext;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
+use thiserror::Error;
 
 use crate::proto::channel_manager_service_server::ChannelManagerService;
 use crate::proto::{
@@ -20,14 +25,20 @@ use crate::sessions::SessionsList;
 
 /// gRPC server for the Channel Manager service
 pub struct ChannelManagerServer {
-    app: Arc<App>,
+    app: Arc<App<AuthProvider, AuthVerifier>>,
     conn_id: u64,
     sessions: Arc<SessionsList>,
 }
 
+#[derive(Error, Debug)]
+pub enum ServiceError {
+    #[error("session creation failed: {0}")]
+    SessionCreationFailed(String),
+}
+
 impl ChannelManagerServer {
     /// Create a new server instance
-    pub fn new(app: Arc<App>, conn_id: u64, sessions: Arc<SessionsList>) -> Self {
+    pub fn new(app: Arc<App<AuthProvider, AuthVerifier>>, conn_id: u64, sessions: Arc<SessionsList>) -> Self {
         Self {
             app,
             conn_id,
@@ -49,6 +60,16 @@ impl ChannelManagerServer {
         }
     }
 
+    async fn create_session_and_wait(
+        &self,
+        config: SessionConfig,
+        destination: ProtoName,
+    ) -> Result<SessionContext, ServiceError> {
+        let (ctx, completion) = self.app.create_session(config, destination, None).await.map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
+        completion.await.map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
+        Ok(ctx)
+    }
+
     async fn handle_create_channel(&self, req: CreateChannelRequest) -> CommandResponse {
         let channel_name = &req.channel_name;
 
@@ -58,7 +79,7 @@ impl ChannelManagerServer {
         }
 
         // Parse the channel name
-        let name = match Name::from_string(channel_name.clone()) {
+        let name = match ProtoName::parse_name(channel_name) {
             Ok(n) => n,
             Err(e) => {
                 return self.error_response(format!("invalid channel name: {e}"));
@@ -67,18 +88,17 @@ impl ChannelManagerServer {
 
         // Create a new session for the channel
         let session_config = SessionConfig {
-            session_type: SessionType::Group,
-            enable_mls: req.mls_enabled,
+            session_type: ProtoSessionType::Multicast,
+            mls_enabled: req.mls_enabled,
             max_retries: Some(10),
             interval: Some(Duration::from_millis(1000)),
+            initiator: true,
             metadata: std::collections::HashMap::new(),
         };
 
-        let session = match self
-            .app
-            .create_session_and_wait_async(session_config, Arc::new(name))
-            .await
-        {
+
+
+        let session = match self.create_session_and_wait(session_config, name).await {
             Ok(s) => s,
             Err(e) => {
                 error!("Failed to create channel {channel_name}: {e}");
@@ -86,15 +106,20 @@ impl ChannelManagerServer {
             }
         };
 
+        // Keep a handle for cleanup in case of race condition
+        let session_handle = session.session_arc();
+
         // Atomically check-and-insert to avoid race conditions
         if !self
             .sessions
-            .try_insert_session(channel_name.clone(), session.clone())
+            .try_insert_session(channel_name.clone(), session)
             .await
         {
             // Channel was created by another concurrent request — clean up
-            if let Err(e) = self.app.delete_session_and_wait_async(session).await {
-                error!("Failed to clean up duplicate session for {channel_name}: {e}");
+            if let Some(s) = session_handle {
+                if let Err(e) = self.app.delete_session(&s) {
+                    error!("Failed to clean up duplicate session for {channel_name}: {e}");
+                }
             }
             return self.error_response(format!("channel {channel_name} already exists"));
         }
@@ -126,7 +151,7 @@ impl ChannelManagerServer {
             }
         };
 
-        let participant_name = match Name::from_string(participant_name_str.clone()) {
+        let participant_name = match ProtoName::parse_name(participant_name_str) {
             Ok(n) => n,
             Err(e) => {
                 return self.error_response(format!("invalid participant name: {e}"));
@@ -136,7 +161,7 @@ impl ChannelManagerServer {
         // Set route for the participant
         if let Err(e) = self
             .app
-            .set_route_async(Arc::new(participant_name.clone()), self.conn_id)
+            .set_route(&participant_name, self.conn_id)
             .await
         {
             return self.error_response(format!(
@@ -145,13 +170,19 @@ impl ChannelManagerServer {
         }
 
         // Invite the participant
-        if let Err(e) = session
-            .invite_and_wait_async(Arc::new(participant_name))
-            .await
-        {
-            return self.error_response(format!(
-                "failed to invite participant {participant_name_str} to channel {channel_name}: {e}"
-            ));
+        match session.invite_participant(&participant_name).await {
+            Ok(completion) => {
+                if let Err(e) = completion.await {
+                    return self.error_response(format!(
+                        "failed to invite participant {participant_name_str} to channel {channel_name}: {e}"
+                    ));
+                }
+            }
+            Err(e) => {
+                return self.error_response(format!(
+                    "failed to invite participant {participant_name_str} to channel {channel_name}: {e}"
+                ));
+            }
         }
 
         info!("Added participant {participant_name_str} to channel {channel_name}");
@@ -169,22 +200,30 @@ impl ChannelManagerServer {
             }
         };
 
-        let participant_name = match Name::from_string(participant_name_str.clone()) {
+        let participant_name = match ProtoName::parse_name(participant_name_str) {
             Ok(n) => n,
             Err(e) => {
                 return self.error_response(format!("invalid participant name: {e}"));
             }
         };
 
-        if let Err(e) = session
-            .remove_and_wait_async(Arc::new(participant_name))
-            .await
-        {
-            return self.error_response(
-                format!(
-                    "failed to remove participant {participant_name_str} from channel {channel_name}: {e}"
-                ),
-            );
+        match session.remove_participant(&participant_name).await {
+            Ok(completion) => {
+                if let Err(e) = completion.await {
+                    return self.error_response(
+                        format!(
+                            "failed to remove participant {participant_name_str} from channel {channel_name}: {e}"
+                        ),
+                    );
+                }
+            }
+            Err(e) => {
+                return self.error_response(
+                    format!(
+                        "failed to remove participant {participant_name_str} from channel {channel_name}: {e}"
+                    ),
+                );
+            }
         }
 
         info!("Removed participant {participant_name_str} from channel {channel_name}");
@@ -219,7 +258,7 @@ impl ChannelManagerServer {
             }
         };
 
-        let participants = match session.participants_list_async().await {
+        let participants = match session.participants_list().await {
             Ok(p) => p,
             Err(e) => {
                 return ListParticipantsResponse {
@@ -232,7 +271,8 @@ impl ChannelManagerServer {
             }
         };
 
-        let participant_names: Vec<String> = participants.iter().map(|p| p.to_string()).collect();
+        let participant_names: Vec<String> =
+            participants.iter().map(|p| p.to_string()).collect();
 
         info!(
             "Listing participants for channel {channel_name}, count: {}",

--- a/data-plane/channel-manager/src/service.rs
+++ b/data-plane/channel-manager/src/service.rs
@@ -11,9 +11,9 @@ use slim_datapath::api::{ProtoName, ProtoSessionType};
 use slim_service::app::App;
 use slim_session::SessionConfig;
 use slim_session::context::SessionContext;
+use thiserror::Error;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
-use thiserror::Error;
 
 use crate::proto::channel_manager_service_server::ChannelManagerService;
 use crate::proto::{
@@ -38,7 +38,11 @@ pub enum ServiceError {
 
 impl ChannelManagerServer {
     /// Create a new server instance
-    pub fn new(app: Arc<App<AuthProvider, AuthVerifier>>, conn_id: u64, sessions: Arc<SessionsList>) -> Self {
+    pub fn new(
+        app: Arc<App<AuthProvider, AuthVerifier>>,
+        conn_id: u64,
+        sessions: Arc<SessionsList>,
+    ) -> Self {
         Self {
             app,
             conn_id,
@@ -65,8 +69,14 @@ impl ChannelManagerServer {
         config: SessionConfig,
         destination: ProtoName,
     ) -> Result<SessionContext, ServiceError> {
-        let (ctx, completion) = self.app.create_session(config, destination, None).await.map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
-        completion.await.map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
+        let (ctx, completion) = self
+            .app
+            .create_session(config, destination, None)
+            .await
+            .map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
+        completion
+            .await
+            .map_err(|e| ServiceError::SessionCreationFailed(e.to_string()))?;
         Ok(ctx)
     }
 
@@ -96,8 +106,6 @@ impl ChannelManagerServer {
             metadata: std::collections::HashMap::new(),
         };
 
-
-
         let session = match self.create_session_and_wait(session_config, name).await {
             Ok(s) => s,
             Err(e) => {
@@ -110,16 +118,17 @@ impl ChannelManagerServer {
         let session_handle = session.session_arc();
 
         // Atomically check-and-insert to avoid race conditions
-        if !self
+        if self
             .sessions
-            .try_insert_session(channel_name.clone(), session)
+            .add_session(channel_name.clone(), session)
             .await
+            .is_err()
         {
             // Channel was created by another concurrent request — clean up
-            if let Some(s) = session_handle {
-                if let Err(e) = self.app.delete_session(&s) {
-                    error!("Failed to clean up duplicate session for {channel_name}: {e}");
-                }
+            if let Some(s) = session_handle
+                && let Err(e) = self.app.delete_session(&s)
+            {
+                error!("Failed to clean up duplicate session for {channel_name}: {e}");
             }
             return self.error_response(format!("channel {channel_name} already exists"));
         }
@@ -159,11 +168,7 @@ impl ChannelManagerServer {
         };
 
         // Set route for the participant
-        if let Err(e) = self
-            .app
-            .set_route(&participant_name, self.conn_id)
-            .await
-        {
+        if let Err(e) = self.app.set_route(&participant_name, self.conn_id).await {
             return self.error_response(format!(
                 "failed to set route for participant {participant_name_str}: {e}"
             ));
@@ -271,8 +276,7 @@ impl ChannelManagerServer {
             }
         };
 
-        let participant_names: Vec<String> =
-            participants.iter().map(|p| p.to_string()).collect();
+        let participant_names: Vec<String> = participants.iter().map(|p| p.to_string()).collect();
 
         info!(
             "Listing participants for channel {channel_name}, count: {}",

--- a/data-plane/channel-manager/src/sessions.rs
+++ b/data-plane/channel-manager/src/sessions.rs
@@ -4,17 +4,20 @@
 //! Thread-safe session list for managing active SLIM channels.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
-use slim_bindings::{App, Session};
-use slim_session::SessionError;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_service::app::App;
+use slim_session::context::SessionContext;
+use slim_session::session_controller::SessionController;
+use slim_session::{AppChannelReceiver, SessionError};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
-/// Per-channel state: the SLIM session and its event monitor task.
+/// Per-channel state: the SLIM session handle and its event monitor task.
 struct Channel {
-    session: Arc<Session>,
+    session: Weak<SessionController>,
     monitor: JoinHandle<()>,
 }
 
@@ -35,12 +38,13 @@ impl SessionsList {
     /// Try to insert a session atomically: checks existence and inserts under a single write lock.
     /// Spawns a background event monitor for the session.
     /// Returns `true` if inserted, `false` if the channel already exists.
-    pub async fn try_insert_session(&self, channel_name: String, session: Arc<Session>) -> bool {
+    pub async fn try_insert_session(&self, channel_name: String, ctx: SessionContext) -> bool {
         let mut channels = self.channels.write().await;
         if channels.contains_key(&channel_name) {
             return false;
         }
-        let monitor = spawn_session_event_monitor(channel_name.clone(), session.clone());
+        let (session, rx) = ctx.into_parts();
+        let monitor = spawn_session_event_monitor(channel_name.clone(), rx);
         channels.insert(channel_name, Channel { session, monitor });
         true
     }
@@ -49,26 +53,27 @@ impl SessionsList {
     pub async fn add_session(
         &self,
         channel_name: String,
-        session: Arc<Session>,
+        ctx: SessionContext,
     ) -> anyhow::Result<()> {
         let mut channels = self.channels.write().await;
         if channels.contains_key(&channel_name) {
             anyhow::bail!("channel {} already exists", channel_name);
         }
-        let monitor = spawn_session_event_monitor(channel_name.clone(), session.clone());
+        let (session, rx) = ctx.into_parts();
+        let monitor = spawn_session_event_monitor(channel_name.clone(), rx);
         channels.insert(channel_name, Channel { session, monitor });
         Ok(())
     }
 
-    /// Get a session by channel name
-    pub async fn get_session(&self, channel_name: &str) -> Option<Arc<Session>> {
+    /// Get the session controller by channel name
+    pub async fn get_session(&self, channel_name: &str) -> Option<Arc<SessionController>> {
         let channels = self.channels.read().await;
-        channels.get(channel_name).map(|c| c.session.clone())
+        channels.get(channel_name).and_then(|c| c.session.upgrade())
     }
 
     /// Remove and delete a session by channel name: aborts the monitor,
     /// deletes the SLIM session, and removes it from the map.
-    pub async fn remove_session(&self, channel_name: &str, app: &App) -> anyhow::Result<()> {
+    pub async fn remove_session(&self, channel_name: &str, app: &App<AuthProvider, AuthVerifier>) -> anyhow::Result<()> {
         // Remove from map and release the lock before the potentially slow SLIM call
         let session = {
             let mut channels = self.channels.write().await;
@@ -80,20 +85,24 @@ impl SessionsList {
         };
 
         // Delete the SLIM session with a timeout to avoid hanging
+        let s = session.upgrade().ok_or_else(|| anyhow::anyhow!("session already closed"))?;
         let completion = app
-            .delete_session_async(session)
-            .await
+            .delete_session(&s)
             .map_err(|e| anyhow::anyhow!("failed to delete session for {channel_name}: {e}"))?;
 
-        match completion
-            .wait_for_async(std::time::Duration::from_secs(5))
-            .await
-        {
-            Ok(()) => Ok(()),
-            Err(e) => {
+        match tokio::time::timeout(std::time::Duration::from_secs(5), completion).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
                 warn!(
                     channel = %channel_name,
-                    "Session deletion did not complete in time: {e}"
+                    "Session deletion completed with error: {e}"
+                );
+                Ok(()) // Session was already removed from the map
+            }
+            Err(_) => {
+                warn!(
+                    channel = %channel_name,
+                    "Session deletion did not complete in time"
                 );
                 Ok(()) // Session was already removed from the map
             }
@@ -107,7 +116,7 @@ impl SessionsList {
     }
 
     /// Delete all sessions (used during shutdown)
-    pub async fn delete_all(&self, app: &App) {
+    pub async fn delete_all(&self, app: &App<AuthProvider, AuthVerifier>) {
         let names: Vec<String> = self.list_channel_names().await;
         for name in names {
             match self.remove_session(&name, app).await {
@@ -120,21 +129,26 @@ impl SessionsList {
 
 /// Spawn a background task that monitors a session for events.
 ///
-/// The task calls `get_session_message` in a loop, dispatching each event
+/// The task reads from the `AppChannelReceiver` in a loop, dispatching each event
 /// to the appropriate handler.
-fn spawn_session_event_monitor(channel_name: String, session: Arc<Session>) -> JoinHandle<()> {
+fn spawn_session_event_monitor(channel_name: String, mut rx: AppChannelReceiver) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            match session.get_session_message(None).await {
-                Ok(_msg) => {
+            match rx.recv().await {
+                Some(Ok(_msg)) => {
                     // Application-level data message received on the channel.
                     // The channel manager does not process data messages.
                     debug!(channel = %channel_name, "Received data message (ignored)");
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     if !handle_session_error(&channel_name, &e) {
                         break;
                     }
+                }
+                None => {
+                    // Channel closed — session was dropped
+                    info!(channel = %channel_name, "Session channel closed");
+                    break;
                 }
             }
         }
@@ -191,23 +205,23 @@ mod tests {
         ));
     }
 
-    // ── Helper: create a dummy Session for testing ─────────────────────
+    // ── Helper: create a dummy SessionContext for testing ────────────────
 
-    /// Build an `Arc<Session>` backed by a dead `Weak` and a real channel.
-    fn dummy_session() -> Arc<Session> {
+    /// Build a `SessionContext` backed by a dead `Weak` and a real channel.
+    fn dummy_session() -> SessionContext {
         let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        Arc::new(Session {
+        SessionContext {
             session: std::sync::Weak::new(),
-            rx: tokio::sync::RwLock::new(rx),
-        })
+            rx,
+        }
     }
 
     #[tokio::test]
     async fn test_try_insert_session_success() {
         let sessions = SessionsList::new();
-        let s = dummy_session();
-        assert!(sessions.try_insert_session("a/b/c".into(), s).await);
-        assert!(sessions.get_session("a/b/c").await.is_some());
+        assert!(sessions.try_insert_session("a/b/c".into(), dummy_session()).await);
+        // get_session returns None because the Weak can't upgrade (no strong ref)
+        assert!(sessions.get_session("a/b/c").await.is_none());
     }
 
     #[tokio::test]
@@ -236,7 +250,6 @@ mod tests {
                 .await
                 .is_ok()
         );
-        assert!(sessions.get_session("a/b/c").await.is_some());
     }
 
     #[tokio::test]

--- a/data-plane/channel-manager/src/sessions.rs
+++ b/data-plane/channel-manager/src/sessions.rs
@@ -38,17 +38,6 @@ impl SessionsList {
     /// Try to insert a session atomically: checks existence and inserts under a single write lock.
     /// Spawns a background event monitor for the session.
     /// Returns `true` if inserted, `false` if the channel already exists.
-    pub async fn try_insert_session(&self, channel_name: String, ctx: SessionContext) -> bool {
-        let mut channels = self.channels.write().await;
-        if channels.contains_key(&channel_name) {
-            return false;
-        }
-        let (session, rx) = ctx.into_parts();
-        let monitor = spawn_session_event_monitor(channel_name.clone(), rx);
-        channels.insert(channel_name, Channel { session, monitor });
-        true
-    }
-
     /// Add a session to the list
     pub async fn add_session(
         &self,
@@ -73,7 +62,11 @@ impl SessionsList {
 
     /// Remove and delete a session by channel name: aborts the monitor,
     /// deletes the SLIM session, and removes it from the map.
-    pub async fn remove_session(&self, channel_name: &str, app: &App<AuthProvider, AuthVerifier>) -> anyhow::Result<()> {
+    pub async fn remove_session(
+        &self,
+        channel_name: &str,
+        app: &App<AuthProvider, AuthVerifier>,
+    ) -> anyhow::Result<()> {
         // Remove from map and release the lock before the potentially slow SLIM call
         let session = {
             let mut channels = self.channels.write().await;
@@ -85,7 +78,9 @@ impl SessionsList {
         };
 
         // Delete the SLIM session with a timeout to avoid hanging
-        let s = session.upgrade().ok_or_else(|| anyhow::anyhow!("session already closed"))?;
+        let s = session
+            .upgrade()
+            .ok_or_else(|| anyhow::anyhow!("session already closed"))?;
         let completion = app
             .delete_session(&s)
             .map_err(|e| anyhow::anyhow!("failed to delete session for {channel_name}: {e}"))?;
@@ -217,31 +212,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_try_insert_session_success() {
-        let sessions = SessionsList::new();
-        assert!(sessions.try_insert_session("a/b/c".into(), dummy_session()).await);
-        // get_session returns None because the Weak can't upgrade (no strong ref)
-        assert!(sessions.get_session("a/b/c").await.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_try_insert_session_duplicate_returns_false() {
-        let sessions = SessionsList::new();
-        assert!(
-            sessions
-                .try_insert_session("a/b/c".into(), dummy_session())
-                .await
-        );
-        assert!(
-            !sessions
-                .try_insert_session("a/b/c".into(), dummy_session())
-                .await
-        );
-        // Only one channel should exist
-        assert_eq!(sessions.list_channel_names().await.len(), 1);
-    }
-
-    #[tokio::test]
     async fn test_add_session_success() {
         let sessions = SessionsList::new();
         assert!(
@@ -250,6 +220,8 @@ mod tests {
                 .await
                 .is_ok()
         );
+        // get_session returns None because the Weak can't upgrade (no strong ref)
+        assert!(sessions.get_session("a/b/c").await.is_none());
     }
 
     #[tokio::test]
@@ -262,20 +234,25 @@ mod tests {
         let err = sessions.add_session("a/b/c".into(), dummy_session()).await;
         assert!(err.is_err());
         assert!(err.unwrap_err().to_string().contains("already exists"));
+        // Only one channel should exist
+        assert_eq!(sessions.list_channel_names().await.len(), 1);
     }
 
     #[tokio::test]
     async fn test_insert_multiple_channels() {
         let sessions = SessionsList::new();
         sessions
-            .try_insert_session("ch/1/a".into(), dummy_session())
-            .await;
+            .add_session("ch/1/a".into(), dummy_session())
+            .await
+            .unwrap();
         sessions
-            .try_insert_session("ch/2/b".into(), dummy_session())
-            .await;
+            .add_session("ch/2/b".into(), dummy_session())
+            .await
+            .unwrap();
         sessions
-            .try_insert_session("ch/3/c".into(), dummy_session())
-            .await;
+            .add_session("ch/3/c".into(), dummy_session())
+            .await
+            .unwrap();
         assert_eq!(sessions.list_channel_names().await.len(), 3);
     }
 

--- a/data-plane/channel-manager/src/sessions.rs
+++ b/data-plane/channel-manager/src/sessions.rs
@@ -35,10 +35,9 @@ impl SessionsList {
         }
     }
 
-    /// Try to insert a session atomically: checks existence and inserts under a single write lock.
+    /// add a session. checks existence and inserts under a single write lock.
     /// Spawns a background event monitor for the session.
-    /// Returns `true` if inserted, `false` if the channel already exists.
-    /// Add a session to the list
+    /// Returns `Ok(())` if inserted, `Err` if the channel already exists.
     pub async fn add_session(
         &self,
         channel_name: String,

--- a/data-plane/channel-manager/tests/integration_test.rs
+++ b/data-plane/channel-manager/tests/integration_test.rs
@@ -110,9 +110,8 @@ async fn create_service_and_connect(slim_port: u16) -> (Arc<Service>, u64) {
         .expect("failed to build service");
     let service = Arc::new(service);
 
-    let client_config =
-        ClientConfig::with_endpoint(&format!("http://127.0.0.1:{slim_port}"))
-            .with_tls_setting(TlsClientConfig::insecure());
+    let client_config = ClientConfig::with_endpoint(&format!("http://127.0.0.1:{slim_port}"))
+        .with_tls_setting(TlsClientConfig::insecure());
 
     let conn_id = service
         .connect(&client_config)
@@ -126,7 +125,10 @@ async fn create_service_and_connect(slim_port: u16) -> (Arc<Service>, u64) {
 async fn create_app_with_shared_secret(
     service: &Service,
     name: &str,
-) -> (App<AuthProvider, AuthVerifier>, tokio::sync::mpsc::Receiver<Result<slim_session::Notification, slim_session::SessionError>>) {
+) -> (
+    App<AuthProvider, AuthVerifier>,
+    tokio::sync::mpsc::Receiver<Result<slim_session::Notification, slim_session::SessionError>>,
+) {
     let app_name = ProtoName::parse_name(name).expect("invalid app name");
 
     let mut provider =

--- a/data-plane/channel-manager/tests/integration_test.rs
+++ b/data-plane/channel-manager/tests/integration_test.rs
@@ -14,12 +14,17 @@ use agntcy_slim_channel_manager::proto::{
 use agntcy_slim_channel_manager::service::ChannelManagerServer;
 use agntcy_slim_channel_manager::sessions::SessionsList;
 
-use slim_bindings::{
-    IdentityProviderConfig, IdentityVerifierConfig, Name, get_global_service,
-    initialize_with_defaults, new_insecure_client_config,
-};
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::traits::{TokenProvider, Verifier};
+use slim_config::client::ClientConfig;
+use slim_config::component::ComponentBuilder;
 use slim_config::grpc::server::ServerConfig;
+use slim_config::tls::client::TlsClientConfig;
 use slim_config::tls::server::TlsServerConfig;
+use slim_datapath::api::ProtoName;
+use slim_service::app::App;
+use slim_service::{Service, ServiceBuilder};
+use slim_session::Direction;
 
 const SHARED_SECRET: &str = "integration-test-shared-secret-0123456789-abcdef";
 
@@ -95,39 +100,59 @@ services:
         .expect("failed to spawn slim runtime thread")
 }
 
+/// Create a SLIM service and connect it to the running node.
+/// Returns the service and the connection ID.
+async fn create_service_and_connect(slim_port: u16) -> (Arc<Service>, u64) {
+    slim_config::tls::provider::initialize_crypto_provider();
+
+    let service = ServiceBuilder::new()
+        .build("test-service".to_string())
+        .expect("failed to build service");
+    let service = Arc::new(service);
+
+    let client_config =
+        ClientConfig::with_endpoint(&format!("http://127.0.0.1:{slim_port}"))
+            .with_tls_setting(TlsClientConfig::insecure());
+
+    let conn_id = service
+        .connect(&client_config)
+        .await
+        .expect("failed to connect to SLIM node");
+
+    (service, conn_id)
+}
+
+/// Create an app with shared secret authentication.
+async fn create_app_with_shared_secret(
+    service: &Service,
+    name: &str,
+) -> (App<AuthProvider, AuthVerifier>, tokio::sync::mpsc::Receiver<Result<slim_session::Notification, slim_session::SessionError>>) {
+    let app_name = ProtoName::parse_name(name).expect("invalid app name");
+
+    let mut provider =
+        AuthProvider::shared_secret_from_str(name, SHARED_SECRET).expect("provider creation");
+    let mut verifier =
+        AuthVerifier::shared_secret_from_str(name, SHARED_SECRET).expect("verifier creation");
+
+    provider.initialize().await.expect("provider init");
+    verifier.initialize().await.expect("verifier init");
+
+    service
+        .create_app_with_direction(&app_name, provider, verifier, Direction::None)
+        .expect("failed to create app")
+}
+
 /// Start the channel-manager gRPC server in-process.
-/// Uses an already-established connection to the SLIM node.
 async fn start_channel_manager(
+    service: &Arc<Service>,
     conn_id: u64,
     cm_port: u16,
-) -> (Arc<slim_bindings::App>, Arc<SessionsList>) {
-    let service = get_global_service();
-
-    // Create the SLIM app with shared secret auth
-    let app_name = Arc::new(
-        Name::from_string("org/ns/channel-manager".to_string())
-            .expect("invalid channel-manager name"),
-    );
-    let provider = IdentityProviderConfig::SharedSecret {
-        id: "org/ns/channel-manager".to_string(),
-        data: SHARED_SECRET.to_string(),
-    };
-    let verifier = IdentityVerifierConfig::SharedSecret {
-        id: "org/ns/channel-manager".to_string(),
-        data: SHARED_SECRET.to_string(),
-    };
-    let app = service
-        .create_app_with_direction_async(
-            app_name.clone(),
-            provider,
-            verifier,
-            slim_bindings::Direction::None,
-        )
-        .await
-        .expect("failed to create SLIM app");
+) -> (Arc<App<AuthProvider, AuthVerifier>>, Arc<SessionsList>) {
+    let (app, _rx) = create_app_with_shared_secret(service, "org/ns/channel-manager").await;
+    let app = Arc::new(app);
 
     // Subscribe to the local name
-    app.subscribe_async(app.name(), Some(conn_id))
+    app.subscribe(app.app_name(), Some(conn_id))
         .await
         .expect("failed to subscribe");
 
@@ -152,18 +177,16 @@ async fn start_channel_manager(
 }
 
 /// Start a receiver app in-process (simulates a channel participant).
-/// Uses an already-established connection to the SLIM node.
-async fn start_receiver(local_name: &str, conn_id: u64) -> Arc<slim_bindings::App> {
-    let service = get_global_service();
-
-    let name = Arc::new(Name::from_string(local_name.to_string()).expect("invalid receiver name"));
-    let app = service
-        .create_app_with_secret_async(name.clone(), SHARED_SECRET.to_string())
-        .await
-        .expect("failed to create receiver app");
+async fn start_receiver(
+    service: &Arc<Service>,
+    local_name: &str,
+    conn_id: u64,
+) -> App<AuthProvider, AuthVerifier> {
+    let (app, _rx) = create_app_with_shared_secret(service, local_name).await;
+    let app_name = app.app_name().clone();
 
     // Subscribe to local name
-    app.subscribe_async(name, Some(conn_id))
+    app.subscribe(&app_name, Some(conn_id))
         .await
         .expect("failed to subscribe receiver");
 
@@ -187,17 +210,11 @@ async fn test_channel_manager_via_cmctl() {
 
     wait_for_port("127.0.0.1", slim_port, Duration::from_secs(60), "SLIM node").await;
 
-    // Initialize SLIM bindings and connect to the SLIM node once (shared by all apps).
-    initialize_with_defaults();
-    let service = get_global_service();
-    let client_config = new_insecure_client_config(format!("http://127.0.0.1:{slim_port}"));
-    let conn_id = service
-        .connect_async(client_config)
-        .await
-        .expect("failed to connect to SLIM node");
+    // Create a service and connect to the SLIM node.
+    let (service, conn_id) = create_service_and_connect(slim_port).await;
 
     // Start channel-manager in-process.
-    let (_cm_app, _cm_sessions) = start_channel_manager(conn_id, cm_port).await;
+    let (_cm_app, _cm_sessions) = start_channel_manager(&service, conn_id, cm_port).await;
 
     wait_for_port(
         "127.0.0.1",
@@ -230,8 +247,8 @@ async fn test_channel_manager_via_cmctl() {
     assert!(resp.success, "create-channel failed: {:?}", resp.error_msg);
 
     // Start 2 receiver apps that act as channel participants.
-    let _receiver_1 = start_receiver("org/ns/p1", conn_id).await;
-    let _receiver_2 = start_receiver("org/ns/p2", conn_id).await;
+    let _receiver_1 = start_receiver(&service, "org/ns/p1", conn_id).await;
+    let _receiver_2 = start_receiver(&service, "org/ns/p2", conn_id).await;
 
     // Give receivers time to register
     tokio::time::sleep(Duration::from_secs(10)).await;

--- a/data-plane/core/config/src/auth.rs
+++ b/data-plane/core/config/src/auth.rs
@@ -33,6 +33,12 @@ pub enum ConfigAuthError {
     // Verifier errors
     #[error("audience required")]
     AuthJwtAudienceRequired,
+
+    // Identity config errors
+    #[error("no identity provider configured")]
+    IdentityProviderNotConfigured,
+    #[error("no identity verifier configured")]
+    IdentityVerifierNotConfigured,
 }
 
 pub trait ClientAuthenticator {

--- a/data-plane/core/config/src/auth/identity.rs
+++ b/data-plane/core/config/src/auth/identity.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::Deserialize;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
 
 use crate::auth::jwt::Config as JwtConfig;
 #[cfg(not(target_family = "windows"))]
 use crate::auth::spire::SpireConfig;
 use crate::auth::static_jwt::Config as StaticJwtConfig;
+use crate::auth::ConfigAuthError;
 
 #[derive(Default, Debug, Clone, Deserialize, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
@@ -35,4 +37,50 @@ pub enum IdentityVerifierConfig {
     Spire(SpireConfig),
     #[default]
     None,
+}
+
+impl IdentityProviderConfig {
+    /// Build an [`AuthProvider`] from this configuration.
+    pub fn build_auth_provider(&self) -> Result<AuthProvider, ConfigAuthError> {
+        match self {
+            Self::SharedSecret { id, data } => {
+                Ok(AuthProvider::shared_secret_from_str(id, data)?)
+            }
+            Self::StaticJwt(jwt_config) => {
+                let provider = jwt_config.build_static_token_provider()?;
+                Ok(AuthProvider::static_token(provider))
+            }
+            Self::Jwt(jwt_config) => {
+                let provider = jwt_config.get_provider()?;
+                Ok(AuthProvider::jwt_signer(provider))
+            }
+            #[cfg(not(target_family = "windows"))]
+            Self::Spire(spire_config) => {
+                let manager = spire_config.create_provider()?;
+                Ok(AuthProvider::spire(manager))
+            }
+            Self::None => Err(ConfigAuthError::IdentityProviderNotConfigured),
+        }
+    }
+}
+
+impl IdentityVerifierConfig {
+    /// Build an [`AuthVerifier`] from this configuration.
+    pub fn build_auth_verifier(&self) -> Result<AuthVerifier, ConfigAuthError> {
+        match self {
+            Self::SharedSecret { id, data } => {
+                Ok(AuthVerifier::shared_secret_from_str(id, data)?)
+            }
+            Self::Jwt(jwt_config) => {
+                let verifier = jwt_config.get_verifier()?;
+                Ok(AuthVerifier::jwt_verifier(verifier))
+            }
+            #[cfg(not(target_family = "windows"))]
+            Self::Spire(spire_config) => {
+                let manager = spire_config.create_verifier()?;
+                Ok(AuthVerifier::spire(manager))
+            }
+            Self::None => Err(ConfigAuthError::IdentityVerifierNotConfigured),
+        }
+    }
 }

--- a/data-plane/core/config/src/auth/identity.rs
+++ b/data-plane/core/config/src/auth/identity.rs
@@ -4,11 +4,11 @@
 use serde::Deserialize;
 use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
 
+use crate::auth::ConfigAuthError;
 use crate::auth::jwt::Config as JwtConfig;
 #[cfg(not(target_family = "windows"))]
 use crate::auth::spire::SpireConfig;
 use crate::auth::static_jwt::Config as StaticJwtConfig;
-use crate::auth::ConfigAuthError;
 
 #[derive(Default, Debug, Clone, Deserialize, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
@@ -43,9 +43,7 @@ impl IdentityProviderConfig {
     /// Build an [`AuthProvider`] from this configuration.
     pub fn build_auth_provider(&self) -> Result<AuthProvider, ConfigAuthError> {
         match self {
-            Self::SharedSecret { id, data } => {
-                Ok(AuthProvider::shared_secret_from_str(id, data)?)
-            }
+            Self::SharedSecret { id, data } => Ok(AuthProvider::shared_secret_from_str(id, data)?),
             Self::StaticJwt(jwt_config) => {
                 let provider = jwt_config.build_static_token_provider()?;
                 Ok(AuthProvider::static_token(provider))
@@ -68,9 +66,7 @@ impl IdentityVerifierConfig {
     /// Build an [`AuthVerifier`] from this configuration.
     pub fn build_auth_verifier(&self) -> Result<AuthVerifier, ConfigAuthError> {
         match self {
-            Self::SharedSecret { id, data } => {
-                Ok(AuthVerifier::shared_secret_from_str(id, data)?)
-            }
+            Self::SharedSecret { id, data } => Ok(AuthVerifier::shared_secret_from_str(id, data)?),
             Self::Jwt(jwt_config) => {
                 let verifier = jwt_config.get_verifier()?;
                 Ok(AuthVerifier::jwt_verifier(verifier))

--- a/data-plane/core/config/src/auth/spire.rs
+++ b/data-plane/core/config/src/auth/spire.rs
@@ -124,7 +124,7 @@ impl SpireConfig {
 
     /// Create a spire verifier (identity manager used only for verification).
     /// The target SPIFFE ID (if configured) is intentionally not set.
-    fn create_verifier(&self) -> Result<SpireIdentityManager, ConfigAuthError> {
+    pub fn create_verifier(&self) -> Result<SpireIdentityManager, ConfigAuthError> {
         self.build_identity_manager()
     }
 }

--- a/data-plane/core/config/src/auth/spire.rs
+++ b/data-plane/core/config/src/auth/spire.rs
@@ -118,13 +118,13 @@ impl SpireConfig {
 
     /// Create a spire provider from this configuration using the builder.
     /// Returns an initialized SpireIdentityManager that will rotate X.509 & JWT SVIDs.
-    pub fn create_provider(&self) -> Result<SpireIdentityManager, ConfigAuthError> {
+    pub(crate) fn create_provider(&self) -> Result<SpireIdentityManager, ConfigAuthError> {
         self.build_identity_manager()
     }
 
     /// Create a spire verifier (identity manager used only for verification).
     /// The target SPIFFE ID (if configured) is intentionally not set.
-    pub fn create_verifier(&self) -> Result<SpireIdentityManager, ConfigAuthError> {
+    pub(crate) fn create_verifier(&self) -> Result<SpireIdentityManager, ConfigAuthError> {
         self.build_identity_manager()
     }
 }

--- a/data-plane/core/datapath/src/api.rs
+++ b/data-plane/core/datapath/src/api.rs
@@ -212,6 +212,19 @@ impl ProtoName {
         let s = self.str_name.as_ref().unwrap();
         (&s.str_component_0, &s.str_component_1, &s.str_component_2)
     }
+
+    /// Parse a name string in "org/namespace/app" format into a `ProtoName`.
+    pub fn parse_name(s: &str) -> Result<ProtoName, DataPathError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(DataPathError::InvalidNameFormat(s.to_string()));
+        }
+        let parts: Vec<&str> = trimmed.split('/').map(str::trim).collect();
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+            return Err(DataPathError::InvalidNameFormat(s.to_string()));
+        }
+        Ok(ProtoName::from_strings([parts[0], parts[1], parts[2]]))
+    }
 }
 
 impl std::fmt::Display for ProtoName {

--- a/data-plane/core/datapath/src/api.rs
+++ b/data-plane/core/datapath/src/api.rs
@@ -415,4 +415,46 @@ mod tests {
         assert_eq!(enc.id(), NameId::NULL_COMPONENT);
         assert_eq!(enc.string_id(), "NULL_COMPONENT");
     }
+
+    #[test]
+    fn test_parse_name_valid() {
+        let n = ProtoName::parse_name("org/ns/app").unwrap();
+        let (a, b, c) = n.str_components();
+        assert_eq!(a, "org");
+        assert_eq!(b, "ns");
+        assert_eq!(c, "app");
+    }
+
+    #[test]
+    fn test_parse_name_trims_whitespace() {
+        let n = ProtoName::parse_name(" org / ns / app ").unwrap();
+        let (a, b, c) = n.str_components();
+        assert_eq!(a, "org");
+        assert_eq!(b, "ns");
+        assert_eq!(c, "app");
+    }
+
+    #[test]
+    fn test_parse_name_empty_string() {
+        assert!(ProtoName::parse_name("").is_err());
+        assert!(ProtoName::parse_name("   ").is_err());
+    }
+
+    #[test]
+    fn test_parse_name_too_few_parts() {
+        assert!(ProtoName::parse_name("org/ns").is_err());
+        assert!(ProtoName::parse_name("org").is_err());
+    }
+
+    #[test]
+    fn test_parse_name_too_many_parts() {
+        assert!(ProtoName::parse_name("a/b/c/d").is_err());
+    }
+
+    #[test]
+    fn test_parse_name_empty_component() {
+        assert!(ProtoName::parse_name("org//app").is_err());
+        assert!(ProtoName::parse_name("/ns/app").is_err());
+        assert!(ProtoName::parse_name("org/ns/").is_err());
+    }
 }

--- a/data-plane/core/datapath/src/errors.rs
+++ b/data-plane/core/datapath/src/errors.rs
@@ -30,6 +30,8 @@ pub enum DataPathError {
     InvalidMessage(MessageError),
     #[error("invalid name id format: {0}")]
     InvalidNameIdFormat(String),
+    #[error("invalid name format: {0}")]
+    InvalidNameFormat(String),
 
     // Subscription / matching
     #[error("no matching found for [{:x}, {:x}, {:x}, {}]", .0, .1, .2, .3)]


### PR DESCRIPTION
# Description

Removes the slim-bindings dependency from the channel-manager crate, replacing it with direct dependencies on the lower-level SLIM crates (slim-auth, slim-service, slim-datapath, slim-session). This reduces coupling and gives the channel-manager explicit control over session lifecycle.

## Key changes

channel-manager binary (channel_manager.rs):
   - Use ServiceBuilder / Service directly instead of initialize_with_defaults / get_global_service
   - Build AuthProvider / AuthVerifier from config and initialize explicitly
   - Use ProtoName::parse_name() instead of Name::from_string()
   - Use two-step session creation (create_session + completion.await)
 
gRPC service (service.rs):
   - Remove ServiceError enum — use SessionError directly
   - Add await_session_op helper to deduplicate the invite/remove completion pattern
   - Inline session creation logic in handle_create_channel

Session management (sessions.rs):
   - Consolidate try_insert_session and add_session into a single add_session method returning Result
   - Store Weak<SessionController> instead of Arc<Session>
   - Accept SessionContext and split into parts (weak ref + event receiver)
   - Monitor sessions via AppChannelReceiver instead of polling get_session_message

Config crate (slim-config):
   - Add IdentityProviderConfig::build_auth_provider() and IdentityVerifierConfig::build_auth_verifier() builder methods
   - Add ProtoName::parse_name() for parsing "org/ns/app" format strings with validation
   - Narrow create_provider / create_verifier visibility to pub(crate)

ref: #1698

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
