### PR TITLE
chore: release

### DIFF
--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-datapath",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.1.20"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.13"
+version = "0.4.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -39,16 +39,16 @@ resolver = "2"
 [workspace.dependencies]
 # Local dependencies
 agntcy-slim = { path = "core/slim", version = "2.0.0-alpha.1" }
-agntcy-slim-auth = { path = "core/auth", version = "0.9.0" }
-agntcy-slim-config = { path = "core/config", version = "0.10.0" }
-agntcy-slim-controller = { path = "core/controller", version = "0.7.0" }
-agntcy-slim-datapath = { path = "core/datapath", version = "0.14.1" }
-agntcy-slim-mls = { path = "core/mls", version = "0.1.20" }
-agntcy-slim-service = { path = "core/service", version = "0.9.0", default-features = false }
-agntcy-slim-session = { path = "core/session", version = "0.2.1" }
-agntcy-slim-signal = { path = "core/signal", version = "0.1.9" }
+agntcy-slim-auth = { path = "core/auth", version = "0.10.0" }
+agntcy-slim-config = { path = "core/config", version = "0.11.0" }
+agntcy-slim-controller = { path = "core/controller", version = "0.8.0" }
+agntcy-slim-datapath = { path = "core/datapath", version = "0.15.0" }
+agntcy-slim-mls = { path = "core/mls", version = "0.2.0" }
+agntcy-slim-service = { path = "core/service", version = "0.10.0", default-features = false }
+agntcy-slim-session = { path = "core/session", version = "0.3.0" }
+agntcy-slim-signal = { path = "core/signal", version = "0.1.10" }
 agntcy-slim-testing = { path = "testing" }
-agntcy-slim-tracing = { path = "core/tracing", version = "0.3.13" }
+agntcy-slim-tracing = { path = "core/tracing", version = "0.4.0" }
 agntcy-slim-version = { path = "core/version", version = "2.0.0-alpha.1" }
 agntcy-slimctl = { path = "slimctl", version = "2.0.0-alpha.1" }
 anyhow = "1.0.98"

--- a/data-plane/core/auth/CHANGELOG.md
+++ b/data-plane/core/auth/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/agntcy/slim/compare/slim-auth-v0.9.0...slim-auth-v0.10.0) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+
+### Other
+
+- *(tests)* use common reserve_local_port helper across all test crates ([#1732](https://github.com/agntcy/slim/pull/1732))
+
 ## [0.9.0](https://github.com/agntcy/slim/compare/slim-auth-v0.8.0...slim-auth-v0.9.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/auth/Cargo.toml
+++ b/data-plane/core/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.9.0"
+version = "0.10.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/data-plane/core/config/CHANGELOG.md
+++ b/data-plane/core/config/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/agntcy/slim/compare/slim-config-v0.10.0...slim-config-v0.11.0) - 2026-06-17
+
+### Added
+
+- add edge connections ([#1741](https://github.com/agntcy/slim/pull/1741))
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
+- *(datapath)* mandatory link negotiation with immutable connections ([#1736](https://github.com/agntcy/slim/pull/1736))
+- remove UUID v4 constraint on link_id, require non-empty string ([#1713](https://github.com/agntcy/slim/pull/1713))
+- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
+- *(datapath)* add peer discovery module with static backend ([#1696](https://github.com/agntcy/slim/pull/1696))
+
+### Other
+
+- *(tests)* use common reserve_local_port helper across all test crates ([#1732](https://github.com/agntcy/slim/pull/1732))
+
 ## [0.10.0](https://github.com/agntcy/slim/compare/slim-config-v0.9.3...slim-config-v0.10.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/config/Cargo.toml
+++ b/data-plane/core/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/data-plane/core/controller/CHANGELOG.md
+++ b/data-plane/core/controller/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/agntcy/slim/compare/slim-controller-v0.7.0...slim-controller-v0.8.0) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
+- *(datapath)* mandatory link negotiation with immutable connections ([#1736](https://github.com/agntcy/slim/pull/1736))
+
+### Fixed
+
+- *(controller)* make sure controller stop retrying connection when signaled ([#1730](https://github.com/agntcy/slim/pull/1730))
+
+### Other
+
+- remove link recovery mechanism ([#1737](https://github.com/agntcy/slim/pull/1737))
+
 ## [0.7.0](https://github.com/agntcy/slim/compare/slim-controller-v0.6.2...slim-controller-v0.7.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/controller/Cargo.toml
+++ b/data-plane/core/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.7.0"
+version = "0.8.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/data-plane/core/datapath/CHANGELOG.md
+++ b/data-plane/core/datapath/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.14.1...slim-datapath-v0.15.0) - 2026-06-17
+
+### Added
+
+- add edge connections ([#1741](https://github.com/agntcy/slim/pull/1741))
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
+- *(datapath)* mandatory link negotiation with immutable connections ([#1736](https://github.com/agntcy/slim/pull/1736))
+- remove UUID v4 constraint on link_id, require non-empty string ([#1713](https://github.com/agntcy/slim/pull/1713))
+- *(datapath)* add TTL support for message forwarding ([#1714](https://github.com/agntcy/slim/pull/1714))
+- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
+- *(datapath)* add peer discovery module with static backend ([#1696](https://github.com/agntcy/slim/pull/1696))
+
+### Other
+
+- remove link recovery mechanism ([#1737](https://github.com/agntcy/slim/pull/1737))
+- *(tests)* use common reserve_local_port helper across all test crates ([#1732](https://github.com/agntcy/slim/pull/1732))
+
 ## [0.14.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.14.0...slim-datapath-v0.14.1) - 2026-06-03
 
 ### Fixed

--- a/data-plane/core/datapath/Cargo.toml
+++ b/data-plane/core/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.14.1"
+version = "0.15.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/data-plane/core/mls/CHANGELOG.md
+++ b/data-plane/core/mls/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/slim/compare/slim-mls-v0.1.20...slim-mls-v0.2.0) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
+
 ## [0.1.20](https://github.com/agntcy/slim/compare/slim-mls-v0.1.19...slim-mls-v0.1.20) - 2026-06-03
 
 ### Other

--- a/data-plane/core/mls/Cargo.toml
+++ b/data-plane/core/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.20"
+version = "0.2.0"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/data-plane/core/service/CHANGELOG.md
+++ b/data-plane/core/service/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/agntcy/slim/compare/slim-service-v0.9.0...slim-service-v0.10.0) - 2026-06-17
+
+### Added
+
+- add edge connections ([#1741](https://github.com/agntcy/slim/pull/1741))
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
+- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
+- *(datapath)* add peer discovery module with static backend ([#1696](https://github.com/agntcy/slim/pull/1696))
+
+### Other
+
+- remove link recovery mechanism ([#1737](https://github.com/agntcy/slim/pull/1737))
+
 ## [0.9.0](https://github.com/agntcy/slim/compare/slim-service-v0.8.15...slim-service-v0.9.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/service/Cargo.toml
+++ b/data-plane/core/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.9.0"
+version = "0.10.0"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/data-plane/core/session/CHANGELOG.md
+++ b/data-plane/core/session/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/agntcy/slim/compare/slim-session-v0.2.1...slim-session-v0.3.0) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
+
+### Other
+
+- *(session)* remove SessionTransmitter, return SessionOutput from layers ([#1702](https://github.com/agntcy/slim/pull/1702))
+
 ## [0.2.1](https://github.com/agntcy/slim/compare/slim-session-v0.2.0...slim-session-v0.2.1) - 2026-06-03
 
 ### Other

--- a/data-plane/core/session/Cargo.toml
+++ b/data-plane/core/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.3.0"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/data-plane/core/signal/CHANGELOG.md
+++ b/data-plane/core/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/agntcy/slim/compare/slim-signal-v0.1.9...slim-signal-v0.1.10) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+
 ## [0.1.9](https://github.com/agntcy/slim/compare/slim-signal-v0.1.8...slim-signal-v0.1.9) - 2026-04-21
 
 ### Other

--- a/data-plane/core/signal/Cargo.toml
+++ b/data-plane/core/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.9"
+version = "0.1.10"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/data-plane/core/slim/CHANGELOG.md
+++ b/data-plane/core/slim/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.1](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.0...slim-v2.0.0-alpha.1) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
+
 ## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slim-v1.4.0...slim-v2.0.0-alpha.0) - 2026-06-03
 
 ### Added

--- a/data-plane/core/tracing/CHANGELOG.md
+++ b/data-plane/core/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.13...slim-tracing-v0.4.0) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+
 ## [0.3.13](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.12...slim-tracing-v0.3.13) - 2026-06-03
 
 ### Added

--- a/data-plane/core/tracing/Cargo.toml
+++ b/data-plane/core/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.13"
+version = "0.4.0"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]

--- a/data-plane/slimctl/CHANGELOG.md
+++ b/data-plane/slimctl/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.1](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.0...slimctl-v2.0.0-alpha.1) - 2026-06-17
+
+### Added
+
+- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
+- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
+- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
+
 ## [2.0.0-alpha.0](https://github.com/agntcy/slim/compare/slimctl-v1.4.0...slimctl-v2.0.0-alpha.0) - 2026-06-03
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.3.13 -> 0.4.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.14.1 -> 0.15.0 (⚠ API breaking changes)
* `agntcy-slim-mls`: 0.1.20 -> 0.2.0 (⚠ API breaking changes)
* `agntcy-slim-session`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `agntcy-slim-signal`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `agntcy-slim`: 2.0.0-alpha.0 -> 2.0.0-alpha.1
* `agntcy-slimctl`: 2.0.0-alpha.0 -> 2.0.0-alpha.1

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AuthError::MlsKeyGenerationFailed, previously in file /tmp/.tmpeSYpLY/agntcy-slim-auth/src/errors.rs:169

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function slim_auth::utils::generate_mls_signature_keys, previously in file /tmp/.tmpeSYpLY/agntcy-slim-auth/src/utils.rs:18

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method slim_auth::traits::TokenProvider::set_signature_keys in file /tmp/.tmpOGDswJ/slim/data-plane/core/auth/src/traits.rs:140

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method rotate_signature_keys of trait TokenProvider, previously in file /tmp/.tmpeSYpLY/agntcy-slim-auth/src/traits.rs:137
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ClientConfig.connection_type in /tmp/.tmpOGDswJ/slim/data-plane/core/config/src/client.rs:252
  field ClientConfig.connection_type in /tmp/.tmpOGDswJ/slim/data-plane/core/config/src/client.rs:252
  field ServerConfig.negotiation_timeout_secs in /tmp/.tmpOGDswJ/slim/data-plane/core/config/src/server.rs:138
  field ServerConfig.negotiation_timeout_secs in /tmp/.tmpOGDswJ/slim/data-plane/core/config/src/server.rs:138

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ConfigError::InvalidLinkId, previously in file /tmp/.tmpeSYpLY/agntcy-slim-config/src/errors.rs:113

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function slim_config::client::is_valid_uuid_v4, previously in file /tmp/.tmpeSYpLY/agntcy-slim-config/src/client.rs:316
  function slim_config::grpc::client::is_valid_uuid_v4, previously in file /tmp/.tmpeSYpLY/agntcy-slim-config/src/client.rs:316

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field link_hmac_timeout_secs of struct ServerConfig, previously in file /tmp/.tmpeSYpLY/agntcy-slim-config/src/server.rs:135
  field link_hmac_timeout_secs of struct ServerConfig, previously in file /tmp/.tmpeSYpLY/agntcy-slim-config/src/server.rs:135
```

### ⚠ `agntcy-slim-tracing` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_tracing::utils, previously in file /tmp/.tmpeSYpLY/agntcy-slim-tracing/src/utils.rs:4

--- failure pub_static_missing: pub static is missing ---

Description:
A public static is missing, renamed, or made private.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_static_missing.ron

Failed in:
  INSTANCE_ID in file /tmp/.tmpeSYpLY/agntcy-slim-tracing/src/utils.rs:7
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field JoinRequestPayload.mls_settings in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:248
  field JoinRequestPayload.mls_settings in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:248
  field LinkNegotiationPayload.connection_type in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:420
  field LinkNegotiationPayload.node_id in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:425
  field LinkNegotiationPayload.deployment_name in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:430
  field LinkNegotiationPayload.connection_type in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:420
  field LinkNegotiationPayload.node_id in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:425
  field LinkNegotiationPayload.deployment_name in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:430
  field SlimHeader.ttl in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:88
  field SlimHeader.ttl in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/api/gen/dataplane.proto.v1.rs:88
  field SlimHeaderFlags.ttl in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/messages/utils.rs:200

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum slim_datapath::tables::ConnType, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/tables.rs:22

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant DataPathError:ConnectionSendError in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/errors.rs:60
  variant DataPathError:TtlExpired in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/errors.rs:101

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  MessageProcessor::new_with_options, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/message_processing.rs:113

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_datapath::messages::utils::ProtoMessageBuilder::build_link_negotiation now takes 7 parameters instead of 4, in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/messages/utils.rs:1750
  slim_datapath::message_processing::MessageProcessor::new_with_server_config now takes 4 parameters instead of 3, in /tmp/.tmpOGDswJ/slim/data-plane/core/datapath/src/message_processing.rs:146

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_datapath::tables::remote_subscription_table, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/tables/remote_subscription_table.rs:4

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  CONN_TYPE_COUNT in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/tables.rs:33

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_datapath::tables::remote_subscription_table::SubscriptionInfo, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/tables/remote_subscription_table.rs:12
  struct slim_datapath::tables::remote_subscription_table::RemoteSubscriptions, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/tables/remote_subscription_table.rs:61

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field enable_mls of struct JoinRequestPayload, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:239
  field enable_mls of struct JoinRequestPayload, previously in file /tmp/.tmpeSYpLY/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:239
```

### ⚠ `agntcy-slim-mls` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_mls::mls::Mls::encrypt_message now takes 2 parameters instead of 1, in /tmp/.tmpOGDswJ/slim/data-plane/core/mls/src/mls.rs:370
```

### ⚠ `agntcy-slim-session` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SessionConfig.mls_settings in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/session_config.rs:27
  field SessionConfig.mls_settings in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/session_config.rs:27

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionMessage:LeaveCleanup in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/common.rs:147

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  SessionBuilder::with_tx, previously in file /tmp/.tmpeSYpLY/agntcy-slim-session/src/session_builder.rs:192
  SessionReceiver::send_ack, previously in file /tmp/.tmpeSYpLY/agntcy-slim-session/src/session_receiver.rs:179

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_session::controller_sender::ControllerSender::new now takes 7 parameters instead of 8, in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/controller_sender.rs:125
  slim_session::session_sender::SessionSender::new now takes 4 parameters instead of 5, in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/session_sender.rs:85
  slim_session::session_receiver::SessionReceiver::new now takes 5 parameters instead of 6, in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/session_receiver.rs:85

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_session::transmitter, previously in file /tmp/.tmpeSYpLY/agntcy-slim-session/src/transmitter.rs:4

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_session::transmitter::SessionTransmitter, previously in file /tmp/.tmpeSYpLY/agntcy-slim-session/src/transmitter.rs:22

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field mls_enabled of struct SessionConfig, previously in file /tmp/.tmpeSYpLY/agntcy-slim-session/src/session_config.rs:22
  field mls_enabled of struct SessionConfig, previously in file /tmp/.tmpeSYpLY/agntcy-slim-session/src/session_config.rs:22

--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct ControllerSender allows 1 -> 0 generic types in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/controller_sender.rs:84
  Struct SessionSender allows 1 -> 0 generic types in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/session_sender.rs:38
  Struct SessionReceiver allows 1 -> 0 generic types in /tmp/.tmpOGDswJ/slim/data-plane/core/session/src/session_receiver.rs:54
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConnectionEntry.peer_node_id in /tmp/.tmpOGDswJ/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:137

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConnectionType:Peer in /tmp/.tmpOGDswJ/slim/data-plane/core/controller/src/api/gen/controller.proto.v1.rs:221
  variant ControllerError:Canceled in /tmp/.tmpOGDswJ/slim/data-plane/core/controller/src/errors.rs:23

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field recovery_ttl of struct Config, previously in file /tmp/.tmpeSYpLY/agntcy-slim-controller/src/config.rs:33
```

### ⚠ `agntcy-slim-service` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ServiceConfiguration.service_id in /tmp/.tmpOGDswJ/slim/data-plane/core/service/src/service.rs:79
  field ServiceConfiguration.peers in /tmp/.tmpOGDswJ/slim/data-plane/core/service/src/service.rs:92
  field ServiceConfiguration.service_id in /tmp/.tmpOGDswJ/slim/data-plane/core/service/src/service.rs:79
  field ServiceConfiguration.peers in /tmp/.tmpOGDswJ/slim/data-plane/core/service/src/service.rs:92
  field ConnectionInfo.conn_type in /tmp/.tmpOGDswJ/slim/data-plane/core/service/src/service.rs:64
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.10.0](https://github.com/agntcy/slim/compare/slim-auth-v0.9.0...slim-auth-v0.10.0) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))

### Other

- *(tests)* use common reserve_local_port helper across all test crates ([#1732](https://github.com/agntcy/slim/pull/1732))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.11.0](https://github.com/agntcy/slim/compare/slim-config-v0.10.0...slim-config-v0.11.0) - 2026-06-17

### Added

- add edge connections ([#1741](https://github.com/agntcy/slim/pull/1741))
- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
- *(datapath)* mandatory link negotiation with immutable connections ([#1736](https://github.com/agntcy/slim/pull/1736))
- remove UUID v4 constraint on link_id, require non-empty string ([#1713](https://github.com/agntcy/slim/pull/1713))
- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
- *(datapath)* add peer discovery module with static backend ([#1696](https://github.com/agntcy/slim/pull/1696))

### Other

- *(tests)* use common reserve_local_port helper across all test crates ([#1732](https://github.com/agntcy/slim/pull/1732))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.0](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.13...slim-tracing-v0.4.0) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.15.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.14.1...slim-datapath-v0.15.0) - 2026-06-17

### Added

- add edge connections ([#1741](https://github.com/agntcy/slim/pull/1741))
- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
- *(datapath)* mandatory link negotiation with immutable connections ([#1736](https://github.com/agntcy/slim/pull/1736))
- remove UUID v4 constraint on link_id, require non-empty string ([#1713](https://github.com/agntcy/slim/pull/1713))
- *(datapath)* add TTL support for message forwarding ([#1714](https://github.com/agntcy/slim/pull/1714))
- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
- *(datapath)* add peer discovery module with static backend ([#1696](https://github.com/agntcy/slim/pull/1696))

### Other

- remove link recovery mechanism ([#1737](https://github.com/agntcy/slim/pull/1737))
- *(tests)* use common reserve_local_port helper across all test crates ([#1732](https://github.com/agntcy/slim/pull/1732))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.0](https://github.com/agntcy/slim/compare/slim-mls-v0.1.20...slim-mls-v0.2.0) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.3.0](https://github.com/agntcy/slim/compare/slim-session-v0.2.1...slim-session-v0.3.0) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))

### Other

- *(session)* remove SessionTransmitter, return SessionOutput from layers ([#1702](https://github.com/agntcy/slim/pull/1702))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.10](https://github.com/agntcy/slim/compare/slim-signal-v0.1.9...slim-signal-v0.1.10) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.8.0](https://github.com/agntcy/slim/compare/slim-controller-v0.7.0...slim-controller-v0.8.0) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
- *(datapath)* mandatory link negotiation with immutable connections ([#1736](https://github.com/agntcy/slim/pull/1736))

### Fixed

- *(controller)* make sure controller stop retrying connection when signaled ([#1730](https://github.com/agntcy/slim/pull/1730))

### Other

- remove link recovery mechanism ([#1737](https://github.com/agntcy/slim/pull/1737))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.10.0](https://github.com/agntcy/slim/compare/slim-service-v0.9.0...slim-service-v0.10.0) - 2026-06-17

### Added

- add edge connections ([#1741](https://github.com/agntcy/slim/pull/1741))
- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
- *(datapath)* add peer discovery module with static backend ([#1696](https://github.com/agntcy/slim/pull/1696))

### Other

- remove link recovery mechanism ([#1737](https://github.com/agntcy/slim/pull/1737))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.1](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.0...slim-v2.0.0-alpha.1) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.1](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.0...slimctl-v2.0.0-alpha.1) - 2026-06-17

### Added

- *(websocket)* Enable the compilation of data-plane for wasm32 ([#1695](https://github.com/agntcy/slim/pull/1695))
- *(peer-sync)* subscription synchronization ([#1705](https://github.com/agntcy/slim/pull/1705))
- e2e header integrity validation ([#1677](https://github.com/agntcy/slim/pull/1677))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).