### PR TITLE
feat(slimctl): improve bench pub/sub commands and reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -982,8 +982,6 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
         }
     }
 
-    tokio::time::sleep(Duration::from_secs(5)).await; // give message processing tasks time to complete
-
     if group.has_samples() {
         println!("\n{}", group.report("Pub stats"));
 

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -494,20 +494,38 @@ impl SampleGroup {
         let mut out = String::new();
         if self.samples.len() > 1 {
             for (s, lbl) in self.samples.iter().zip(self.labels.iter()) {
-                out.push_str(&format!(
-                    "  [{}] {} ({} msgs)\n",
-                    lbl,
-                    s,
-                    comma_format(s.job_msg_cnt as i64),
-                ));
+                let count_str = if s.msg_cnt == s.job_msg_cnt {
+                    format!("{} msgs", comma_format(s.msg_cnt as i64))
+                } else {
+                    let dropped = s.job_msg_cnt.saturating_sub(s.msg_cnt);
+                    format!(
+                        "{}/{} msgs, {} dropped",
+                        comma_format(s.msg_cnt as i64),
+                        comma_format(s.job_msg_cnt as i64),
+                        comma_format(dropped as i64),
+                    )
+                };
+                out.push_str(&format!("  [{}] {} ({})\n", lbl, s, count_str));
             }
             out.push_str(&format!("  {}\n", self.statistics()));
         }
+        let agg_count_str = if self.total_msgs == self.job_msg_cnt {
+            format!("{} msgs", comma_format(self.total_msgs as i64))
+        } else {
+            let dropped = self.job_msg_cnt.saturating_sub(self.total_msgs);
+            format!(
+                "{}/{} msgs, {} dropped",
+                comma_format(self.total_msgs as i64),
+                comma_format(self.job_msg_cnt as i64),
+                comma_format(dropped as i64),
+            )
+        };
         out.push_str(&format!(
-            "{}: {} msgs/sec ~ {}/sec\n",
+            "{}: {} msgs/sec ~ {}/sec ({})\n",
             label,
             comma_format(self.aggregate_rate() as i64),
             human_bytes(self.aggregate_throughput()),
+            agg_count_str,
         ));
         out
     }
@@ -849,6 +867,8 @@ async fn run_sub_worker(
     let mut msg_cnt = 0u64;
     let mut msg_bytes = 0u64;
 
+    println!("[sub-{i}] expecting {} messages", if job_msg_cnt == 0 { "unlimited".to_string() } else { job_msg_cnt.to_string() });
+
     while let Some(msg) = recv_session_message(&mut session_rx, recv_timeout).await {
         if start.is_none() {
             start = Some(Instant::now());
@@ -867,9 +887,12 @@ async fn run_sub_worker(
         }
 
         if job_msg_cnt > 0 && msg_cnt >= job_msg_cnt {
+            println!("[sub-{i}] received all expected messages, exiting");
             break;
         }
     }
+
+    println!("[sub-{i}] received {} messages", msg_cnt);
 
     Ok(build_sample(start, msg_cnt, msg_bytes, job_msg_cnt, size))
 }

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -129,11 +129,6 @@ pub struct BenchSubArgs {
     #[arg(long, default_value_t = 0)]
     pub start_index: usize,
 
-    /// Run in reliable mode.
-    /// By default the benchmark runs in unreliable (fire-and-forget) mode. With
-    /// --reliable, the session layer retransmits unacknowledged messages.
-    #[arg(long)]
-    pub reliable: bool,
 }
 
 // ── Pub args ───────────────────────────────────────────────────────────────────
@@ -271,6 +266,13 @@ pub struct BenchChannelPubArgs {
     /// Append results to CSV file
     #[arg(long)]
     pub csv: Option<String>,
+
+    /// Run in reliable mode.
+    /// By default the benchmark runs in unreliable (fire-and-forget) mode. With
+    /// --reliable, the session layer retransmits unacknowledged messages and the
+    /// publisher waits for an ACK before sending the next message.
+    #[arg(long)]
+    pub reliable: bool,
 }
 
 // ── Dispatch ───────────────────────────────────────────────────────────────────
@@ -767,11 +769,6 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
     if args.reply {
         println!("  Reply mode: ON (echoing messages back)");
     }
-    if args.reliable {
-        println!("  Mode           : reliable (ACK-gated)");
-    } else {
-        println!("  Mode           : unreliable (fire-and-forget)");
-    }
     println!("  Waiting for publishers...\n");
 
     let client_config =
@@ -1259,6 +1256,11 @@ async fn run_channel_pub(args: &BenchChannelPubArgs, service: &Arc<Service>) -> 
     println!("  Channel        : {}/{}/channel", org, ns);
     println!("  Total messages : {}", comma_format(args.msgs as i64));
     println!("  Payload size   : {} bytes", args.size);
+    if args.reliable {
+        println!("  Mode           : reliable (ACK-gated)");
+    } else {
+        println!("  Mode           : unreliable (fire-and-forget)");
+    }
     println!();
 
     let payload = vec![0u8; args.size];
@@ -1279,6 +1281,7 @@ async fn run_channel_pub(args: &BenchChannelPubArgs, service: &Arc<Service>) -> 
         args.count,
         args.msgs,
         payload,
+        args.reliable,
     )
     .await
     {
@@ -1309,6 +1312,7 @@ async fn run_channel_pub_worker(
     sub_count: usize,
     msg_count: u64,
     payload: Vec<u8>,
+    reliable: bool,
 ) -> Result<Sample> {
     let own_name = make_channel_pub_name(org, ns);
     let channel_name = make_channel_name(org, ns);
@@ -1334,7 +1338,7 @@ async fn run_channel_pub_worker(
         channel_name.clone(),
         Duration::from_secs(5),
         "group session creation timed out unexpectedly",
-        true,
+        reliable,
     )
     .await?;
 

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -982,6 +982,8 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
         }
     }
 
+    tokio::time::sleep(Duration::from_secs(5)).await; // give message processing tasks time to complete
+
     if group.has_samples() {
         println!("\n{}", group.report("Pub stats"));
 
@@ -1078,6 +1080,8 @@ async fn run_pub_worker(
             latencies.push(t0.elapsed());
         }
     }
+
+    controller.close()?.await?;
 
     let end = Instant::now();
 

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -1379,6 +1379,8 @@ async fn run_channel_pub_worker(
             .context("publish completion failed")?;
     }
 
+    controller.close()?.await?;
+
     let end = Instant::now();
 
     Ok(Sample {

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -128,7 +128,6 @@ pub struct BenchSubArgs {
     ///          process B: --count 2 --start-index 2  (registers sub-2, sub-3)
     #[arg(long, default_value_t = 0)]
     pub start_index: usize,
-
 }
 
 // ── Pub args ───────────────────────────────────────────────────────────────────
@@ -706,8 +705,16 @@ async fn create_and_wait_session(
         // Both max_retries AND interval must be Some for the session to create
         // a timer factory. Without both, the session runs in unreliable mode:
         // CompletionHandles resolve immediately and no ACKs are sent.
-        max_retries: if reliable { Some(SESSION_MAX_RETRIES) } else { None },
-        interval: if reliable { Some(SESSION_RETRY_INTERVAL) } else { None },
+        max_retries: if reliable {
+            Some(SESSION_MAX_RETRIES)
+        } else {
+            None
+        },
+        interval: if reliable {
+            Some(SESSION_RETRY_INTERVAL)
+        } else {
+            None
+        },
         initiator: true,
         metadata: HashMap::new(),
     };
@@ -795,7 +802,15 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
             (
                 actual_index,
                 run_sub_worker(
-                    &service, actual_index, &org, &ns, &secret, conn_id, job_cnt, size, reply,
+                    &service,
+                    actual_index,
+                    &org,
+                    &ns,
+                    &secret,
+                    conn_id,
+                    job_cnt,
+                    size,
+                    reply,
                 )
                 .await,
             )
@@ -864,7 +879,14 @@ async fn run_sub_worker(
     let mut msg_cnt = 0u64;
     let mut msg_bytes = 0u64;
 
-    println!("[sub-{i}] expecting {} messages", if job_msg_cnt == 0 { "unlimited".to_string() } else { job_msg_cnt.to_string() });
+    println!(
+        "[sub-{i}] expecting {} messages",
+        if job_msg_cnt == 0 {
+            "unlimited".to_string()
+        } else {
+            job_msg_cnt.to_string()
+        }
+    );
 
     while let Some(msg) = recv_session_message(&mut session_rx, recv_timeout).await {
         if start.is_none() {
@@ -957,7 +979,15 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
             (
                 actual_index,
                 run_pub_worker(
-                    &service, actual_index, &org, &ns, &secret, conn_id, msgs, p, request,
+                    &service,
+                    actual_index,
+                    &org,
+                    &ns,
+                    &secret,
+                    conn_id,
+                    msgs,
+                    p,
+                    request,
                     reliable,
                 )
                 .await,
@@ -1574,20 +1604,26 @@ mod tests {
     fn sample_group_aggregate() {
         let now = Instant::now();
         let mut g = SampleGroup::new();
-        g.add("sub-0", Sample {
-            job_msg_cnt: 500,
-            msg_cnt: 500,
-            msg_bytes: 64_000,
-            start: now,
-            end: now + Duration::from_secs(1),
-        });
-        g.add("sub-1", Sample {
-            job_msg_cnt: 500,
-            msg_cnt: 500,
-            msg_bytes: 64_000,
-            start: now,
-            end: now + Duration::from_secs(1),
-        });
+        g.add(
+            "sub-0",
+            Sample {
+                job_msg_cnt: 500,
+                msg_cnt: 500,
+                msg_bytes: 64_000,
+                start: now,
+                end: now + Duration::from_secs(1),
+            },
+        );
+        g.add(
+            "sub-1",
+            Sample {
+                job_msg_cnt: 500,
+                msg_cnt: 500,
+                msg_bytes: 64_000,
+                start: now,
+                end: now + Duration::from_secs(1),
+            },
+        );
         assert!(g.has_samples());
         // Aggregate over the same 1s window → 1000 msgs/s
         assert!((g.aggregate_rate() - 1_000.0).abs() < 1.0);

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -121,6 +121,19 @@ pub struct BenchSubArgs {
     /// Append results to CSV file
     #[arg(long)]
     pub csv: Option<String>,
+
+    /// Index of the first subscriber in this process.
+    /// Use with --count to distribute subscribers across multiple processes.
+    /// Example: process A: --count 2 --start-index 0  (registers sub-0, sub-1)
+    ///          process B: --count 2 --start-index 2  (registers sub-2, sub-3)
+    #[arg(long, default_value_t = 0)]
+    pub start_index: usize,
+
+    /// Run in reliable mode.
+    /// By default the benchmark runs in unreliable (fire-and-forget) mode. With
+    /// --reliable, the session layer retransmits unacknowledged messages.
+    #[arg(long)]
+    pub reliable: bool,
 }
 
 // ── Pub args ───────────────────────────────────────────────────────────────────
@@ -158,6 +171,20 @@ pub struct BenchPubArgs {
     /// Append results to CSV file
     #[arg(long)]
     pub csv: Option<String>,
+
+    /// Index of the first publisher in this process.
+    /// Use with --count to distribute publishers across multiple processes.
+    /// Example: process A: --count 2 --start-index 0  (registers pub-0, pub-1)
+    ///          process B: --count 2 --start-index 2  (registers pub-2, pub-3)
+    #[arg(long, default_value_t = 0)]
+    pub start_index: usize,
+
+    /// Run in reliable mode.
+    /// By default the benchmark runs in unreliable (fire-and-forget) mode. With
+    /// --reliable, the session layer retransmits unacknowledged messages and the
+    /// publisher waits for an ACK before sending the next message.
+    #[arg(long)]
+    pub reliable: bool,
 }
 
 // ── Channel args ───────────────────────────────────────────────────────────────
@@ -352,6 +379,7 @@ fn build_sample(
 /// (min start → max end across all samples), matching nats bench semantics.
 struct SampleGroup {
     samples: Vec<Sample>,
+    labels: Vec<String>,
     start: Option<Instant>,
     end: Option<Instant>,
     total_msgs: u64,
@@ -363,6 +391,7 @@ impl SampleGroup {
     fn new() -> Self {
         Self {
             samples: Vec::new(),
+            labels: Vec::new(),
             start: None,
             end: None,
             total_msgs: 0,
@@ -371,7 +400,7 @@ impl SampleGroup {
         }
     }
 
-    fn add(&mut self, s: Sample) {
+    fn add(&mut self, label: impl Into<String>, s: Sample) {
         self.start = Some(match self.start {
             None => s.start,
             Some(existing) => existing.min(s.start),
@@ -383,6 +412,7 @@ impl SampleGroup {
         self.total_msgs += s.msg_cnt;
         self.total_bytes += s.msg_bytes;
         self.job_msg_cnt += s.job_msg_cnt;
+        self.labels.push(label.into());
         self.samples.push(s);
     }
 
@@ -461,23 +491,24 @@ impl SampleGroup {
     }
 
     fn report(&self, label: &str) -> String {
-        let mut out = format!(
-            "{}: {} msgs/sec ~ {}/sec\n",
-            label,
-            comma_format(self.aggregate_rate() as i64),
-            human_bytes(self.aggregate_throughput()),
-        );
+        let mut out = String::new();
         if self.samples.len() > 1 {
-            for (i, s) in self.samples.iter().enumerate() {
+            for (s, lbl) in self.samples.iter().zip(self.labels.iter()) {
                 out.push_str(&format!(
                     "  [{}] {} ({} msgs)\n",
-                    i + 1,
+                    lbl,
                     s,
                     comma_format(s.job_msg_cnt as i64),
                 ));
             }
             out.push_str(&format!("  {}\n", self.statistics()));
         }
+        out.push_str(&format!(
+            "{}: {} msgs/sec ~ {}/sec\n",
+            label,
+            comma_format(self.aggregate_rate() as i64),
+            human_bytes(self.aggregate_throughput()),
+        ));
         out
     }
 
@@ -647,12 +678,16 @@ async fn create_and_wait_session(
     destination: ProtoName,
     timeout: Duration,
     timeout_msg: &str,
+    reliable: bool,
 ) -> Result<SessionContext> {
     let session_config = SessionConfig {
         session_type,
         mls_settings: None,
-        max_retries: Some(SESSION_MAX_RETRIES),
-        interval: Some(SESSION_RETRY_INTERVAL),
+        // Both max_retries AND interval must be Some for the session to create
+        // a timer factory. Without both, the session runs in unreliable mode:
+        // CompletionHandles resolve immediately and no ACKs are sent.
+        max_retries: if reliable { Some(SESSION_MAX_RETRIES) } else { None },
+        interval: if reliable { Some(SESSION_RETRY_INTERVAL) } else { None },
         initiator: true,
         metadata: HashMap::new(),
     };
@@ -697,10 +732,11 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
         args.count, args.server
     );
     println!(
-        "  Listening at {}/{}/sub-0..sub-{}",
+        "  Listening at {}/{}/sub-{}..sub-{}",
         org,
         ns,
-        args.count - 1
+        args.start_index,
+        args.start_index + args.count - 1
     );
     if args.msgs > 0 {
         println!(
@@ -713,6 +749,11 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
     if args.reply {
         println!("  Reply mode: ON (echoing messages back)");
     }
+    if args.reliable {
+        println!("  Mode           : reliable (ACK-gated)");
+    } else {
+        println!("  Mode           : unreliable (fire-and-forget)");
+    }
     println!("  Waiting for publishers...\n");
 
     let client_config =
@@ -722,8 +763,10 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
         .await
         .context("connect to server failed")?;
 
+    let start_index = args.start_index;
     let mut join_set: JoinSet<(usize, Result<Sample>)> = JoinSet::new();
     for i in 0..args.count {
+        let actual_index = start_index + i;
         let org = org.clone();
         let ns = ns.clone();
         let secret = args.secret.clone();
@@ -735,9 +778,9 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
 
         join_set.spawn(async move {
             (
-                i,
+                actual_index,
                 run_sub_worker(
-                    &service, i, &org, &ns, &secret, conn_id, job_cnt, size, reply,
+                    &service, actual_index, &org, &ns, &secret, conn_id, job_cnt, size, reply,
                 )
                 .await,
             )
@@ -748,7 +791,7 @@ async fn run_sub(args: &BenchSubArgs, service: &Arc<Service>) -> Result<()> {
     let mut group = SampleGroup::new();
     while let Some(res) = join_set.join_next().await {
         match res {
-            Ok((_i, Ok(sample))) => group.add(sample),
+            Ok((i, Ok(sample))) => group.add(format!("sub-{i}"), sample),
             Ok((i, Err(e))) => eprintln!("[sub-{i}] error: {e:#}"),
             Err(e) => eprintln!("sub worker panicked: {e}"),
         }
@@ -850,10 +893,22 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
         "SLIM Bench Pub: {} publisher(s) on {}",
         args.count, args.server
     );
+    println!(
+        "  Publishing at {}/{}/pub-{}..pub-{}",
+        org,
+        ns,
+        args.start_index,
+        args.start_index + args.count - 1
+    );
     println!("  Total messages : {}", comma_format(args.msgs as i64));
     println!("  Payload size   : {} bytes", args.size);
+    let reliable = args.reliable;
     if args.request {
         println!("  Mode           : request-reply (measuring round-trip latency)");
+    } else if reliable {
+        println!("  Mode           : reliable (ACK-gated)");
+    } else {
+        println!("  Mode           : unreliable (fire-and-forget)");
     }
     println!();
 
@@ -866,8 +921,10 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
         .await
         .context("connect to server failed")?;
 
+    let start_index = args.start_index;
     let mut join_set: JoinSet<(usize, Result<(Sample, Vec<Duration>)>)> = JoinSet::new();
     for i in 0..args.count {
+        let actual_index = start_index + i;
         let org = org.clone();
         let ns = ns.clone();
         let secret = args.secret.clone();
@@ -878,8 +935,12 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
 
         join_set.spawn(async move {
             (
-                i,
-                run_pub_worker(&service, i, &org, &ns, &secret, conn_id, msgs, p, request).await,
+                actual_index,
+                run_pub_worker(
+                    &service, actual_index, &org, &ns, &secret, conn_id, msgs, p, request,
+                    reliable,
+                )
+                .await,
             )
         });
     }
@@ -889,8 +950,8 @@ async fn run_pub(args: &BenchPubArgs, service: &Arc<Service>) -> Result<()> {
     let mut all_latencies = Vec::new();
     while let Some(res) = join_set.join_next().await {
         match res {
-            Ok((_i, Ok((sample, latencies)))) => {
-                group.add(sample);
+            Ok((i, Ok((sample, latencies)))) => {
+                group.add(format!("pub-{i}"), sample);
                 all_latencies.extend(latencies);
             }
             Ok((i, Err(e))) => eprintln!("[pub-{i}] error: {e:#}"),
@@ -930,6 +991,7 @@ async fn run_pub_worker(
     msg_count: u64,
     payload: Vec<u8>,
     request: bool,
+    reliable: bool,
 ) -> Result<(Sample, Vec<Duration>)> {
     let own_name = make_pub_name(org, ns, i);
     let target_name = make_sub_name(org, ns, i);
@@ -955,6 +1017,7 @@ async fn run_pub_worker(
             "[pub-{i}] session to {target_name} not established within 35 s — \
              is `slimctl bench sub` running with a matching --prefix and --count?"
         ),
+        reliable,
     )
     .await?;
 
@@ -1083,7 +1146,7 @@ async fn run_channel_sub(args: &BenchChannelSubArgs, service: &Arc<Service>) -> 
     let mut group = SampleGroup::new();
     while let Some(res) = join_set.join_next().await {
         match res {
-            Ok((_idx, Ok(sample))) => group.add(sample),
+            Ok((idx, Ok(sample))) => group.add(format!("ch-sub-{idx}"), sample),
             Ok((idx, Err(e))) => eprintln!("[ch-sub-{idx}] error: {e:#}"),
             Err(e) => eprintln!("channel sub worker panicked: {e}"),
         }
@@ -1196,7 +1259,7 @@ async fn run_channel_pub(args: &BenchChannelPubArgs, service: &Arc<Service>) -> 
     {
         Ok(sample) => {
             let mut group = SampleGroup::new();
-            group.add(sample);
+            group.add("ch-pub", sample);
             println!("\n{}", group.report("Channel pub stats"));
             if let Some(csv_path) = &args.csv {
                 let run_id = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
@@ -1246,6 +1309,7 @@ async fn run_channel_pub_worker(
         channel_name.clone(),
         Duration::from_secs(5),
         "group session creation timed out unexpectedly",
+        true,
     )
     .await?;
 
@@ -1479,14 +1543,14 @@ mod tests {
     fn sample_group_aggregate() {
         let now = Instant::now();
         let mut g = SampleGroup::new();
-        g.add(Sample {
+        g.add("sub-0", Sample {
             job_msg_cnt: 500,
             msg_cnt: 500,
             msg_bytes: 64_000,
             start: now,
             end: now + Duration::from_secs(1),
         });
-        g.add(Sample {
+        g.add("sub-1", Sample {
             job_msg_cnt: 500,
             msg_cnt: 500,
             msg_bytes: 64_000,


### PR DESCRIPTION
## Description

Improves the `slimctl bench` pub/sub commands with better reporting and minor correctness fixes.

- **Richer per-worker and aggregate output**: the `SampleGroup` report now includes actual sent/received message counts alongside the throughput figures. When messages are dropped the output shows `<actual>/<expected> msgs, <N> dropped`; when there are no drops it stays compact: `(50,000 msgs)`. This makes message loss immediately visible without post-processing logs.
- **Propagate `controller.close()` await error**: the awaited result of `controller.close()` in `run_pub_worker` was silently discarded; added a trailing `?` to propagate it.
- **Remove unnecessary 5s sleep**: `run_pub` was sleeping 5 s unconditionally after all pub workers completed. Message processing tasks complete when the session closes, so the delay served no purpose.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass