### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-datapath",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,18 @@ resolver = "2"
 [workspace.dependencies]
 # Local dependencies
 agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.2" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.10.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.11.0" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.11.0" }
+agntcy-slim-config = { path = "crates/config", version = "0.11.1" }
 agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.2" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.8.0" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.15.0" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.2.0" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.9.0" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.0" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.2.1" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.1.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.10.0", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.3.0" }
+agntcy-slim-service = { path = "crates/service", version = "0.10.1", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.4.0" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.10" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.0" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.1" }
 agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.2" }
 agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.2" }
 anyhow = "1.0.103"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/agntcy/slim/compare/slim-auth-v0.10.0...slim-auth-v0.11.0) - 2026-07-01
+
+### Added
+
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
+### Other
+
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [0.10.0](https://github.com/agntcy/slim/compare/slim-auth-v0.9.0...slim-auth-v0.10.0) - 2026-06-17
 
 ### Added

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.10.0"
+version = "0.11.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/agntcy/slim/compare/slim-config-v0.11.0...slim-config-v0.11.1) - 2026-07-01
+
+### Added
+
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
+### Other
+
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [0.11.0](https://github.com/agntcy/slim/compare/slim-config-v0.10.0...slim-config-v0.11.0) - 2026-06-17
 
 ### Added

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.11.0"
+version = "0.11.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-control-plane-v2.0.0-alpha.2) - 2026-07-01
+
+### Added
+
+- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
+- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))
+
+### Other
+
+- release 2.0.0 alpha 2 ([#1783](https://github.com/agntcy/slim/pull/1783))
+- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/agntcy/slim/compare/slim-controller-v0.8.0...slim-controller-v0.9.0) - 2026-07-01
+
+### Added
+
+- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
+- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
+### Other
+
+- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [0.8.0](https://github.com/agntcy/slim/compare/slim-controller-v0.7.0...slim-controller-v0.8.0) - 2026-06-17
 
 ### Added

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.8.0"
+version = "0.9.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.15.0...slim-datapath-v0.16.0) - 2026-07-01
+
+### Added
+
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
+### Other
+
+- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [0.15.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.14.1...slim-datapath-v0.15.0) - 2026-06-17
 
 ### Added

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.15.0"
+version = "0.16.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/agntcy/slim/compare/slim-mls-v0.2.0...slim-mls-v0.2.1) - 2026-07-01
+
+### Added
+
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
 ## [0.2.0](https://github.com/agntcy/slim/compare/slim-mls-v0.1.20...slim-mls-v0.2.0) - 2026-06-17
 
 ### Added

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.2.1"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/agntcy/slim/releases/tag/slim-proto-v0.1.0) - 2026-07-01
+
+### Added
+
+- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
+### Other
+
+- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/agntcy/slim/compare/slim-service-v0.10.0...slim-service-v0.10.1) - 2026-07-01
+
+### Added
+
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
+### Other
+
+- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [0.10.0](https://github.com/agntcy/slim/compare/slim-service-v0.9.0...slim-service-v0.10.0) - 2026-06-17
 
 ### Added

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.10.0"
+version = "0.10.1"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/agntcy/slim/compare/slim-session-v0.3.0...slim-session-v0.4.0) - 2026-07-01
+
+### Added
+
+- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))
+- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
+
 ## [0.3.0](https://github.com/agntcy/slim/compare/slim-session-v0.2.1...slim-session-v0.3.0) - 2026-06-17
 
 ### Added

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.4.0"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.2](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.1...slim-v2.0.0-alpha.2) - 2026-07-01
+
+### Other
+
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [2.0.0-alpha.1](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.0...slim-v2.0.0-alpha.1) - 2026-06-17
 
 ### Added

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.2](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.1...slimctl-v2.0.0-alpha.2) - 2026-07-01
+
+### Added
+
+- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
+- *(slimctl)* improve bench pub/sub commands and reporting ([#1748](https://github.com/agntcy/slim/pull/1748))
+
+### Other
+
+- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
+
 ## [2.0.0-alpha.1](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.0...slimctl-v2.0.0-alpha.1) - 2026-06-17
 
 ### Added

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.0...slim-tracing-v0.4.1) - 2026-07-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-config
+
 ## [0.4.0](https://github.com/agntcy/slim/compare/slim-tracing-v0.3.13...slim-tracing-v0.4.0) - 2026-06-17
 
 ### Added

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.0"
+version = "0.4.1"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `agntcy-slim-proto`: 0.1.0
* `agntcy-slim-datapath`: 0.15.0 -> 0.16.0 (⚠ API breaking changes)
* `agntcy-slim-mls`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `agntcy-slim-session`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `agntcy-slim-controller`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `agntcy-slim`: 2.0.0-alpha.1 -> 2.0.0-alpha.2
* `agntcy-slim-control-plane`: 2.0.0-alpha.2
* `agntcy-slimctl`: 2.0.0-alpha.1 -> 2.0.0-alpha.2
* `agntcy-slim-tracing`: 0.4.0 -> 0.4.1

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthError:MlsKeyGenerationFailed in /tmp/.tmpW88mUx/slim/crates/auth/src/errors.rs:175
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type PeerDiscoveryConfig no longer derives Eq, in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:83
  type PeerDiscoveryConfig no longer derives Eq, in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:83

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum slim_datapath::api::proto::dataplane::v1::LinkConnectionType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:541
  enum slim_datapath::api::proto::dataplane::v1::SessionType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:434
  enum slim_datapath::api::ProtoSessionType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:434
  enum slim_datapath::api::proto::dataplane::v1::message::MessageType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:43
  enum slim_datapath::api::MessageType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:43
  enum slim_datapath::api::proto::dataplane::v1::link::LinkType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:66
  enum slim_datapath::api::ProtoLinkType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:66
  enum slim_datapath::api::proto::dataplane::v1::content::ContentType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:156
  enum slim_datapath::messages::utils::MessageError, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:77
  enum slim_datapath::api::proto::dataplane::v1::command_payload::CommandPayloadType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:183
  enum slim_datapath::api::proto::dataplane::v1::SessionMessageType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:463
  enum slim_datapath::api::ProtoSessionMessageType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:463

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant PeerDiscoveryConfig::Kubernetes 0 -> 1 in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:96
  variant PeerDiscoveryConfig::Kubernetes 0 -> 1 in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:96

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field service_name of variant PeerDiscoveryConfig::Kubernetes in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:100
  field port of variant PeerDiscoveryConfig::Kubernetes in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:102
  field service_name of variant PeerDiscoveryConfig::Kubernetes in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:100
  field port of variant PeerDiscoveryConfig::Kubernetes in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:102

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field label_selector of variant PeerDiscoveryConfig::Kubernetes, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/peer_discovery/config.rs:103
  field label_selector of variant PeerDiscoveryConfig::Kubernetes, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/peer_discovery/config.rs:103

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PeerDiscoveryConfig:Static in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:88
  variant PeerDiscoveryConfig:Static in /tmp/.tmpW88mUx/slim/crates/datapath/src/peer_discovery/config.rs:88

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant PeerTopology::HubAndSpoke, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/peer_discovery/config.rs:21
  variant PeerTopology::HubAndSpoke, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/peer_discovery/config.rs:21

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_datapath::api::proto::dataplane::v1, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/proto.rs:5
  mod slim_datapath::api::proto::dataplane, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/proto.rs:4
  mod slim_datapath::api::proto::dataplane::v1::content, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:154
  mod slim_datapath::api::proto::dataplane::v1::data_plane_service_server, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:693
  mod slim_datapath::api::proto::dataplane::v1::link, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:64
  mod slim_datapath::api::proto::dataplane::v1::message, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:41
  mod slim_datapath::api::proto::dataplane::v1::command_payload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:181
  mod slim_datapath::api::proto::dataplane::v1::data_plane_service_client, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:573

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DELETE_GROUP in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:43
  LEAVING_SESSION in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:59
  MAX_PUBLISH_ID in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:71
  PUBLISH_TO in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:48
  TRUE_VAL in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:62
  DEFAULT_TTL in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:74
  DISCONNECTION_DETECTED in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:54
  FALSE_VAL in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:65
  SERVICE_NAME in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:876

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_datapath::api::proto::dataplane::v1::Message, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:31
  struct slim_datapath::api::ProtoMessage, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:31
  struct slim_datapath::api::proto::dataplane::v1::Participant, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:215
  struct slim_datapath::api::Participant, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:215
  struct slim_datapath::api::proto::dataplane::v1::data_plane_service_client::DataPlaneServiceClient, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:584
  struct slim_datapath::api::DataPlaneServiceClient, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:584
  struct slim_datapath::api::proto::dataplane::v1::HeaderIntegrityAad, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:295
  struct slim_datapath::api::HeaderIntegrityAad, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:295
  struct slim_datapath::api::proto::dataplane::v1::Subscribe, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:4
  struct slim_datapath::api::ProtoSubscribe, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:4
  struct slim_datapath::messages::utils::CommandPayloadBuilder, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:1177
  struct slim_datapath::api::proto::dataplane::v1::Unsubscribe, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:13
  struct slim_datapath::api::ProtoUnsubscribe, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:13
  struct slim_datapath::api::proto::dataplane::v1::TimerSettings, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:251
  struct slim_datapath::api::proto::dataplane::v1::Publish, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:22
  struct slim_datapath::api::ProtoPublish, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:22
  struct slim_datapath::api::proto::dataplane::v1::MlsPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:276
  struct slim_datapath::api::MlsPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:276
  struct slim_datapath::api::proto::dataplane::v1::MlsSettings, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:287
  struct slim_datapath::api::ProtoMlsSettings, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:287
  struct slim_datapath::api::proto::dataplane::v1::Link, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:59
  struct slim_datapath::api::ProtoLink, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:59
  struct slim_datapath::api::proto::dataplane::v1::DiscoveryRequestPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:232
  struct slim_datapath::api::DiscoveryRequestPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:232
  struct slim_datapath::api::proto::dataplane::v1::SubscriptionAck, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:387
  struct slim_datapath::api::ProtoSubscriptionAck, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:387
  struct slim_datapath::api::proto::dataplane::v1::DiscoveryReplyPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:235
  struct slim_datapath::api::DiscoveryReplyPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:235
  struct slim_datapath::api::proto::dataplane::v1::JoinRequestPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:238
  struct slim_datapath::api::JoinRequestPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:238
  struct slim_datapath::api::proto::dataplane::v1::JoinReplyPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:260
  struct slim_datapath::api::JoinReplyPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:260
  struct slim_datapath::api::proto::dataplane::v1::LeaveRequestPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:269
  struct slim_datapath::api::LeaveRequestPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:269
  struct slim_datapath::api::proto::dataplane::v1::ApplicationPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:164
  struct slim_datapath::api::ApplicationPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:164
  struct slim_datapath::api::proto::dataplane::v1::LinkNegotiationPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:403
  struct slim_datapath::api::LinkNegotiationPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:403
  struct slim_datapath::api::proto::dataplane::v1::LeaveReplyPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:272
  struct slim_datapath::api::LeaveReplyPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:272
  struct slim_datapath::api::proto::dataplane::v1::CommandPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:171
  struct slim_datapath::api::CommandPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:171
  struct slim_datapath::api::proto::dataplane::v1::Content, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:149
  struct slim_datapath::api::Content, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:149
  struct slim_datapath::api::proto::dataplane::v1::GroupAddPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:318
  struct slim_datapath::api::GroupAddPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:318
  struct slim_datapath::api::proto::dataplane::v1::SlimHeader, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:76
  struct slim_datapath::api::SlimHeader, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:76
  struct slim_datapath::api::proto::dataplane::v1::StringName, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:139
  struct slim_datapath::api::StringName, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:139
  struct slim_datapath::api::proto::dataplane::v1::GroupRemovePayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:332
  struct slim_datapath::api::GroupRemovePayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:332
  struct slim_datapath::api::proto::dataplane::v1::Name, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:112
  struct slim_datapath::api::ProtoName, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:112
  struct slim_datapath::api::proto::dataplane::v1::GroupWelcomePayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:346
  struct slim_datapath::api::GroupWelcomePayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:346
  struct slim_datapath::api::proto::dataplane::v1::NameId, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:119
  struct slim_datapath::api::NameId, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:119
  struct slim_datapath::api::proto::dataplane::v1::GroupClosePayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:356
  struct slim_datapath::messages::utils::ProtoMessageBuilder, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:1456
  struct slim_datapath::api::proto::dataplane::v1::GroupProposalPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:363
  struct slim_datapath::api::GroupProposalPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:363
  struct slim_datapath::api::proto::dataplane::v1::GroupAckPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:376
  struct slim_datapath::api::GroupAckPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:376
  struct slim_datapath::api::proto::dataplane::v1::GroupNackPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:379
  struct slim_datapath::api::GroupNackPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:379
  struct slim_datapath::api::proto::dataplane::v1::PingPayload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:382
  struct slim_datapath::api::proto::dataplane::v1::EncodedName, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:128
  struct slim_datapath::api::EncodedName, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:128
  struct slim_datapath::api::proto::dataplane::v1::data_plane_service_server::DataPlaneServiceServer, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:720
  struct slim_datapath::api::DataPlaneServiceServer, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:720
  struct slim_datapath::api::proto::dataplane::v1::ParticipantSettings, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:222
  struct slim_datapath::api::ParticipantSettings, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:222
  struct slim_datapath::api::proto::dataplane::v1::SessionHeader, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:101
  struct slim_datapath::api::SessionHeader, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:101
  struct slim_datapath::messages::utils::SlimHeaderFlags, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/messages/utils.rs:194

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field is_hub of struct PeerSyncConfig, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/sync/forwarder.rs:83
  field static_peers of struct PeerConfig, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/peer_discovery/config.rs:73
  field static_peers of struct PeerConfig, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/peer_discovery/config.rs:73

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait slim_datapath::api::proto::dataplane::v1::data_plane_service_server::DataPlaneService, previously in file /tmp/.tmpUmHeGz/agntcy-slim-datapath/src/api/gen/dataplane.proto.v1.rs:704
```

### ⚠ `agntcy-slim-session` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MlsSettings.max_seen_control_message_ids_size in /tmp/.tmpW88mUx/slim/crates/session/src/session_config.rs:15

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionError:SignatureKeyIsEmpty in /tmp/.tmpW88mUx/slim/crates/session/src/errors.rs:55
  variant SessionError:SignatureKeyCollectionFailedWithAuthErr in /tmp/.tmpW88mUx/slim/crates/session/src/errors.rs:57
  variant SessionError:ControlMessageReplay in /tmp/.tmpW88mUx/slim/crates/session/src/errors.rs:89
  variant SessionError:SignatureKeyIsEmpty in /tmp/.tmpW88mUx/slim/crates/session/src/errors.rs:55
  variant SessionError:SignatureKeyCollectionFailedWithAuthErr in /tmp/.tmpW88mUx/slim/crates/session/src/errors.rs:57
  variant SessionError:ControlMessageReplay in /tmp/.tmpW88mUx/slim/crates/session/src/errors.rs:89
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum slim_controller::api::proto::api::v1::ConnectionType, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:218
  enum slim_controller::api::proto::api::v1::control_message::Payload, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:15
  enum slim_controller::api::proto::api::v1::ConnectionDirection, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:247

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod slim_controller::api::proto::api, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/proto.rs:4
  mod slim_controller::api::proto::api::v1::connection_details, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:167
  mod slim_controller::api::proto::api::v1::control_message, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:13
  mod slim_controller::api::proto::api::v1::controller_service_client, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:272
  mod slim_controller::api::proto::api::v1, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/proto.rs:5
  mod slim_controller::api::proto::api::v1::controller_service_server, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:394

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  SERVICE_NAME in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:583

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct slim_controller::api::proto::api::v1::connection_details::SpireMtls, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:169
  struct slim_controller::api::proto::api::v1::ConnectionEntry, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:124
  struct slim_controller::api::proto::api::v1::RegisterNodeRequest, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:177
  struct slim_controller::api::proto::api::v1::RegisterNodeResponse, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:193
  struct slim_controller::api::proto::api::v1::controller_service_server::ControllerServiceServer, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:421
  struct slim_controller::api::proto::api::v1::ControlMessage, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:3
  struct slim_controller::api::proto::api::v1::Connection, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:41
  struct slim_controller::api::proto::api::v1::DeregisterNodeRequest, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:205
  struct slim_controller::api::proto::api::v1::ConnectionAck, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:48
  struct slim_controller::api::proto::api::v1::DeregisterNodeResponse, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:210
  struct slim_controller::api::proto::api::v1::ConfigurationCommand, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:75
  struct slim_controller::api::proto::api::v1::ConnectionDetails, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:156
  struct slim_controller::api::proto::api::v1::ConfigurationCommandAck, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:88
  struct slim_controller::api::proto::api::v1::Ack, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:97
  struct slim_controller::api::proto::api::v1::RouteEntry, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:117
  struct slim_controller::api::proto::api::v1::Node, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:151
  struct slim_controller::api::proto::api::v1::RouteListRequest, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:106
  struct slim_controller::api::proto::api::v1::RouteListResponse, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:108
  struct slim_controller::api::proto::api::v1::RouteAck, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:66
  struct slim_controller::api::proto::api::v1::Route, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:57
  struct slim_controller::api::proto::api::v1::ConnectionListRequest, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:140
  struct slim_controller::api::proto::api::v1::ConnectionListResponse, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:142
  struct slim_controller::api::proto::api::v1::controller_service_client::ControllerServiceClient, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:283

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait slim_controller::api::proto::api::v1::controller_service_server::ControllerService, previously in file /tmp/.tmpUmHeGz/agntcy-slim-controller/src/api/gen/controller.proto.v1.rs:405
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.11.0](https://github.com/agntcy/slim/compare/slim-auth-v0.10.0...slim-auth-v0.11.0) - 2026-07-01

### Added

- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.11.1](https://github.com/agntcy/slim/compare/slim-config-v0.11.0...slim-config-v0.11.1) - 2026-07-01

### Added

- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.1.0](https://github.com/agntcy/slim/releases/tag/slim-proto-v0.1.0) - 2026-07-01

### Added

- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.15.0...slim-datapath-v0.16.0) - 2026-07-01

### Added

- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.1](https://github.com/agntcy/slim/compare/slim-mls-v0.2.0...slim-mls-v0.2.1) - 2026-07-01

### Added

- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.4.0](https://github.com/agntcy/slim/compare/slim-session-v0.3.0...slim-session-v0.4.0) - 2026-07-01

### Added

- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))
- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.9.0](https://github.com/agntcy/slim/compare/slim-controller-v0.8.0...slim-controller-v0.9.0) - 2026-07-01

### Added

- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))
- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.10.1](https://github.com/agntcy/slim/compare/slim-service-v0.10.0...slim-service-v0.10.1) - 2026-07-01

### Added

- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.2](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.1...slim-v2.0.0-alpha.2) - 2026-07-01

### Other

- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-control-plane-v2.0.0-alpha.2) - 2026-07-01

### Added

- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))

### Other

- release 2.0.0 alpha 2 ([#1783](https://github.com/agntcy/slim/pull/1783))
- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.2](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.1...slimctl-v2.0.0-alpha.2) - 2026-07-01

### Added

- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
- *(slimctl)* improve bench pub/sub commands and reporting ([#1748](https://github.com/agntcy/slim/pull/1748))

### Other

- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.1](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.0...slim-tracing-v0.4.1) - 2026-07-01

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).