### PR TITLE
ci: add agntcy-slim-control-plane to release-plz

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -84,3 +84,9 @@ name = "agntcy-slim-proto"
 publish = true
 release = true
 changelog_update = true
+
+[[package]]
+name = "agntcy-slim-control-plane"
+publish = false
+release = true
+changelog_update = true


### PR DESCRIPTION
## Summary

- Register `agntcy-slim-control-plane` in `.release-plz.toml` with `publish = false` / `release = true`


The `crates/control-plane` binary crate (`agntcy-slim-control-plane`) was introduced in the pure-Rust workspace restructure (#1693, Jun 18) but was never added to release-plz. The last `control-plane` Docker image was published as `slim-controller-v0.8.0` on **Jun 17** — before the restructure — and `ghcr.io/agntcy/slim/control-plane:latest` has served that old **Go binary** ever since.

Trivy consequently reports 17 Go stdlib CVEs (HIGH/MEDIUM) against the control-plane image, all of which are false positives for the current Rust codebase.
