### PR TITLE
ci: pin image versions in trivy scan matrix

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -27,10 +27,10 @@ jobs:
         include:
           - image: slim-node
             repo: ghcr.io/${{ github.repository_owner }}/slim
-            version: latest
+            version: 2.0.0-alpha.1
           - image: slim-controller
             repo: ghcr.io/${{ github.repository_owner }}/slim/control-plane
-            version: latest
+            version: 1.4.0
           - image: spire-server
             repo: ghcr.io/spiffe/spire-server
             version: 1.14.5


### PR DESCRIPTION
## Summary

- Pin `slim-node` to `2.0.0-alpha.1` (from `slim-v2.0.0-alpha.1` tag)
- Pin `slim-controller` to `1.4.0` (from `control-plane-v1.4.0` tag)

