### PR TITLE
fix: upgrade diesel to 2.3.10

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.9"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "diesel_derives",
  "downcast-rs",


### PR DESCRIPTION
# Description

Upgrades `diesel` from 2.3.9 to 2.3.10 to fix RUSTSEC-2026-0172 — a possible use-after-free when deserialising a SQLite database via `SqliteConnection::deserialize_readonly_database`.

Only `Cargo.lock` is affected; the existing semver constraint in `Cargo.toml` already allows 2.3.10.

Reference: https://rustsec.org/advisories/RUSTSEC-2026-0172

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass