### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-tracing",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -47,10 +47,10 @@ agntcy-slim-auth = { path = "core/auth", version = "0.9.0" }
 agntcy-slim-bindings = { path = "bindings/rust", version = "2.0.0-alpha.0" }
 agntcy-slim-config = { path = "core/config", version = "0.10.0" }
 agntcy-slim-controller = { path = "core/controller", version = "0.7.0" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.14.0" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.19" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.14.1" }
+agntcy-slim-mls = { path = "core/mls", version = "0.1.20" }
 agntcy-slim-service = { path = "core/service", version = "0.9.0", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.2.0" }
+agntcy-slim-session = { path = "core/session", version = "0.2.1" }
 agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
 agntcy-slim-testing = { path = "testing" }
 agntcy-slim-tracing = { path = "core/tracing", version = "0.3.13" }

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.14.0...slim-datapath-v0.14.1) - 2026-06-03
+
+### Fixed
+
+- *(build)* skip proto compilation in published packages ([#1706](https://github.com/agntcy/slim/pull/1706))
+
 ## [0.14.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.13.2...slim-datapath-v0.14.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.14.0"
+version = "0.14.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/agntcy/slim/compare/slim-mls-v0.1.19...slim-mls-v0.1.20) - 2026-06-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-datapath
+
 ## [0.1.19](https://github.com/agntcy/slim/compare/slim-mls-v0.1.18...slim-mls-v0.1.19) - 2026-06-03
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.19"
+version = "0.1.20"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/agntcy/slim/compare/slim-session-v0.2.0...slim-session-v0.2.1) - 2026-06-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.2.0](https://github.com/agntcy/slim/compare/slim-session-v0.1.15...slim-session-v0.2.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.2.1"
 description = "SLIM session internal implementation."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-datapath`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.6.2 -> 0.7.0
* `agntcy-slim-service`: 0.8.15 -> 0.9.0
* `agntcy-slim`: 1.4.0 -> 2.0.0-alpha.0
* `agntcy-slim-bindings`: 1.4.0 -> 2.0.0-alpha.0
* `agntcy-slimctl`: 1.4.0 -> 2.0.0-alpha.0
* `agntcy-protoc-slimrpc-plugin`: 1.4.0 -> 1.4.1
* `agntcy-slim-mls`: 0.1.19 -> 0.1.20
* `agntcy-slim-session`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-datapath`

<blockquote>

## [0.14.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.14.0...slim-datapath-v0.14.1) - 2026-06-03

### Fixed

- *(build)* skip proto compilation in published packages ([#1706](https://github.com/agntcy/slim/pull/1706))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.7.0](https://github.com/agntcy/slim/compare/slim-controller-v0.6.2...slim-controller-v0.7.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))

### Other

- *(datapath)* replace is_local bool with ConnType enum ([#1689](https://github.com/agntcy/slim/pull/1689))
- remove unused code from controller service ([#1682](https://github.com/agntcy/slim/pull/1682))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.9.0](https://github.com/agntcy/slim/compare/slim-service-v0.8.15...slim-service-v0.9.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- split data and control channel ([#1418](https://github.com/agntcy/slim/pull/1418))

### Fixed

- *(datapath)* update doctests to match current API ([#1686](https://github.com/agntcy/slim/pull/1686))

### Other

- *(session)* drop AppTransmitter, Transmitter trait, and MockTransmitter ([#1679](https://github.com/agntcy/slim/pull/1679))
- *(session)* replace interceptor layer with direct identity handling ([#1676](https://github.com/agntcy/slim/pull/1676))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-v1.4.0...slim-v2.0.0-alpha.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))

### Fixed

- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-bindings-v1.4.0...slim-bindings-v2.0.0-alpha.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(data-plane)* add node-to-node header integrity check ([#1609](https://github.com/agntcy/slim/pull/1609))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))

### Fixed

- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))

### Other

- publish alpha release 2.0.0-alpha.0 ([#1704](https://github.com/agntcy/slim/pull/1704))
- drop transport field from the config ([#1662](https://github.com/agntcy/slim/pull/1662))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slimctl-v1.4.0...slimctl-v2.0.0-alpha.0) - 2026-06-03

### Added

- increase Name ID from u64 to u128 ([#1680](https://github.com/agntcy/slim/pull/1680))
- *(slimctl)* add bench sub/pub and channel sub/pub commands ([#1602](https://github.com/agntcy/slim/pull/1602))
- *(websocket)* add WebSocket transport for data-plane ([#1638](https://github.com/agntcy/slim/pull/1638))
- *(dataplane)* remove group creation ([#1594](https://github.com/agntcy/slim/pull/1594))
- *(slimctl)* use channel manager to create groups ([#1589](https://github.com/agntcy/slim/pull/1589))
- *(slimctl)* add commands for channel manager ([#1586](https://github.com/agntcy/slim/pull/1586))

### Fixed

- *(bindings)* deadlock when using single thread runtime ([#1657](https://github.com/agntcy/slim/pull/1657))

### Other

- publish alpha release 2.0.0-alpha.0 ([#1704](https://github.com/agntcy/slim/pull/1704))
- remove agntcy-slim-bindings dependency from slimctl ([#1700](https://github.com/agntcy/slim/pull/1700))
- control plane in rust ([#1581](https://github.com/agntcy/slim/pull/1581))
- *(data-plane)* replace encoder::Name with ProtoName throughout ([#1596](https://github.com/agntcy/slim/pull/1596))
</blockquote>

## `agntcy-protoc-slimrpc-plugin`

<blockquote>

## [1.4.1](https://github.com/agntcy/slim/compare/protoc-slimrpc-plugin-v1.4.0...protoc-slimrpc-plugin-v1.4.1) - 2026-06-03

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.1.20](https://github.com/agntcy/slim/compare/slim-mls-v0.1.19...slim-mls-v0.1.20) - 2026-06-03

### Other

- updated the following local packages: agntcy-slim-datapath
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.2.1](https://github.com/agntcy/slim/compare/slim-session-v0.2.0...slim-session-v0.2.1) - 2026-06-03

### Other

- updated the following local packages: agntcy-slim-datapath, agntcy-slim-mls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).