### PR TITLE
fix: disable all-features by default for builds

### DIFF
--- a/tasks/rust.yaml
+++ b/tasks/rust.yaml
@@ -216,7 +216,7 @@ tasks:
     cmds:
       - cargo build {{.RELEASE}} {{.TARGET_ARGS}} {{.ARGS}}
     vars:
-      ARGS: '{{.ARGS | default "--all-targets --locked --all-features"}}'
+      ARGS: '{{.ARGS | default "--all-targets --locked"}}'
 
   vuln:
     desc: "Check for vulnerabilities"


### PR DESCRIPTION
# Description

This keeps the setting for testing etc. This prevents things like otel_tracing getting enabled automatically when they are not part of that standard build and they impact performance.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
