### PR TITLE
fix(build): skip proto compilation in published packages

### DIFF
--- a/data-plane/channel-manager/build.rs
+++ b/data-plane/channel-manager/build.rs
@@ -22,6 +22,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let include_dir = std::path::Path::new(&manifest_dir).join("proto/v1");
     tonic_prost_build::configure()
         .out_dir("src/gen")
-        .compile_protos(&[proto_file.to_str().unwrap()], &[include_dir.to_str().unwrap()])?;
+        .compile_protos(
+            &[proto_file.to_str().unwrap()],
+            &[include_dir.to_str().unwrap()],
+        )?;
     Ok(())
 }

--- a/data-plane/channel-manager/build.rs
+++ b/data-plane/channel-manager/build.rs
@@ -8,8 +8,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::set_var("PROTOC", protoc_path);
     }
 
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let proto_file = std::path::Path::new(&manifest_dir).join("proto/v1/commands.proto");
+    let repo_proto_dir = std::path::Path::new(&manifest_dir).join("../../proto");
+
+    if !proto_file.exists() || !repo_proto_dir.exists() {
+        // Published package: rely on the pre-generated src/gen/ file.
+        return Ok(());
+    }
+
+    println!("cargo:rerun-if-changed={}", proto_file.display());
+
+    let include_dir = std::path::Path::new(&manifest_dir).join("proto/v1");
     tonic_prost_build::configure()
         .out_dir("src/gen")
-        .compile_protos(&["proto/v1/commands.proto"], &["proto/v1"])?;
+        .compile_protos(&[proto_file.to_str().unwrap()], &[include_dir.to_str().unwrap()])?;
     Ok(())
 }

--- a/data-plane/control-plane/build.rs
+++ b/data-plane/control-plane/build.rs
@@ -18,7 +18,7 @@ fn main() {
     let controlplane_proto = base.join("proto/controlplane/v1/controlplane.proto");
     let datapath_proto_dir = base.join("../../proto");
 
-    if controller_proto.exists() && controlplane_proto.exists() {
+    if controller_proto.exists() && controlplane_proto.exists() && datapath_proto_dir.exists() {
         println!("cargo:rerun-if-changed={}", controller_proto.display());
         println!("cargo:rerun-if-changed={}", controlplane_proto.display());
 

--- a/data-plane/core/controller/build.rs
+++ b/data-plane/core/controller/build.rs
@@ -23,8 +23,9 @@ fn main() {
     // used as-is and this build script skips proto compilation.
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let proto_file = std::path::Path::new(&manifest_dir).join("proto/v1/controller.proto");
+    let repo_proto_dir = std::path::Path::new(&manifest_dir).join("../../../proto");
 
-    if !proto_file.exists() {
+    if !proto_file.exists() || !repo_proto_dir.exists() {
         // Published package: rely on the pre-generated src/api/gen/ file.
         return;
     }

--- a/data-plane/core/datapath/build.rs
+++ b/data-plane/core/datapath/build.rs
@@ -11,8 +11,20 @@ fn main() {
         std::env::set_var("PROTOC", protoc_path);
     }
 
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let proto_file = std::path::Path::new(&manifest_dir).join("proto/v1/data_plane.proto");
+    let repo_proto_dir = std::path::Path::new(&manifest_dir).join("../../../proto");
+
+    if !proto_file.exists() || !repo_proto_dir.exists() {
+        // Published package: rely on the pre-generated src/api/gen/ file.
+        return;
+    }
+
+    println!("cargo:rerun-if-changed={}", proto_file.display());
+
+    let include_dir = std::path::Path::new(&manifest_dir).join("proto/v1");
     tonic_prost_build::configure()
         .out_dir("src/api/gen")
-        .compile_protos(&["proto/v1/data_plane.proto"], &["proto/v1"])
+        .compile_protos(&[proto_file.to_str().unwrap()], &[include_dir.to_str().unwrap()])
         .unwrap();
 }

--- a/data-plane/core/datapath/build.rs
+++ b/data-plane/core/datapath/build.rs
@@ -25,6 +25,9 @@ fn main() {
     let include_dir = std::path::Path::new(&manifest_dir).join("proto/v1");
     tonic_prost_build::configure()
         .out_dir("src/api/gen")
-        .compile_protos(&[proto_file.to_str().unwrap()], &[include_dir.to_str().unwrap()])
+        .compile_protos(
+            &[proto_file.to_str().unwrap()],
+            &[include_dir.to_str().unwrap()],
+        )
         .unwrap();
 }

--- a/data-plane/slimctl/build.rs
+++ b/data-plane/slimctl/build.rs
@@ -18,11 +18,23 @@ fn main() {
     let controller_proto = proto_dir.join("controller/v1/controller.proto");
     let channel_manager_proto = proto_dir.join("channel_manager/v1/commands.proto");
 
+    let datapath_proto_dir = std::path::Path::new(&manifest_dir).join("../../proto");
+
+    // When building from a published package the symlinked proto files are
+    // resolved but the repo-level proto directory (needed for the
+    // data-plane/v1/data_plane.proto import) is absent.  Skip compilation
+    // and rely on pre-generated code in that case.
+    if !controlplane_proto.exists()
+        || !controller_proto.exists()
+        || !channel_manager_proto.exists()
+        || !datapath_proto_dir.exists()
+    {
+        return;
+    }
+
     println!("cargo:rerun-if-changed={}", controlplane_proto.display());
     println!("cargo:rerun-if-changed={}", controller_proto.display());
     println!("cargo:rerun-if-changed={}", channel_manager_proto.display());
-
-    let datapath_proto_dir = std::path::Path::new(&manifest_dir).join("../../proto");
 
     tonic_prost_build::configure()
         .extern_path(


### PR DESCRIPTION
# Description

When `cargo package` creates a tarball, symlinked proto files are
resolved into regular files. This caused build.rs scripts to attempt
proto compilation even in published packages, where the repo-level
proto/ directory (needed for cross-crate imports like
data-plane/v1/data_plane.proto) is absent.

Add existence checks for the repo proto directory in all affected
build.rs files so they fall back to pre-generated code when built
outside the workspace.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
