### PR TITLE
fix(controller): make sure controller stop retrying connection when signaled

### DIFF
--- a/data-plane/core/controller/src/errors.rs
+++ b/data-plane/core/controller/src/errors.rs
@@ -19,6 +19,8 @@ pub enum ControllerError {
     AlreadyStopped,
     #[error("timeout waiting for shutdown to complete")]
     ShutdownTimeout,
+    #[error("connection canceled")]
+    Canceled,
     #[error("grpc error")]
     GrpcError(#[from] Status),
 

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -1872,11 +1872,11 @@ impl ControllerService {
             result = connect_fut => { result? }
             _ = cancellation_token.cancelled() => {
                 debug!("connection cancelled during setup");
-                return Err(ControllerError::AlreadyStopped);
+                return Err(ControllerError::Canceled);
             }
             _ = watch.signaled() => {
                 debug!("drain signal received during connection setup");
-                return Err(ControllerError::AlreadyStopped);
+                return Err(ControllerError::Canceled);
             }
         };
 

--- a/data-plane/core/controller/src/service.rs
+++ b/data-plane/core/controller/src/service.rs
@@ -1840,27 +1840,45 @@ impl ControllerService {
         self.inner.route_subscription_ids.lock().clear();
         self.inner.link_id_to_conn_id.write().clear();
 
-        let channel = match config.to_channel().await? {
-            TransportChannel::Grpc(c) => c,
-            TransportChannel::Websocket(_) => {
-                return Err(ControllerError::ConfigError(
-                    slim_config::errors::ConfigError::GrpcChannelUnsupportedTransport,
-                ));
-            }
+        // Obtain drain watch to handle graceful shutdown during connection
+        let watch = self.drain_watch()?;
+
+        let connect_fut = async {
+            let channel = match config.to_channel().await? {
+                TransportChannel::Grpc(c) => c,
+                TransportChannel::Websocket(_) => {
+                    return Err(ControllerError::ConfigError(
+                        slim_config::errors::ConfigError::GrpcChannelUnsupportedTransport,
+                    ));
+                }
+            };
+
+            let mut client = ControllerServiceClient::new(channel.clone());
+            let (tx, rx) = mpsc::channel::<Result<ControlMessage, Status>>(128);
+            let out_stream = ReceiverStream::new(rx).filter_map(|res| match res {
+                Ok(msg) => Some(msg),
+                Err(e) => {
+                    error!(error = %e, "dropping outbound control message due to error");
+                    None
+                }
+            });
+            let stream = client
+                .open_control_channel(Request::new(out_stream))
+                .await?;
+            Ok((tx, stream))
         };
 
-        let mut client = ControllerServiceClient::new(channel.clone());
-        let (tx, rx) = mpsc::channel::<Result<ControlMessage, Status>>(128);
-        let out_stream = ReceiverStream::new(rx).filter_map(|res| match res {
-            Ok(msg) => Some(msg),
-            Err(e) => {
-                error!(error = %e, "dropping outbound control message due to error");
-                None
+        let (tx, stream) = tokio::select! {
+            result = connect_fut => { result? }
+            _ = cancellation_token.cancelled() => {
+                debug!("connection cancelled during setup");
+                return Err(ControllerError::AlreadyStopped);
             }
-        });
-        let stream = client
-            .open_control_channel(Request::new(out_stream))
-            .await?;
+            _ = watch.signaled() => {
+                debug!("drain signal received during connection setup");
+                return Err(ControllerError::AlreadyStopped);
+            }
+        };
 
         // start processing the incoming stream
         let endpoint_key = config.endpoint.clone();


### PR DESCRIPTION
# Description

Currently the controller keep retrying the connection even when a drain signal is received.

This PR fixes it.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
