### PR TITLE
refactor(tests): use common reserve_local_port helper across all test crates

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "agntcy-slim-service",
  "agntcy-slim-session",
  "agntcy-slim-signal",
+ "agntcy-slim-testing",
  "agntcy-slim-tracing",
  "anyhow",
  "clap",
@@ -279,6 +280,7 @@ name = "agntcy-slim-datapath"
 version = "0.14.1"
 dependencies = [
  "agntcy-slim-config",
+ "agntcy-slim-testing",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
  "anyhow",

--- a/data-plane/channel-manager/Cargo.toml
+++ b/data-plane/channel-manager/Cargo.toml
@@ -40,6 +40,7 @@ tonic-prost-build = { workspace = true }
 agntcy-slim = { workspace = true }
 agntcy-slim-config = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
+agntcy-slim-testing = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }

--- a/data-plane/channel-manager/tests/integration_test.rs
+++ b/data-plane/channel-manager/tests/integration_test.rs
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -25,20 +25,11 @@ use slim_datapath::api::ProtoName;
 use slim_service::app::App;
 use slim_service::{Service, ServiceBuilder};
 use slim_session::Direction;
+use slim_testing::common::reserve_local_port;
 
 const SHARED_SECRET: &str = "integration-test-shared-secret-0123456789-abcdef";
 
 // --- Helpers ---
-
-fn reserve_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind local test port");
-    let port = listener
-        .local_addr()
-        .expect("failed to read local address")
-        .port();
-    drop(listener);
-    port
-}
 
 async fn wait_for_port(host: &str, port: u16, timeout: Duration, label: &str) {
     let deadline = tokio::time::Instant::now() + timeout;
@@ -204,8 +195,8 @@ async fn create_cm_client(cm_port: u16) -> ChannelManagerServiceClient<tonic::tr
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_channel_manager_via_cmctl() {
-    let slim_port = reserve_port();
-    let cm_port = reserve_port();
+    let slim_port = reserve_local_port();
+    let cm_port = reserve_local_port();
 
     // Start a SLIM node in-process (separate thread with its own runtime).
     let _slim_handle = start_slim_node(slim_port);

--- a/data-plane/control-plane/tests/integration_test.rs
+++ b/data-plane/control-plane/tests/integration_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use rlimit::increase_nofile_limit;
-use std::net::TcpListener;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -24,6 +23,7 @@ use slim_control_plane::config::{Config, DatabaseConfig, ReconcilerConfig};
 use slim_control_plane::server::ControlPlane;
 use slim_datapath::api::ProtoName as Name;
 use slim_service::{Service, ServiceConfiguration};
+use slim_testing::common::reserve_local_port;
 use slim_testing::utils::TEST_VALID_SECRET;
 use tokio_stream::StreamExt;
 use tracing_subscriber::EnvFilter;
@@ -39,10 +39,7 @@ fn raise_fd_limit() {
 
 fn reserve_port() -> u16 {
     raise_fd_limit();
-    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test port");
-    let port = listener.local_addr().expect("failed to read port").port();
-    drop(listener);
-    port
+    reserve_local_port()
 }
 
 fn test_reconciler_config() -> ReconcilerConfig {

--- a/data-plane/core/auth/tests/spiffe_integration_test.rs
+++ b/data-plane/core/auth/tests/spiffe_integration_test.rs
@@ -501,9 +501,7 @@ async fn test_spiffe_grpc_jwt_auth() {
     let spire_cfg = env.get_spiffe_config();
 
     // Reserve an available TCP port for the test gRPC server
-    let tcp_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind failed");
-    let port = tcp_listener.local_addr().expect("local addr").port();
-    drop(tcp_listener);
+    let port = slim_testing::common::reserve_local_port();
 
     let mut server_task: Option<tokio::task::JoinHandle<()>> = None;
     let mut should_panic = false;

--- a/data-plane/core/config/tests/e2e.rs
+++ b/data-plane/core/config/tests/e2e.rs
@@ -98,6 +98,7 @@ mod tests {
     use slim_config::testutils::helloworld::greeter_client::GreeterClient;
     use slim_config::testutils::helloworld::greeter_server::GreeterServer;
     use slim_config::{client::ClientConfig, server::ServerConfig};
+    use slim_testing::common::reserve_local_port;
     use slim_testing::utils::setup_test_jwt_resolver;
     #[cfg(unix)]
     use {
@@ -107,16 +108,6 @@ mod tests {
     };
 
     static TEST_DATA_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata");
-
-    fn reserve_port() -> u16 {
-        let listener = std::net::TcpListener::bind("[::1]:0")
-            .or_else(|_| std::net::TcpListener::bind("127.0.0.1:0"))
-            .expect("failed to reserve test port");
-        listener
-            .local_addr()
-            .expect("failed to read reserved port")
-            .port()
-    }
 
     async fn run_server(
         client_config: ClientConfig,
@@ -260,7 +251,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_grpc_configuration() -> Result<(), Box<dyn std::error::Error>> {
-        let port = reserve_port();
+        let port = reserve_local_port();
         // create a client configuration and derive a channel from it
         let client_config = ClientConfig::with_endpoint(&format!("http://[::1]:{}", port))
             .with_headers(HashMap::from([(
@@ -281,7 +272,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_tls_grpc_configuration() -> Result<(), Box<dyn std::error::Error>> {
-        let port = reserve_port();
+        let port = reserve_local_port();
         // create a client configuration and derive a channel from it
         let client_config = ClientConfig::with_endpoint(&format!("https://[::1]:{}", port))
             .with_headers(HashMap::from([(
@@ -315,9 +306,8 @@ mod tests {
         auth_client_config: ClientAuthenticationConfig,
         auth_server_config: ServerAuthenticationConfig,
         auth_wrong_client_config: ClientAuthenticationConfig,
-        _port: u16,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let port = reserve_port();
+        let port = reserve_local_port();
         // create a client configuration and derive a channel from it
         let client_config = ClientConfig::with_endpoint(&format!("https://[::1]:{}", port))
             .with_headers(HashMap::from([(
@@ -402,7 +392,7 @@ mod tests {
             ClientAuthenticationConfig::Basic(BasicAuthConfig::new("wrong", "password"));
 
         // run grpc server and client
-        test_grpc_auth(client_config, server_config, wrong_client_config, 50054).await
+        test_grpc_auth(client_config, server_config, wrong_client_config).await
     }
 
     #[cfg(unix)]
@@ -527,7 +517,7 @@ mod tests {
         );
 
         // run grpc server and client
-        test_grpc_auth(client_config, server_config, wrong_client_config, 50055).await?;
+        test_grpc_auth(client_config, server_config, wrong_client_config).await?;
 
         // Clean up temporary files
         let _ = std::fs::remove_file(token_path);
@@ -539,7 +529,6 @@ mod tests {
         key_client: Key,
         key_server: Key,
         key_client_wrong: Key,
-        port: u16,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Create JWT claims
         let claims = slim_config::auth::jwt::Claims::default()
@@ -566,7 +555,7 @@ mod tests {
         ));
 
         // run grpc server and client
-        test_grpc_auth(client_config, server_config, wring_client_config, port).await
+        test_grpc_auth(client_config, server_config, wring_client_config).await
     }
 
     #[tokio::test]
@@ -589,7 +578,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::Data("wrong-key".to_string()),
             },
-            50057,
         )
         .await
     }
@@ -614,7 +602,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
-            50058,
         )
         .await
     }
@@ -639,7 +626,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
-            50059,
         )
         .await
     }
@@ -664,7 +650,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
-            50060,
         )
         .await
     }
@@ -689,7 +674,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec256-wrong.pem"),
             },
-            50061,
         )
         .await
     }
@@ -714,7 +698,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/ec384-wrong.pem"),
             },
-            50062,
         )
         .await
     }
@@ -739,7 +722,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
-            50063,
         )
         .await
     }
@@ -764,7 +746,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
-            50064,
         )
         .await
     }
@@ -789,7 +770,6 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/rsa-wrong.pem"),
             },
-            50065,
         )
         .await
     }
@@ -814,14 +794,12 @@ mod tests {
                 format: KeyFormat::Pem,
                 key: KeyData::File(TEST_DATA_PATH.to_string() + "/jwt/eddsa-wrong.pem"),
             },
-            50066,
         )
         .await
     }
 
     async fn test_tls_jwt_resolver_grpc_configuration(
         algorithm: Algorithm,
-        port: u16,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (test_key, mock_server, _alg_str) = setup_test_jwt_resolver(algorithm).await;
 
@@ -871,7 +849,7 @@ mod tests {
         ));
 
         // run grpc server and client
-        test_grpc_auth(client_config, server_config, wring_client_config, port).await
+        test_grpc_auth(client_config, server_config, wring_client_config).await
     }
 
     #[tokio::test]
@@ -879,7 +857,7 @@ mod tests {
     async fn test_tls_jwt_ecdsa256_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::ES256, 51111).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::ES256).await
     }
 
     #[tokio::test]
@@ -887,7 +865,7 @@ mod tests {
     async fn test_tls_jwt_ecdsa384_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::ES384, 51112).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::ES384).await
     }
 
     #[tokio::test]
@@ -895,7 +873,7 @@ mod tests {
     async fn test_tls_jwt_rsa256_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::RS256, 51113).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::RS256).await
     }
 
     #[tokio::test]
@@ -903,7 +881,7 @@ mod tests {
     async fn test_tls_jwt_rsa384_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::RS384, 51114).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::RS384).await
     }
 
     #[tokio::test]
@@ -911,7 +889,7 @@ mod tests {
     async fn test_tls_jwt_rsa512_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::RS512, 51115).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::RS512).await
     }
 
     #[tokio::test]
@@ -919,7 +897,7 @@ mod tests {
     async fn test_tls_jwt_rsap256_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::PS256, 51116).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::PS256).await
     }
 
     #[tokio::test]
@@ -927,7 +905,7 @@ mod tests {
     async fn test_tls_jwt_rsap384_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::PS384, 51117).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::PS384).await
     }
 
     #[tokio::test]
@@ -935,7 +913,7 @@ mod tests {
     async fn test_tls_jwt_rsap512_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::PS512, 51118).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::PS512).await
     }
 
     #[tokio::test]
@@ -943,7 +921,7 @@ mod tests {
     async fn test_tls_jwt_eddsa_autoresolve_grpc_configuration()
     -> Result<(), Box<dyn std::error::Error>> {
         // Test RSA JWT configuration
-        test_tls_jwt_resolver_grpc_configuration(Algorithm::EdDSA, 51119).await
+        test_tls_jwt_resolver_grpc_configuration(Algorithm::EdDSA).await
     }
 
     #[tokio::test]
@@ -979,7 +957,7 @@ mod tests {
         let spiffe_cfg = env.get_spiffe_config();
 
         // TEST 1: SPIFFE TLS without client authentication
-        let port1 = reserve_port();
+        let port1 = reserve_local_port();
 
         // Server TLS config uses dynamic SPIFFE resolver (no cert/key files)
         let server_tls = TlsServerConfig::new()
@@ -1005,7 +983,7 @@ mod tests {
         }
 
         // TEST 2: SPIFFE mTLS with client authentication
-        let port2 = reserve_port();
+        let port2 = reserve_local_port();
 
         // Server TLS config uses dynamic SPIFFE resolver (no cert/key files)
         let server_tls = TlsServerConfig::new()
@@ -1033,7 +1011,7 @@ mod tests {
         }
 
         // TEST 3: SPIFFE mTLS with different client_ca on server side (should fail)
-        let port3 = reserve_port();
+        let port3 = reserve_local_port();
 
         // Server TLS config uses dynamic SPIFFE resolver (no cert/key files)
         let server_tls = TlsServerConfig::new()
@@ -1064,7 +1042,7 @@ mod tests {
         }
 
         // TEST 4: SPIFFE TLS with no CA on client side (should fail)
-        let port4 = reserve_port();
+        let port4 = reserve_local_port();
 
         // Server TLS config uses dynamic SPIFFE resolver (no cert/key files)
         let server_tls = TlsServerConfig::new()

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -47,6 +47,7 @@ protoc-bin-vendored = { workspace = true }
 tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
+agntcy-slim-testing = { workspace = true }
 anyhow = { workspace = true }
 criterion = { workspace = true }
 serde_yaml = { workspace = true }

--- a/data-plane/core/datapath/tests/data_path_test.rs
+++ b/data-plane/core/datapath/tests/data_path_test.rs
@@ -7,6 +7,7 @@ mod tests {
     use anyhow::Context;
     use slim_datapath::api::ProtoName as Name;
     use slim_datapath::messages::utils::SlimHeaderFlags;
+    use slim_testing::common::reserve_local_port;
     use tracing::info;
     use tracing_test::traced_test;
 
@@ -97,8 +98,9 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_connection() {
+        let port = reserve_local_port();
         // setup server from configuration
-        let mut server_conf = ServerConfig::with_endpoint("127.0.0.1:50051");
+        let mut server_conf = ServerConfig::with_endpoint(&format!("127.0.0.1:{port}"));
         server_conf.tls_setting.insecure = true;
 
         let processor = MessageProcessor::new();
@@ -117,10 +119,10 @@ mod tests {
             }
         });
 
-        wait_for_server_ready("127.0.0.1:50051", 40).await;
+        wait_for_server_ready(&format!("127.0.0.1:{port}"), 40).await;
 
         // connect client
-        let mut client_config = ClientConfig::with_endpoint("http://127.0.0.1:50051");
+        let mut client_config = ClientConfig::with_endpoint(&format!("http://127.0.0.1:{port}"));
         client_config.tls_setting.insecure = true;
 
         // create bidirectional stream
@@ -129,7 +131,7 @@ mod tests {
             .connect(
                 client_config,
                 None,
-                Some(SocketAddr::from(([127, 0, 0, 1], 50051))),
+                Some(SocketAddr::from(([127, 0, 0, 1], port))),
             )
             .await
             .expect("error creating channel");
@@ -232,8 +234,9 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_disconnection() {
+        let port = reserve_local_port();
         // setup server from configuration
-        let mut server_conf = ServerConfig::with_endpoint("127.0.0.1:50053");
+        let mut server_conf = ServerConfig::with_endpoint(&format!("127.0.0.1:{port}"));
         server_conf.tls_setting.insecure = true;
 
         let processor = MessageProcessor::new();
@@ -251,10 +254,10 @@ mod tests {
             }
         });
 
-        wait_for_server_ready("127.0.0.1:50053", 40).await;
+        wait_for_server_ready(&format!("127.0.0.1:{port}"), 40).await;
 
         // create a client config we will attach to the connection
-        let mut client_config = ClientConfig::with_endpoint("http://127.0.0.1:50053");
+        let mut client_config = ClientConfig::with_endpoint(&format!("http://127.0.0.1:{port}"));
         client_config.tls_setting.insecure = true;
 
         // connect with client_config Some(...)
@@ -262,7 +265,7 @@ mod tests {
             .connect(
                 client_config.clone(),
                 None,
-                Some(SocketAddr::from(([127, 0, 0, 1], 50053))),
+                Some(SocketAddr::from(([127, 0, 0, 1], port))),
             )
             .await
             .expect("error creating channel");
@@ -288,16 +291,17 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_transport_roundtrip_grpc() -> anyhow::Result<()> {
-        let server_conf = ServerConfig::with_endpoint("127.0.0.1:51060")
+        let port = reserve_local_port();
+        let server_conf = ServerConfig::with_endpoint(&format!("127.0.0.1:{port}"))
             .with_tls_settings(TlsServerConfig::insecure());
 
-        let client_conf = ClientConfig::with_endpoint("http://127.0.0.1:51060")
+        let client_conf = ClientConfig::with_endpoint(&format!("http://127.0.0.1:{port}"))
             .with_tls_setting(TlsClientConfig::insecure());
 
         let conn_index = run_transport_roundtrip(
             server_conf,
             client_conf,
-            Some(SocketAddr::from(([127, 0, 0, 1], 51060))),
+            Some(SocketAddr::from(([127, 0, 0, 1], port))),
             "grpc",
         )
         .await?;
@@ -313,10 +317,11 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_websocket_connection_ws() -> anyhow::Result<()> {
-        let server_conf = ServerConfig::with_endpoint("ws://127.0.0.1:51061")
+        let port = reserve_local_port();
+        let server_conf = ServerConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
             .with_tls_settings(TlsServerConfig::insecure());
 
-        let client_conf = ClientConfig::with_endpoint("ws://127.0.0.1:51061")
+        let client_conf = ClientConfig::with_endpoint(&format!("ws://127.0.0.1:{port}"))
             .with_tls_setting(TlsClientConfig::insecure());
         let conn_index =
             run_transport_roundtrip(server_conf, client_conf, None, "websocket ws").await?;
@@ -332,6 +337,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_websocket_connection_wss() -> anyhow::Result<()> {
+        let port = reserve_local_port();
         let grpc_tls_testdata = format!("{}/../config/testdata/grpc", env!("CARGO_MANIFEST_DIR"));
 
         let server_tls = TlsServerConfig::new().with_cert_and_key_file(
@@ -339,13 +345,13 @@ mod tests {
             &format!("{}/server.key", grpc_tls_testdata),
         );
 
-        let server_conf =
-            ServerConfig::with_endpoint("wss://127.0.0.1:51062").with_tls_settings(server_tls);
+        let server_conf = ServerConfig::with_endpoint(&format!("wss://127.0.0.1:{port}"))
+            .with_tls_settings(server_tls);
 
         let client_tls =
             TlsClientConfig::new().with_ca_file(&format!("{}/ca.crt", grpc_tls_testdata));
 
-        let client_conf = ClientConfig::with_endpoint("wss://127.0.0.1:51062")
+        let client_conf = ClientConfig::with_endpoint(&format!("wss://127.0.0.1:{port}"))
             .with_server_name("example1")
             .with_tls_setting(client_tls);
         let conn_index =


### PR DESCRIPTION
# Description

Replace hardcoded ports and duplicated port reservation functions in test files with the shared slim_testing::common::reserve_local_port() helper. This eliminates port conflicts when tests run in parallel.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
