### PR TITLE
perf(datapath): zero-copy proto layout and forwarding path improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "bollard",
+ "bytes",
  "clap",
  "futures",
  "jsonwebtoken",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "aws-lc-rs",
+ "bytes",
  "cfg-if",
  "criterion",
  "display-error-chain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ version = "0.1.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
+ "bytes",
  "prost",
  "prost-types",
  "protoc-bin-vendored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,38 +1,38 @@
 [workspace]
 
 members = [
-  "crates/auth",
-  "crates/channel-manager",
-  "crates/config",
-  "crates/control-plane",
-  "crates/controller",
-  "crates/datapath",
-  "crates/examples",
-  "crates/mls",
-  "crates/proto",
-  "crates/service",
-  "crates/session",
-  "crates/signal",
-  "crates/slim",
-  "crates/slimctl",
-  "crates/testing",
-  "crates/tracing",
-  "crates/version",
+    "crates/auth",
+    "crates/channel-manager",
+    "crates/config",
+    "crates/control-plane",
+    "crates/controller",
+    "crates/datapath",
+    "crates/examples",
+    "crates/mls",
+    "crates/proto",
+    "crates/service",
+    "crates/session",
+    "crates/signal",
+    "crates/slim",
+    "crates/slimctl",
+    "crates/testing",
+    "crates/tracing",
+    "crates/version",
 ]
 
 default-members = [
-  "crates/control-plane",
-  "crates/channel-manager",
-  "crates/config",
-  "crates/datapath",
-  "crates/service",
-  "crates/signal",
-  "crates/slim",
-  "crates/tracing",
-  "crates/version",
-  "crates/examples",
-  "crates/slimctl",
-  "crates/testing",
+    "crates/control-plane",
+    "crates/channel-manager",
+    "crates/config",
+    "crates/datapath",
+    "crates/service",
+    "crates/signal",
+    "crates/slim",
+    "crates/tracing",
+    "crates/version",
+    "crates/examples",
+    "crates/slimctl",
+    "crates/testing",
 ]
 
 resolver = "2"
@@ -71,17 +71,17 @@ clap = { version = "4.5.23", features = ["derive", "env"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 diesel = { version = "2.3.10", features = ["sqlite"] }
 diesel-async = { version = "0.9", features = [
-  "sqlite",
-  "deadpool",
-  "migrations",
+    "sqlite",
+    "deadpool",
+    "migrations",
 ] }
 diesel_migrations = { version = "2" }
 display-error-chain = { version = "0.2" }
 drain = { version = "0.2", features = ["retain"] }
 duration-string = { version = "0.5.3", features = ["serde"] }
 fastwebsockets = { version = "0.10.0", features = [
-  "upgrade",
-  "unstable-split",
+    "upgrade",
+    "unstable-split",
 ] }
 futures = "0.3.31"
 futures-timer = "3.0.3"
@@ -97,8 +97,8 @@ http = "1.2.0"
 http-body-util = "0.1.3"
 hyper = { version = "1.8.1", features = ["http1", "server", "client"] }
 hyper-rustls = { version = "0.27", features = [
-  "http2",
-  "aws-lc-rs",
+    "http2",
+    "aws-lc-rs",
 ], default-features = false }
 hyper-util = "0.1.10"
 indexmap = "2"
@@ -108,9 +108,9 @@ js-sys = "0.3"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 k8s-openapi = { version = "0.27", default-features = false }
 kube = { version = "3.1", default-features = false, features = [
-  "client",
-  "runtime",
-  "rustls-tls",
+    "client",
+    "runtime",
+    "rustls-tls",
 ] }
 
 lazy_static = "1.5.0"
@@ -128,16 +128,16 @@ oauth2 = { version = "5", default-features = false, features = ["reqwest"] }
 once_cell = "1.21.0"
 opentelemetry = { version = "0.31.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.31.0", features = [
-  "metrics",
-  "grpc-tonic",
+    "metrics",
+    "grpc-tonic",
 ] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = [
-  "semconv_experimental",
+    "semconv_experimental",
 ] }
 opentelemetry-stdout = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
-  "trace",
-  "rt-tokio",
+    "trace",
+    "rt-tokio",
 ] }
 parking_lot = "0.12.3"
 percent-encoding = "2.3"
@@ -152,12 +152,12 @@ rand = "0.9.0"
 regex = "1.11.1"
 
 reqwest = { version = "0.12", features = [
-  "json",
-  "rustls-tls-no-provider",
-  "charset",
-  "http2",
-  "system-proxy",
-  "blocking",
+    "json",
+    "rustls-tls-no-provider",
+    "charset",
+    "http2",
+    "system-proxy",
+    "blocking",
 ], default-features = false }
 rlimit = "0.11.0"
 rstest = "0.25"
@@ -172,9 +172,9 @@ serde_yaml = "0.9.34"
 sha2 = "0.10"
 smallvec = "1"
 spiffe = { version = "0.12.0", features = [
-  "x509-source",
-  "jwt-source",
-  "jwt-verify-aws-lc-rs",
+    "x509-source",
+    "jwt-source",
+    "jwt-verify-aws-lc-rs",
 ] }
 tempfile = "3"
 test-fork = "0.1.3"
@@ -213,17 +213,17 @@ repository = "https://github.com/agntcy/slim"
 
 [workspace.metadata.cargo-machete]
 ignored = [
-  "agntcy-slim",
-  "agntcy-slim-auth",
-  "agntcy-slim-config",
-  "agntcy-slim-controller",
-  "agntcy-slim-datapath",
-  "agntcy-slim-mls",
-  "agntcy-slim-service",
-  "agntcy-slim-session",
-  "agntcy-slim-signal",
-  "agntcy-slim-testing",
-  "agntcy-slim-tracing",
-  "agntcy-slim-version",
-  "agntcy-slimctl",
+    "agntcy-slim",
+    "agntcy-slim-auth",
+    "agntcy-slim-config",
+    "agntcy-slim-controller",
+    "agntcy-slim-datapath",
+    "agntcy-slim-mls",
+    "agntcy-slim-service",
+    "agntcy-slim-session",
+    "agntcy-slim-signal",
+    "agntcy-slim-testing",
+    "agntcy-slim-tracing",
+    "agntcy-slim-version",
+    "agntcy-slimctl",
 ]

--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -222,6 +222,14 @@ pub struct ClientConfig {
     /// ReadBufferSize.
     pub buffer_size: Option<usize>,
 
+    /// HTTP/2 per-stream initial flow control window size (bytes).
+    /// Defaults to 4 MiB when unset.
+    pub initial_stream_window_size: Option<u32>,
+
+    /// HTTP/2 per-connection initial flow control window size (bytes).
+    /// Defaults to 16 MiB when unset.
+    pub initial_connection_window_size: Option<u32>,
+
     /// The headers associated with gRPC requests.
     #[serde(default)]
     pub headers: HashMap<String, String>,
@@ -268,6 +276,8 @@ impl Default for ClientConfig {
             connect_timeout: default_connect_timeout(),
             request_timeout: default_request_timeout(),
             buffer_size: None,
+            initial_stream_window_size: Some(4 * 1024 * 1024),
+            initial_connection_window_size: Some(16 * 1024 * 1024),
             headers: HashMap::new(),
             auth: AuthenticationConfig::None,
             backoff: BackoffConfig::default(),
@@ -300,7 +310,7 @@ impl std::fmt::Display for ClientConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ClientConfig {{ endpoint: {}, transport: {:?}, origin: {:?}, server_name: {:?}, compression: {:?}, rate_limit: {:?}, tls_setting: {:?}, keepalive: {:?}, proxy: {:?}, connect_timeout: {:?}, request_timeout: {:?}, buffer_size: {:?}, headers: {:?}, auth: {:?}, backoff: {:?}, metadata: {:?}, link_id: {:?}, connection_type: {:?} }}",
+            "ClientConfig {{ endpoint: {}, transport: {:?}, origin: {:?}, server_name: {:?}, compression: {:?}, rate_limit: {:?}, tls_setting: {:?}, keepalive: {:?}, proxy: {:?}, connect_timeout: {:?}, request_timeout: {:?}, buffer_size: {:?}, initial_stream_window_size: {:?}, initial_connection_window_size: {:?}, headers: {:?}, auth: {:?}, backoff: {:?}, metadata: {:?}, link_id: {:?}, connection_type: {:?} }}",
             self.endpoint,
             self.resolved_transport(),
             self.origin,
@@ -313,6 +323,8 @@ impl std::fmt::Display for ClientConfig {
             self.connect_timeout,
             self.request_timeout,
             self.buffer_size,
+            self.initial_stream_window_size,
+            self.initial_connection_window_size,
             self.headers,
             self.auth,
             self.backoff,
@@ -554,6 +566,11 @@ mod tests {
         assert_eq!(client.connect_timeout, Duration::from_secs(0));
         assert_eq!(client.request_timeout, Duration::from_secs(0));
         assert_eq!(client.buffer_size, None);
+        assert_eq!(client.initial_stream_window_size, Some(4 * 1024 * 1024));
+        assert_eq!(
+            client.initial_connection_window_size,
+            Some(16 * 1024 * 1024)
+        );
         assert_eq!(client.headers, HashMap::new());
         assert_eq!(client.auth, AuthenticationConfig::None);
     }

--- a/crates/config/src/grpc/client.rs
+++ b/crates/config/src/grpc/client.rs
@@ -240,6 +240,14 @@ impl ClientConfig {
             builder = builder.buffer_size(size);
         }
 
+        // set HTTP/2 flow control window sizes
+        if let Some(sz) = self.initial_stream_window_size {
+            builder = builder.initial_stream_window_size(sz);
+        }
+        if let Some(sz) = self.initial_connection_window_size {
+            builder = builder.initial_connection_window_size(sz);
+        }
+
         // set keepalive settings
         if let Some(keepalive) = &self.keepalive {
             builder = builder

--- a/crates/config/src/grpc/server.rs
+++ b/crates/config/src/grpc/server.rs
@@ -227,6 +227,16 @@ impl ServerConfig {
             None => builder,
         };
 
+        let builder = match self.initial_stream_window_size {
+            Some(sz) => builder.initial_stream_window_size(sz),
+            None => builder,
+        };
+
+        let builder = match self.initial_connection_window_size {
+            Some(sz) => builder.initial_connection_window_size(sz),
+            None => builder,
+        };
+
         let builder = builder.http2_keepalive_interval(Some(self.keepalive.time.into()));
         let builder = builder.http2_keepalive_timeout(Some(self.keepalive.timeout.into()));
 

--- a/crates/config/src/server.rs
+++ b/crates/config/src/server.rs
@@ -113,6 +113,14 @@ pub struct ServerConfig {
     // TODO(msardara): not implemented yet
     pub write_buffer_size: Option<usize>,
 
+    /// HTTP/2 per-stream initial flow control window size (bytes).
+    /// Defaults to 4 MiB when unset.
+    pub initial_stream_window_size: Option<u32>,
+
+    /// HTTP/2 per-connection initial flow control window size (bytes).
+    /// Defaults to 16 MiB when unset.
+    pub initial_connection_window_size: Option<u32>,
+
     /// Keepalive anchor for all the settings related to keepalive.
     #[serde(default)]
     pub keepalive: KeepaliveServerParameters,
@@ -188,6 +196,8 @@ impl Default for ServerConfig {
             max_header_list_size: None,
             read_buffer_size: Some(1024 * 1024),
             write_buffer_size: Some(1024 * 1024),
+            initial_stream_window_size: Some(4 * 1024 * 1024),
+            initial_connection_window_size: Some(16 * 1024 * 1024),
             keepalive: KeepaliveServerParameters::default(),
             auth: AuthenticationConfig::default(),
             metadata: None,
@@ -219,7 +229,7 @@ impl std::fmt::Display for ServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ServerConfig {{ endpoint: {}, transport: {:?}, tls_setting: {}, http2_only: {}, max_frame_size: {:?}, max_concurrent_streams: {:?}, max_header_list_size: {:?}, read_buffer_size: {:?}, write_buffer_size: {:?}, keepalive: {:?}, auth: {:?}, metadata: {:?}, require_header_mac: {}, negotiation_timeout_secs: {}, link_hmac_poll_interval_ms: {} }}",
+            "ServerConfig {{ endpoint: {}, transport: {:?}, tls_setting: {}, http2_only: {}, max_frame_size: {:?}, max_concurrent_streams: {:?}, max_header_list_size: {:?}, read_buffer_size: {:?}, write_buffer_size: {:?}, initial_stream_window_size: {:?}, initial_connection_window_size: {:?}, keepalive: {:?}, auth: {:?}, metadata: {:?}, require_header_mac: {}, negotiation_timeout_secs: {}, link_hmac_poll_interval_ms: {} }}",
             self.endpoint,
             self.resolved_transport(),
             self.tls_setting,
@@ -229,6 +239,8 @@ impl std::fmt::Display for ServerConfig {
             self.max_header_list_size,
             self.read_buffer_size,
             self.write_buffer_size,
+            self.initial_stream_window_size,
+            self.initial_connection_window_size,
             self.keepalive,
             self.auth,
             self.metadata,
@@ -424,6 +436,14 @@ mod tests {
         assert_eq!(server_config.max_header_list_size, None);
         assert_eq!(server_config.read_buffer_size, Some(1024 * 1024));
         assert_eq!(server_config.write_buffer_size, Some(1024 * 1024));
+        assert_eq!(
+            server_config.initial_stream_window_size,
+            Some(4 * 1024 * 1024)
+        );
+        assert_eq!(
+            server_config.initial_connection_window_size,
+            Some(16 * 1024 * 1024)
+        );
         assert_eq!(
             server_config.keepalive,
             KeepaliveServerParameters::default()

--- a/crates/config/src/transport_common.rs
+++ b/crates/config/src/transport_common.rs
@@ -74,7 +74,7 @@ impl ClientConfig {
 
         // NOTE(msardara): we might want to make these configurable as well.
         http.enforce_http(false);
-        http.set_nodelay(false);
+        http.set_nodelay(true); // disable Nagle for low-latency RPC
 
         match self.connect_timeout.as_secs() {
             0 => http.set_connect_timeout(None),

--- a/crates/control-plane/src/route_service/commands.rs
+++ b/crates/control-plane/src/route_service/commands.rs
@@ -4,7 +4,7 @@
 //! Public API commands called by the northbound gRPC handlers.
 //! These are the entry points that `slimctl` and other clients invoke.
 
-use slim_datapath::api::NameId;
+use slim_datapath::api::NULL_COMPONENT;
 use uuid::Uuid;
 
 use crate::api::proto::controller::proto::v1::{
@@ -37,7 +37,7 @@ impl super::RouteService {
         // downward path from root to new announcer).
         let existing_root = if source_node_id == ALL_NODES_ID {
             let (c0, c1, c2) = route_name.str_components();
-            let comp_id = if route_name.id() == NameId::NULL_COMPONENT {
+            let comp_id = if route_name.id() == NULL_COMPONENT {
                 None
             } else {
                 Some(route_name.string_id())
@@ -81,7 +81,7 @@ impl super::RouteService {
             let all_nodes = self.0.db.list_nodes().await?;
             let all_links = self.0.db.list_all_links().await?;
             let (c0, c1, c2) = route_name.str_components();
-            let comp_id = if route_name.id() == NameId::NULL_COMPONENT {
+            let comp_id = if route_name.id() == NULL_COMPONENT {
                 None
             } else {
                 Some(route_name.string_id())
@@ -137,7 +137,7 @@ impl super::RouteService {
         };
 
         let (c0, c1, c2) = route_name.str_components();
-        let comp_id = if route_name.id() == NameId::NULL_COMPONENT {
+        let comp_id = if route_name.id() == NULL_COMPONENT {
             None
         } else {
             Some(route_name.string_id())

--- a/crates/control-plane/src/route_service/node_lifecycle.rs
+++ b/crates/control-plane/src/route_service/node_lifecycle.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use slim_config::grpc::client::ClientConfig;
-use slim_datapath::api::NameId;
+use slim_datapath::api::NULL_COMPONENT;
 
 use crate::api::proto::controller::proto::v1::ConnectionDirection;
 use crate::db::{LinkStatus, RouteStatus};
@@ -153,7 +153,7 @@ impl super::RouteService {
                         return false;
                     };
                     let (c0, c1, c2) = dp_name.str_components();
-                    let comp_id = if dp_name.id() == NameId::NULL_COMPONENT {
+                    let comp_id = if dp_name.id() == NULL_COMPONENT {
                         None
                     } else {
                         Some(dp_name.string_id())

--- a/crates/control-plane/src/route_service/reconciler.rs
+++ b/crates/control-plane/src/route_service/reconciler.rs
@@ -18,7 +18,7 @@ use crate::api::proto::controller::proto::v1::{
 use crate::db::{LinkStatus, RouteStatus, SharedDb};
 use crate::node_transport::{DefaultNodeCommandHandler, NodeStatus, ResponseKind};
 use crate::workqueue::WorkQueue;
-use slim_datapath::api::{NULL_COMPONENT, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName, id_from_str};
 
 use super::is_connection_not_found;
 
@@ -334,8 +334,7 @@ async fn build_desired_routes<'a>(
                         route
                             .component_id
                             .as_deref()
-                            .and_then(|s| uuid::Uuid::parse_str(s).ok())
-                            .map(|u| u.as_u128())
+                            .and_then(|s| id_from_str(s).ok())
                             .unwrap_or(NULL_COMPONENT),
                     ),
             ),

--- a/crates/control-plane/src/route_service/reconciler.rs
+++ b/crates/control-plane/src/route_service/reconciler.rs
@@ -18,7 +18,7 @@ use crate::api::proto::controller::proto::v1::{
 use crate::db::{LinkStatus, RouteStatus, SharedDb};
 use crate::node_transport::{DefaultNodeCommandHandler, NodeStatus, ResponseKind};
 use crate::workqueue::WorkQueue;
-use slim_datapath::api::{NameId, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName};
 
 use super::is_connection_not_found;
 
@@ -334,9 +334,9 @@ async fn build_desired_routes<'a>(
                         route
                             .component_id
                             .as_deref()
-                            .and_then(|s| NameId::try_from(s.to_string()).ok())
-                            .map(|nid| -> u128 { nid.into() })
-                            .unwrap_or(NameId::NULL_COMPONENT),
+                            .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                            .map(|u| u.as_u128())
+                            .unwrap_or(NULL_COMPONENT),
                     ),
             ),
             link_id: Some(link_id.to_string()),
@@ -440,7 +440,7 @@ async fn process_route_acks(
         let link_id = sub.link_id.clone().unwrap_or_default();
         let proto_name = sub.name.as_ref().unwrap();
         let (c0, c1, c2) = proto_name.str_components();
-        let comp_id = if proto_name.id() == NameId::NULL_COMPONENT {
+        let comp_id = if proto_name.id() == NULL_COMPONENT {
             None
         } else {
             Some(proto_name.string_id())

--- a/crates/control-plane/src/services/northbound.rs
+++ b/crates/control-plane/src/services/northbound.rs
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use slim_datapath::api::{NameId, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
@@ -289,12 +289,9 @@ impl ControlPlaneService for NorthboundApiService {
                     .with_id(
                         r.component_id
                             .as_deref()
-                            .map(|s| {
-                                NameId::try_from(s.to_string())
-                                    .map(u128::from)
-                                    .unwrap_or(NameId::NULL_COMPONENT)
-                            })
-                            .unwrap_or(NameId::NULL_COMPONENT),
+                            .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                            .map(|u| u.as_u128())
+                            .unwrap_or(NULL_COMPONENT),
                     );
                 RouteEntry {
                     id: r.id.clone(),

--- a/crates/control-plane/src/services/northbound.rs
+++ b/crates/control-plane/src/services/northbound.rs
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use slim_datapath::api::{NULL_COMPONENT, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName, id_from_str};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
@@ -289,8 +289,7 @@ impl ControlPlaneService for NorthboundApiService {
                     .with_id(
                         r.component_id
                             .as_deref()
-                            .and_then(|s| uuid::Uuid::parse_str(s).ok())
-                            .map(|u| u.as_u128())
+                            .and_then(|s| id_from_str(s).ok())
                             .unwrap_or(NULL_COMPONENT),
                     );
                 RouteEntry {

--- a/crates/control-plane/src/services/southbound.rs
+++ b/crates/control-plane/src/services/southbound.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use slim_datapath::api::{NULL_COMPONENT, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName, id_from_str};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -266,8 +266,7 @@ async fn build_node_routes(db: &SharedDb, node_id: &str) -> Vec<ProtoRoute> {
                     route
                         .component_id
                         .as_deref()
-                        .and_then(|s| uuid::Uuid::parse_str(s).ok())
-                        .map(|u| u.as_u128())
+                        .and_then(|s| id_from_str(s).ok())
                         .unwrap_or(NULL_COMPONENT),
                 );
         routes.push(ProtoRoute {

--- a/crates/control-plane/src/services/southbound.rs
+++ b/crates/control-plane/src/services/southbound.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use slim_datapath::api::{NameId, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -266,12 +266,9 @@ async fn build_node_routes(db: &SharedDb, node_id: &str) -> Vec<ProtoRoute> {
                     route
                         .component_id
                         .as_deref()
-                        .map(|s| {
-                            NameId::try_from(s.to_string())
-                                .map(u128::from)
-                                .unwrap_or(NameId::NULL_COMPONENT)
-                        })
-                        .unwrap_or(NameId::NULL_COMPONENT),
+                        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                        .map(|u| u.as_u128())
+                        .unwrap_or(NULL_COMPONENT),
                 );
         routes.push(ProtoRoute {
             name: Some(name),

--- a/crates/control-plane/src/types.rs
+++ b/crates/control-plane/src/types.rs
@@ -4,7 +4,7 @@
 use std::time::SystemTime;
 
 use crate::api::proto::controller::proto::v1::Route as ProtoRoute;
-use slim_datapath::api::NameId;
+use slim_datapath::api::NULL_COMPONENT;
 
 use crate::db::RouteStatus;
 use crate::error::{Error, Result};
@@ -47,7 +47,7 @@ impl ProtoRouteExt for ProtoRoute {
     ) -> crate::db::Route {
         let n = self.name.as_ref().unwrap();
         let (c0, c1, c2) = n.str_components();
-        let comp_id = if n.id() == NameId::NULL_COMPONENT {
+        let comp_id = if n.id() == NULL_COMPONENT {
             None
         } else {
             Some(n.string_id())

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -632,8 +632,7 @@ async fn test_subscription_routing() {
             && r.status == ROUTE_APPLIED
             && r.name
                 .as_ref()
-                .and_then(|n| n.str_name.as_ref())
-                .map(|sn| sn.str_component_2 == "no-propagate")
+                .map(|n| n.str_components().2 == "no-propagate")
                 .unwrap_or(false)
     });
     assert!(
@@ -1360,8 +1359,7 @@ async fn test_multiple_wildcard_routes_different_names() {
         .filter_map(|r| {
             r.name
                 .as_ref()
-                .and_then(|n| n.str_name.as_ref())
-                .map(|sn| sn.str_component_2.clone())
+                .map(|n| n.str_components().2.to_string())
         })
         .collect();
     assert!(
@@ -1383,8 +1381,7 @@ async fn test_multiple_wildcard_routes_different_names() {
         r.status == ROUTE_APPLIED
             && r.name
                 .as_ref()
-                .and_then(|n| n.str_name.as_ref())
-                .map(|sn| sn.str_component_2 == "svc-beta")
+                .map(|n| n.str_components().2 == "svc-beta")
                 .unwrap_or(false)
     });
     assert!(

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -1356,11 +1356,7 @@ async fn test_multiple_wildcard_routes_different_names() {
     let wildcard_names: std::collections::HashSet<_> = routes
         .iter()
         .filter(|r| r.status == ROUTE_APPLIED)
-        .filter_map(|r| {
-            r.name
-                .as_ref()
-                .map(|n| n.str_components().2.to_string())
-        })
+        .filter_map(|r| r.name.as_ref().map(|n| n.str_components().2.to_string()))
         .collect();
     assert!(
         wildcard_names.contains("svc-alpha"),

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -36,7 +36,7 @@ use slim_datapath::api::{
     MessageType::SubscriptionAck as SubscriptionAckType, MessageType::Unsubscribe,
     ProtoMessage as DataPlaneMessage,
 };
-use slim_datapath::api::{NameId, ProtoName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName};
 use slim_datapath::message_processing::MessageProcessor;
 use slim_datapath::messages::utils::SlimHeaderFlags;
 use slim_datapath::tables::{ConnType, SubscriptionTable};
@@ -1054,7 +1054,7 @@ impl ControllerService {
 
                                 if let Ok(Some(conn)) = conn {
                                     let name = route.name.clone().unwrap();
-                                    let source = name.clone().with_id(NameId::NULL_COMPONENT);
+                                    let source = name.clone().with_id(NULL_COMPONENT);
 
                                     let msg = DataPlaneMessage::builder()
                                         .source(source.clone())
@@ -1110,7 +1110,7 @@ impl ControllerService {
 
                                 if let Ok(Some(conn)) = conn {
                                     let name = route.name.clone().unwrap();
-                                    let source = name.clone().with_id(NameId::NULL_COMPONENT);
+                                    let source = name.clone().with_id(NULL_COMPONENT);
 
                                     let msg = DataPlaneMessage::builder()
                                         .source(source.clone())

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -18,6 +18,7 @@ agntcy-slim-config = { workspace = true }
 agntcy-slim-proto = { workspace = true }
 agntcy-slim-version = { workspace = true }
 arc-swap = { workspace = true }
+bytes = { workspace = true }
 cfg-if = { workspace = true }
 futures = { workspace = true }
 # Optional deps must be unconditional so `dep:` references resolve in `[features]`.

--- a/crates/datapath/benches/name_benchmark.rs
+++ b/crates/datapath/benches/name_benchmark.rs
@@ -3,7 +3,6 @@
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use slim_datapath::api::{NULL_COMPONENT, ProtoName, SlimHeader};
-use slim_datapath::messages::utils::DEFAULT_TTL;
 use slim_datapath::tables::SubscriptionTable;
 use slim_datapath::tables::subscription_table::SubscriptionTableImpl;
 use slim_datapath::tables::{ConnType, MatchFilter};
@@ -16,20 +15,7 @@ fn make_proto_name() -> ProtoName {
 /// (org/namespace/agent, id=42).
 fn make_slim_header() -> SlimHeader {
     let proto_name = ProtoName::from_strings(["org", "namespace", "agent"]).with_id(42);
-    SlimHeader {
-        source: Some(proto_name.clone()),
-        destination: Some(proto_name),
-        identity: Default::default(),
-        version: Default::default(),
-        fanout: 1,
-        recv_from: None,
-        forward_to: None,
-        incoming_conn: None,
-        error: None,
-        header_mac: None,
-        ttl: DEFAULT_TTL,
-        e2e_header_sig: None,
-    }
+    SlimHeader::new(proto_name.clone(), proto_name, "", None)
 }
 
 fn bench_proto_name_from_strings(c: &mut Criterion) {

--- a/crates/datapath/benches/name_benchmark.rs
+++ b/crates/datapath/benches/name_benchmark.rs
@@ -17,9 +17,9 @@ fn make_proto_name() -> ProtoName {
             name_id: Some(NameId::from(u128::MAX)),
         }),
         str_name: Some(StringName {
-            str_component_0: "org".to_string(),
-            str_component_1: "namespace".to_string(),
-            str_component_2: "agent".to_string(),
+            str_component_0: bytes::Bytes::from_static(b"org"),
+            str_component_1: bytes::Bytes::from_static(b"namespace"),
+            str_component_2: bytes::Bytes::from_static(b"agent"),
         }),
     }
 }

--- a/crates/datapath/benches/name_benchmark.rs
+++ b/crates/datapath/benches/name_benchmark.rs
@@ -2,26 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use slim_datapath::api::{EncodedName, NameId, ProtoName, SlimHeader, StringName};
+use slim_datapath::api::{NULL_COMPONENT, ProtoName, SlimHeader};
 use slim_datapath::messages::utils::DEFAULT_TTL;
 use slim_datapath::tables::SubscriptionTable;
 use slim_datapath::tables::subscription_table::SubscriptionTableImpl;
 use slim_datapath::tables::{ConnType, MatchFilter};
 
 fn make_proto_name() -> ProtoName {
-    ProtoName {
-        name: Some(EncodedName {
-            component_0: 0x1234_5678_9abc_def0,
-            component_1: 0xfeed_cafe_dead_beef,
-            component_2: 0x0101_0101_0101_0101,
-            name_id: Some(NameId::from(u128::MAX)),
-        }),
-        str_name: Some(StringName {
-            str_component_0: bytes::Bytes::from_static(b"org"),
-            str_component_1: bytes::Bytes::from_static(b"namespace"),
-            str_component_2: bytes::Bytes::from_static(b"agent"),
-        }),
-    }
+    ProtoName::from_strings(["org", "namespace", "agent"]).with_id(NULL_COMPONENT)
 }
 
 /// Build a SlimHeader whose destination matches the subscription used in routing benchmarks
@@ -31,8 +19,8 @@ fn make_slim_header() -> SlimHeader {
     SlimHeader {
         source: Some(proto_name.clone()),
         destination: Some(proto_name),
-        identity: String::new(),
-        version: String::new(),
+        identity: Default::default(),
+        version: Default::default(),
         fanout: 1,
         recv_from: None,
         forward_to: None,
@@ -68,7 +56,7 @@ fn bench_proto_name_from_other(c: &mut Criterion) {
     });
 }
 
-/// Routing flow via the EncodedName extracted from get_dst().
+/// Routing flow via components/id decoded from the destination Name.
 fn bench_routing_via_proto_name(c: &mut Criterion) {
     let table = SubscriptionTableImpl::default();
     let sub = ProtoName::from_strings(["org", "namespace", "agent"]).with_id(42);
@@ -78,14 +66,17 @@ fn bench_routing_via_proto_name(c: &mut Criterion) {
     c.bench_function("routing_via_proto_name", |b| {
         b.iter(|| {
             let dst = black_box(slim_header.get_dst());
-            let enc = dst.name.as_ref().unwrap();
-            black_box(table.match_one(black_box(enc), 0, MatchFilter::ALL))
+            black_box(table.match_one(
+                black_box(dst.components()),
+                black_box(dst.id()),
+                0,
+                MatchFilter::ALL,
+            ))
         })
     });
 }
 
-/// Optimized: full routing flow via the EncodedName path.
-/// get_encoded_dst() is a Copy of 4 u64s — zero heap allocation.
+/// Optimized: full routing flow via get_encoded_dst() — returns ([u64; 3], u128), zero alloc.
 fn bench_routing_via_encoded_name(c: &mut Criterion) {
     let table = SubscriptionTableImpl::default();
     let sub = ProtoName::from_strings(["org", "namespace", "agent"]).with_id(42);
@@ -94,8 +85,8 @@ fn bench_routing_via_encoded_name(c: &mut Criterion) {
 
     c.bench_function("routing_via_encoded_name", |b| {
         b.iter(|| {
-            let encoded = black_box(slim_header.get_encoded_dst());
-            black_box(table.match_one(black_box(&encoded), 0, MatchFilter::ALL))
+            let (components, id) = black_box(slim_header.get_encoded_dst());
+            black_box(table.match_one(black_box(components), black_box(id), 0, MatchFilter::ALL))
         })
     });
 }

--- a/crates/datapath/benches/subscription_table_benchmark.rs
+++ b/crates/datapath/benches/subscription_table_benchmark.rs
@@ -2,20 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use slim_datapath::api::{EncodedName, ProtoName};
+use slim_datapath::api::ProtoName;
 use slim_datapath::tables::SubscriptionTable;
 use slim_datapath::tables::subscription_table::SubscriptionTableImpl;
 use slim_datapath::tables::{ConnType, MatchFilter};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn encoded(name: &ProtoName) -> EncodedName {
-    name.name.unwrap()
-}
-
 /// Build a table with `n` distinct specific IDs under one prefix.
 /// The target is the last-inserted ID — worst-case scan position.
-fn build_specific_ids(n: usize) -> (SubscriptionTableImpl, EncodedName) {
+fn build_specific_ids(n: usize) -> (SubscriptionTableImpl, ([u64; 3], u128)) {
     let base = ProtoName::from_strings(["org", "ns", "svc"]);
     let table = SubscriptionTableImpl::default();
     for i in 1..=n {
@@ -25,13 +21,13 @@ fn build_specific_ids(n: usize) -> (SubscriptionTableImpl, EncodedName) {
             .unwrap();
     }
     let target = base.with_id(n as u128);
-    (table, encoded(&target))
+    (table, (target.components(), target.id()))
 }
 
 /// Build a table with `n` entries under one prefix: 1 NULL_COMPONENT entry
 /// (conn 1) plus n−1 specific IDs, each with 1 remote connection.
 /// Returns the encoded NULL_COMPONENT name for fan-out benchmarks.
-fn build_with_null(n: usize) -> (SubscriptionTableImpl, EncodedName) {
+fn build_with_null(n: usize) -> (SubscriptionTableImpl, ([u64; 3], u128)) {
     let base = ProtoName::from_strings(["org", "ns", "svc"]);
     let table = SubscriptionTableImpl::default();
     table
@@ -43,12 +39,12 @@ fn build_with_null(n: usize) -> (SubscriptionTableImpl, EncodedName) {
             .add_subscription(name, (i + 100) as u64, ConnType::Remote, (i + 100) as u64)
             .unwrap();
     }
-    (table, encoded(&base))
+    (table, (base.components(), base.id()))
 }
 
 /// Build a table with a single specific ID (42) having `n_conns` connections.
 /// The first half are local, the rest remote.
-fn build_one_id_n_conns(n_conns: usize) -> (SubscriptionTableImpl, EncodedName) {
+fn build_one_id_n_conns(n_conns: usize) -> (SubscriptionTableImpl, ([u64; 3], u128)) {
     let name = ProtoName::from_strings(["org", "ns", "svc"]).with_id(42);
     let table = SubscriptionTableImpl::default();
     let half = n_conns.div_ceil(2);
@@ -62,7 +58,7 @@ fn build_one_id_n_conns(n_conns: usize) -> (SubscriptionTableImpl, EncodedName) 
             .add_subscription(name.clone(), (i + 10) as u64, category, i as u64)
             .unwrap();
     }
-    (table, encoded(&name))
+    (table, (name.components(), name.id()))
 }
 
 /// Build a table with `n` distinct prefixes (org/ns/svcN), each with 1
@@ -70,7 +66,7 @@ fn build_one_id_n_conns(n_conns: usize) -> (SubscriptionTableImpl, EncodedName) 
 /// last-inserted prefix — every lookup costs exactly one HashMap probe
 /// regardless of table size, so this group isolates HashMap / cache-miss
 /// overhead as the routing table grows.
-fn build_many_prefixes(n: usize) -> (SubscriptionTableImpl, EncodedName) {
+fn build_many_prefixes(n: usize) -> (SubscriptionTableImpl, ([u64; 3], u128)) {
     let table = SubscriptionTableImpl::default();
     for i in 0..n {
         let svc = format!("svc{i}");
@@ -81,7 +77,7 @@ fn build_many_prefixes(n: usize) -> (SubscriptionTableImpl, EncodedName) {
     }
     let last_svc = format!("svc{}", n - 1);
     let target = ProtoName::from_strings(["org", "ns", last_svc.as_str()]).with_id(1);
-    (table, encoded(&target))
+    (table, (target.components(), target.id()))
 }
 
 // ── match_one benchmarks ──────────────────────────────────────────────────────
@@ -93,7 +89,14 @@ fn bench_match_one_specific_id(c: &mut Criterion) {
     for &n in &[1usize, 4, 8, 16, 64, 256, 1024] {
         let (table, enc) = build_specific_ids(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
-            b.iter(|| black_box(table.match_one(black_box(e), u64::MAX, MatchFilter::ALL)))
+            b.iter(|| {
+                black_box(table.match_one(
+                    black_box(e.0),
+                    black_box(e.1),
+                    u64::MAX,
+                    MatchFilter::ALL,
+                ))
+            })
         });
     }
     group.finish();
@@ -105,7 +108,14 @@ fn bench_match_one_null_component(c: &mut Criterion) {
     for &n in &[1usize, 4, 8, 16, 64, 256] {
         let (table, enc) = build_with_null(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
-            b.iter(|| black_box(table.match_one(black_box(e), u64::MAX, MatchFilter::ALL)))
+            b.iter(|| {
+                black_box(table.match_one(
+                    black_box(e.0),
+                    black_box(e.1),
+                    u64::MAX,
+                    MatchFilter::ALL,
+                ))
+            })
         });
     }
     group.finish();
@@ -127,9 +137,16 @@ fn bench_match_one_local_preference(c: &mut Criterion) {
             .add_subscription(name.clone(), i, ConnType::Local, i)
             .unwrap();
     }
-    let enc = encoded(&name);
+    let (components, id) = (name.components(), name.id());
     c.bench_function("match_one/local_preference", |b| {
-        b.iter(|| black_box(table.match_one(black_box(&enc), u64::MAX, MatchFilter::ALL)))
+        b.iter(|| {
+            black_box(table.match_one(
+                black_box(components),
+                black_box(id),
+                u64::MAX,
+                MatchFilter::ALL,
+            ))
+        })
     });
 }
 
@@ -141,7 +158,14 @@ fn bench_match_one_many_prefixes(c: &mut Criterion) {
     for &n in &[64usize, 256, 1024, 4096] {
         let (table, enc) = build_many_prefixes(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
-            b.iter(|| black_box(table.match_one(black_box(e), u64::MAX, MatchFilter::ALL)))
+            b.iter(|| {
+                black_box(table.match_one(
+                    black_box(e.0),
+                    black_box(e.1),
+                    u64::MAX,
+                    MatchFilter::ALL,
+                ))
+            })
         });
     }
     group.finish();
@@ -155,7 +179,14 @@ fn bench_match_all_specific_id(c: &mut Criterion) {
     for &n in &[1usize, 4, 8, 16, 64, 256] {
         let (table, enc) = build_one_id_n_conns(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
-            b.iter(|| black_box(table.match_all(black_box(e), u64::MAX, MatchFilter::ALL)))
+            b.iter(|| {
+                black_box(table.match_all(
+                    black_box(e.0),
+                    black_box(e.1),
+                    u64::MAX,
+                    MatchFilter::ALL,
+                ))
+            })
         });
     }
     group.finish();
@@ -167,7 +198,14 @@ fn bench_match_all_null_component(c: &mut Criterion) {
     for &n in &[1usize, 4, 8, 16, 64, 256] {
         let (table, enc) = build_with_null(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
-            b.iter(|| black_box(table.match_all(black_box(e), u64::MAX, MatchFilter::ALL)))
+            b.iter(|| {
+                black_box(table.match_all(
+                    black_box(e.0),
+                    black_box(e.1),
+                    u64::MAX,
+                    MatchFilter::ALL,
+                ))
+            })
         });
     }
     group.finish();
@@ -180,7 +218,14 @@ fn bench_match_all_many_prefixes(c: &mut Criterion) {
     for &n in &[64usize, 256, 1024, 4096] {
         let (table, enc) = build_many_prefixes(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &enc, |b, e| {
-            b.iter(|| black_box(table.match_all(black_box(e), u64::MAX, MatchFilter::ALL)))
+            b.iter(|| {
+                black_box(table.match_all(
+                    black_box(e.0),
+                    black_box(e.1),
+                    u64::MAX,
+                    MatchFilter::ALL,
+                ))
+            })
         });
     }
     group.finish();

--- a/crates/datapath/src/api.rs
+++ b/crates/datapath/src/api.rs
@@ -4,12 +4,20 @@
 //! gRPC bindings for data plane service.
 pub mod proto;
 
+pub use agntcy_slim_proto::CONTROL_CHANNEL_ID;
+pub use agntcy_slim_proto::DATA_CHANNEL_ID;
+pub use agntcy_slim_proto::NULL_COMPONENT;
+pub use agntcy_slim_proto::RESERVED_IDS;
+pub use agntcy_slim_proto::decode_str_bytes;
+pub use agntcy_slim_proto::encode_str_bytes;
+pub use agntcy_slim_proto::id_from_str;
+pub use agntcy_slim_proto::id_to_string;
+pub use agntcy_slim_proto::is_reserved_id;
 pub use proto::dataplane::v1::ApplicationPayload;
 pub use proto::dataplane::v1::CommandPayload;
 pub use proto::dataplane::v1::Content;
 pub use proto::dataplane::v1::DiscoveryReplyPayload;
 pub use proto::dataplane::v1::DiscoveryRequestPayload;
-pub use proto::dataplane::v1::EncodedName;
 pub use proto::dataplane::v1::GroupAckPayload;
 pub use proto::dataplane::v1::GroupAddPayload;
 pub use proto::dataplane::v1::GroupNackPayload;
@@ -27,7 +35,6 @@ pub use proto::dataplane::v1::Message as ProtoMessage;
 pub use proto::dataplane::v1::MlsPayload;
 pub use proto::dataplane::v1::MlsSettings as ProtoMlsSettings;
 pub use proto::dataplane::v1::Name as ProtoName;
-pub use proto::dataplane::v1::NameId;
 pub use proto::dataplane::v1::Participant;
 pub use proto::dataplane::v1::ParticipantSettings;
 pub use proto::dataplane::v1::Publish as ProtoPublish;
@@ -35,7 +42,6 @@ pub use proto::dataplane::v1::SessionHeader;
 pub use proto::dataplane::v1::SessionMessageType as ProtoSessionMessageType;
 pub use proto::dataplane::v1::SessionType as ProtoSessionType;
 pub use proto::dataplane::v1::SlimHeader;
-pub use proto::dataplane::v1::StringName;
 pub use proto::dataplane::v1::Subscribe as ProtoSubscribe;
 pub use proto::dataplane::v1::SubscriptionAck as ProtoSubscriptionAck;
 pub use proto::dataplane::v1::Unsubscribe as ProtoUnsubscribe;

--- a/crates/datapath/src/forwarder.rs
+++ b/crates/datapath/src/forwarder.rs
@@ -8,7 +8,7 @@ use super::tables::SubscriptionTable;
 use super::tables::connection_table::ConnectionTable;
 use super::tables::subscription_table::SubscriptionTableImpl;
 use super::tables::{ConnType, MatchFilter};
-use crate::api::{EncodedName, ProtoName};
+use crate::api::ProtoName;
 use crate::errors::DataPathError;
 
 use tracing::debug;
@@ -96,18 +96,19 @@ where
 
     pub fn on_publish_msg_match(
         &self,
-        encoded: EncodedName,
+        components: [u64; 3],
+        id: u128,
         incoming_conn: u64,
         fanout: u32,
         filter: MatchFilter,
     ) -> Result<Vec<u64>, DataPathError> {
         if fanout == 1 {
             self.subscription_table
-                .match_one(&encoded, incoming_conn, filter)
+                .match_one(components, id, incoming_conn, filter)
                 .map(|out| vec![out])
         } else {
             self.subscription_table
-                .match_all(&encoded, incoming_conn, filter)
+                .match_all(components, id, incoming_conn, filter)
         }
     }
 
@@ -121,10 +122,6 @@ where
 mod tests {
     use super::*;
     use tracing_test::traced_test;
-
-    fn enc(name: &ProtoName) -> EncodedName {
-        name.name.unwrap()
-    }
 
     #[test]
     #[traced_test]
@@ -149,15 +146,29 @@ mod tests {
                 .is_ok()
         );
 
+        let name_with_id1 = name.clone().with_id(1);
+        let (comp1, id1) = name_with_id1.components_and_id();
         assert_eq!(
-            fwd.on_publish_msg_match(enc(&name.clone().with_id(1)), 100, 1, MatchFilter::ALL)
-                .unwrap(),
+            fwd.on_publish_msg_match(
+                comp1,
+                id1,
+                100,
+                1,
+                MatchFilter::ALL
+            )
+            .unwrap(),
             vec![12]
         );
 
         let expected = name.clone().with_id(2);
-
-        let err = fwd.on_publish_msg_match(enc(&expected), 100, 1, MatchFilter::ALL);
+        let (comp2, id2) = expected.components_and_id();
+        let err = fwd.on_publish_msg_match(
+            comp2,
+            id2,
+            100,
+            1,
+            MatchFilter::ALL,
+        );
         assert!(matches!(err, Err(DataPathError::NoMatchEncoded(..))));
 
         assert!(

--- a/crates/datapath/src/forwarder.rs
+++ b/crates/datapath/src/forwarder.rs
@@ -149,26 +149,14 @@ mod tests {
         let name_with_id1 = name.clone().with_id(1);
         let (comp1, id1) = name_with_id1.components_and_id();
         assert_eq!(
-            fwd.on_publish_msg_match(
-                comp1,
-                id1,
-                100,
-                1,
-                MatchFilter::ALL
-            )
-            .unwrap(),
+            fwd.on_publish_msg_match(comp1, id1, 100, 1, MatchFilter::ALL)
+                .unwrap(),
             vec![12]
         );
 
         let expected = name.clone().with_id(2);
         let (comp2, id2) = expected.components_and_id();
-        let err = fwd.on_publish_msg_match(
-            comp2,
-            id2,
-            100,
-            1,
-            MatchFilter::ALL,
-        );
+        let err = fwd.on_publish_msg_match(comp2, id2, 100, 1, MatchFilter::ALL);
         assert!(matches!(err, Err(DataPathError::NoMatchEncoded(..))));
 
         assert!(

--- a/crates/datapath/src/header_mac.rs
+++ b/crates/datapath/src/header_mac.rs
@@ -249,9 +249,9 @@ fn push_encoded_name(buf: &mut Vec<u8>, n: &Option<Name>) {
             }
             if let Some(sn) = name.str_name.as_ref() {
                 buf.push(1);
-                push_bytes(buf, sn.str_component_0.as_bytes());
-                push_bytes(buf, sn.str_component_1.as_bytes());
-                push_bytes(buf, sn.str_component_2.as_bytes());
+                push_bytes(buf, &sn.str_component_0);
+                push_bytes(buf, &sn.str_component_1);
+                push_bytes(buf, &sn.str_component_2);
             } else {
                 buf.push(0);
             }
@@ -295,9 +295,9 @@ mod tests {
                     name_id: Some(NameId { id_0: 0, id_1: 4 }),
                 }),
                 str_name: Some(StringName {
-                    str_component_0: "a".into(),
-                    str_component_1: "b".into(),
-                    str_component_2: "c".into(),
+                    str_component_0: bytes::Bytes::from_static(b"a"),
+                    str_component_1: bytes::Bytes::from_static(b"b"),
+                    str_component_2: bytes::Bytes::from_static(b"c"),
                 }),
             }),
             destination: Some(Name {
@@ -308,9 +308,9 @@ mod tests {
                     name_id: Some(NameId { id_0: 0, id_1: 8 }),
                 }),
                 str_name: Some(StringName {
-                    str_component_0: "x".into(),
-                    str_component_1: "y".into(),
-                    str_component_2: "z".into(),
+                    str_component_0: bytes::Bytes::from_static(b"x"),
+                    str_component_1: bytes::Bytes::from_static(b"y"),
+                    str_component_2: bytes::Bytes::from_static(b"z"),
                 }),
             }),
             identity: "id1".into(),

--- a/crates/datapath/src/header_mac.rs
+++ b/crates/datapath/src/header_mac.rs
@@ -172,7 +172,12 @@ fn encoded_name_upper_bound(encoded: &Bytes, str_name: &Bytes) -> usize {
     // 1 byte: encoded presence + 40 bytes (when present)
     // 1 byte: str_name presence + 4 bytes len prefix + N str bytes (when present)
     1 + if encoded.is_empty() { 0 } else { 40 }
-        + 1 + if str_name.is_empty() { 0 } else { 4 + str_name.len() }
+        + 1
+        + if str_name.is_empty() {
+            0
+        } else {
+            4 + str_name.len()
+        }
 }
 
 #[inline]

--- a/crates/datapath/src/header_mac.rs
+++ b/crates/datapath/src/header_mac.rs
@@ -83,7 +83,7 @@ impl HeaderMacSession {
             reserve_preimage_upper_bound(&mut buf, header, link_id);
             write_preimage(&mut buf, header, link_id.as_bytes());
             let tag = hmac::sign(&self.key, buf.as_slice());
-            header.header_mac = Some(Vec::from(tag.as_ref()));
+            header.header_mac = Some(tag.as_ref().to_vec().into());
             Ok(())
         })
     }
@@ -171,29 +171,10 @@ fn encoded_name_upper_bound(name_opt: &Option<Name>) -> usize {
     match name_opt {
         None => 1,
         Some(name) => {
-            /// Byte size of presence flags:
-            /// * 1 byte for Some(name) that [`push_encoded_name`] pushes.
-            /// * 1 byte for the flag showing if name.name is present.
-            /// * 1 byte for `str_name` present/absent.
-            const PRESENCE_FLAGS_SIZE: usize = 3;
-            /// Byte size of 3 `u64` components + name_id (1 presence byte + 2 `u64`):
-            /// * 3*8 bytes for component 0..2 serialized by [`to_le_bytes`].
-            /// * 1 byte for name_id presence flag
-            /// * 2*8 bytes for name_id.id_0 and id_1 (when present)
-            const ENCODED_NAME_SIZE: usize = 24 + 1 + 16;
-
-            // Byte sizs of 3 `u32` prefixes:
-            // * 3*4 byte length size prefix before each component
-            const LENGTH_PREFIXES_SIZE: usize = 12;
-
-            let mut encoded_name_bound = PRESENCE_FLAGS_SIZE + ENCODED_NAME_SIZE;
-            if let Some(sn) = name.str_name.as_ref() {
-                encoded_name_bound += LENGTH_PREFIXES_SIZE
-                    + sn.str_component_0.len()
-                    + sn.str_component_1.len()
-                    + sn.str_component_2.len();
-            }
-            encoded_name_bound
+            // 1 byte: Some(name) presence
+            // 1 byte: encoded_name presence + 40 bytes (when present)
+            // 1 byte: str_name presence + 4 bytes len prefix + N str bytes (when present)
+            2 + 40 + 1 + 4 + name.str_name.len()
         }
     }
 }
@@ -231,29 +212,20 @@ fn push_encoded_name(buf: &mut Vec<u8>, n: &Option<Name>) {
         None => buf.push(0),
         Some(name) => {
             buf.push(1);
-            if let Some(enc) = name.name.as_ref() {
-                buf.push(1);
-                for v in [enc.component_0, enc.component_1, enc.component_2] {
-                    buf.extend_from_slice(&v.to_le_bytes());
-                }
-                match enc.name_id.as_ref() {
-                    Some(nid) => {
-                        buf.push(1);
-                        buf.extend_from_slice(&nid.id_0.to_le_bytes());
-                        buf.extend_from_slice(&nid.id_1.to_le_bytes());
-                    }
-                    None => buf.push(0),
-                }
-            } else {
+            // encoded_name: presence byte + raw 40-byte flat encoding
+            if name.encoded_name.is_empty() {
                 buf.push(0);
+            } else {
+                buf.push(1);
+                buf.extend_from_slice(&name.encoded_name);
             }
-            if let Some(sn) = name.str_name.as_ref() {
-                buf.push(1);
-                push_bytes(buf, &sn.str_component_0);
-                push_bytes(buf, &sn.str_component_1);
-                push_bytes(buf, &sn.str_component_2);
-            } else {
+            // str_name: presence byte + u32 LE total length + raw packed bytes
+            if name.str_name.is_empty() {
                 buf.push(0);
+            } else {
+                buf.push(1);
+                buf.extend_from_slice(&(name.str_name.len() as u32).to_le_bytes());
+                buf.extend_from_slice(&name.str_name);
             }
         }
     }
@@ -266,7 +238,7 @@ fn write_preimage(buf: &mut Vec<u8>, hdr: &SlimHeader, link_id_bytes: &[u8]) {
     buf.extend_from_slice(link_id_bytes);
     push_encoded_name(buf, &hdr.source);
     push_encoded_name(buf, &hdr.destination);
-    push_bytes(buf, hdr.identity.as_bytes());
+    push_bytes(buf, &hdr.identity);
     buf.extend_from_slice(&hdr.fanout.to_le_bytes());
     push_u64_opt(buf, hdr.recv_from);
     push_u64_opt(buf, hdr.forward_to);
@@ -277,7 +249,7 @@ fn write_preimage(buf: &mut Vec<u8>, hdr: &SlimHeader, link_id_bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::proto::dataplane::v1::{EncodedName, Name, NameId, StringName};
+    use crate::api::ProtoName;
     use crate::messages::utils::DEFAULT_TTL;
     use uuid::Uuid;
 
@@ -287,35 +259,11 @@ mod tests {
 
     fn sample_header() -> SlimHeader {
         SlimHeader {
-            source: Some(Name {
-                name: Some(EncodedName {
-                    component_0: 1,
-                    component_1: 2,
-                    component_2: 3,
-                    name_id: Some(NameId { id_0: 0, id_1: 4 }),
-                }),
-                str_name: Some(StringName {
-                    str_component_0: bytes::Bytes::from_static(b"a"),
-                    str_component_1: bytes::Bytes::from_static(b"b"),
-                    str_component_2: bytes::Bytes::from_static(b"c"),
-                }),
-            }),
-            destination: Some(Name {
-                name: Some(EncodedName {
-                    component_0: 5,
-                    component_1: 6,
-                    component_2: 7,
-                    name_id: Some(NameId { id_0: 0, id_1: 8 }),
-                }),
-                str_name: Some(StringName {
-                    str_component_0: bytes::Bytes::from_static(b"x"),
-                    str_component_1: bytes::Bytes::from_static(b"y"),
-                    str_component_2: bytes::Bytes::from_static(b"z"),
-                }),
-            }),
+            source: Some(ProtoName::from_strings(["a", "b", "c"]).with_id(4)),
+            destination: Some(ProtoName::from_strings(["x", "y", "z"]).with_id(8)),
             identity: "id1".into(),
             fanout: 2,
-            version: String::new(),
+            version: Default::default(),
             recv_from: Some(9),
             forward_to: Some(10),
             incoming_conn: Some(999),
@@ -362,9 +310,10 @@ mod tests {
         let mac = HeaderMacSession::new(&test_key()).unwrap();
         let mut hdr = sample_header();
         mac.sign_slim_header(&mut hdr, &lid).unwrap();
-        let mac_val = hdr.header_mac.as_mut().unwrap();
-        // HMAC key is tampered
-        mac_val[0] ^= 1;
+        // HMAC tag is tampered
+        let mut v = hdr.header_mac.take().unwrap().to_vec();
+        v[0] ^= 1;
+        hdr.header_mac = Some(v.into());
         let err = mac.verify_slim_header(&hdr, &lid).unwrap_err();
         assert!(matches!(err, HeaderMacError::VerificationFailed));
     }
@@ -392,8 +341,8 @@ mod tests {
         let lid = Uuid::new_v4().to_string();
         let mac = HeaderMacSession::new(&test_key()).unwrap();
         let mut hdr = sample_header();
-        // Remove name_id from source
-        hdr.source.as_mut().unwrap().name.as_mut().unwrap().name_id = None;
+        // Clear the id from source (reset to NULL_COMPONENT)
+        hdr.source.as_mut().unwrap().reset_id();
         mac.sign_slim_header(&mut hdr, &lid).unwrap();
         mac.verify_slim_header(&hdr, &lid).unwrap();
     }
@@ -404,9 +353,8 @@ mod tests {
         let mac = HeaderMacSession::new(&test_key()).unwrap();
         let mut hdr = sample_header();
         mac.sign_slim_header(&mut hdr, &lid).unwrap();
-        // Tamper with source name_id
-        hdr.source.as_mut().unwrap().name.as_mut().unwrap().name_id =
-            Some(NameId { id_0: 99, id_1: 99 });
+        // Tamper with source id — equivalent to old NameId { id_0: 99, id_1: 99 }
+        hdr.source.as_mut().unwrap().set_id((99u128 << 64) | 99u128);
         assert!(mac.verify_slim_header(&hdr, &lid).is_err());
     }
 }

--- a/crates/datapath/src/header_mac.rs
+++ b/crates/datapath/src/header_mac.rs
@@ -16,7 +16,8 @@ use std::cell::RefCell;
 use aws_lc_rs::hmac;
 use thiserror::Error;
 
-use crate::api::proto::dataplane::v1::{Name, SlimHeader};
+use crate::api::proto::dataplane::v1::SlimHeader;
+use bytes::Bytes;
 
 thread_local! {
     static PREIMAGE_BUF: RefCell<Vec<u8>> = RefCell::new(Vec::with_capacity(512));
@@ -162,21 +163,16 @@ fn preimage_upper_bound(header: &SlimHeader, link_id: &str) -> usize {
         + FORWARD_TO_SIZE
         + ERROR_SIZE
         + TTL_SIZE
-        + encoded_name_upper_bound(&header.source)
-        + encoded_name_upper_bound(&header.destination)
+        + encoded_name_upper_bound(&header.source, &header.source_str)
+        + encoded_name_upper_bound(&header.destination, &header.destination_str)
 }
 
 #[inline]
-fn encoded_name_upper_bound(name_opt: &Option<Name>) -> usize {
-    match name_opt {
-        None => 1,
-        Some(name) => {
-            // 1 byte: Some(name) presence
-            // 1 byte: encoded_name presence + 40 bytes (when present)
-            // 1 byte: str_name presence + 4 bytes len prefix + N str bytes (when present)
-            2 + 40 + 1 + 4 + name.str_name.len()
-        }
-    }
+fn encoded_name_upper_bound(encoded: &Bytes, str_name: &Bytes) -> usize {
+    // 1 byte: encoded presence + 40 bytes (when present)
+    // 1 byte: str_name presence + 4 bytes len prefix + N str bytes (when present)
+    1 + if encoded.is_empty() { 0 } else { 40 }
+        + 1 + if str_name.is_empty() { 0 } else { 4 + str_name.len() }
 }
 
 #[inline]
@@ -207,27 +203,21 @@ fn push_bool_opt(buf: &mut Vec<u8>, v: Option<bool>) {
     }
 }
 
-fn push_encoded_name(buf: &mut Vec<u8>, n: &Option<Name>) {
-    match n {
-        None => buf.push(0),
-        Some(name) => {
-            buf.push(1);
-            // encoded_name: presence byte + raw 40-byte flat encoding
-            if name.encoded_name.is_empty() {
-                buf.push(0);
-            } else {
-                buf.push(1);
-                buf.extend_from_slice(&name.encoded_name);
-            }
-            // str_name: presence byte + u32 LE total length + raw packed bytes
-            if name.str_name.is_empty() {
-                buf.push(0);
-            } else {
-                buf.push(1);
-                buf.extend_from_slice(&(name.str_name.len() as u32).to_le_bytes());
-                buf.extend_from_slice(&name.str_name);
-            }
-        }
+fn push_encoded_name(buf: &mut Vec<u8>, encoded: &Bytes, str_name: &Bytes) {
+    // encoded: presence byte + raw 40-byte flat encoding
+    if encoded.is_empty() {
+        buf.push(0);
+    } else {
+        buf.push(1);
+        buf.extend_from_slice(encoded);
+    }
+    // str_name: presence byte + u32 LE total length + raw packed bytes
+    if str_name.is_empty() {
+        buf.push(0);
+    } else {
+        buf.push(1);
+        buf.extend_from_slice(&(str_name.len() as u32).to_le_bytes());
+        buf.extend_from_slice(str_name);
     }
 }
 
@@ -236,8 +226,8 @@ fn write_preimage(buf: &mut Vec<u8>, hdr: &SlimHeader, link_id_bytes: &[u8]) {
     buf.extend_from_slice(DOMAIN_V1);
     buf.extend_from_slice(&(link_id_bytes.len() as u32).to_le_bytes());
     buf.extend_from_slice(link_id_bytes);
-    push_encoded_name(buf, &hdr.source);
-    push_encoded_name(buf, &hdr.destination);
+    push_encoded_name(buf, &hdr.source, &hdr.source_str);
+    push_encoded_name(buf, &hdr.destination, &hdr.destination_str);
     push_bytes(buf, &hdr.identity);
     buf.extend_from_slice(&hdr.fanout.to_le_bytes());
     push_u64_opt(buf, hdr.recv_from);
@@ -258,20 +248,20 @@ mod tests {
     }
 
     fn sample_header() -> SlimHeader {
-        SlimHeader {
-            source: Some(ProtoName::from_strings(["a", "b", "c"]).with_id(4)),
-            destination: Some(ProtoName::from_strings(["x", "y", "z"]).with_id(8)),
-            identity: "id1".into(),
-            fanout: 2,
-            version: Default::default(),
-            recv_from: Some(9),
-            forward_to: Some(10),
-            incoming_conn: Some(999),
-            error: Some(false),
-            header_mac: None,
-            ttl: DEFAULT_TTL,
-            e2e_header_sig: None,
-        }
+        use crate::messages::utils::SlimHeaderFlags;
+        SlimHeader::new(
+            ProtoName::from_strings(["a", "b", "c"]).with_id(4),
+            ProtoName::from_strings(["x", "y", "z"]).with_id(8),
+            "id1",
+            Some(SlimHeaderFlags {
+                fanout: 2,
+                recv_from: Some(9),
+                forward_to: Some(10),
+                incoming_conn: Some(999),
+                error: Some(false),
+                ttl: DEFAULT_TTL,
+            }),
+        )
     }
 
     #[test]
@@ -341,8 +331,10 @@ mod tests {
         let lid = Uuid::new_v4().to_string();
         let mac = HeaderMacSession::new(&test_key()).unwrap();
         let mut hdr = sample_header();
-        // Clear the id from source (reset to NULL_COMPONENT)
-        hdr.source.as_mut().unwrap().reset_id();
+        // Clear the id from source (reset to NULL_COMPONENT) via ProtoName helper
+        let mut src = hdr.get_source();
+        src.reset_id();
+        hdr.set_source(src);
         mac.sign_slim_header(&mut hdr, &lid).unwrap();
         mac.verify_slim_header(&hdr, &lid).unwrap();
     }
@@ -354,7 +346,9 @@ mod tests {
         let mut hdr = sample_header();
         mac.sign_slim_header(&mut hdr, &lid).unwrap();
         // Tamper with source id — equivalent to old NameId { id_0: 99, id_1: 99 }
-        hdr.source.as_mut().unwrap().set_id((99u128 << 64) | 99u128);
+        let mut src = hdr.get_source();
+        src.set_id((99u128 << 64) | 99u128);
+        hdr.set_source(src);
         assert!(mac.verify_slim_header(&hdr, &lid).is_err());
     }
 }

--- a/crates/datapath/src/link_ecdh.rs
+++ b/crates/datapath/src/link_ecdh.rs
@@ -68,8 +68,10 @@ mod tests {
         let b = derive_header_mac_from_ecdh(resp_sk, init_pk.as_slice(), &link_id).unwrap();
         let lid = link_id.clone();
         let mut h = crate::api::proto::dataplane::v1::SlimHeader {
-            source: None,
-            destination: None,
+            source: Default::default(),
+            destination: Default::default(),
+            source_str: Default::default(),
+            destination_str: Default::default(),
             identity: "i".into(),
             fanout: 0,
             version: Default::default(),

--- a/crates/datapath/src/link_ecdh.rs
+++ b/crates/datapath/src/link_ecdh.rs
@@ -80,8 +80,8 @@ mod tests {
             incoming_conn: None,
             error: None,
             header_mac: None,
-            ttl: DEFAULT_TTL,
             e2e_header_sig: None,
+            ttl: DEFAULT_TTL,
         };
         a.sign_slim_header(&mut h, &lid).unwrap();
         b.verify_slim_header(&h, &lid).unwrap();

--- a/crates/datapath/src/link_ecdh.rs
+++ b/crates/datapath/src/link_ecdh.rs
@@ -72,7 +72,7 @@ mod tests {
             destination: None,
             identity: "i".into(),
             fanout: 0,
-            version: String::new(),
+            version: Default::default(),
             recv_from: None,
             forward_to: None,
             incoming_conn: None,

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -5,7 +5,6 @@ use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::api::DataPlaneServiceServer;
 use display_error_chain::ErrorChainExt;
@@ -132,15 +131,6 @@ enum StreamSetup {
         connection: Box<Connection>,
         existing_index: Option<u64>,
     },
-}
-
-/// Per-connection metrics collected by the `process_stream` loop and
-/// reported once per second by a companion task.
-#[derive(Default)]
-struct StreamMetrics {
-    count: AtomicU64,
-    sum_inbound_wait_us: AtomicU64,
-    sum_elapsed_us: AtomicU64,
 }
 
 impl MessageProcessor {
@@ -1652,44 +1642,12 @@ impl MessageProcessor {
                 return;
             };
 
-            // Metrics shared with the reporter task.
-            let metrics = Arc::new(StreamMetrics::default());
-            let reporter_cancel = CancellationToken::new();
-            {
-                let m = metrics.clone();
-                let cancel = reporter_cancel.clone();
-                tokio::spawn(async move {
-                    loop {
-                        tokio::select! {
-                            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
-                                let count = m.count.swap(0, Ordering::Relaxed);
-                                if count > 0 {
-                                    let avg_inbound_wait_us =
-                                        m.sum_inbound_wait_us.swap(0, Ordering::Relaxed) / count;
-                                    let avg_elapsed_us =
-                                        m.sum_elapsed_us.swap(0, Ordering::Relaxed) / count;
-                                    info!(
-                                        %conn_index,
-                                        msgs_per_sec = count,
-                                        avg_inbound_wait_us,
-                                        avg_elapsed_us,
-                                        "process_stream metrics",
-                                    );
-                                }
-                            }
-                            _ = cancel.cancelled() => break,
-                        }
-                    }
-                });
-            }
-
             let mut watch = std::pin::pin!(watch.signaled());
             // Tracks the wall-clock instant at which we last finished processing
             // a message (or entered the loop for the first time). The elapsed
             // time when stream.next() returns is the inbound stream wait time:
             // near-zero means messages were already buffered in the h2 receive
             // window; a larger value means the loop was idle waiting for data.
-            let mut inbound_wait_start = std::time::Instant::now();
             loop {
                 tokio::select! {
                     next = stream.next() => {
@@ -1697,10 +1655,6 @@ impl MessageProcessor {
                             Some(result) => {
                                 match result {
                                     Ok(msg) => {
-                                        let inbound_wait_us =
-                                            inbound_wait_start.elapsed().as_micros() as u64;
-                                        let iter_start = std::time::Instant::now();
-
                                         if !is_local
                                             && !msg.is_link()
                                             && !msg.is_subscription_ack()
@@ -1754,13 +1708,6 @@ impl MessageProcessor {
                                                 self_clone.send_error_to_local_app(conn_index, e).await;
                                             }
                                         }
-
-                                        let elapsed_us =
-                                            iter_start.elapsed().as_micros() as u64;
-                                        metrics.count.fetch_add(1, Ordering::Relaxed);
-                                        metrics.sum_inbound_wait_us.fetch_add(inbound_wait_us, Ordering::Relaxed);
-                                        metrics.sum_elapsed_us.fetch_add(elapsed_us, Ordering::Relaxed);
-                                        inbound_wait_start = std::time::Instant::now();
                                     }
                                     Err(e) => {
                                         if e.code() == tonic::Code::PermissionDenied {
@@ -1799,8 +1746,6 @@ impl MessageProcessor {
                     }
                 }
             }
-
-            reporter_cancel.cancel();
 
             // we drop rx now as otherwise the connection will be closed only
             // when the task is dropped and we want to make sure that the rx

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::api::DataPlaneServiceServer;
 use display_error_chain::ErrorChainExt;
@@ -16,6 +17,7 @@ use slim_config::server::ServerConfig;
 use slim_config::server_handler::ServerHandler;
 use slim_config::websocket::server as websocket_server;
 use slim_config::websocket::server::AcceptedWebSocketConnection;
+use futures::future::try_join_all;
 use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -130,6 +132,15 @@ enum StreamSetup {
         connection: Box<Connection>,
         existing_index: Option<u64>,
     },
+}
+
+/// Per-connection metrics collected by the `process_stream` loop and
+/// reported once per second by a companion task.
+#[derive(Default)]
+struct StreamMetrics {
+    count: AtomicU64,
+    sum_inbound_wait_us: AtomicU64,
+    sum_elapsed_us: AtomicU64,
 }
 
 impl MessageProcessor {
@@ -394,7 +405,7 @@ impl MessageProcessor {
         match channel {
             TransportChannel::Grpc(grpc_channel) => {
                 let mut client = DataPlaneServiceClient::new(grpc_channel);
-                let (tx, rx) = mpsc::channel(128);
+                let (tx, rx) = mpsc::channel(1024);
                 let stream = client
                     .open_channel(Request::new(ReceiverStream::new(rx)))
                     .await?;
@@ -760,12 +771,15 @@ impl MessageProcessor {
                     len as u32,
                 );
 
-                let mut i = 0usize;
-                while i < len - 1 {
-                    self.send_msg_raw(msg.clone(), out_vec[i]).await?;
-                    i += 1;
-                }
-                self.send_msg_raw(msg, out_vec[i]).await?;
+                // Send to all subscribers concurrently: a single slow/full
+                // outbound channel no longer blocks delivery to the others.
+                let last = len - 1;
+                let mut sends: Vec<_> = out_vec[..last]
+                    .iter()
+                    .map(|&conn| self.send_msg_raw(msg.clone(), conn))
+                    .collect();
+                sends.push(self.send_msg_raw(msg, out_vec[last]));
+                try_join_all(sends).await?;
                 Ok(())
             }
             Err(e) => {
@@ -1636,7 +1650,44 @@ impl MessageProcessor {
                 return;
             };
 
+            // Metrics shared with the reporter task.
+            let metrics = Arc::new(StreamMetrics::default());
+            let reporter_cancel = CancellationToken::new();
+            {
+                let m = metrics.clone();
+                let cancel = reporter_cancel.clone();
+                tokio::spawn(async move {
+                    loop {
+                        tokio::select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                                let count = m.count.swap(0, Ordering::Relaxed);
+                                if count > 0 {
+                                    let avg_inbound_wait_us =
+                                        m.sum_inbound_wait_us.swap(0, Ordering::Relaxed) / count;
+                                    let avg_elapsed_us =
+                                        m.sum_elapsed_us.swap(0, Ordering::Relaxed) / count;
+                                    info!(
+                                        %conn_index,
+                                        msgs_per_sec = count,
+                                        avg_inbound_wait_us,
+                                        avg_elapsed_us,
+                                        "process_stream metrics",
+                                    );
+                                }
+                            }
+                            _ = cancel.cancelled() => break,
+                        }
+                    }
+                });
+            }
+
             let mut watch = std::pin::pin!(watch.signaled());
+            // Tracks the wall-clock instant at which we last finished processing
+            // a message (or entered the loop for the first time). The elapsed
+            // time when stream.next() returns is the inbound stream wait time:
+            // near-zero means messages were already buffered in the h2 receive
+            // window; a larger value means the loop was idle waiting for data.
+            let mut inbound_wait_start = std::time::Instant::now();
             loop {
                 tokio::select! {
                     next = stream.next() => {
@@ -1644,6 +1695,10 @@ impl MessageProcessor {
                             Some(result) => {
                                 match result {
                                     Ok(msg) => {
+                                        let inbound_wait_us =
+                                            inbound_wait_start.elapsed().as_micros() as u64;
+                                        let iter_start = std::time::Instant::now();
+
                                         if !is_local
                                             && !msg.is_link()
                                             && !msg.is_subscription_ack()
@@ -1697,6 +1752,13 @@ impl MessageProcessor {
                                                 self_clone.send_error_to_local_app(conn_index, e).await;
                                             }
                                         }
+
+                                        let elapsed_us =
+                                            iter_start.elapsed().as_micros() as u64;
+                                        metrics.count.fetch_add(1, Ordering::Relaxed);
+                                        metrics.sum_inbound_wait_us.fetch_add(inbound_wait_us, Ordering::Relaxed);
+                                        metrics.sum_elapsed_us.fetch_add(elapsed_us, Ordering::Relaxed);
+                                        inbound_wait_start = std::time::Instant::now();
                                     }
                                     Err(e) => {
                                         if e.code() == tonic::Code::PermissionDenied {
@@ -1735,6 +1797,8 @@ impl MessageProcessor {
                     }
                 }
             }
+
+            reporter_cancel.cancel();
 
             // we drop rx now as otherwise the connection will be closed only
             // when the task is dropped and we want to make sure that the rx
@@ -1819,6 +1883,58 @@ impl MessageProcessor {
         Ok((handle, conn_index_rx))
     }
 
+    /// Process a single message received from an inbound stream.
+    ///
+    /// Returns `true` if the calling loop should continue, or `false` if it
+    /// should break (fatal [`DataPathError::NegotiationError`]).
+    async fn process_stream_message(
+        &self,
+        msg: Message,
+        conn_index: u64,
+        category: ConnType,
+        is_local: bool,
+        from_control_plane: bool,
+        require_header_mac: bool,
+        tx_cp: &Option<Sender<Result<Message, Status>>>,
+    ) -> bool {
+        if !is_local
+            && !msg.is_link()
+            && !msg.is_subscription_ack()
+            && let Err(e) = self.verify_remote_header_mac(conn_index, &msg, require_header_mac)
+        {
+            error!(
+                %conn_index,
+                error = %e.chain(),
+                "SLIM header integrity verification failed",
+            );
+            return true;
+        }
+
+        // Forward subscriptions and unsubscriptions to the control plane
+        // (remote messages only, excluding messages originating from the CP itself).
+        if !is_local && !from_control_plane && let Some(txcp) = tx_cp {
+            match msg.get_type() {
+                PublishType(_) | LinkType(_) | SubscriptionAckType(_) => {}
+                _ => {
+                    let _ = txcp.send(Ok(msg.clone())).await;
+                }
+            }
+        }
+
+        if let Err(e) = self.handle_new_message(conn_index, category, msg).await {
+            if matches!(e, DataPathError::NegotiationError(_)) {
+                error!(%conn_index, "fatal link negotiation error, closing connection");
+                return false;
+            }
+            debug!(%conn_index, error = %e.chain(), "error processing incoming message");
+            if is_local {
+                self.send_error_to_local_app(conn_index, e).await;
+            }
+        }
+
+        true
+    }
+
     fn match_for_io_error(err_status: &Status) -> Option<&std::io::Error> {
         let mut err: &(dyn std::error::Error + 'static) = err_status;
 
@@ -1895,7 +2011,7 @@ impl DataPlaneService for MessageProcessor {
         let local_addr = request.local_addr();
 
         let stream = request.into_inner();
-        let (tx, rx) = mpsc::channel(128);
+        let (tx, rx) = mpsc::channel(1024);
 
         let connection = Connection::new(ConnType::Remote, Channel::Server(tx))
             .with_remote_addr(remote_addr)

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::api::DataPlaneServiceServer;
 use display_error_chain::ErrorChainExt;
+use futures::future::try_join_all;
 use parking_lot::RwLock;
 use slim_config::client::ClientConfig;
 use slim_config::client::TransportChannel;
@@ -16,7 +17,6 @@ use slim_config::server::ServerConfig;
 use slim_config::server_handler::ServerHandler;
 use slim_config::websocket::server as websocket_server;
 use slim_config::websocket::server::AcceptedWebSocketConnection;
-use futures::future::try_join_all;
 use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -395,8 +395,7 @@ impl MessageProcessor {
         match channel {
             TransportChannel::Grpc(grpc_channel) => {
                 let mut client = DataPlaneServiceClient::new(grpc_channel);
-                // Buffer of 1024 reduces backpressure on high-throughput forwarding paths.
-                let (tx, rx) = mpsc::channel(1024);
+                let (tx, rx) = mpsc::channel(128);
                 let stream = client
                     .open_channel(Request::new(ReceiverStream::new(rx)))
                     .await?;

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -395,7 +395,7 @@ impl MessageProcessor {
         match channel {
             TransportChannel::Grpc(grpc_channel) => {
                 let mut client = DataPlaneServiceClient::new(grpc_channel);
-                let (tx, rx) = mpsc::channel(128);
+                let (tx, rx) = mpsc::channel(1024);
                 let stream = client
                     .open_channel(Request::new(ReceiverStream::new(rx)))
                     .await?;

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -395,6 +395,7 @@ impl MessageProcessor {
         match channel {
             TransportChannel::Grpc(grpc_channel) => {
                 let mut client = DataPlaneServiceClient::new(grpc_channel);
+                // Buffer of 1024 reduces backpressure on high-throughput forwarding paths.
                 let (tx, rx) = mpsc::channel(1024);
                 let stream = client
                     .open_channel(Request::new(ReceiverStream::new(rx)))

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -684,7 +685,9 @@ impl MessageProcessor {
                             && let Some(dest) = header.destination.as_mut()
                             && let Some(sn) = dest.str_name.as_mut()
                         {
-                            sn.str_component_2.push_str("-integrity-test-tamper");
+                            sn.str_component_2 = Bytes::from(
+                                [sn.str_component_2.as_ref(), b"-integrity-test-tamper"].concat(),
+                            );
                         }
                     } else {
                         return Err(DataPathError::HeaderMacAwaitingLinkNegotiation(out_conn));
@@ -2254,7 +2257,9 @@ mod tests {
         if let Some(dest) = header.destination.as_mut()
             && let Some(sn) = dest.str_name.as_mut()
         {
-            sn.str_component_2.push_str("-integrity-test-tamper");
+            sn.str_component_2 = Bytes::from(
+                [sn.str_component_2.as_ref(), b"-integrity-test-tamper"].concat(),
+            );
         }
 
         let err = processor
@@ -2295,7 +2300,7 @@ mod tests {
         let require_header_mac = true;
 
         // The tampering happens in send_msg_raw if the env var is set.
-        assert!(str_name.str_component_2.ends_with("-integrity-test-tamper"));
+        assert!(str_name.str_component_2.ends_with(b"-integrity-test-tamper"));
 
         // Also verify that verify_remote_header_mac rejects it.
         let err = processor

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -1883,58 +1883,6 @@ impl MessageProcessor {
         Ok((handle, conn_index_rx))
     }
 
-    /// Process a single message received from an inbound stream.
-    ///
-    /// Returns `true` if the calling loop should continue, or `false` if it
-    /// should break (fatal [`DataPathError::NegotiationError`]).
-    async fn process_stream_message(
-        &self,
-        msg: Message,
-        conn_index: u64,
-        category: ConnType,
-        is_local: bool,
-        from_control_plane: bool,
-        require_header_mac: bool,
-        tx_cp: &Option<Sender<Result<Message, Status>>>,
-    ) -> bool {
-        if !is_local
-            && !msg.is_link()
-            && !msg.is_subscription_ack()
-            && let Err(e) = self.verify_remote_header_mac(conn_index, &msg, require_header_mac)
-        {
-            error!(
-                %conn_index,
-                error = %e.chain(),
-                "SLIM header integrity verification failed",
-            );
-            return true;
-        }
-
-        // Forward subscriptions and unsubscriptions to the control plane
-        // (remote messages only, excluding messages originating from the CP itself).
-        if !is_local && !from_control_plane && let Some(txcp) = tx_cp {
-            match msg.get_type() {
-                PublishType(_) | LinkType(_) | SubscriptionAckType(_) => {}
-                _ => {
-                    let _ = txcp.send(Ok(msg.clone())).await;
-                }
-            }
-        }
-
-        if let Err(e) = self.handle_new_message(conn_index, category, msg).await {
-            if matches!(e, DataPathError::NegotiationError(_)) {
-                error!(%conn_index, "fatal link negotiation error, closing connection");
-                return false;
-            }
-            debug!(%conn_index, error = %e.chain(), "error processing incoming message");
-            if is_local {
-                self.send_error_to_local_app(conn_index, e).await;
-            }
-        }
-
-        true
-    }
-
     fn match_for_io_error(err_status: &Status) -> Option<&std::io::Error> {
         let mut err: &(dyn std::error::Error + 'static) = err_status;
 

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -680,17 +680,13 @@ impl MessageProcessor {
                         // Debug / integration-test builds only (`--release` omits this; env var is inert).
                         // Must run *after* sign so the tag does not cover the mutated preimage fields.
                         #[cfg(debug_assertions)]
-                        if std::env::var("SLIM_TEST_TAMPER_DESTINATION").is_ok() {
-                            if let Some(dest) = header.destination.as_mut() {
-                                if let Some((s0, s1, s2)) =
-                                    crate::api::decode_str_bytes(&dest.str_name)
-                                {
-                                    let tampered: Vec<u8> =
-                                        [s2, b"-integrity-test-tamper"].concat();
-                                    dest.str_name =
-                                        crate::api::encode_str_bytes(s0, s1, &tampered);
-                                }
-                            }
+                        if std::env::var("SLIM_TEST_TAMPER_DESTINATION").is_ok()
+                            && let Some((s0, s1, s2)) =
+                                crate::api::decode_str_bytes(&header.destination_str)
+                        {
+                            let tampered: Vec<u8> = [s2, b"-integrity-test-tamper"].concat();
+                            header.destination_str =
+                                crate::api::encode_str_bytes(s0, s1, &tampered);
                         }
                     } else {
                         return Err(DataPathError::HeaderMacAwaitingLinkNegotiation(out_conn));
@@ -2264,11 +2260,9 @@ mod tests {
             .expect("sign header");
 
         let header = msg.get_slim_header_mut();
-        if let Some(dest) = header.destination.as_mut() {
-            if let Some((s0, s1, s2)) = crate::api::decode_str_bytes(&dest.str_name) {
-                let tampered: Vec<u8> = [s2, b"-integrity-test-tamper"].concat();
-                dest.str_name = crate::api::encode_str_bytes(s0, s1, &tampered);
-            }
+        if let Some((s0, s1, s2)) = crate::api::decode_str_bytes(&header.destination_str) {
+            let tampered: Vec<u8> = [s2, b"-integrity-test-tamper"].concat();
+            header.destination_str = crate::api::encode_str_bytes(s0, s1, &tampered);
         }
 
         let err = processor
@@ -2304,13 +2298,12 @@ mod tests {
 
         let sent_msg = rx.recv().await.unwrap().unwrap();
         let header = sent_msg.get_slim_header();
-        let dest_name = header.destination.as_ref().expect("destination");
         let require_header_mac = true;
 
         // The tampering happens in send_msg_raw if the env var is set.
         // Decode the packed str_name bytes and check the third component.
         let (_, _, s2) =
-            crate::api::decode_str_bytes(&dest_name.str_name).expect("str_name must be set");
+            crate::api::decode_str_bytes(&header.destination_str).expect("str_name must be set");
         assert!(s2.ends_with(b"-integrity-test-tamper"));
 
         // Also verify that verify_remote_header_mac rejects it.

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -1,7 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -681,13 +680,17 @@ impl MessageProcessor {
                         // Debug / integration-test builds only (`--release` omits this; env var is inert).
                         // Must run *after* sign so the tag does not cover the mutated preimage fields.
                         #[cfg(debug_assertions)]
-                        if std::env::var("SLIM_TEST_TAMPER_DESTINATION").is_ok()
-                            && let Some(dest) = header.destination.as_mut()
-                            && let Some(sn) = dest.str_name.as_mut()
-                        {
-                            sn.str_component_2 = Bytes::from(
-                                [sn.str_component_2.as_ref(), b"-integrity-test-tamper"].concat(),
-                            );
+                        if std::env::var("SLIM_TEST_TAMPER_DESTINATION").is_ok() {
+                            if let Some(dest) = header.destination.as_mut() {
+                                if let Some((s0, s1, s2)) =
+                                    crate::api::decode_str_bytes(&dest.str_name)
+                                {
+                                    let tampered: Vec<u8> =
+                                        [s2, b"-integrity-test-tamper"].concat();
+                                    dest.str_name =
+                                        crate::api::encode_str_bytes(s0, s1, &tampered);
+                                }
+                            }
                         }
                     } else {
                         return Err(DataPathError::HeaderMacAwaitingLinkNegotiation(out_conn));
@@ -753,11 +756,11 @@ impl MessageProcessor {
             return self.send_msg(msg, val).await;
         }
 
-        let encoded = header.get_encoded_dst();
+        let (components, id) = header.get_encoded_dst();
 
         match self
             .forwarder()
-            .on_publish_msg_match(encoded, in_connection, fanout, filter)
+            .on_publish_msg_match(components, id, in_connection, fanout, filter)
         {
             Ok(out_vec) => {
                 let len = out_vec.len();
@@ -1845,12 +1848,19 @@ impl MessageProcessor {
                 {
                     let fwd = self_clone.peer_sync();
                     for name in local_subs.keys() {
-                        let still_reachable = name.name.is_some_and(|enc| {
+                        let still_reachable = !name.encoded_name.is_empty() && {
+                            let (comp, id) = name.components_and_id();
                             self_clone
                                 .forwarder()
-                                .on_publish_msg_match(enc, u64::MAX, u32::MAX, MatchFilter::ALL)
+                                .on_publish_msg_match(
+                                    comp,
+                                    id,
+                                    u64::MAX,
+                                    u32::MAX,
+                                    MatchFilter::ALL,
+                                )
                                 .is_ok()
-                        });
+                        };
                         if !still_reachable {
                             debug!(
                                 %name,
@@ -2254,12 +2264,11 @@ mod tests {
             .expect("sign header");
 
         let header = msg.get_slim_header_mut();
-        if let Some(dest) = header.destination.as_mut()
-            && let Some(sn) = dest.str_name.as_mut()
-        {
-            sn.str_component_2 = Bytes::from(
-                [sn.str_component_2.as_ref(), b"-integrity-test-tamper"].concat(),
-            );
+        if let Some(dest) = header.destination.as_mut() {
+            if let Some((s0, s1, s2)) = crate::api::decode_str_bytes(&dest.str_name) {
+                let tampered: Vec<u8> = [s2, b"-integrity-test-tamper"].concat();
+                dest.str_name = crate::api::encode_str_bytes(s0, s1, &tampered);
+            }
         }
 
         let err = processor
@@ -2296,11 +2305,13 @@ mod tests {
         let sent_msg = rx.recv().await.unwrap().unwrap();
         let header = sent_msg.get_slim_header();
         let dest_name = header.destination.as_ref().expect("destination");
-        let str_name = dest_name.str_name.as_ref().expect("str_name");
         let require_header_mac = true;
 
         // The tampering happens in send_msg_raw if the env var is set.
-        assert!(str_name.str_component_2.ends_with(b"-integrity-test-tamper"));
+        // Decode the packed str_name bytes and check the third component.
+        let (_, _, s2) =
+            crate::api::decode_str_bytes(&dest_name.str_name).expect("str_name must be set");
+        assert!(s2.ends_with(b"-integrity-test-tamper"));
 
         // Also verify that verify_remote_header_mac rejects it.
         let err = processor

--- a/crates/datapath/src/message_processing.rs
+++ b/crates/datapath/src/message_processing.rs
@@ -1962,7 +1962,7 @@ impl DataPlaneService for MessageProcessor {
         let local_addr = request.local_addr();
 
         let stream = request.into_inner();
-        let (tx, rx) = mpsc::channel(1024);
+        let (tx, rx) = mpsc::channel(128);
 
         let connection = Connection::new(ConnType::Remote, Channel::Server(tx))
             .with_remote_addr(remote_addr)

--- a/crates/datapath/src/sync/forwarder.rs
+++ b/crates/datapath/src/sync/forwarder.rs
@@ -803,7 +803,7 @@ impl PeerSync {
         // Track in remote subscription table (for reconnection replay) — both add and remove.
         let source = msg.get_source();
         let dst = msg.get_dst();
-        let identity = msg.get_identity();
+        let identity = msg.get_identity().to_string();
         mp.remote_sync()
             .on_forwarded_subscription(source, dst, identity, out_conn, add, sub_id);
 

--- a/crates/datapath/src/tables.rs
+++ b/crates/datapath/src/tables.rs
@@ -11,7 +11,7 @@ pub mod subscription_table;
 
 pub mod pool;
 
-use crate::api::{EncodedName, ProtoName};
+use crate::api::ProtoName;
 
 pub use slim_config::conn_type::ConnType;
 
@@ -81,14 +81,16 @@ pub trait SubscriptionTable {
 
     fn match_one(
         &self,
-        encoded: &EncodedName,
+        components: [u64; 3],
+        id: u128,
         incoming_conn: u64,
         filter: MatchFilter,
     ) -> Result<u64, Self::Error>;
 
     fn match_all(
         &self,
-        encoded: &EncodedName,
+        components: [u64; 3],
+        id: u128,
         incoming_conn: u64,
         filter: MatchFilter,
     ) -> Result<Vec<u64>, Self::Error>;

--- a/crates/datapath/src/tables/subscription_table.rs
+++ b/crates/datapath/src/tables/subscription_table.rs
@@ -12,7 +12,7 @@ use tracing::{debug, warn};
 
 use super::SubscriptionTable;
 use super::{ConnType, MatchFilter};
-use crate::api::{EncodedName, NameId, ProtoName};
+use crate::api::{self, ProtoName};
 use crate::errors::DataPathError;
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -321,7 +321,7 @@ impl PrefixEntry {
             self.strings[1].as_str(),
             self.strings[2].as_str(),
         ]);
-        if id != NameId::NULL_COMPONENT {
+        if id != api::NULL_COMPONENT {
             base.with_id(id)
         } else {
             base
@@ -347,7 +347,8 @@ impl Clone for PrefixEntry {
 
 #[derive(Debug, Clone, Copy)]
 struct SubRecord {
-    encoded: EncodedName,
+    prefix: [u64; 3],
+    id: u128,
     conn_id: u64,
     category: ConnType,
 }
@@ -392,13 +393,13 @@ impl SubscriptionState {
         Some(record)
     }
 
-    /// True when `conn` still has at least one subscription for `encoded`.
-    fn conn_still_subscribed(&self, conn: u64, encoded: EncodedName) -> bool {
+    /// True when `conn` still has at least one subscription for `(prefix, id)`.
+    fn conn_still_subscribed(&self, conn: u64, prefix: [u64; 3], id: u128) -> bool {
         self.conn_subs.get(&conn).is_some_and(|subs| {
             subs.iter().any(|&s| {
                 self.subscriptions
                     .get(&s)
-                    .is_some_and(|r| r.encoded == encoded)
+                    .is_some_and(|r| r.prefix == prefix && r.id == id)
             })
         })
     }
@@ -503,10 +504,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         category: ConnType,
         subscription_id: u64,
     ) -> Result<bool, Self::Error> {
-        let enc = name.name.as_ref().unwrap();
-        let prefix = [enc.component_0, enc.component_1, enc.component_2];
-        let id = enc.id();
-        let encoded = *enc;
+        let (prefix, id) = name.components_and_id();
 
         // subscription_state locked first; routing updated via clone-modify-store.
         let mut ss = self.subscription_state.lock();
@@ -531,7 +529,8 @@ impl SubscriptionTable for SubscriptionTableImpl {
         ss.add(
             subscription_id,
             SubRecord {
-                encoded,
+                prefix,
+                id,
                 conn_id: conn,
                 category,
             },
@@ -548,10 +547,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         category: ConnType,
         subscription_id: u64,
     ) -> Result<bool, Self::Error> {
-        let enc = name.name.as_ref().unwrap();
-        let prefix = [enc.component_0, enc.component_1, enc.component_2];
-        let id = enc.id();
-        let encoded = *enc;
+        let (prefix, id) = name.components_and_id();
 
         // subscription_state locked first; routing validated then updated via clone-modify-store.
         let mut ss = self.subscription_state.lock();
@@ -565,9 +561,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
             }
             if !current[&prefix].has_id(id) {
                 warn!(%id, "not found");
-                let nid: NameId = id.into();
-                let str_nid: String = nid.into();
-                return Err(DataPathError::IdNotFound(str_nid));
+                return Err(DataPathError::IdNotFound(api::id_to_string(id)));
             }
         }
 
@@ -581,16 +575,16 @@ impl SubscriptionTable for SubscriptionTableImpl {
         if record.conn_id != conn {
             return Err(DataPathError::ConnectionIdNotFound(conn));
         }
-        if record.encoded != encoded {
+        if record.prefix != prefix || record.id != id {
             return Err(DataPathError::SubscriptionIdNotFound(subscription_id));
         }
 
         // Remove sub_id from both maps (conn_subs is cleaned up when empty).
         ss.remove(subscription_id);
 
-        // Check whether the connection is still subscribed to the same encoded name via another
+        // Check whether the connection is still subscribed to the same (prefix, id) via another
         // subscription_id.
-        let conn_still_subscribed = ss.conn_still_subscribed(conn, encoded);
+        let conn_still_subscribed = ss.conn_still_subscribed(conn, prefix, id);
 
         let last = if !conn_still_subscribed {
             let mut rs = (**self.routing.load()).clone();
@@ -631,27 +625,19 @@ impl SubscriptionTable for SubscriptionTableImpl {
 
         // Pass 1: remove each subscription record and build the result map.
         // Use a read snapshot (no clone yet) for proto_name lookups.
-        let mut encoded_names: Vec<EncodedName> = Vec::new();
+        let mut encoded_names: Vec<([u64; 3], u128)> = Vec::new();
 
         let current = self.routing.load();
         for sub_id in sub_ids {
             if let Some(record) = ss.subscriptions.remove(&sub_id) {
-                let prefix = [
-                    record.encoded.component_0,
-                    record.encoded.component_1,
-                    record.encoded.component_2,
-                ];
                 let proto_name = current
-                    .get(&prefix)
-                    .map(|pe| pe.to_proto_name(record.encoded.id()))
-                    .unwrap_or(ProtoName {
-                        name: Some(record.encoded),
-                        str_name: None,
-                    });
+                    .get(&record.prefix)
+                    .map(|pe| pe.to_proto_name(record.id))
+                    .unwrap_or_else(|| ProtoName::from_components(record.prefix, record.id));
                 result.entry(proto_name).or_default().insert(sub_id);
 
-                if !encoded_names.contains(&record.encoded) {
-                    encoded_names.push(record.encoded);
+                if !encoded_names.contains(&(record.prefix, record.id)) {
+                    encoded_names.push((record.prefix, record.id));
                 }
             }
         }
@@ -659,14 +645,9 @@ impl SubscriptionTable for SubscriptionTableImpl {
         // Pass 2: clone snapshot, remove conn from routing for every affected encoded name.
         let mut rs = (**current).clone();
         drop(current);
-        for encoded in &encoded_names {
-            debug!(%conn, ?encoded, "remove subscription");
-            let prefix = [
-                encoded.component_0,
-                encoded.component_1,
-                encoded.component_2,
-            ];
-            let id = encoded.id();
+        for (prefix, id) in &encoded_names {
+            let (prefix, id) = (*prefix, *id);
+            debug!(%conn, ?prefix, id, "remove subscription");
 
             let should_remove_prefix = if let Some(entry) = rs.get_mut(&prefix) {
                 let pe = Arc::make_mut(entry);
@@ -688,49 +669,44 @@ impl SubscriptionTable for SubscriptionTableImpl {
 
     fn match_one(
         &self,
-        encoded: &EncodedName,
+        components: [u64; 3],
+        id: u128,
         incoming_conn: u64,
         filter: MatchFilter,
     ) -> Result<u64, Self::Error> {
-        let prefix = [
-            encoded.component_0,
-            encoded.component_1,
-            encoded.component_2,
-        ];
-        let id = encoded.id();
         let rs = self.routing.load();
 
-        // ONE HashMap lookup — the same for any c3 value.
-        let prefix_entry = match rs.get(&prefix) {
+        // ONE HashMap lookup — the same for any id value.
+        let prefix_entry = match rs.get(&components) {
             None => {
                 debug!(
-                    component_0 = encoded.component_0,
-                    component_1 = encoded.component_1,
-                    component_2 = encoded.component_2,
+                    component_0 = components[0],
+                    component_1 = components[1],
+                    component_2 = components[2],
                     component_3 = id,
                     "match not found for name"
                 );
                 return Err(DataPathError::NoMatchEncoded(
-                    encoded.component_0,
-                    encoded.component_1,
-                    encoded.component_2,
-                    encoded.string_id(),
+                    components[0],
+                    components[1],
+                    components[2],
+                    api::id_to_string(id),
                 ));
             }
             Some(pe) => pe,
         };
 
-        if id != NameId::NULL_COMPONENT {
+        if id != api::NULL_COMPONENT {
             // Specific ID: linear scan over ids (8 per cache line).
             prefix_entry
                 .get_one(id, incoming_conn, filter)
                 .ok_or_else(|| {
                     debug!(component_3 = id, "match not found for name");
                     DataPathError::NoMatchEncoded(
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        encoded.string_id(),
+                        components[0],
+                        components[1],
+                        components[2],
+                        api::id_to_string(id),
                     )
                 })
         } else {
@@ -741,10 +717,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 .ok_or_else(|| {
                     debug!("no output connection available");
                     DataPathError::NoMatchEncoded(
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        encoded.string_id(),
+                        components[0],
+                        components[1],
+                        components[2],
+                        api::id_to_string(id),
                     )
                 })
         }
@@ -752,57 +728,52 @@ impl SubscriptionTable for SubscriptionTableImpl {
 
     fn match_all(
         &self,
-        encoded: &EncodedName,
+        components: [u64; 3],
+        id: u128,
         incoming_conn: u64,
         filter: MatchFilter,
     ) -> Result<Vec<u64>, Self::Error> {
-        let prefix = [
-            encoded.component_0,
-            encoded.component_1,
-            encoded.component_2,
-        ];
-        let id = encoded.id();
         let rs = self.routing.load();
 
-        // ONE HashMap lookup — the same for any c3 value.
-        let prefix_entry = match rs.get(&prefix) {
+        // ONE HashMap lookup — the same for any id value.
+        let prefix_entry = match rs.get(&components) {
             None => {
                 debug!(
-                    component_0 = encoded.component_0,
-                    component_1 = encoded.component_1,
-                    component_2 = encoded.component_2,
+                    component_0 = components[0],
+                    component_1 = components[1],
+                    component_2 = components[2],
                     component_3 = id,
                     "match not found for name"
                 );
                 return Err(DataPathError::NoMatchEncoded(
-                    encoded.component_0,
-                    encoded.component_1,
-                    encoded.component_2,
-                    encoded.string_id(),
+                    components[0],
+                    components[1],
+                    components[2],
+                    api::id_to_string(id),
                 ));
             }
             Some(pe) => pe,
         };
 
-        if id != NameId::NULL_COMPONENT {
+        if id != api::NULL_COMPONENT {
             // Specific ID: linear scan over ids (8 per cache line).
             match prefix_entry.get_all(id, incoming_conn, filter) {
                 None => {
                     debug!(component_3 = id, "match not found for name");
                     Err(DataPathError::NoMatchEncoded(
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        encoded.string_id(),
+                        components[0],
+                        components[1],
+                        components[2],
+                        api::id_to_string(id),
                     ))
                 }
                 Some(out) if out.is_empty() => {
                     debug!("no connection available (local/remote/peer)");
                     Err(DataPathError::NoMatchEncoded(
-                        encoded.component_0,
-                        encoded.component_1,
-                        encoded.component_2,
-                        encoded.string_id(),
+                        components[0],
+                        components[1],
+                        components[2],
+                        api::id_to_string(id),
                     ))
                 }
                 Some(out) => {
@@ -817,10 +788,10 @@ impl SubscriptionTable for SubscriptionTableImpl {
             if out.is_empty() {
                 debug!("no connection available");
                 Err(DataPathError::NoMatchEncoded(
-                    encoded.component_0,
-                    encoded.component_1,
-                    encoded.component_2,
-                    encoded.string_id(),
+                    components[0],
+                    components[1],
+                    components[2],
+                    api::id_to_string(id),
                 ))
             } else {
                 debug!(?out, "found connections");
@@ -842,18 +813,10 @@ impl SubscriptionTableImpl {
         let ss = self.subscription_state.lock();
         let rs = self.routing.load();
         for (&sub_id, record) in &ss.subscriptions {
-            let prefix = [
-                record.encoded.component_0,
-                record.encoded.component_1,
-                record.encoded.component_2,
-            ];
             let proto_name = rs
-                .get(&prefix)
-                .map(|pe| pe.to_proto_name(record.encoded.id()))
-                .unwrap_or(ProtoName {
-                    name: Some(record.encoded),
-                    str_name: None,
-                });
+                .get(&record.prefix)
+                .map(|pe| pe.to_proto_name(record.id))
+                .unwrap_or_else(|| ProtoName::from_components(record.prefix, record.id));
             f(proto_name, sub_id, record.conn_id, record.category);
         }
     }
@@ -864,10 +827,6 @@ mod tests {
     use super::*;
 
     use tracing_test::traced_test;
-
-    fn enc(name: &ProtoName) -> EncodedName {
-        name.name.unwrap()
-    }
 
     #[test]
     #[traced_test]
@@ -899,14 +858,14 @@ mod tests {
         );
 
         // returns three matches on connection 1,2,3
-        let out = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 3);
         assert!(out.contains(&1));
         assert!(out.contains(&2));
         assert!(out.contains(&3));
 
         // return two matches on connection 2,3
-        let out = t.match_all(&enc(&name1), 1, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 1, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&2));
         assert!(out.contains(&3));
@@ -917,7 +876,7 @@ mod tests {
         );
 
         // return two matches on connection 1,3
-        let out = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&1));
         assert!(out.contains(&3));
@@ -928,12 +887,12 @@ mod tests {
         );
 
         // return one matches on connection 1
-        let out = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 1);
         assert!(out.contains(&1));
 
         // return no match
-        let err = t.match_all(&enc(&name1), 1, MatchFilter::ALL);
+        let err = t.match_all(name1.components(), name1.id(), 1, MatchFilter::ALL);
         assert!(matches!(err, Err(DataPathError::NoMatchEncoded(..))));
 
         // add subscription again
@@ -943,14 +902,14 @@ mod tests {
         );
 
         // returns two matches on connection 1 and 2
-        let out = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&1));
         assert!(out.contains(&2));
 
         // run multiple times for randomness
         for _ in 0..20 {
-            let out = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+            let out = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
             if out != 1 && out != 2 {
                 // the output must be 1 or 2
                 panic!("the output must be 1 or 2");
@@ -958,18 +917,18 @@ mod tests {
         }
 
         // return connection 2
-        let out = t.match_one(&enc(&name1_1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_one(name1_1.components(), name1_1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out, 2);
 
         // return connection 3
-        let out = t.match_one(&enc(&name2_2), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_one(name2_2.components(), name2_2.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out, 3);
         let removed_subs = t.remove_connection(2, ConnType::Remote).unwrap();
         assert_eq!(removed_subs.len(), 1);
         assert!(removed_subs.contains_key(&name1_1));
 
         // returns one match on connection 1
-        let out = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 1);
         assert!(out.contains(&1));
 
@@ -980,7 +939,7 @@ mod tests {
 
         // run multiple times for randomness
         for _ in 0..20 {
-            let out = t.match_one(&enc(&name2_2), 100, MatchFilter::ALL).unwrap();
+            let out = t.match_one(name2_2.components(), name2_2.id(), 100, MatchFilter::ALL).unwrap();
             if out != 3 && out != 4 {
                 // the output must be 3 or 4
                 panic!("the output must be 3 or 4");
@@ -988,7 +947,7 @@ mod tests {
         }
 
         for _ in 0..20 {
-            let out = t.match_one(&enc(&name2_2), 4, MatchFilter::ALL).unwrap();
+            let out = t.match_one(name2_2.components(), name2_2.id(), 4, MatchFilter::ALL).unwrap();
             if out != 3 {
                 // the output must be 3
                 panic!("the output must be 3");
@@ -1007,22 +966,22 @@ mod tests {
         );
 
         // returns both local (2) and remote (1) connections
-        let out = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&2));
         assert!(out.contains(&1));
 
         // returns one match on connection 2
-        let out = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out, 2);
 
         // returns both local (2) and remote (1) connections, excluding incoming connection (2)
-        let out = t.match_all(&enc(&name1), 2, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name1.components(), name1.id(), 2, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 1);
         assert!(out.contains(&1));
 
         // same here
-        let out = t.match_one(&enc(&name1), 2, MatchFilter::ALL).unwrap();
+        let out = t.match_one(name1.components(), name1.id(), 2, MatchFilter::ALL).unwrap();
         assert_eq!(out, 1);
 
         // test errors
@@ -1031,7 +990,7 @@ mod tests {
 
         // Test that specific ID (name1_1) does NOT match NULL_COMPONENT subscriptions
         // At this point only name1 (NULL_COMPONENT) subscriptions exist on conn 1 and 2
-        let err = t.match_one(&enc(&name1_1), 100, MatchFilter::ALL);
+        let err = t.match_one(name1_1.components(), name1_1.id(), 100, MatchFilter::ALL);
         assert!(matches!(err, Err(DataPathError::NoMatchEncoded(..))));
 
         assert!(
@@ -1116,7 +1075,7 @@ mod tests {
         );
 
         // Test match_all returns both local and remote connections
-        let result = t.match_all(&enc(&name), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(
             result.len(),
             4,
@@ -1128,7 +1087,7 @@ mod tests {
         assert!(result.contains(&4), "Should contain remote connection 4");
 
         // Test excluding incoming connection works for local
-        let result = t.match_all(&enc(&name), 1, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 1, MatchFilter::ALL).unwrap();
         assert_eq!(
             result.len(),
             3,
@@ -1143,7 +1102,7 @@ mod tests {
         assert!(result.contains(&4), "Should contain remote connection 4");
 
         // Test excluding incoming connection works for remote
-        let result = t.match_all(&enc(&name), 3, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 3, MatchFilter::ALL).unwrap();
         assert_eq!(
             result.len(),
             3,
@@ -1159,7 +1118,7 @@ mod tests {
 
         // Test match_one prefers local over remote
         for _ in 0..20 {
-            let result = t.match_one(&enc(&name), 100, MatchFilter::ALL).unwrap();
+            let result = t.match_one(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
             assert!(
                 result == 1 || result == 2,
                 "match_one should always prefer local connections"
@@ -1171,14 +1130,14 @@ mod tests {
         assert!(t.remove_subscription(&name, 2, ConnType::Local, 2).is_ok());
 
         // Now match_all should only return remote connections
-        let result = t.match_all(&enc(&name), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result.len(), 2, "Should return only 2 remote connections");
         assert!(result.contains(&3), "Should contain remote connection 3");
         assert!(result.contains(&4), "Should contain remote connection 4");
 
         // And match_one should fall back to remote
         for _ in 0..20 {
-            let result = t.match_one(&enc(&name), 100, MatchFilter::ALL).unwrap();
+            let result = t.match_one(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
             assert!(
                 result == 3 || result == 4,
                 "Should return remote connections"
@@ -1207,7 +1166,7 @@ mod tests {
         );
 
         let result = t
-            .match_one(&enc(&name1), 100_u64, MatchFilter::ALL)
+            .match_one(name1.components(), name1.id(), 100_u64, MatchFilter::ALL)
             .unwrap();
         assert_eq!(result, 1, "Should match to connection 1");
 
@@ -1216,7 +1175,7 @@ mod tests {
             t.remove_subscription(&name1, 1, ConnType::Remote, 100)
                 .is_ok()
         );
-        let err = t.match_one(&enc(&name1), 100_u64, MatchFilter::ALL);
+        let err = t.match_one(name1.components(), name1.id(), 100_u64, MatchFilter::ALL);
         assert!(
             matches!(err, Err(DataPathError::NoMatchEncoded(..))),
             "Subscription should be fully removed after removing its subscription_id"
@@ -1257,7 +1216,7 @@ mod tests {
 
         // All three connections should be available
         let result = t
-            .match_all(&enc(&name2), 100_u64, MatchFilter::ALL)
+            .match_all(name2.components(), name2.id(), 100_u64, MatchFilter::ALL)
             .unwrap();
         assert_eq!(result.len(), 3, "Should have 3 connections");
         assert!(result.contains(&1));
@@ -1270,7 +1229,7 @@ mod tests {
                 .is_ok()
         );
         let result = t
-            .match_all(&enc(&name2), 100_u64, MatchFilter::ALL)
+            .match_all(name2.components(), name2.id(), 100_u64, MatchFilter::ALL)
             .unwrap();
         assert_eq!(
             result.len(),
@@ -1286,7 +1245,7 @@ mod tests {
         );
         // Connection 1 still has 2 more subscription_ids
         let result = t
-            .match_all(&enc(&name2), 100_u64, MatchFilter::ALL)
+            .match_all(name2.components(), name2.id(), 100_u64, MatchFilter::ALL)
             .unwrap();
         assert_eq!(result.len(), 2, "Should still have 2 connections");
         assert!(result.contains(&1));
@@ -1301,7 +1260,7 @@ mod tests {
                 .is_ok()
         );
         let result = t
-            .match_all(&enc(&name2), 100_u64, MatchFilter::ALL)
+            .match_all(name2.components(), name2.id(), 100_u64, MatchFilter::ALL)
             .unwrap();
         assert_eq!(result.len(), 1, "Should have 1 connection");
         assert!(result.contains(&3));
@@ -1315,7 +1274,7 @@ mod tests {
             t.remove_subscription(&name2, 3, ConnType::Remote, 206)
                 .is_ok()
         );
-        let err = t.match_one(&enc(&name2), 100_u64, MatchFilter::ALL);
+        let err = t.match_one(name2.components(), name2.id(), 100_u64, MatchFilter::ALL);
         assert!(
             matches!(err, Err(DataPathError::NoMatchEncoded(..))),
             "No connections should remain"
@@ -1349,7 +1308,7 @@ mod tests {
         );
 
         // Both connections should be available
-        let result = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result.len(), 2, "Should have 2 connections");
 
         // Connection 1 dies - should be force-removed regardless of ref count
@@ -1360,13 +1319,13 @@ mod tests {
         assert_eq!(removed[&name1], HashSet::from([301u64, 302, 303]));
 
         // Now only connection 2 should be available
-        let result = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(
             result, 2,
             "Should only match to connection 2 after conn 1 dies"
         );
 
-        let result = t.match_all(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result.len(), 1, "Should only have 1 connection remaining");
         assert!(result.contains(&2));
     }
@@ -1403,7 +1362,7 @@ mod tests {
 
         // Should prefer local connection
         for _ in 0..10 {
-            let result = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+            let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
             assert_eq!(result, 1, "Should prefer local connection");
         }
 
@@ -1412,7 +1371,7 @@ mod tests {
             t.remove_subscription(&name1, 1, ConnType::Local, 401)
                 .is_ok()
         );
-        let result = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result, 1, "Local connection should still exist");
 
         // Remove last local subscription_id - should be gone, fall back to remote
@@ -1421,7 +1380,7 @@ mod tests {
                 .is_ok()
         );
         for _ in 0..10 {
-            let result = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+            let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
             assert_eq!(result, 2, "Should fall back to remote connection");
         }
 
@@ -1435,14 +1394,14 @@ mod tests {
                 .is_ok()
         );
         // Still has one remaining
-        let result = t.match_one(&enc(&name1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result, 2, "Remote should still exist with one sub");
 
         assert!(
             t.remove_subscription(&name1, 2, ConnType::Remote, 405)
                 .is_ok()
         );
-        let err = t.match_one(&enc(&name1), 100, MatchFilter::ALL);
+        let err = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL);
         assert!(
             matches!(err, Err(DataPathError::NoMatchEncoded(..))),
             "No connections should remain"
@@ -1486,7 +1445,7 @@ mod tests {
 
         // Test 1: Message with NULL_COMPONENT should match ALL subscriptions
         // (both NULL_COMPONENT and specific IDs)
-        let result = t.match_all(&enc(&name), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(
             result.len(),
             4,
@@ -1499,7 +1458,7 @@ mod tests {
 
         // Test 2: Message with specific ID 1 should match ONLY ID 1 subscription
         // (excluding NULL_COMPONENT subscriptions)
-        let result = t.match_all(&enc(&name_id1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(
             result.len(),
             1,
@@ -1508,12 +1467,12 @@ mod tests {
         assert!(result.contains(&3), "Should match only conn 3 (ID 1)");
 
         // Test 3: Message with specific ID 2 should match ONLY ID 2 subscription
-        let result = t.match_all(&enc(&name_id2), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name_id2.components(), name_id2.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains(&4), "Should match only conn 4 (ID 2)");
 
         // Test 4: match_one should also respect these rules
-        let result = t.match_one(&enc(&name_id1), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_one(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result, 3, "Should return only the specific ID connection");
 
         // Test 5: Remove specific ID subscription, the match for message with that ID should fail
@@ -1521,14 +1480,14 @@ mod tests {
             t.remove_subscription(&name_id1, 3, ConnType::Remote, 3)
                 .is_ok()
         );
-        let err = t.match_one(&enc(&name_id1), 100, MatchFilter::ALL);
+        let err = t.match_one(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL);
         assert!(
             matches!(err, Err(DataPathError::NoMatchEncoded(..))),
             "Specific ID message should NOT match NULL_COMPONENT subscriptions"
         );
 
         // Test 6: But NULL_COMPONENT message should still match remaining subscriptions
-        let result = t.match_all(&enc(&name), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result.len(), 3, "Should match remaining subscriptions");
         assert!(result.contains(&1));
         assert!(result.contains(&2));
@@ -1539,16 +1498,16 @@ mod tests {
         assert!(t.remove_subscription(&name, 2, ConnType::Remote, 2).is_ok());
 
         // NULL_COMPONENT message should still match the specific ID subscription
-        let result = t.match_all(&enc(&name), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains(&4), "Should match ID 2 subscription");
 
         // Specific ID 2 message should still work
-        let result = t.match_one(&enc(&name_id2), 100, MatchFilter::ALL).unwrap();
+        let result = t.match_one(name_id2.components(), name_id2.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(result, 4);
 
         // But specific ID 1 should still fail (was removed earlier)
-        let err = t.match_one(&enc(&name_id1), 100, MatchFilter::ALL);
+        let err = t.match_one(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL);
         assert!(matches!(err, Err(DataPathError::NoMatchEncoded(..))));
     }
 
@@ -1574,7 +1533,7 @@ mod tests {
         );
 
         // MatchFilter::ALL returns all three connections
-        let out = t.match_all(&enc(&name), 100, MatchFilter::ALL).unwrap();
+        let out = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
         assert_eq!(out.len(), 3);
         assert!(out.contains(&10));
         assert!(out.contains(&20));
@@ -1582,7 +1541,7 @@ mod tests {
 
         // MatchFilter::EXCLUDE_PEER excludes the peer connection
         let out = t
-            .match_all(&enc(&name), 100, MatchFilter::EXCLUDE_PEER)
+            .match_all(name.components(), name.id(), 100, MatchFilter::EXCLUDE_PEER)
             .unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&10));
@@ -1591,13 +1550,13 @@ mod tests {
 
         // match_one with EXCLUDE_PEER should never return the peer connection
         let result = t
-            .match_one(&enc(&name), 100, MatchFilter::EXCLUDE_PEER)
+            .match_one(name.components(), name.id(), 100, MatchFilter::EXCLUDE_PEER)
             .unwrap();
         assert!(result == 10 || result == 20);
 
         // match_one with EXCLUDE_PEER skipping the local conn should return remote
         let result = t
-            .match_one(&enc(&name), 10, MatchFilter::EXCLUDE_PEER)
+            .match_one(name.components(), name.id(), 10, MatchFilter::EXCLUDE_PEER)
             .unwrap();
         assert_eq!(result, 20);
     }

--- a/crates/datapath/src/tables/subscription_table.rs
+++ b/crates/datapath/src/tables/subscription_table.rs
@@ -686,12 +686,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                     component_3 = id,
                     "match not found for name"
                 );
-                return Err(DataPathError::NoMatchEncoded(
-                    components[0],
-                    components[1],
-                    components[2],
-                    api::id_to_string(id),
-                ));
+                return Err(no_match_err(components, id));
             }
             Some(pe) => pe,
         };
@@ -702,12 +697,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 .get_one(id, incoming_conn, filter)
                 .ok_or_else(|| {
                     debug!(component_3 = id, "match not found for name");
-                    DataPathError::NoMatchEncoded(
-                        components[0],
-                        components[1],
-                        components[2],
-                        api::id_to_string(id),
-                    )
+                    no_match_err(components, id)
                 })
         } else {
             // NULL_COMPONENT: pick one connection across all registered IDs,
@@ -716,12 +706,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                 .pick_one_any(incoming_conn, filter)
                 .ok_or_else(|| {
                     debug!("no output connection available");
-                    DataPathError::NoMatchEncoded(
-                        components[0],
-                        components[1],
-                        components[2],
-                        api::id_to_string(id),
-                    )
+                    no_match_err(components, id)
                 })
         }
     }
@@ -745,12 +730,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
                     component_3 = id,
                     "match not found for name"
                 );
-                return Err(DataPathError::NoMatchEncoded(
-                    components[0],
-                    components[1],
-                    components[2],
-                    api::id_to_string(id),
-                ));
+                return Err(no_match_err(components, id));
             }
             Some(pe) => pe,
         };
@@ -760,21 +740,11 @@ impl SubscriptionTable for SubscriptionTableImpl {
             match prefix_entry.get_all(id, incoming_conn, filter) {
                 None => {
                     debug!(component_3 = id, "match not found for name");
-                    Err(DataPathError::NoMatchEncoded(
-                        components[0],
-                        components[1],
-                        components[2],
-                        api::id_to_string(id),
-                    ))
+                    Err(no_match_err(components, id))
                 }
                 Some(out) if out.is_empty() => {
                     debug!("no connection available (local/remote/peer)");
-                    Err(DataPathError::NoMatchEncoded(
-                        components[0],
-                        components[1],
-                        components[2],
-                        api::id_to_string(id),
-                    ))
+                    Err(no_match_err(components, id))
                 }
                 Some(out) => {
                     debug!(?out, "found connections");
@@ -787,18 +757,24 @@ impl SubscriptionTable for SubscriptionTableImpl {
             let out = prefix_entry.get_all_any(incoming_conn, filter);
             if out.is_empty() {
                 debug!("no connection available");
-                Err(DataPathError::NoMatchEncoded(
-                    components[0],
-                    components[1],
-                    components[2],
-                    api::id_to_string(id),
-                ))
+                Err(no_match_err(components, id))
             } else {
                 debug!(?out, "found connections");
                 Ok(out)
             }
         }
     }
+}
+
+/// Build the standard "no route found" error from raw components.
+#[inline]
+fn no_match_err(components: [u64; 3], id: u128) -> DataPathError {
+    DataPathError::NoMatchEncoded(
+        components[0],
+        components[1],
+        components[2],
+        api::id_to_string(id),
+    )
 }
 
 impl SubscriptionTableImpl {

--- a/crates/datapath/src/tables/subscription_table.rs
+++ b/crates/datapath/src/tables/subscription_table.rs
@@ -833,14 +833,18 @@ mod tests {
         );
 
         // returns three matches on connection 1,2,3
-        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 3);
         assert!(out.contains(&1));
         assert!(out.contains(&2));
         assert!(out.contains(&3));
 
         // return two matches on connection 2,3
-        let out = t.match_all(name1.components(), name1.id(), 1, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 1, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&2));
         assert!(out.contains(&3));
@@ -851,7 +855,9 @@ mod tests {
         );
 
         // return two matches on connection 1,3
-        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&1));
         assert!(out.contains(&3));
@@ -862,7 +868,9 @@ mod tests {
         );
 
         // return one matches on connection 1
-        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 1);
         assert!(out.contains(&1));
 
@@ -877,14 +885,18 @@ mod tests {
         );
 
         // returns two matches on connection 1 and 2
-        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&1));
         assert!(out.contains(&2));
 
         // run multiple times for randomness
         for _ in 0..20 {
-            let out = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+            let out = t
+                .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+                .unwrap();
             if out != 1 && out != 2 {
                 // the output must be 1 or 2
                 panic!("the output must be 1 or 2");
@@ -892,18 +904,24 @@ mod tests {
         }
 
         // return connection 2
-        let out = t.match_one(name1_1.components(), name1_1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_one(name1_1.components(), name1_1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out, 2);
 
         // return connection 3
-        let out = t.match_one(name2_2.components(), name2_2.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_one(name2_2.components(), name2_2.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out, 3);
         let removed_subs = t.remove_connection(2, ConnType::Remote).unwrap();
         assert_eq!(removed_subs.len(), 1);
         assert!(removed_subs.contains_key(&name1_1));
 
         // returns one match on connection 1
-        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 1);
         assert!(out.contains(&1));
 
@@ -914,7 +932,9 @@ mod tests {
 
         // run multiple times for randomness
         for _ in 0..20 {
-            let out = t.match_one(name2_2.components(), name2_2.id(), 100, MatchFilter::ALL).unwrap();
+            let out = t
+                .match_one(name2_2.components(), name2_2.id(), 100, MatchFilter::ALL)
+                .unwrap();
             if out != 3 && out != 4 {
                 // the output must be 3 or 4
                 panic!("the output must be 3 or 4");
@@ -922,7 +942,9 @@ mod tests {
         }
 
         for _ in 0..20 {
-            let out = t.match_one(name2_2.components(), name2_2.id(), 4, MatchFilter::ALL).unwrap();
+            let out = t
+                .match_one(name2_2.components(), name2_2.id(), 4, MatchFilter::ALL)
+                .unwrap();
             if out != 3 {
                 // the output must be 3
                 panic!("the output must be 3");
@@ -941,22 +963,30 @@ mod tests {
         );
 
         // returns both local (2) and remote (1) connections
-        let out = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 2);
         assert!(out.contains(&2));
         assert!(out.contains(&1));
 
         // returns one match on connection 2
-        let out = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out, 2);
 
         // returns both local (2) and remote (1) connections, excluding incoming connection (2)
-        let out = t.match_all(name1.components(), name1.id(), 2, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name1.components(), name1.id(), 2, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 1);
         assert!(out.contains(&1));
 
         // same here
-        let out = t.match_one(name1.components(), name1.id(), 2, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_one(name1.components(), name1.id(), 2, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out, 1);
 
         // test errors
@@ -1050,7 +1080,9 @@ mod tests {
         );
 
         // Test match_all returns both local and remote connections
-        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(
             result.len(),
             4,
@@ -1062,7 +1094,9 @@ mod tests {
         assert!(result.contains(&4), "Should contain remote connection 4");
 
         // Test excluding incoming connection works for local
-        let result = t.match_all(name.components(), name.id(), 1, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 1, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(
             result.len(),
             3,
@@ -1077,7 +1111,9 @@ mod tests {
         assert!(result.contains(&4), "Should contain remote connection 4");
 
         // Test excluding incoming connection works for remote
-        let result = t.match_all(name.components(), name.id(), 3, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 3, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(
             result.len(),
             3,
@@ -1093,7 +1129,9 @@ mod tests {
 
         // Test match_one prefers local over remote
         for _ in 0..20 {
-            let result = t.match_one(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+            let result = t
+                .match_one(name.components(), name.id(), 100, MatchFilter::ALL)
+                .unwrap();
             assert!(
                 result == 1 || result == 2,
                 "match_one should always prefer local connections"
@@ -1105,14 +1143,18 @@ mod tests {
         assert!(t.remove_subscription(&name, 2, ConnType::Local, 2).is_ok());
 
         // Now match_all should only return remote connections
-        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result.len(), 2, "Should return only 2 remote connections");
         assert!(result.contains(&3), "Should contain remote connection 3");
         assert!(result.contains(&4), "Should contain remote connection 4");
 
         // And match_one should fall back to remote
         for _ in 0..20 {
-            let result = t.match_one(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+            let result = t
+                .match_one(name.components(), name.id(), 100, MatchFilter::ALL)
+                .unwrap();
             assert!(
                 result == 3 || result == 4,
                 "Should return remote connections"
@@ -1283,7 +1325,9 @@ mod tests {
         );
 
         // Both connections should be available
-        let result = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result.len(), 2, "Should have 2 connections");
 
         // Connection 1 dies - should be force-removed regardless of ref count
@@ -1294,13 +1338,17 @@ mod tests {
         assert_eq!(removed[&name1], HashSet::from([301u64, 302, 303]));
 
         // Now only connection 2 should be available
-        let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(
             result, 2,
             "Should only match to connection 2 after conn 1 dies"
         );
 
-        let result = t.match_all(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result.len(), 1, "Should only have 1 connection remaining");
         assert!(result.contains(&2));
     }
@@ -1337,7 +1385,9 @@ mod tests {
 
         // Should prefer local connection
         for _ in 0..10 {
-            let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+            let result = t
+                .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+                .unwrap();
             assert_eq!(result, 1, "Should prefer local connection");
         }
 
@@ -1346,7 +1396,9 @@ mod tests {
             t.remove_subscription(&name1, 1, ConnType::Local, 401)
                 .is_ok()
         );
-        let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result, 1, "Local connection should still exist");
 
         // Remove last local subscription_id - should be gone, fall back to remote
@@ -1355,7 +1407,9 @@ mod tests {
                 .is_ok()
         );
         for _ in 0..10 {
-            let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+            let result = t
+                .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+                .unwrap();
             assert_eq!(result, 2, "Should fall back to remote connection");
         }
 
@@ -1369,7 +1423,9 @@ mod tests {
                 .is_ok()
         );
         // Still has one remaining
-        let result = t.match_one(name1.components(), name1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_one(name1.components(), name1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result, 2, "Remote should still exist with one sub");
 
         assert!(
@@ -1420,7 +1476,9 @@ mod tests {
 
         // Test 1: Message with NULL_COMPONENT should match ALL subscriptions
         // (both NULL_COMPONENT and specific IDs)
-        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(
             result.len(),
             4,
@@ -1433,7 +1491,9 @@ mod tests {
 
         // Test 2: Message with specific ID 1 should match ONLY ID 1 subscription
         // (excluding NULL_COMPONENT subscriptions)
-        let result = t.match_all(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(
             result.len(),
             1,
@@ -1442,12 +1502,16 @@ mod tests {
         assert!(result.contains(&3), "Should match only conn 3 (ID 1)");
 
         // Test 3: Message with specific ID 2 should match ONLY ID 2 subscription
-        let result = t.match_all(name_id2.components(), name_id2.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name_id2.components(), name_id2.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains(&4), "Should match only conn 4 (ID 2)");
 
         // Test 4: match_one should also respect these rules
-        let result = t.match_one(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_one(name_id1.components(), name_id1.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result, 3, "Should return only the specific ID connection");
 
         // Test 5: Remove specific ID subscription, the match for message with that ID should fail
@@ -1462,7 +1526,9 @@ mod tests {
         );
 
         // Test 6: But NULL_COMPONENT message should still match remaining subscriptions
-        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result.len(), 3, "Should match remaining subscriptions");
         assert!(result.contains(&1));
         assert!(result.contains(&2));
@@ -1473,12 +1539,16 @@ mod tests {
         assert!(t.remove_subscription(&name, 2, ConnType::Remote, 2).is_ok());
 
         // NULL_COMPONENT message should still match the specific ID subscription
-        let result = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_all(name.components(), name.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains(&4), "Should match ID 2 subscription");
 
         // Specific ID 2 message should still work
-        let result = t.match_one(name_id2.components(), name_id2.id(), 100, MatchFilter::ALL).unwrap();
+        let result = t
+            .match_one(name_id2.components(), name_id2.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(result, 4);
 
         // But specific ID 1 should still fail (was removed earlier)
@@ -1508,7 +1578,9 @@ mod tests {
         );
 
         // MatchFilter::ALL returns all three connections
-        let out = t.match_all(name.components(), name.id(), 100, MatchFilter::ALL).unwrap();
+        let out = t
+            .match_all(name.components(), name.id(), 100, MatchFilter::ALL)
+            .unwrap();
         assert_eq!(out.len(), 3);
         assert!(out.contains(&10));
         assert!(out.contains(&20));

--- a/crates/datapath/src/tables/subscription_table.rs
+++ b/crates/datapath/src/tables/subscription_table.rs
@@ -645,8 +645,7 @@ impl SubscriptionTable for SubscriptionTableImpl {
         // Pass 2: clone snapshot, remove conn from routing for every affected encoded name.
         let mut rs = (**current).clone();
         drop(current);
-        for (prefix, id) in &encoded_names {
-            let (prefix, id) = (*prefix, *id);
+        for &(prefix, id) in &encoded_names {
             debug!(%conn, ?prefix, id, "remove subscription");
 
             let should_remove_prefix = if let Some(entry) = rs.get_mut(&prefix) {

--- a/crates/examples/src/sdk-mock/main.rs
+++ b/crates/examples/src/sdk-mock/main.rs
@@ -38,14 +38,14 @@ fn spawn_session_receiver(
                         match msg_result {
                             Some(Ok(message)) => match &message.message_type {
                                 Some(slim_datapath::api::MessageType::Publish(msg)) => {
-                                    let payload = msg.get_payload();
-                                    match std::str::from_utf8(&payload.as_application_payload().unwrap().blob) {
+                                    let payload = msg.get_payload().unwrap().into_application_payload().unwrap();
+                                    match std::str::from_utf8(&payload.blob) {
                                         Ok(text) => {
                                             info!(msg = %text, "received message");
                                         }
                                         Err(_) => {
                                             info!(
-                                                msg_len = %payload.as_application_payload().unwrap().blob.len(),
+                                                msg_len = %payload.blob.len(),
                                                 "received encrypted message",
                                             );
                                         }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -11,6 +11,7 @@ description = "Consolidated protobuf/gRPC generated code for SLIM"
 [dependencies]
 agntcy-slim-config = { workspace = true }
 agntcy-slim-version = { workspace = true }
+bytes = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -34,6 +34,9 @@ fn main() {
     // Gate tonic client/server modules to non-wasm32 targets.
     tonic_prost_build::configure()
         .out_dir("src/gen")
+        // Generate bytes::Bytes (zero-copy) for all bytes fields in StringName
+        // instead of the default Vec<u8>.
+        .bytes(".dataplane.proto.v1.StringName")
         .client_mod_attribute(".", "#[cfg(not(target_arch = \"wasm32\"))]")
         .server_mod_attribute(".", "#[cfg(not(target_arch = \"wasm32\"))]")
         .compile_protos(

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -40,6 +40,7 @@ fn main() {
         .bytes(".dataplane.proto.v1.Name")
         .bytes(".dataplane.proto.v1.ApplicationPayload")
         .bytes(".dataplane.proto.v1.SLIMHeader")
+        .bytes(".dataplane.proto.v1.Publish")
         .client_mod_attribute(".", "#[cfg(not(target_arch = \"wasm32\"))]")
         .server_mod_attribute(".", "#[cfg(not(target_arch = \"wasm32\"))]")
         .compile_protos(

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -34,9 +34,12 @@ fn main() {
     // Gate tonic client/server modules to non-wasm32 targets.
     tonic_prost_build::configure()
         .out_dir("src/gen")
-        // Generate bytes::Bytes (zero-copy) for all bytes fields in StringName
-        // instead of the default Vec<u8>.
-        .bytes(".dataplane.proto.v1.StringName")
+        // Generate bytes::Bytes (zero-copy) for all bytes fields in Name
+        // (encoded_name and str_name) and ApplicationPayload (blob) instead
+        // of the default Vec<u8>.
+        .bytes(".dataplane.proto.v1.Name")
+        .bytes(".dataplane.proto.v1.ApplicationPayload")
+        .bytes(".dataplane.proto.v1.SLIMHeader")
         .client_mod_attribute(".", "#[cfg(not(target_arch = \"wasm32\"))]")
         .server_mod_attribute(".", "#[cfg(not(target_arch = \"wasm32\"))]")
         .compile_protos(

--- a/crates/proto/proto/data-plane/v1/data_plane.proto
+++ b/crates/proto/proto/data-plane/v1/data_plane.proto
@@ -96,9 +96,9 @@ message EncodedName {
 }
 
 message StringName {
-  string str_component_0 = 1;
-  string str_component_1 = 2;
-  string str_component_2 = 3;
+  bytes str_component_0 = 1;
+  bytes str_component_1 = 2;
+  bytes str_component_2 = 3;
 }
 
 enum SessionType {

--- a/crates/proto/proto/data-plane/v1/data_plane.proto
+++ b/crates/proto/proto/data-plane/v1/data_plane.proto
@@ -73,11 +73,12 @@ message SLIMHeader {
   optional uint64 incoming_conn = 9;
   optional bool error = 10;
   optional bytes header_mac = 11;
+  optional bytes e2e_header_sig = 12;
   // Packed human-readable string components for source (was Name.str_name).
   // Layout: [len_0: u32 LE][component_0][len_1: u32 LE][component_1][len_2: u32 LE][component_2]
-  bytes source_str = 12;
+  bytes source_str = 13;
   // Packed human-readable string components for destination (was Name.str_name).
-  bytes destination_str = 13;
+  bytes destination_str = 14;
 }
 
 message SessionHeader {

--- a/crates/proto/proto/data-plane/v1/data_plane.proto
+++ b/crates/proto/proto/data-plane/v1/data_plane.proto
@@ -57,9 +57,9 @@ message Link {
 message SLIMHeader {
   Name source = 1;
   Name destination = 2;
-  string identity = 3;
+  bytes identity = 3;
   uint32 fanout = 4;
-  string version = 5;
+  bytes version = 5;
   uint32 ttl = 6;
   optional uint64 recv_from = 7;
   optional uint64 forward_to = 8;
@@ -76,29 +76,20 @@ message SessionHeader {
   uint32 message_id = 4;
 }
 
+// Name encodes a hierarchical 3-component SLIM name.
+//
+// encoded_name: 40-byte flat encoding of the numeric components and id.
+//   Layout: [component_0: u64 LE][component_1: u64 LE][component_2: u64 LE]
+//           [id_0: u64 LE][id_1: u64 LE]
+//   Empty bytes = name not set. id = u128::MAX (NULL_COMPONENT) means "no id".
+//
+// str_name: packed human-readable components.
+//   Layout: [len_0: u32 LE][component_0 bytes][len_1: u32 LE][component_1 bytes]
+//           [len_2: u32 LE][component_2 bytes]
+//   Empty bytes = str_name not set.
 message Name {
-  EncodedName name = 1;
-  StringName str_name = 2;
-}
-
-message NameId {
-  // higher 64 bits
-  uint64 id_0 = 1;
-  // lower 64 bits
-  uint64 id_1 = 2;
-}
-
-message EncodedName {
-  uint64 component_0 = 1;
-  uint64 component_1 = 2;
-  uint64 component_2 = 3;
-  NameId name_id = 4;
-}
-
-message StringName {
-  bytes str_component_0 = 1;
-  bytes str_component_1 = 2;
-  bytes str_component_2 = 3;
+  bytes encoded_name = 1;
+  bytes str_name = 2;
 }
 
 enum SessionType {

--- a/crates/proto/proto/data-plane/v1/data_plane.proto
+++ b/crates/proto/proto/data-plane/v1/data_plane.proto
@@ -58,8 +58,12 @@ message Link {
 // incomingConn = connection from where the packet was received
 // error = if true the publication contains an error notification
 message SLIMHeader {
-  Name source = 1;
-  Name destination = 2;
+  // Flat 40-byte encoded name (3×u64 LE hash components + u128 LE id).
+  // Replaces the former `Name source = 1` message field for zero-copy routing.
+  bytes source = 1;
+  // Flat 40-byte encoded name (3×u64 LE hash components + u128 LE id).
+  // Replaces the former `Name destination = 2` message field for zero-copy routing.
+  bytes destination = 2;
   bytes identity = 3;
   uint32 fanout = 4;
   bytes version = 5;
@@ -69,7 +73,11 @@ message SLIMHeader {
   optional uint64 incoming_conn = 9;
   optional bool error = 10;
   optional bytes header_mac = 11;
-  optional bytes e2e_header_sig = 12;
+  // Packed human-readable string components for source (was Name.str_name).
+  // Layout: [len_0: u32 LE][component_0][len_1: u32 LE][component_1][len_2: u32 LE][component_2]
+  bytes source_str = 12;
+  // Packed human-readable string components for destination (was Name.str_name).
+  bytes destination_str = 13;
 }
 
 message SessionHeader {

--- a/crates/proto/proto/data-plane/v1/data_plane.proto
+++ b/crates/proto/proto/data-plane/v1/data_plane.proto
@@ -26,7 +26,10 @@ message Unsubscribe {
 message Publish {
   SLIMHeader header = 1;
   SessionHeader session = 2;
-  Content msg = 3;
+  // Raw-bytes encoding of a Content message. Stored as bytes so that
+  // data-plane-only forwarding nodes can pass it through without decoding.
+  // Wire-compatible with the original `Content msg = 3` field (same wire type 2).
+  bytes msg = 3;
 }
 
 message Message {

--- a/crates/proto/src/gen/dataplane.proto.v1.rs
+++ b/crates/proto/src/gen/dataplane.proto.v1.rs
@@ -18,14 +18,17 @@ pub struct Unsubscribe {
     #[prost(uint64, tag = "2")]
     pub subscription_id: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Publish {
     #[prost(message, optional, tag = "1")]
     pub header: ::core::option::Option<SlimHeader>,
     #[prost(message, optional, tag = "2")]
     pub session: ::core::option::Option<SessionHeader>,
-    #[prost(message, optional, tag = "3")]
-    pub msg: ::core::option::Option<Content>,
+    /// Raw-bytes encoding of a Content message. Stored as bytes so that
+    /// data-plane-only forwarding nodes can pass it through without decoding.
+    /// Wire-compatible with the original `Content msg = 3` field (same wire type 2).
+    #[prost(bytes = "bytes", tag = "3")]
+    pub msg: ::prost::bytes::Bytes,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
@@ -39,7 +42,7 @@ pub struct Message {
 }
 /// Nested message and enum types in `Message`.
 pub mod message {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum MessageType {
         #[prost(message, tag = "1")]
         Subscribe(super::Subscribe),

--- a/crates/proto/src/gen/dataplane.proto.v1.rs
+++ b/crates/proto/src/gen/dataplane.proto.v1.rs
@@ -103,12 +103,14 @@ pub struct SlimHeader {
     pub error: ::core::option::Option<bool>,
     #[prost(bytes = "bytes", optional, tag = "11")]
     pub header_mac: ::core::option::Option<::prost::bytes::Bytes>,
+    #[prost(bytes = "bytes", optional, tag = "12")]
+    pub e2e_header_sig: ::core::option::Option<::prost::bytes::Bytes>,
     /// Packed human-readable string components for source (was Name.str_name).
     /// Layout: \[len_0: u32 LE\]\[component_0\]\[len_1: u32 LE\]\[component_1\]\[len_2: u32 LE\]\[component_2\]
-    #[prost(bytes = "bytes", tag = "12")]
+    #[prost(bytes = "bytes", tag = "13")]
     pub source_str: ::prost::bytes::Bytes,
     /// Packed human-readable string components for destination (was Name.str_name).
-    #[prost(bytes = "bytes", tag = "13")]
+    #[prost(bytes = "bytes", tag = "14")]
     pub destination_str: ::prost::bytes::Bytes,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/proto/src/gen/dataplane.proto.v1.rs
+++ b/crates/proto/src/gen/dataplane.proto.v1.rs
@@ -78,12 +78,12 @@ pub struct SlimHeader {
     pub source: ::core::option::Option<Name>,
     #[prost(message, optional, tag = "2")]
     pub destination: ::core::option::Option<Name>,
-    #[prost(string, tag = "3")]
-    pub identity: ::prost::alloc::string::String,
+    #[prost(bytes = "bytes", tag = "3")]
+    pub identity: ::prost::bytes::Bytes,
     #[prost(uint32, tag = "4")]
     pub fanout: u32,
-    #[prost(string, tag = "5")]
-    pub version: ::prost::alloc::string::String,
+    #[prost(bytes = "bytes", tag = "5")]
+    pub version: ::prost::bytes::Bytes,
     #[prost(uint32, tag = "6")]
     pub ttl: u32,
     #[prost(uint64, optional, tag = "7")]
@@ -94,10 +94,8 @@ pub struct SlimHeader {
     pub incoming_conn: ::core::option::Option<u64>,
     #[prost(bool, optional, tag = "10")]
     pub error: ::core::option::Option<bool>,
-    #[prost(bytes = "vec", optional, tag = "11")]
-    pub header_mac: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    #[prost(bytes = "vec", optional, tag = "12")]
-    pub e2e_header_sig: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", optional, tag = "11")]
+    pub header_mac: ::core::option::Option<::prost::bytes::Bytes>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SessionHeader {
@@ -110,41 +108,23 @@ pub struct SessionHeader {
     #[prost(uint32, tag = "4")]
     pub message_id: u32,
 }
+/// Name encodes a hierarchical 3-component SLIM name.
+///
+/// encoded_name: 40-byte flat encoding of the numeric components and id.
+/// Layout: \[component_0: u64 LE\]\[component_1: u64 LE\]\[component_2: u64 LE\]
+/// \[id_0: u64 LE\]\[id_1: u64 LE\]
+/// Empty bytes = name not set. id = u128::MAX (NULL_COMPONENT) means "no id".
+///
+/// str_name: packed human-readable components.
+/// Layout: \[len_0: u32 LE\]\[component_0 bytes\]\[len_1: u32 LE\]\[component_1 bytes\]
+/// \[len_2: u32 LE\]\[component_2 bytes\]
+/// Empty bytes = str_name not set.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Name {
-    #[prost(message, optional, tag = "1")]
-    pub name: ::core::option::Option<EncodedName>,
-    #[prost(message, optional, tag = "2")]
-    pub str_name: ::core::option::Option<StringName>,
-}
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct NameId {
-    /// higher 64 bits
-    #[prost(uint64, tag = "1")]
-    pub id_0: u64,
-    /// lower 64 bits
-    #[prost(uint64, tag = "2")]
-    pub id_1: u64,
-}
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct EncodedName {
-    #[prost(uint64, tag = "1")]
-    pub component_0: u64,
-    #[prost(uint64, tag = "2")]
-    pub component_1: u64,
-    #[prost(uint64, tag = "3")]
-    pub component_2: u64,
-    #[prost(message, optional, tag = "4")]
-    pub name_id: ::core::option::Option<NameId>,
-}
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct StringName {
     #[prost(bytes = "bytes", tag = "1")]
-    pub str_component_0: ::prost::bytes::Bytes,
+    pub encoded_name: ::prost::bytes::Bytes,
     #[prost(bytes = "bytes", tag = "2")]
-    pub str_component_1: ::prost::bytes::Bytes,
-    #[prost(bytes = "bytes", tag = "3")]
-    pub str_component_2: ::prost::bytes::Bytes,
+    pub str_name: ::prost::bytes::Bytes,
 }
 /// SLIM message content
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -166,8 +146,8 @@ pub mod content {
 pub struct ApplicationPayload {
     #[prost(string, tag = "1")]
     pub payload_type: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", tag = "2")]
-    pub blob: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub blob: ::prost::bytes::Bytes,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandPayload {

--- a/crates/proto/src/gen/dataplane.proto.v1.rs
+++ b/crates/proto/src/gen/dataplane.proto.v1.rs
@@ -77,10 +77,14 @@ pub mod link {
 /// error = if true the publication contains an error notification
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SlimHeader {
-    #[prost(message, optional, tag = "1")]
-    pub source: ::core::option::Option<Name>,
-    #[prost(message, optional, tag = "2")]
-    pub destination: ::core::option::Option<Name>,
+    /// Flat 40-byte encoded name (3×u64 LE hash components + u128 LE id).
+    /// Replaces the former `Name source = 1` message field for zero-copy routing.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub source: ::prost::bytes::Bytes,
+    /// Flat 40-byte encoded name (3×u64 LE hash components + u128 LE id).
+    /// Replaces the former `Name destination = 2` message field for zero-copy routing.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub destination: ::prost::bytes::Bytes,
     #[prost(bytes = "bytes", tag = "3")]
     pub identity: ::prost::bytes::Bytes,
     #[prost(uint32, tag = "4")]
@@ -99,6 +103,13 @@ pub struct SlimHeader {
     pub error: ::core::option::Option<bool>,
     #[prost(bytes = "bytes", optional, tag = "11")]
     pub header_mac: ::core::option::Option<::prost::bytes::Bytes>,
+    /// Packed human-readable string components for source (was Name.str_name).
+    /// Layout: \[len_0: u32 LE\]\[component_0\]\[len_1: u32 LE\]\[component_1\]\[len_2: u32 LE\]\[component_2\]
+    #[prost(bytes = "bytes", tag = "12")]
+    pub source_str: ::prost::bytes::Bytes,
+    /// Packed human-readable string components for destination (was Name.str_name).
+    #[prost(bytes = "bytes", tag = "13")]
+    pub destination_str: ::prost::bytes::Bytes,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SessionHeader {

--- a/crates/proto/src/gen/dataplane.proto.v1.rs
+++ b/crates/proto/src/gen/dataplane.proto.v1.rs
@@ -139,12 +139,12 @@ pub struct EncodedName {
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StringName {
-    #[prost(string, tag = "1")]
-    pub str_component_0: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub str_component_1: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
-    pub str_component_2: ::prost::alloc::string::String,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub str_component_0: ::prost::bytes::Bytes,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub str_component_1: ::prost::bytes::Bytes,
+    #[prost(bytes = "bytes", tag = "3")]
+    pub str_component_2: ::prost::bytes::Bytes,
 }
 /// SLIM message content
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -521,8 +521,8 @@ impl SlimHeader {
             incoming_conn: flags.incoming_conn,
             error: flags.error,
             header_mac: None,
-            ttl: flags.ttl,
             e2e_header_sig: None,
+            ttl: flags.ttl,
         }
     }
 
@@ -2266,8 +2266,8 @@ mod message_tests {
             incoming_conn: None,
             error: None,
             header_mac: None,
-            ttl: DEFAULT_TTL,
             e2e_header_sig: None,
+            ttl: DEFAULT_TTL,
         };
 
         // get_source/get_dst return ProtoName with empty fields (no panic)

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -285,7 +285,7 @@ pub(crate) fn decode_name_bytes(b: &bytes::Bytes) -> Option<(u64, u64, u64, u128
 
 /// Encode three string components into a packed `Bytes` value.
 #[inline]
-pub(crate) fn encode_str_bytes(s0: &[u8], s1: &[u8], s2: &[u8]) -> bytes::Bytes {
+pub fn encode_str_bytes(s0: &[u8], s1: &[u8], s2: &[u8]) -> bytes::Bytes {
     let total = 4 + s0.len() + 4 + s1.len() + 4 + s2.len();
     let mut buf = Vec::with_capacity(total);
     buf.extend_from_slice(&(s0.len() as u32).to_le_bytes());
@@ -300,7 +300,7 @@ pub(crate) fn encode_str_bytes(s0: &[u8], s1: &[u8], s2: &[u8]) -> bytes::Bytes 
 /// Decode packed str_name bytes into three byte slices.
 /// Returns `None` if the slice is empty (field absent).
 #[inline]
-pub(crate) fn decode_str_bytes(b: &bytes::Bytes) -> Option<(&[u8], &[u8], &[u8])> {
+pub fn decode_str_bytes(b: &bytes::Bytes) -> Option<(&[u8], &[u8], &[u8])> {
     if b.is_empty() {
         return None;
     }

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -360,11 +360,6 @@ impl ProtoName {
         id_to_string(self.id())
     }
 
-    pub fn name_id(&self) -> Option<u128> {
-        let id = self.id();
-        if id == NULL_COMPONENT { None } else { Some(id) }
-    }
-
     pub fn has_id(&self) -> bool {
         self.id() != NULL_COMPONENT
     }
@@ -620,10 +615,6 @@ impl SlimHeader {
         self.incoming_conn = incoming_conn;
     }
 
-    pub fn set_error_flag(&mut self, error: Option<bool>) {
-        self.error = error;
-    }
-
     pub fn get_ttl(&self) -> u32 {
         self.ttl
     }
@@ -814,42 +805,6 @@ impl ProtoPublish {
         self.msg = payload.encode_to_vec().into();
     }
 
-    pub fn is_command(&self) -> bool {
-        match self
-            .get_payload()
-            .expect("msg must be set")
-            .content_type
-            .as_ref()
-            .unwrap()
-        {
-            ContentType::AppPayload(_) => false,
-            ContentType::CommandPayload(_) => true,
-        }
-    }
-
-    pub fn get_application_payload(&self) -> ApplicationPayload {
-        match self
-            .get_payload()
-            .expect("msg must be set")
-            .content_type
-            .unwrap()
-        {
-            ContentType::AppPayload(application_payload) => application_payload,
-            ContentType::CommandPayload(_) => panic!("the payload is not an application payload"),
-        }
-    }
-
-    pub fn get_command_payload(&self) -> CommandPayload {
-        match self
-            .get_payload()
-            .expect("msg must be set")
-            .content_type
-            .unwrap()
-        {
-            ContentType::AppPayload(_) => panic!("the payload is not a command payload"),
-            ContentType::CommandPayload(command_payload) => command_payload,
-        }
-    }
 }
 
 impl From<ProtoMessage> for ProtoPublish {
@@ -1152,10 +1107,6 @@ impl ProtoMessage {
 
     pub fn set_incoming_conn(&mut self, incoming_conn: Option<u64>) {
         self.get_slim_header_mut().set_incoming_conn(incoming_conn);
-    }
-
-    pub fn set_error_flag(&mut self, error: Option<bool>) {
-        self.get_slim_header_mut().set_error_flag(error);
     }
 
     pub fn get_ttl(&self) -> u32 {

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -322,11 +322,13 @@ pub(crate) fn decode_str_bytes(b: &bytes::Bytes) -> Option<(&[u8], &[u8], &[u8])
 
 impl ProtoName {
     /// Construct from three string components (org, namespace, app).
-    pub fn from_strings(components: [impl Into<String>; 3]) -> Self {
-        let [s0, s1, s2] = components.map(Into::into);
-        let c0 = calculate_hash(&s0);
-        let c1 = calculate_hash(&s1);
-        let c2 = calculate_hash(&s2);
+    pub fn from_strings(components: [impl AsRef<str>; 3]) -> Self {
+        let s0 = components[0].as_ref();
+        let s1 = components[1].as_ref();
+        let s2 = components[2].as_ref();
+        let c0 = calculate_hash(s0);
+        let c1 = calculate_hash(s1);
+        let c2 = calculate_hash(s2);
         Self {
             encoded_name: encode_name_bytes(c0, c1, c2, NULL_COMPONENT),
             str_name: encode_str_bytes(s0.as_bytes(), s1.as_bytes(), s2.as_bytes()),
@@ -382,23 +384,29 @@ impl ProtoName {
     }
 
     pub fn match_prefix(&self, other: &ProtoName) -> bool {
-        if self.encoded_name.len() < 24 || other.encoded_name.len() < 24 {
+        // encoded_name is always 40 bytes when present, or empty when absent.
+        if self.encoded_name.is_empty() || other.encoded_name.is_empty() {
             return false;
         }
         self.encoded_name[..24] == other.encoded_name[..24]
     }
 
     pub fn str_components(&self) -> (&str, &str, &str) {
-        let (s0, s1, s2) = decode_str_bytes(&self.str_name)
-            .expect("str_name must be set to call str_components()");
+        self.try_str_components()
+            .expect("str_name must be set to call str_components()")
+    }
+
+    /// Returns the three string components if `str_name` is present, or `None`.
+    fn try_str_components(&self) -> Option<(&str, &str, &str)> {
+        let (s0, s1, s2) = decode_str_bytes(&self.str_name)?;
         // SAFETY: str_name bytes always originate from valid UTF-8 strings
         // (constructed via from_strings / parse_name, which accept &str / String inputs).
         unsafe {
-            (
+            Some((
                 std::str::from_utf8_unchecked(s0),
                 std::str::from_utf8_unchecked(s1),
                 std::str::from_utf8_unchecked(s2),
-            )
+            ))
         }
     }
 
@@ -425,15 +433,7 @@ impl ProtoName {
 
 impl std::fmt::Display for ProtoName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some((s0, s1, s2)) = decode_str_bytes(&self.str_name) {
-            // SAFETY: see str_components() — bytes are always valid UTF-8.
-            let (c0, c1, c2) = unsafe {
-                (
-                    std::str::from_utf8_unchecked(s0),
-                    std::str::from_utf8_unchecked(s1),
-                    std::str::from_utf8_unchecked(s2),
-                )
-            };
+        if let Some((c0, c1, c2)) = self.try_str_components() {
             write!(f, "{}/{}/{}/{}", c0, c1, c2, id_to_string(self.id()))
         } else if let Some((c0, c1, c2, id)) = decode_name_bytes(&self.encoded_name) {
             write!(f, "{}/{}/{}/{}", c0, c1, c2, id_to_string(id))
@@ -575,12 +575,7 @@ impl SlimHeader {
     }
 
     pub fn get_identity(&self) -> &str {
-        // SAFETY: identity originated as a UTF-8 String; stored as Bytes on this branch.
-        unsafe { std::str::from_utf8_unchecked(&self.identity) }
-    }
-
-    pub fn get_version(&self) -> String {
-        String::from_utf8_lossy(&self.version).into_owned()
+        std::str::from_utf8(&self.identity).unwrap_or("")
     }
 
     pub fn set_source(&mut self, source: ProtoName) {

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -21,13 +21,13 @@ use crate::dataplane::proto::v1::message::MessageType::SubscriptionAck as ProtoS
 use crate::dataplane::proto::v1::message::MessageType::Unsubscribe as ProtoUnsubscribeType;
 use crate::dataplane::proto::v1::{
     ApplicationPayload, CommandPayload, Content, DiscoveryReplyPayload, DiscoveryRequestPayload,
-    EncodedName, GroupAckPayload, GroupAddPayload, GroupClosePayload, GroupNackPayload,
+    GroupAckPayload, GroupAddPayload, GroupClosePayload, GroupNackPayload,
     GroupProposalPayload, GroupRemovePayload, GroupWelcomePayload, JoinReplyPayload,
     JoinRequestPayload, LeaveReplyPayload, LeaveRequestPayload, Link as ProtoLink,
     LinkConnectionType, LinkNegotiationPayload, Message as ProtoMessage, MlsPayload,
-    MlsSettings as ProtoMlsSettings, Name as ProtoName, NameId, Participant, ParticipantSettings,
+    MlsSettings as ProtoMlsSettings, Name as ProtoName, Participant, ParticipantSettings,
     PingPayload, Publish as ProtoPublish, SessionHeader, SessionMessageType,
-    SessionType as ProtoSessionType, SlimHeader, StringName, Subscribe as ProtoSubscribe,
+    SessionType as ProtoSessionType, SlimHeader, Subscribe as ProtoSubscribe,
     SubscriptionAck as ProtoSubscriptionAck, TimerSettings, Unsubscribe as ProtoUnsubscribe,
 };
 
@@ -211,152 +211,202 @@ impl SlimHeaderFlags {
     }
 }
 
-impl NameId {
-    pub const NULL_COMPONENT: u128 = u128::MAX;
-    pub const DATA_CHANNEL_ID: u128 = u128::MAX - 2;
-    pub const CONTROL_CHANNEL_ID: u128 = u128::MAX - 3;
-    pub const RESERVED_IDS: u128 = 50;
+// ---------------------------------------------------------------------------
+// NameId constants and helpers (previously proto-generated NameId struct)
+// ---------------------------------------------------------------------------
 
-    pub const fn is_reserved_id(id: u128) -> bool {
-        id >= (u128::MAX - Self::RESERVED_IDS)
+/// `NULL_COMPONENT` is used to represent an id component that is not set.
+pub const NULL_COMPONENT: u128 = u128::MAX;
+/// `DATA_CHANNEL_ID` is the id for the data channel name.
+pub const DATA_CHANNEL_ID: u128 = u128::MAX - 2;
+/// `CONTROL_CHANNEL_ID` is the id for the control channel name.
+pub const CONTROL_CHANNEL_ID: u128 = u128::MAX - 3;
+/// `RESERVED_IDS` is the number of reserved IDs `[u128::MAX - RESERVED_IDS, u128::MAX)`
+/// that are not valid for user-defined names.
+pub const RESERVED_IDS: u128 = 50;
+
+/// Returns true if `id` is one of the reserved values.
+pub const fn is_reserved_id(id: u128) -> bool {
+    id >= (u128::MAX - RESERVED_IDS)
+}
+
+/// Converts an id `u128` to its string representation.
+pub fn id_to_string(id: u128) -> String {
+    match id {
+        NULL_COMPONENT => "NULL_COMPONENT".to_string(),
+        DATA_CHANNEL_ID => "DATA_CHANNEL_ID".to_string(),
+        CONTROL_CHANNEL_ID => "CONTROL_CHANNEL_ID".to_string(),
+        other => uuid::Uuid::from_u128(other).to_string(),
     }
 }
 
-impl std::fmt::Display for NameId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s: String = (*self).into();
-        write!(f, "{}", s)
-    }
-}
-
-impl From<u128> for NameId {
-    fn from(id: u128) -> Self {
-        NameId {
-            id_0: (id >> 64) as u64,
-            id_1: (id & 0xFFFFFFFFFFFFFFFF) as u64,
-        }
-    }
-}
-
-impl From<NameId> for u128 {
-    fn from(name_id: NameId) -> Self {
-        (name_id.id_0 as u128) << 64 | (name_id.id_1 as u128)
-    }
-}
-
-impl TryFrom<String> for NameId {
-    type Error = NameError;
-
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        match s.as_str() {
-            "NULL_COMPONENT" => Ok(Self::from(Self::NULL_COMPONENT)),
-            "DATA_CHANNEL_ID" => Ok(Self::from(Self::DATA_CHANNEL_ID)),
-            "CONTROL_CHANNEL_ID" => Ok(Self::from(Self::CONTROL_CHANNEL_ID)),
-            _ => {
-                if let Ok(uuid) = uuid::Uuid::parse_str(&s) {
-                    return Ok(Self::from(uuid.as_u128()));
-                }
-                Err(NameError::InvalidNameIdFormat(s))
+/// Parses a string as an id `u128`.
+pub fn id_from_str(s: &str) -> Result<u128, NameError> {
+    match s {
+        "NULL_COMPONENT" => Ok(NULL_COMPONENT),
+        "DATA_CHANNEL_ID" => Ok(DATA_CHANNEL_ID),
+        "CONTROL_CHANNEL_ID" => Ok(CONTROL_CHANNEL_ID),
+        _ => {
+            if let Ok(uuid) = uuid::Uuid::parse_str(s) {
+                return Ok(uuid.as_u128());
             }
+            Err(NameError::InvalidNameIdFormat(s.to_string()))
         }
     }
 }
 
-impl From<NameId> for String {
-    fn from(name_id: NameId) -> String {
-        let val: u128 = name_id.into();
-        match val {
-            NameId::NULL_COMPONENT => "NULL_COMPONENT".to_string(),
-            NameId::DATA_CHANNEL_ID => "DATA_CHANNEL_ID".to_string(),
-            NameId::CONTROL_CHANNEL_ID => "CONTROL_CHANNEL_ID".to_string(),
-            id => uuid::Uuid::from_u128(id).to_string(),
-        }
-    }
+// ---------------------------------------------------------------------------
+// Private encode/decode helpers for flat bytes fields
+// ---------------------------------------------------------------------------
+
+/// Encode 3 hash components + a u128 id into a 40-byte `Bytes` value.
+#[inline]
+fn encode_name_bytes(c0: u64, c1: u64, c2: u64, id: u128) -> bytes::Bytes {
+    let mut buf = [0u8; 40];
+    buf[0..8].copy_from_slice(&c0.to_le_bytes());
+    buf[8..16].copy_from_slice(&c1.to_le_bytes());
+    buf[16..24].copy_from_slice(&c2.to_le_bytes());
+    buf[24..32].copy_from_slice(&((id >> 64) as u64).to_le_bytes());
+    buf[32..40].copy_from_slice(&((id & 0xFFFF_FFFF_FFFF_FFFF) as u64).to_le_bytes());
+    bytes::Bytes::copy_from_slice(&buf)
 }
 
-impl EncodedName {
-    pub fn id(&self) -> u128 {
-        self.name_id
-            .as_ref()
-            .map_or(NameId::NULL_COMPONENT, |nid| (*nid).into())
+/// Decode a 40-byte flat `Bytes` value into `(c0, c1, c2, id)`.
+/// Returns `None` if the slice is empty (field absent).
+#[inline]
+fn decode_name_bytes(b: &bytes::Bytes) -> Option<(u64, u64, u64, u128)> {
+    if b.is_empty() {
+        return None;
     }
+    assert!(b.len() == 40, "encoded_name must be 40 bytes, got {}", b.len());
+    let c0 = u64::from_le_bytes(b[0..8].try_into().unwrap());
+    let c1 = u64::from_le_bytes(b[8..16].try_into().unwrap());
+    let c2 = u64::from_le_bytes(b[16..24].try_into().unwrap());
+    let id_hi = u64::from_le_bytes(b[24..32].try_into().unwrap()) as u128;
+    let id_lo = u64::from_le_bytes(b[32..40].try_into().unwrap()) as u128;
+    Some((c0, c1, c2, (id_hi << 64) | id_lo))
+}
 
-    pub fn string_id(&self) -> String {
-        self.name_id
-            .as_ref()
-            .map_or("NULL_COMPONENT".to_string(), |nid| (*nid).into())
+/// Encode three string components into a packed `Bytes` value.
+#[inline]
+pub(crate) fn encode_str_bytes(s0: &[u8], s1: &[u8], s2: &[u8]) -> bytes::Bytes {
+    let total = 4 + s0.len() + 4 + s1.len() + 4 + s2.len();
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(&(s0.len() as u32).to_le_bytes());
+    buf.extend_from_slice(s0);
+    buf.extend_from_slice(&(s1.len() as u32).to_le_bytes());
+    buf.extend_from_slice(s1);
+    buf.extend_from_slice(&(s2.len() as u32).to_le_bytes());
+    buf.extend_from_slice(s2);
+    bytes::Bytes::from(buf)
+}
+
+/// Decode packed str_name bytes into three byte slices.
+/// Returns `None` if the slice is empty (field absent).
+#[inline]
+pub(crate) fn decode_str_bytes(b: &bytes::Bytes) -> Option<(&[u8], &[u8], &[u8])> {
+    if b.is_empty() {
+        return None;
     }
+    let data = b.as_ref();
+    let len0 = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
+    let s0_end = 4 + len0;
+    let s0 = &data[4..s0_end];
+    let len1 = u32::from_le_bytes(data[s0_end..s0_end + 4].try_into().unwrap()) as usize;
+    let s1_end = s0_end + 4 + len1;
+    let s1 = &data[s0_end + 4..s1_end];
+    let len2 = u32::from_le_bytes(data[s1_end..s1_end + 4].try_into().unwrap()) as usize;
+    let s2 = &data[s1_end + 4..s1_end + 4 + len2];
+    Some((s0, s1, s2))
 }
 
 impl ProtoName {
+    /// Construct from three string components (org, namespace, app).
     pub fn from_strings(components: [impl Into<String>; 3]) -> Self {
         let [s0, s1, s2] = components.map(Into::into);
+        let c0 = calculate_hash(&s0);
+        let c1 = calculate_hash(&s1);
+        let c2 = calculate_hash(&s2);
         Self {
-            name: Some(EncodedName {
-                component_0: calculate_hash(&s0),
-                component_1: calculate_hash(&s1),
-                component_2: calculate_hash(&s2),
-                name_id: Some(NameId::from(NameId::NULL_COMPONENT)),
-            }),
-            str_name: Some(StringName {
-                str_component_0: s0.into(),
-                str_component_1: s1.into(),
-                str_component_2: s2.into(),
-            }),
+            encoded_name: encode_name_bytes(c0, c1, c2, NULL_COMPONENT),
+            str_name: encode_str_bytes(s0.as_bytes(), s1.as_bytes(), s2.as_bytes()),
         }
     }
 
+    /// Builder-style: set the ID.
     pub fn with_id(mut self, id: u128) -> Self {
-        self.name.as_mut().expect("encoded name missing").name_id = Some(NameId::from(id));
+        self.set_id(id);
         self
     }
 
+    /// Returns both components and id in a single decode pass.
+    #[inline]
+    pub fn components_and_id(&self) -> ([u64; 3], u128) {
+        let (c0, c1, c2, id) = decode_name_bytes(&self.encoded_name)
+            .expect("encoded_name must be set to call components_and_id()");
+        ([c0, c1, c2], id)
+    }
+
+    /// Returns the three hash components as `[u64; 3]`.
+    pub fn components(&self) -> [u64; 3] {
+        let (c0, c1, c2, _) = decode_name_bytes(&self.encoded_name)
+            .expect("encoded_name must be set to call components()");
+        [c0, c1, c2]
+    }
+
     pub fn id(&self) -> u128 {
-        self.name.as_ref().expect("encoded name missing").id()
+        decode_name_bytes(&self.encoded_name).map_or(NULL_COMPONENT, |(_, _, _, id)| id)
     }
 
     pub fn string_id(&self) -> String {
-        self.name
-            .as_ref()
-            .expect("encoded name missing")
-            .string_id()
+        id_to_string(self.id())
     }
 
-    pub fn name_id(&self) -> Option<NameId> {
-        self.name.as_ref().expect("encoded name missing").name_id
+    pub fn name_id(&self) -> Option<u128> {
+        let id = self.id();
+        if id == NULL_COMPONENT { None } else { Some(id) }
     }
 
     pub fn has_id(&self) -> bool {
-        self.id() != NameId::NULL_COMPONENT
+        self.id() != NULL_COMPONENT
     }
 
     pub fn set_id(&mut self, id: u128) {
-        self.name.as_mut().expect("encoded name missing").name_id = Some(NameId::from(id));
+        let (c0, c1, c2, _) = decode_name_bytes(&self.encoded_name)
+            .expect("encoded_name must be set to call set_id()");
+        self.encoded_name = encode_name_bytes(c0, c1, c2, id);
     }
 
     pub fn reset_id(&mut self) {
-        self.name.as_mut().expect("encoded name missing").name_id =
-            Some(NameId::from(NameId::NULL_COMPONENT));
+        self.set_id(NULL_COMPONENT);
     }
 
     pub fn match_prefix(&self, other: &ProtoName) -> bool {
-        let a = self.name.as_ref().expect("encoded name missing");
-        let b = other.name.as_ref().expect("encoded name missing");
-        a.component_0 == b.component_0
-            && a.component_1 == b.component_1
-            && a.component_2 == b.component_2
+        if self.encoded_name.len() < 24 || other.encoded_name.len() < 24 {
+            return false;
+        }
+        self.encoded_name[..24] == other.encoded_name[..24]
     }
 
     pub fn str_components(&self) -> (&str, &str, &str) {
-        let s = self.str_name.as_ref().expect("string name missing");
-        // SAFETY: StringName bytes always originate from valid UTF-8 strings
+        let (s0, s1, s2) = decode_str_bytes(&self.str_name)
+            .expect("str_name must be set to call str_components()");
+        // SAFETY: str_name bytes always originate from valid UTF-8 strings
         // (constructed via from_strings / parse_name, which accept &str / String inputs).
         unsafe {
             (
-                std::str::from_utf8_unchecked(&s.str_component_0),
-                std::str::from_utf8_unchecked(&s.str_component_1),
-                std::str::from_utf8_unchecked(&s.str_component_2),
+                std::str::from_utf8_unchecked(s0),
+                std::str::from_utf8_unchecked(s1),
+                std::str::from_utf8_unchecked(s2),
             )
+        }
+    }
+
+    /// Construct a `ProtoName` from raw hash components and an id, without string names.
+    pub fn from_components(prefix: [u64; 3], id: u128) -> Self {
+        Self {
+            encoded_name: encode_name_bytes(prefix[0], prefix[1], prefix[2], id),
+            str_name: bytes::Bytes::new(),
         }
     }
 
@@ -375,35 +425,18 @@ impl ProtoName {
 
 impl std::fmt::Display for ProtoName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(s) = &self.str_name {
+        if let Some((s0, s1, s2)) = decode_str_bytes(&self.str_name) {
             // SAFETY: see str_components() — bytes are always valid UTF-8.
-            let (c0, c1, c2) = unsafe {(
-                std::str::from_utf8_unchecked(&s.str_component_0),
-                std::str::from_utf8_unchecked(&s.str_component_1),
-                std::str::from_utf8_unchecked(&s.str_component_2),
-            )};
-            write!(
-                f,
-                "{}/{}/{}/{}",
-                c0,
-                c1,
-                c2,
-                self.name
-                    .as_ref()
-                    .and_then(|n| n.name_id)
-                    .map_or("NULL_COMPONENT".to_string(), |id| id.to_string())
-            )
-        } else if let Some(enc) = &self.name {
-            write!(
-                f,
-                "{}/{}/{}/{}",
-                enc.component_0,
-                enc.component_1,
-                enc.component_2,
-                enc.name_id
-                    .as_ref()
-                    .map_or("NULL_COMPONENT".to_string(), |id| id.to_string())
-            )
+            let (c0, c1, c2) = unsafe {
+                (
+                    std::str::from_utf8_unchecked(s0),
+                    std::str::from_utf8_unchecked(s1),
+                    std::str::from_utf8_unchecked(s2),
+                )
+            };
+            write!(f, "{}/{}/{}/{}", c0, c1, c2, id_to_string(self.id()))
+        } else if let Some((c0, c1, c2, id)) = decode_name_bytes(&self.encoded_name) {
+            write!(f, "{}/{}/{}/{}", c0, c1, c2, id_to_string(id))
         } else {
             write!(f, "<empty>")
         }
@@ -529,32 +562,25 @@ impl SlimHeader {
         self.source.clone().expect("source not found")
     }
 
-    pub fn get_encoded_source(&self) -> EncodedName {
-        self.source
-            .as_ref()
-            .expect("source not found")
-            .name
-            .expect("source encoded name not found")
+    pub fn get_encoded_source(&self) -> ([u64; 3], u128) {
+        self.source.as_ref().unwrap().components_and_id()
     }
 
     pub fn get_dst(&self) -> ProtoName {
         self.destination.clone().expect("destination not found")
     }
 
-    pub fn get_encoded_dst(&self) -> EncodedName {
-        self.destination
-            .as_ref()
-            .expect("destination not found")
-            .name
-            .expect("destination encoded name not found")
+    pub fn get_encoded_dst(&self) -> ([u64; 3], u128) {
+        self.destination.as_ref().unwrap().components_and_id()
     }
 
-    pub fn get_identity(&self) -> String {
-        self.identity.clone()
+    pub fn get_identity(&self) -> &str {
+        // SAFETY: identity originated as a UTF-8 String; stored as Bytes on this branch.
+        unsafe { std::str::from_utf8_unchecked(&self.identity) }
     }
 
     pub fn get_version(&self) -> String {
-        self.version.clone()
+        String::from_utf8_lossy(&self.version).into_owned()
     }
 
     pub fn set_source(&mut self, source: ProtoName) {
@@ -565,8 +591,8 @@ impl SlimHeader {
         self.destination = Some(dst);
     }
 
-    pub fn set_identity(&mut self, identity: String) {
-        self.identity = identity;
+    pub fn set_identity(&mut self, identity: impl Into<bytes::Bytes>) {
+        self.identity = identity.into();
     }
 
     pub fn set_fanout(&mut self, fanout: u32) {
@@ -1026,7 +1052,7 @@ impl ProtoMessage {
         self.get_slim_header().get_encoded_dst()
     }
 
-    pub fn get_identity(&self) -> String {
+    pub fn get_identity(&self) -> &str {
         self.get_slim_header().get_identity()
     }
 
@@ -1265,10 +1291,10 @@ impl Content {
 }
 
 impl ApplicationPayload {
-    pub fn new(payload_type: &str, blob: Vec<u8>) -> Self {
+    pub fn new(payload_type: &str, blob: impl Into<bytes::Bytes>) -> Self {
         Self {
             payload_type: payload_type.to_string(),
-            blob,
+            blob: blob.into(),
         }
     }
 
@@ -1610,7 +1636,7 @@ impl ProtoMessageBuilder {
         self
     }
 
-    pub fn application_payload(mut self, payload_type: &str, blob: Vec<u8>) -> Self {
+    pub fn application_payload(mut self, payload_type: &str, blob: impl Into<bytes::Bytes>) -> Self {
         let app_payload = ApplicationPayload::new(payload_type, blob);
         self.payload = Some(app_payload.as_content());
         self
@@ -1629,7 +1655,7 @@ impl ProtoMessageBuilder {
             self.destination = Some(dst);
         }
         if !header.identity.is_empty() {
-            self.identity = Some(header.identity.clone());
+            self.identity = Some(String::from_utf8_lossy(&header.identity).into_owned());
         }
 
         self.flags = Some(SlimHeaderFlags {
@@ -1806,7 +1832,7 @@ mod name_tests {
     fn test_proto_name_reset_id() {
         let mut n = ProtoName::from_strings(["a", "b", "c"]).with_id(42);
         n.reset_id();
-        assert_eq!(n.id(), NameId::NULL_COMPONENT);
+        assert_eq!(n.id(), NULL_COMPONENT);
         assert!(!n.has_id());
     }
 
@@ -1832,66 +1858,58 @@ mod name_tests {
     #[test]
     fn test_proto_name_hash_stability() {
         let proto = ProtoName::from_strings(["Org", "Default", "App"]).with_id(7);
-        let enc = proto.name.unwrap();
         let proto2 = ProtoName::from_strings(["Org", "Default", "App"]).with_id(7);
-        let enc2 = proto2.name.unwrap();
-        assert_eq!(enc, enc2);
-        assert_eq!(enc.id(), 7);
+        assert_eq!(proto, proto2);
+        assert_eq!(proto.id(), 7);
     }
 
     #[test]
     fn test_name_id_roundtrip() {
         let values = [0u128, 1, 42, u128::MAX / 2, u128::MAX - 4];
         for v in values {
-            let nid = NameId::from(v);
-            let result: u128 = nid.into();
-            assert_eq!(result, v, "roundtrip failed for {v}");
+            let n = ProtoName::from_strings(["a", "b", "c"]).with_id(v);
+            assert_eq!(n.id(), v, "roundtrip failed for {v}");
         }
     }
 
     #[test]
     fn test_name_id_from_string_valid_uuid() {
-        let nid = NameId::try_from("00000000-0000-0000-0000-00000000002a".to_string())
+        let id = id_from_str("00000000-0000-0000-0000-00000000002a")
             .expect("valid UUID string should parse");
-        let result: u128 = nid.into();
-        assert_eq!(result, 42);
+        assert_eq!(id, 42);
     }
 
     #[test]
     fn test_name_id_from_string_invalid() {
-        assert!(NameId::try_from("not-a-uuid".to_string()).is_err());
-        assert!(NameId::try_from("".to_string()).is_err());
+        assert!(id_from_str("not-a-uuid").is_err());
+        assert!(id_from_str("").is_err());
     }
 
     #[test]
     fn test_name_id_display_uuid() {
-        let nid = NameId::from(42);
-        assert_eq!(nid.to_string(), "00000000-0000-0000-0000-00000000002a");
+        assert_eq!(id_to_string(42), "00000000-0000-0000-0000-00000000002a");
     }
 
     #[test]
     fn test_name_id_display_reserved() {
-        let mut str_nid: String = NameId::from(NameId::NULL_COMPONENT).into();
-        assert_eq!(str_nid, "NULL_COMPONENT");
-        str_nid = NameId::from(NameId::DATA_CHANNEL_ID).into();
-        assert_eq!(str_nid, "DATA_CHANNEL_ID");
-        str_nid = NameId::from(NameId::CONTROL_CHANNEL_ID).into();
-        assert_eq!(str_nid, "CONTROL_CHANNEL_ID");
+        assert_eq!(id_to_string(NULL_COMPONENT), "NULL_COMPONENT");
+        assert_eq!(id_to_string(DATA_CHANNEL_ID), "DATA_CHANNEL_ID");
+        assert_eq!(id_to_string(CONTROL_CHANNEL_ID), "CONTROL_CHANNEL_ID");
     }
 
     #[test]
     fn test_name_id_is_reserved() {
-        assert!(NameId::is_reserved_id(NameId::NULL_COMPONENT));
-        assert!(NameId::is_reserved_id(NameId::DATA_CHANNEL_ID));
-        assert!(NameId::is_reserved_id(NameId::CONTROL_CHANNEL_ID));
-        assert!(!NameId::is_reserved_id(0));
-        assert!(!NameId::is_reserved_id(42));
+        assert!(is_reserved_id(NULL_COMPONENT));
+        assert!(is_reserved_id(DATA_CHANNEL_ID));
+        assert!(is_reserved_id(CONTROL_CHANNEL_ID));
+        assert!(!is_reserved_id(0));
+        assert!(!is_reserved_id(42));
     }
 
     #[test]
     fn test_proto_name_default_id_is_null_component() {
         let n = ProtoName::from_strings(["a", "b", "c"]);
-        assert_eq!(n.id(), NameId::NULL_COMPONENT);
+        assert_eq!(n.id(), NULL_COMPONENT);
         assert!(!n.has_id());
     }
 
@@ -1921,18 +1939,6 @@ mod name_tests {
         let n = ProtoName::from_strings(["org", "ns", "app"]);
         let s = format!("{}", n);
         assert_eq!(s, "org/ns/app/NULL_COMPONENT");
-    }
-
-    #[test]
-    fn test_encoded_name_id_when_name_id_none() {
-        let enc = EncodedName {
-            component_0: 0,
-            component_1: 0,
-            component_2: 0,
-            name_id: None,
-        };
-        assert_eq!(enc.id(), NameId::NULL_COMPONENT);
-        assert_eq!(enc.string_id(), "NULL_COMPONENT");
     }
 
     #[test]

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -274,11 +274,9 @@ pub(crate) fn decode_name_bytes(b: &bytes::Bytes) -> Option<(u64, u64, u64, u128
     if b.is_empty() {
         return None;
     }
-    assert!(
-        b.len() == 40,
-        "encoded_name must be 40 bytes, got {}",
-        b.len()
-    );
+    if b.len() != 40 {
+        return None;
+    }
     let c0 = u64::from_le_bytes(b[0..8].try_into().unwrap());
     let c1 = u64::from_le_bytes(b[8..16].try_into().unwrap());
     let c2 = u64::from_le_bytes(b[16..24].try_into().unwrap());
@@ -302,21 +300,21 @@ pub fn encode_str_bytes(s0: &[u8], s1: &[u8], s2: &[u8]) -> bytes::Bytes {
 }
 
 /// Decode packed str_name bytes into three byte slices.
-/// Returns `None` if the slice is empty (field absent).
+/// Returns `None` if the slice is empty (field absent) or malformed.
 #[inline]
 pub fn decode_str_bytes(b: &bytes::Bytes) -> Option<(&[u8], &[u8], &[u8])> {
     if b.is_empty() {
         return None;
     }
     let data = b.as_ref();
-    let len0 = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
-    let s0_end = 4 + len0;
-    let s0 = &data[4..s0_end];
-    let len1 = u32::from_le_bytes(data[s0_end..s0_end + 4].try_into().unwrap()) as usize;
-    let s1_end = s0_end + 4 + len1;
-    let s1 = &data[s0_end + 4..s1_end];
-    let len2 = u32::from_le_bytes(data[s1_end..s1_end + 4].try_into().unwrap()) as usize;
-    let s2 = &data[s1_end + 4..s1_end + 4 + len2];
+    let len0 = u32::from_le_bytes(data.get(0..4)?.try_into().unwrap()) as usize;
+    let s0_end = 4usize.checked_add(len0)?;
+    let s0 = data.get(4..s0_end)?;
+    let len1 = u32::from_le_bytes(data.get(s0_end..s0_end + 4)?.try_into().unwrap()) as usize;
+    let s1_end = s0_end.checked_add(4)?.checked_add(len1)?;
+    let s1 = data.get(s0_end + 4..s1_end)?;
+    let len2 = u32::from_le_bytes(data.get(s1_end..s1_end + 4)?.try_into().unwrap()) as usize;
+    let s2 = data.get(s1_end + 4..s1_end.checked_add(4)?.checked_add(len2)?)?;
     Some((s0, s1, s2))
 }
 
@@ -391,18 +389,14 @@ impl ProtoName {
             .expect("str_name must be set to call str_components()")
     }
 
-    /// Returns the three string components if `str_name` is present, or `None`.
+    /// Returns the three string components if `str_name` is present and valid UTF-8, or `None`.
     fn try_str_components(&self) -> Option<(&str, &str, &str)> {
         let (s0, s1, s2) = decode_str_bytes(&self.str_name)?;
-        // SAFETY: str_name bytes always originate from valid UTF-8 strings
-        // (constructed via from_strings / parse_name, which accept &str / String inputs).
-        unsafe {
-            Some((
-                std::str::from_utf8_unchecked(s0),
-                std::str::from_utf8_unchecked(s1),
-                std::str::from_utf8_unchecked(s2),
-            ))
-        }
+        Some((
+            std::str::from_utf8(s0).ok()?,
+            std::str::from_utf8(s1).ok()?,
+            std::str::from_utf8(s2).ok()?,
+        ))
     }
 
     /// Construct a `ProtoName` from raw hash components and an id, without string names.

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -307,13 +307,13 @@ pub fn decode_str_bytes(b: &bytes::Bytes) -> Option<(&[u8], &[u8], &[u8])> {
         return None;
     }
     let data = b.as_ref();
-    let len0 = u32::from_le_bytes(data.get(0..4)?.try_into().unwrap()) as usize;
+    let len0 = u32::from_le_bytes(data.get(0..4)?.try_into().ok()?) as usize;
     let s0_end = 4usize.checked_add(len0)?;
     let s0 = data.get(4..s0_end)?;
-    let len1 = u32::from_le_bytes(data.get(s0_end..s0_end + 4)?.try_into().unwrap()) as usize;
+    let len1 = u32::from_le_bytes(data.get(s0_end..s0_end + 4)?.try_into().ok()?) as usize;
     let s1_end = s0_end.checked_add(4)?.checked_add(len1)?;
     let s1 = data.get(s0_end + 4..s1_end)?;
-    let len2 = u32::from_le_bytes(data.get(s1_end..s1_end + 4)?.try_into().unwrap()) as usize;
+    let len2 = u32::from_le_bytes(data.get(s1_end..s1_end + 4)?.try_into().ok()?) as usize;
     let s2 = data.get(s1_end + 4..s1_end.checked_add(4)?.checked_add(len2)?)?;
     Some((s0, s1, s2))
 }

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -299,9 +299,9 @@ impl ProtoName {
                 name_id: Some(NameId::from(NameId::NULL_COMPONENT)),
             }),
             str_name: Some(StringName {
-                str_component_0: s0,
-                str_component_1: s1,
-                str_component_2: s2,
+                str_component_0: s0.into(),
+                str_component_1: s1.into(),
+                str_component_2: s2.into(),
             }),
         }
     }
@@ -349,7 +349,15 @@ impl ProtoName {
 
     pub fn str_components(&self) -> (&str, &str, &str) {
         let s = self.str_name.as_ref().expect("string name missing");
-        (&s.str_component_0, &s.str_component_1, &s.str_component_2)
+        // SAFETY: StringName bytes always originate from valid UTF-8 strings
+        // (constructed via from_strings / parse_name, which accept &str / String inputs).
+        unsafe {
+            (
+                std::str::from_utf8_unchecked(&s.str_component_0),
+                std::str::from_utf8_unchecked(&s.str_component_1),
+                std::str::from_utf8_unchecked(&s.str_component_2),
+            )
+        }
     }
 
     pub fn parse_name(s: &str) -> Result<ProtoName, NameError> {
@@ -368,12 +376,18 @@ impl ProtoName {
 impl std::fmt::Display for ProtoName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(s) = &self.str_name {
+            // SAFETY: see str_components() — bytes are always valid UTF-8.
+            let (c0, c1, c2) = unsafe {(
+                std::str::from_utf8_unchecked(&s.str_component_0),
+                std::str::from_utf8_unchecked(&s.str_component_1),
+                std::str::from_utf8_unchecked(&s.str_component_2),
+            )};
             write!(
                 f,
                 "{}/{}/{}/{}",
-                s.str_component_0,
-                s.str_component_1,
-                s.str_component_2,
+                c0,
+                c1,
+                c2,
                 self.name
                     .as_ref()
                     .and_then(|n| n.name_id)

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -764,7 +764,7 @@ impl ProtoPublish {
     fn with_header(
         header: Option<SlimHeader>,
         session: Option<SessionHeader>,
-        payload: Option<Content>,
+        payload: bytes::Bytes,
     ) -> Self {
         ProtoPublish {
             header,
@@ -789,44 +789,52 @@ impl ProtoPublish {
         self.session.as_mut().expect("session header missing")
     }
 
-    pub fn get_payload(&self) -> &Content {
-        self.msg.as_ref().expect("payload missing")
+    /// Decodes the raw `msg` bytes into a [`Content`], returning `None` if absent.
+    pub fn get_payload(&self) -> Option<Content> {
+        if self.msg.is_empty() {
+            None
+        } else {
+            use prost::Message;
+            Content::decode(self.msg.as_ref()).ok()
+        }
     }
 
     pub fn set_payload(&mut self, payload: Content) {
-        self.msg = Some(payload);
+        use prost::Message;
+        self.msg = payload.encode_to_vec().into();
     }
 
     pub fn is_command(&self) -> bool {
-        match &self
+        match self
             .get_payload()
+            .expect("msg must be set")
             .content_type
             .as_ref()
-            .expect("content missing")
+            .unwrap()
         {
             ContentType::AppPayload(_) => false,
             ContentType::CommandPayload(_) => true,
         }
     }
 
-    pub fn get_application_payload(&self) -> &ApplicationPayload {
+    pub fn get_application_payload(&self) -> ApplicationPayload {
         match self
             .get_payload()
+            .expect("msg must be set")
             .content_type
-            .as_ref()
-            .expect("content missing")
+            .unwrap()
         {
             ContentType::AppPayload(application_payload) => application_payload,
             ContentType::CommandPayload(_) => panic!("the payload is not an application payload"),
         }
     }
 
-    pub fn get_command_payload(&self) -> &CommandPayload {
+    pub fn get_command_payload(&self) -> CommandPayload {
         match self
             .get_payload()
+            .expect("msg must be set")
             .content_type
-            .as_ref()
-            .expect("content missing")
+            .unwrap()
         {
             ContentType::AppPayload(_) => panic!("the payload is not a command payload"),
             ContentType::CommandPayload(command_payload) => command_payload,
@@ -843,10 +851,14 @@ impl From<ProtoMessage> for ProtoPublish {
     }
 }
 
+// Macro to generate payload extraction methods for ProtoMessage.
+// Uses the consuming `into_*` getters on CommandPayload so callers
+// receive owned payload types (no references to temporary values).
 macro_rules! impl_payload_extractors {
     ($($method_name:ident => $getter_method:ident($payload_type:ty)),* $(,)?) => {
         $(
-            pub fn $method_name(&self) -> Result<&$payload_type, MessageError> {
+            /// Extracts a specific command payload from the message.
+            pub fn $method_name(&self) -> Result<$payload_type, MessageError> {
                 self.extract_command_payload()?.$getter_method()
             }
         )*
@@ -871,12 +883,14 @@ impl ProtoMessage {
     fn validate_routed_header(slim_header: &SlimHeader) -> Result<(), MessageError> {
         match &slim_header.source {
             None => return Err(MessageError::SourceNotFound),
-            Some(src) if src.name.is_none() => return Err(MessageError::SourceEncodedNameNotFound),
+            Some(src) if src.encoded_name.is_empty() => {
+                return Err(MessageError::SourceEncodedNameNotFound);
+            }
             _ => {}
         }
         match &slim_header.destination {
             None => return Err(MessageError::DestinationNotFound),
-            Some(dst) if dst.name.is_none() => {
+            Some(dst) if dst.encoded_name.is_empty() => {
                 return Err(MessageError::DestinationEncodedNameNotFound);
             }
             _ => {}
@@ -1084,14 +1098,15 @@ impl ProtoMessage {
         }
     }
 
-    pub fn get_payload(&self) -> Option<&Content> {
+    /// Decodes and returns the [`Content`] payload, or `None` if absent.
+    pub fn get_payload(&self) -> Option<Content> {
         match &self.message_type {
-            Some(ProtoPublishType(p)) => p.msg.as_ref(),
-            Some(ProtoSubscribeType(_))
-            | Some(ProtoUnsubscribeType(_))
-            | Some(ProtoLinkMessageType(_))
-            | Some(ProtoSubscriptionAckType(_))
-            | None => panic!("payload not found"),
+            Some(ProtoPublishType(p)) => p.get_payload(),
+            Some(ProtoSubscribeType(_)) => panic!("payload not found"),
+            Some(ProtoUnsubscribeType(_)) => panic!("payload not found"),
+            Some(ProtoLinkMessageType(_)) => panic!("payload not found"),
+            Some(ProtoSubscriptionAckType(_)) => panic!("payload not found"),
+            None => panic!("payload not found"),
         }
     }
 
@@ -1239,27 +1254,29 @@ impl ProtoMessage {
         }
     }
 
-    pub fn extract_command_payload(&self) -> Result<&CommandPayload, MessageError> {
+    /// Extracts the command payload from the message.
+    pub fn extract_command_payload(&self) -> Result<CommandPayload, MessageError> {
         self.get_payload()
             .ok_or(MessageError::ContentTypeNotSet)?
-            .as_command_payload()
+            .into_command_payload()
     }
 
+    // Generate all payload extraction methods (return owned types via consuming getters)
     impl_payload_extractors! {
-        extract_discovery_request => as_discovery_request_payload(DiscoveryRequestPayload),
-        extract_discovery_reply => as_discovery_reply_payload(DiscoveryReplyPayload),
-        extract_join_request => as_join_request_payload(JoinRequestPayload),
-        extract_join_reply => as_join_reply_payload(JoinReplyPayload),
-        extract_leave_request => as_leave_request_payload(LeaveRequestPayload),
-        extract_leave_reply => as_leave_reply_payload(LeaveReplyPayload),
-        extract_group_add => as_group_add_payload(GroupAddPayload),
-        extract_group_remove => as_group_remove_payload(GroupRemovePayload),
-        extract_group_welcome => as_welcome_payload(GroupWelcomePayload),
-        extract_group_close => as_group_close_payload(GroupClosePayload),
-        extract_group_proposal => as_group_proposal_payload(GroupProposalPayload),
-        extract_group_ack => as_group_ack_payload(GroupAckPayload),
-        extract_group_nack => as_group_nack_payload(GroupNackPayload),
-        extract_ping => as_ping_payload(PingPayload),
+        extract_discovery_request => into_discovery_request_payload(DiscoveryRequestPayload),
+        extract_discovery_reply => into_discovery_reply_payload(DiscoveryReplyPayload),
+        extract_join_request => into_join_request_payload(JoinRequestPayload),
+        extract_join_reply => into_join_reply_payload(JoinReplyPayload),
+        extract_leave_request => into_leave_request_payload(LeaveRequestPayload),
+        extract_leave_reply => into_leave_reply_payload(LeaveReplyPayload),
+        extract_group_add => into_group_add_payload(GroupAddPayload),
+        extract_group_remove => into_group_remove_payload(GroupRemovePayload),
+        extract_group_welcome => into_welcome_payload(GroupWelcomePayload),
+        extract_group_close => into_group_close_payload(GroupClosePayload),
+        extract_group_proposal => into_group_proposal_payload(GroupProposalPayload),
+        extract_group_ack => into_group_ack_payload(GroupAckPayload),
+        extract_group_nack => into_group_nack_payload(GroupNackPayload),
+        extract_ping => into_ping_payload(PingPayload),
     }
 
     pub fn builder() -> ProtoMessageBuilder {
@@ -1283,6 +1300,24 @@ impl Content {
             None => Err(MessageError::ContentTypeNotSet),
         }
     }
+
+    /// Consuming variant: extracts the [`ApplicationPayload`] by value.
+    pub fn into_application_payload(self) -> Result<ApplicationPayload, MessageError> {
+        match self.content_type {
+            Some(ContentType::AppPayload(app_payload)) => Ok(app_payload),
+            Some(ContentType::CommandPayload(_)) => Err(MessageError::NotApplicationPayload),
+            None => Err(MessageError::ContentTypeNotSet),
+        }
+    }
+
+    /// Consuming variant: extracts the [`CommandPayload`] by value.
+    pub fn into_command_payload(self) -> Result<CommandPayload, MessageError> {
+        match self.content_type {
+            Some(ContentType::AppPayload(_)) => Err(MessageError::NotCommandPayload),
+            Some(ContentType::CommandPayload(comm_payload)) => Ok(comm_payload),
+            None => Err(MessageError::ContentTypeNotSet),
+        }
+    }
 }
 
 impl ApplicationPayload {
@@ -1300,11 +1335,36 @@ impl ApplicationPayload {
     }
 }
 
+// Macro to generate borrowing getter methods for all CommandPayloadType variants
 macro_rules! impl_command_payload_getters {
     ($($method_name:ident => $variant:ident($payload_type:ty)),* $(,)?) => {
         $(
             pub fn $method_name(&self) -> Result<&$payload_type, MessageError> {
                 match &self.command_payload_type {
+                    Some(CommandPayloadType::$variant(payload)) => Ok(payload),
+                    Some(other) => Err(MessageError::InvalidCommandPayloadType {
+                        expected: Box::new(stringify!($variant).to_string()),
+                        got: Box::new(format!("{:?}", other)),
+                    }),
+                    None => Err(MessageError::InvalidCommandPayloadType {
+                        expected: Box::new(stringify!($variant).to_string()),
+                        got: Box::new("None".to_string()),
+                    }),
+                }
+            }
+        )*
+    };
+}
+
+// Macro to generate consuming getter methods for all CommandPayloadType variants.
+// Used by extract_* methods that build on get_payload() returning an owned Content.
+macro_rules! impl_command_payload_into_getters {
+    ($(
+        $method_name:ident => $variant:ident($payload_type:ty)
+    ),* $(,)?) => {
+        $(
+            pub fn $method_name(self) -> Result<$payload_type, MessageError> {
+                match self.command_payload_type {
                     Some(CommandPayloadType::$variant(payload)) => Ok(payload),
                     Some(other) => Err(MessageError::InvalidCommandPayloadType {
                         expected: Box::new(stringify!($variant).to_string()),
@@ -1342,6 +1402,24 @@ impl CommandPayload {
         as_group_ack_payload => GroupAck(GroupAckPayload),
         as_group_nack_payload => GroupNack(GroupNackPayload),
         as_ping_payload => Ping(PingPayload),
+    }
+
+    // Consuming getter methods (by value) for all CommandPayloadType variants
+    impl_command_payload_into_getters! {
+        into_discovery_request_payload => DiscoveryRequest(DiscoveryRequestPayload),
+        into_discovery_reply_payload => DiscoveryReply(DiscoveryReplyPayload),
+        into_join_request_payload => JoinRequest(JoinRequestPayload),
+        into_join_reply_payload => JoinReply(JoinReplyPayload),
+        into_leave_request_payload => LeaveRequest(LeaveRequestPayload),
+        into_leave_reply_payload => LeaveReply(LeaveReplyPayload),
+        into_group_add_payload => GroupAdd(GroupAddPayload),
+        into_group_remove_payload => GroupRemove(GroupRemovePayload),
+        into_welcome_payload => GroupWelcome(GroupWelcomePayload),
+        into_group_close_payload => GroupClose(GroupClosePayload),
+        into_group_proposal_payload => GroupProposal(GroupProposalPayload),
+        into_group_ack_payload => GroupAck(GroupAckPayload),
+        into_group_nack_payload => GroupNack(GroupNackPayload),
+        into_ping_payload => Ping(PingPayload),
     }
 
     pub fn builder() -> CommandPayloadBuilder {
@@ -1717,8 +1795,17 @@ impl ProtoMessageBuilder {
             Some(SessionHeader::default())
         };
 
-        let publish = ProtoPublish::with_header(slim_header, session_header, self.payload);
-        Ok(ProtoMessage::new(self.metadata, ProtoPublishType(publish)))
+        let msg_bytes: bytes::Bytes = self
+            .payload
+            .map(|p| {
+                use prost::Message;
+                p.encode_to_vec().into()
+            })
+            .unwrap_or_default();
+
+        let publish = ProtoPublish::with_header(slim_header, session_header, msg_bytes);
+        let message = ProtoMessage::new(self.metadata, ProtoPublishType(publish));
+        Ok(message)
     }
 
     pub fn build_subscribe(self) -> Result<ProtoMessage, MessageError> {

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -21,14 +21,14 @@ use crate::dataplane::proto::v1::message::MessageType::SubscriptionAck as ProtoS
 use crate::dataplane::proto::v1::message::MessageType::Unsubscribe as ProtoUnsubscribeType;
 use crate::dataplane::proto::v1::{
     ApplicationPayload, CommandPayload, Content, DiscoveryReplyPayload, DiscoveryRequestPayload,
-    GroupAckPayload, GroupAddPayload, GroupClosePayload, GroupNackPayload,
-    GroupProposalPayload, GroupRemovePayload, GroupWelcomePayload, JoinReplyPayload,
-    JoinRequestPayload, LeaveReplyPayload, LeaveRequestPayload, Link as ProtoLink,
-    LinkConnectionType, LinkNegotiationPayload, Message as ProtoMessage, MlsPayload,
-    MlsSettings as ProtoMlsSettings, Name as ProtoName, Participant, ParticipantSettings,
-    PingPayload, Publish as ProtoPublish, SessionHeader, SessionMessageType,
-    SessionType as ProtoSessionType, SlimHeader, Subscribe as ProtoSubscribe,
-    SubscriptionAck as ProtoSubscriptionAck, TimerSettings, Unsubscribe as ProtoUnsubscribe,
+    GroupAckPayload, GroupAddPayload, GroupClosePayload, GroupNackPayload, GroupProposalPayload,
+    GroupRemovePayload, GroupWelcomePayload, JoinReplyPayload, JoinRequestPayload,
+    LeaveReplyPayload, LeaveRequestPayload, Link as ProtoLink, LinkConnectionType,
+    LinkNegotiationPayload, Message as ProtoMessage, MlsPayload, MlsSettings as ProtoMlsSettings,
+    Name as ProtoName, Participant, ParticipantSettings, PingPayload, Publish as ProtoPublish,
+    SessionHeader, SessionMessageType, SessionType as ProtoSessionType, SlimHeader,
+    Subscribe as ProtoSubscribe, SubscriptionAck as ProtoSubscriptionAck, TimerSettings,
+    Unsubscribe as ProtoUnsubscribe,
 };
 
 fn calculate_hash<T: Hash + ?Sized>(t: &T) -> u64 {
@@ -274,7 +274,11 @@ pub(crate) fn decode_name_bytes(b: &bytes::Bytes) -> Option<(u64, u64, u64, u128
     if b.is_empty() {
         return None;
     }
-    assert!(b.len() == 40, "encoded_name must be 40 bytes, got {}", b.len());
+    assert!(
+        b.len() == 40,
+        "encoded_name must be 40 bytes, got {}",
+        b.len()
+    );
     let c0 = u64::from_le_bytes(b[0..8].try_into().unwrap());
     let c1 = u64::from_le_bytes(b[8..16].try_into().unwrap());
     let c2 = u64::from_le_bytes(b[16..24].try_into().unwrap());
@@ -559,8 +563,7 @@ impl SlimHeader {
     }
 
     pub fn get_encoded_source(&self) -> ([u64; 3], u128) {
-        let (c0, c1, c2, id) =
-            decode_name_bytes(&self.source).expect("source not set");
+        let (c0, c1, c2, id) = decode_name_bytes(&self.source).expect("source not set");
         ([c0, c1, c2], id)
     }
 
@@ -572,8 +575,7 @@ impl SlimHeader {
     }
 
     pub fn get_encoded_dst(&self) -> ([u64; 3], u128) {
-        let (c0, c1, c2, id) =
-            decode_name_bytes(&self.destination).expect("destination not set");
+        let (c0, c1, c2, id) = decode_name_bytes(&self.destination).expect("destination not set");
         ([c0, c1, c2], id)
     }
 
@@ -804,7 +806,6 @@ impl ProtoPublish {
         use prost::Message;
         self.msg = payload.encode_to_vec().into();
     }
-
 }
 
 impl From<ProtoMessage> for ProtoPublish {
@@ -1662,7 +1663,11 @@ impl ProtoMessageBuilder {
         self
     }
 
-    pub fn application_payload(mut self, payload_type: &str, blob: impl Into<bytes::Bytes>) -> Self {
+    pub fn application_payload(
+        mut self,
+        payload_type: &str,
+        blob: impl Into<bytes::Bytes>,
+    ) -> Self {
         let app_payload = ApplicationPayload::new(payload_type, blob);
         self.payload = Some(app_payload.as_content());
         self

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -85,12 +85,8 @@ pub const DEFAULT_TTL: u32 = 8;
 pub enum MessageError {
     #[error("SLIM header not found")]
     SlimHeaderNotFound,
-    #[error("source not found")]
-    SourceNotFound,
     #[error("source encoded name not found")]
     SourceEncodedNameNotFound,
-    #[error("destination not found")]
-    DestinationNotFound,
     #[error("destination encoded name not found")]
     DestinationEncodedNameNotFound,
     #[error("session header not found")]
@@ -274,7 +270,7 @@ fn encode_name_bytes(c0: u64, c1: u64, c2: u64, id: u128) -> bytes::Bytes {
 /// Decode a 40-byte flat `Bytes` value into `(c0, c1, c2, id)`.
 /// Returns `None` if the slice is empty (field absent).
 #[inline]
-fn decode_name_bytes(b: &bytes::Bytes) -> Option<(u64, u64, u64, u128)> {
+pub(crate) fn decode_name_bytes(b: &bytes::Bytes) -> Option<(u64, u64, u64, u128)> {
     if b.is_empty() {
         return None;
     }
@@ -518,11 +514,13 @@ impl SlimHeader {
     ) -> Self {
         let flags = flags.unwrap_or_default();
         Self {
-            source: Some(source),
-            destination: Some(destination),
-            identity: identity.to_string(),
+            source: source.encoded_name,
+            destination: destination.encoded_name,
+            source_str: source.str_name,
+            destination_str: destination.str_name,
+            identity: identity.to_string().into(),
             fanout: flags.fanout,
-            version: version().to_string(),
+            version: version().to_string().into(),
             recv_from: flags.recv_from,
             forward_to: flags.forward_to,
             incoming_conn: flags.incoming_conn,
@@ -559,19 +557,29 @@ impl SlimHeader {
     }
 
     pub fn get_source(&self) -> ProtoName {
-        self.source.clone().expect("source not found")
+        ProtoName {
+            encoded_name: self.source.clone(),
+            str_name: self.source_str.clone(),
+        }
     }
 
     pub fn get_encoded_source(&self) -> ([u64; 3], u128) {
-        self.source.as_ref().unwrap().components_and_id()
+        let (c0, c1, c2, id) =
+            decode_name_bytes(&self.source).expect("source not set");
+        ([c0, c1, c2], id)
     }
 
     pub fn get_dst(&self) -> ProtoName {
-        self.destination.clone().expect("destination not found")
+        ProtoName {
+            encoded_name: self.destination.clone(),
+            str_name: self.destination_str.clone(),
+        }
     }
 
     pub fn get_encoded_dst(&self) -> ([u64; 3], u128) {
-        self.destination.as_ref().unwrap().components_and_id()
+        let (c0, c1, c2, id) =
+            decode_name_bytes(&self.destination).expect("destination not set");
+        ([c0, c1, c2], id)
     }
 
     pub fn get_identity(&self) -> &str {
@@ -579,11 +587,13 @@ impl SlimHeader {
     }
 
     pub fn set_source(&mut self, source: ProtoName) {
-        self.source = Some(source);
+        self.source = source.encoded_name;
+        self.source_str = source.str_name;
     }
 
     pub fn set_destination(&mut self, dst: ProtoName) {
-        self.destination = Some(dst);
+        self.destination = dst.encoded_name;
+        self.destination_str = dst.str_name;
     }
 
     pub fn set_identity(&mut self, identity: impl Into<bytes::Bytes>) {
@@ -881,19 +891,11 @@ impl ProtoMessage {
     }
 
     fn validate_routed_header(slim_header: &SlimHeader) -> Result<(), MessageError> {
-        match &slim_header.source {
-            None => return Err(MessageError::SourceNotFound),
-            Some(src) if src.encoded_name.is_empty() => {
-                return Err(MessageError::SourceEncodedNameNotFound);
-            }
-            _ => {}
+        if slim_header.source.is_empty() {
+            return Err(MessageError::SourceEncodedNameNotFound);
         }
-        match &slim_header.destination {
-            None => return Err(MessageError::DestinationNotFound),
-            Some(dst) if dst.encoded_name.is_empty() => {
-                return Err(MessageError::DestinationEncodedNameNotFound);
-            }
-            _ => {}
+        if slim_header.destination.is_empty() {
+            return Err(MessageError::DestinationEncodedNameNotFound);
         }
         Ok(())
     }
@@ -1049,7 +1051,7 @@ impl ProtoMessage {
         self.get_slim_header().get_source()
     }
 
-    pub fn get_encoded_source(&self) -> EncodedName {
+    pub fn get_encoded_source(&self) -> ([u64; 3], u128) {
         self.get_slim_header().get_encoded_source()
     }
 
@@ -1057,7 +1059,7 @@ impl ProtoMessage {
         self.get_slim_header().get_dst()
     }
 
-    pub fn get_encoded_dst(&self) -> EncodedName {
+    pub fn get_encoded_dst(&self) -> ([u64; 3], u128) {
         self.get_slim_header().get_encoded_dst()
     }
 
@@ -1721,11 +1723,17 @@ impl ProtoMessageBuilder {
     }
 
     pub fn with_slim_header(mut self, header: SlimHeader) -> Self {
-        if let Some(src) = header.source.clone() {
-            self.source = Some(src);
+        if !header.source.is_empty() {
+            self.source = Some(ProtoName {
+                encoded_name: header.source.clone(),
+                str_name: header.source_str.clone(),
+            });
         }
-        if let Some(dst) = header.destination.clone() {
-            self.destination = Some(dst);
+        if !header.destination.is_empty() {
+            self.destination = Some(ProtoName {
+                encoded_name: header.destination.clone(),
+                str_name: header.destination_str.clone(),
+            });
         }
         if !header.identity.is_empty() {
             self.identity = Some(String::from_utf8_lossy(&header.identity).into_owned());
@@ -2293,12 +2301,15 @@ mod message_tests {
 
     #[test]
     fn test_panic_header() {
+        // create an unusual SLIM header with empty source/destination
         let header = SlimHeader {
-            source: None,
-            destination: None,
-            identity: String::new(),
+            source: Default::default(),
+            destination: Default::default(),
+            source_str: Default::default(),
+            destination_str: Default::default(),
+            identity: Default::default(),
             fanout: 0,
-            version: version().to_string(),
+            version: version().to_string().into(),
             recv_from: None,
             forward_to: None,
             incoming_conn: None,
@@ -2308,8 +2319,14 @@ mod message_tests {
             e2e_header_sig: None,
         };
 
-        assert!(std::panic::catch_unwind(|| header.get_source()).is_err());
-        assert!(std::panic::catch_unwind(|| header.get_dst()).is_err());
+        // get_source/get_dst return ProtoName with empty fields (no panic)
+        // get_encoded_source/get_encoded_dst panic when encoded bytes are empty
+        let result = std::panic::catch_unwind(|| header.get_encoded_source());
+        assert!(result.is_err());
+
+        let result = std::panic::catch_unwind(|| header.get_encoded_dst());
+        assert!(result.is_err());
+
         assert!(std::panic::catch_unwind(|| header.get_recv_from()).is_ok());
         assert!(std::panic::catch_unwind(|| header.get_forward_to()).is_ok());
         assert!(std::panic::catch_unwind(|| header.get_incoming_conn()).is_ok());
@@ -2577,11 +2594,9 @@ mod message_tests {
     fn test_validate_subscribe_missing_source_encoded_name() {
         let valid = ProtoName::from_strings(["org", "ns", "agent"]);
         let hdr = SlimHeader {
-            source: Some(ProtoName {
-                name: None,
-                str_name: None,
-            }),
-            destination: Some(valid),
+            source: Default::default(), // empty = not set
+            destination: valid.encoded_name,
+            destination_str: valid.str_name,
             ..Default::default()
         };
         let msg = ProtoMessage::new(
@@ -2601,11 +2616,9 @@ mod message_tests {
     fn test_validate_subscribe_missing_destination_encoded_name() {
         let valid = ProtoName::from_strings(["org", "ns", "agent"]);
         let hdr = SlimHeader {
-            source: Some(valid),
-            destination: Some(ProtoName {
-                name: None,
-                str_name: None,
-            }),
+            source: valid.encoded_name,
+            source_str: valid.str_name,
+            destination: Default::default(), // empty = not set
             ..Default::default()
         };
         let msg = ProtoMessage::new(

--- a/crates/service/src/app.rs
+++ b/crates/service/src/app.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 // Third-party crates
 use display_error_chain::ErrorChainExt;
-use slim_datapath::api::NameId;
+use slim_datapath::api::{RESERVED_IDS, is_reserved_id};
 use slim_datapath::errors::ErrorPayload;
 use slim_session::Direction;
 use tokio::sync::mpsc;
@@ -117,8 +117,8 @@ where
             Ok(token_id) => {
                 // Use XXH3-128 for a native 128-bit hash of the token ID
                 let mut id_hash = twox_hash::XxHash3_128::oneshot(token_id.as_bytes());
-                if NameId::is_reserved_id(id_hash) {
-                    id_hash %= u128::MAX - NameId::RESERVED_IDS;
+                if is_reserved_id(id_hash) {
+                    id_hash %= u128::MAX - RESERVED_IDS;
                 }
 
                 app_name.clone().with_id(id_hash)
@@ -451,7 +451,7 @@ mod tests {
     use crate::SubscriptionAckError;
     use slim_auth::shared_secret::SharedSecret;
     use slim_datapath::api::{
-        CommandPayload, NameId, Participant, ParticipantSettings, ProtoMessage,
+        CommandPayload, DATA_CHANNEL_ID, Participant, ParticipantSettings, ProtoMessage,
         ProtoSessionMessageType, ProtoSessionType,
     };
     use slim_datapath::messages::utils::SlimHeaderFlags;
@@ -1226,7 +1226,7 @@ mod tests {
 
             // For multicast sessions, the destination is the channel name with DATA_CHANNEL_ID
             let dst = session_arc.dst();
-            let expected_dst = channel_name.clone().with_id(NameId::DATA_CHANNEL_ID);
+            let expected_dst = channel_name.clone().with_id(DATA_CHANNEL_ID);
             assert_eq!(dst, &expected_dst);
 
             total_received_sessions += 1;
@@ -1577,7 +1577,7 @@ mod tests {
                     .as_application_payload()
                     .unwrap()
                     .blob
-                    .clone();
+                    .to_vec();
             } else {
                 println!("Ignoring control message");
             }
@@ -1683,8 +1683,9 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob,
-            msg2
+                .blob
+                .as_ref(),
+            msg2.as_ref()
         );
 
         let spy_payload2 = receive_spy_msg(&mut spy_rx).await;

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -1028,7 +1028,7 @@ mod tests {
 
         // make sure message is correct
         assert_eq!(
-            publ.get_payload().as_application_payload().unwrap().blob,
+            publ.get_payload().unwrap().into_application_payload().unwrap().blob,
             message_blob
         );
 

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -1028,7 +1028,11 @@ mod tests {
 
         // make sure message is correct
         assert_eq!(
-            publ.get_payload().unwrap().into_application_payload().unwrap().blob,
+            publ.get_payload()
+                .unwrap()
+                .into_application_payload()
+                .unwrap()
+                .blob,
             message_blob
         );
 

--- a/crates/session/src/common.rs
+++ b/crates/session/src/common.rs
@@ -7,9 +7,7 @@ use std::time::Duration;
 use smallvec::SmallVec;
 use tonic::Status;
 
-use slim_datapath::api::{
-    EncodedName, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
-};
+use slim_datapath::api::{ProtoMessage as Message, ProtoName, ProtoSessionMessageType};
 
 // Local crate
 use crate::SessionError;
@@ -118,7 +116,7 @@ pub enum SessionMessage {
     TimerTimeout {
         message_id: u32,
         message_type: ProtoSessionMessageType,
-        name: Option<EncodedName>,
+        name: Option<[u64; 3]>,
         timeouts: u32,
     },
     /// timer failure, signal to the owner of the packet that
@@ -126,7 +124,7 @@ pub enum SessionMessage {
     TimerFailure {
         message_id: u32,
         message_type: ProtoSessionMessageType,
-        name: Option<EncodedName>,
+        name: Option<[u64; 3]>,
         timeouts: u32,
     },
     /// sent by the controller sender when a disconnection is detected

--- a/crates/session/src/controller_sender.rs
+++ b/crates/session/src/controller_sender.rs
@@ -693,8 +693,8 @@ mod tests {
     use super::*;
     use crate::common::{OutboundMessage, SessionOutput};
     use slim_datapath::api::{
-        CommandPayload, DATA_CHANNEL_ID, Participant, ParticipantSettings,
-        ProtoSessionMessageType, ProtoSessionType,
+        CommandPayload, DATA_CHANNEL_ID, Participant, ParticipantSettings, ProtoSessionMessageType,
+        ProtoSessionType,
     };
     use std::time::Duration;
     use tokio::time::timeout;

--- a/crates/session/src/controller_sender.rs
+++ b/crates/session/src/controller_sender.rs
@@ -8,8 +8,8 @@ use std::{
 
 use display_error_chain::ErrorChainExt;
 use slim_datapath::api::{
-    CommandPayload, NameId, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
-    ProtoSessionType,
+    CONTROL_CHANNEL_ID, CommandPayload, ProtoMessage as Message, ProtoName,
+    ProtoSessionMessageType, ProtoSessionType,
 };
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
@@ -218,7 +218,7 @@ impl ControllerSender {
                         .as_ref()
                         .ok_or(SessionError::MissingGroupNameInJoinRequest)?
                         .clone();
-                    group_name.set_id(NameId::CONTROL_CHANNEL_ID);
+                    group_name.set_id(CONTROL_CHANNEL_ID);
                     debug!(
                         destination = %group_name,
                         "update group name on join request message for multicast session",
@@ -693,7 +693,8 @@ mod tests {
     use super::*;
     use crate::common::{OutboundMessage, SessionOutput};
     use slim_datapath::api::{
-        CommandPayload, Participant, ParticipantSettings, ProtoSessionMessageType, ProtoSessionType,
+        CommandPayload, DATA_CHANNEL_ID, Participant, ParticipantSettings,
+        ProtoSessionMessageType, ProtoSessionType,
     };
     use std::time::Duration;
     use tokio::time::timeout;
@@ -1704,9 +1705,9 @@ mod tests {
 
         let source = ProtoName::from_strings(["org", "ns", "source"]);
         let data_channel_name =
-            ProtoName::from_strings(["org", "ns", "channel"]).with_id(NameId::DATA_CHANNEL_ID);
+            ProtoName::from_strings(["org", "ns", "channel"]).with_id(DATA_CHANNEL_ID);
         let control_channel_name =
-            ProtoName::from_strings(["org", "ns", "channel"]).with_id(NameId::CONTROL_CHANNEL_ID);
+            ProtoName::from_strings(["org", "ns", "channel"]).with_id(CONTROL_CHANNEL_ID);
         let participant = ProtoName::from_strings(["org", "ns", "participant"]);
         let session_id = 1;
 

--- a/crates/session/src/mls_state.rs
+++ b/crates/session/src/mls_state.rs
@@ -631,7 +631,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob.as_ref(),
+                .blob
+                .as_ref(),
             original_payload.as_ref()
         );
 
@@ -644,7 +645,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob.as_ref(),
+                .blob
+                .as_ref(),
             original_payload.as_ref()
         );
     }
@@ -699,7 +701,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob.as_ref(),
+                .blob
+                .as_ref(),
             original_payload.as_ref()
         );
     }
@@ -770,7 +773,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob.as_ref(),
+                .blob
+                .as_ref(),
             original_payload.as_ref()
         );
     }
@@ -979,7 +983,8 @@ mod tests {
                     .unwrap()
                     .as_application_payload()
                     .unwrap()
-                    .blob.as_ref(),
+                    .blob
+                    .as_ref(),
                 original_payload.as_ref()
             );
         }

--- a/crates/session/src/mls_state.rs
+++ b/crates/session/src/mls_state.rs
@@ -631,8 +631,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob,
-            original_payload
+                .blob.as_ref(),
+            original_payload.as_ref()
         );
 
         let mut bob_msg = alice_msg.clone();
@@ -644,8 +644,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob,
-            original_payload
+                .blob.as_ref(),
+            original_payload.as_ref()
         );
     }
 
@@ -699,8 +699,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob,
-            original_payload
+                .blob.as_ref(),
+            original_payload.as_ref()
         );
     }
 
@@ -770,8 +770,8 @@ mod tests {
                 .unwrap()
                 .as_application_payload()
                 .unwrap()
-                .blob,
-            original_payload
+                .blob.as_ref(),
+            original_payload.as_ref()
         );
     }
 
@@ -979,8 +979,8 @@ mod tests {
                     .unwrap()
                     .as_application_payload()
                     .unwrap()
-                    .blob,
-                original_payload
+                    .blob.as_ref(),
+                original_payload.as_ref()
             );
         }
     }

--- a/crates/session/src/mls_state.rs
+++ b/crates/session/src/mls_state.rs
@@ -365,7 +365,7 @@ where
             return Ok(());
         }
 
-        let payload = msg.get_payload().unwrap().as_application_payload()?;
+        let payload = msg.get_payload().unwrap().into_application_payload()?;
 
         debug!("Encrypting message for group member");
         let aad = build_aad(msg);
@@ -391,7 +391,7 @@ where
             return Ok(());
         }
 
-        let payload = msg.get_payload().unwrap().as_application_payload()?;
+        let payload = msg.get_payload().unwrap().into_application_payload()?;
 
         debug!("Decrypting message for group member");
         let (decrypted_payload, auth_data) = self.mls.decrypt_message(&payload.blob).await?;

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use slim_datapath::api::{
-    EncodedName, Participant, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
+    Participant, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
 };
 
 use tokio::sync::mpsc::{self};
@@ -218,7 +218,7 @@ impl Session {
         &mut self,
         id: u32,
         message_type: ProtoSessionMessageType,
-        name: Option<EncodedName>,
+        name: Option<[u64; 3]>,
     ) -> Result<SessionOutput, SessionError> {
         match message_type {
             ProtoSessionMessageType::Msg => match self.sender.as_mut() {
@@ -243,7 +243,7 @@ impl Session {
         &mut self,
         id: u32,
         message_type: ProtoSessionMessageType,
-        name: Option<EncodedName>,
+        name: Option<[u64; 3]>,
     ) -> Result<SessionOutput, SessionError> {
         match message_type {
             ProtoSessionMessageType::Msg => match self.sender.as_mut() {

--- a/crates/session/src/session_builder.rs
+++ b/crates/session/src/session_builder.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 
 use slim_auth::traits::{TokenProvider, Verifier};
-use slim_datapath::api::{NameId, ProtoName};
+use slim_datapath::api::{CONTROL_CHANNEL_ID, DATA_CHANNEL_ID, ProtoName};
 
 use crate::{
     Direction, SlimChannelSender,
@@ -285,8 +285,8 @@ where
             }
             slim_datapath::api::ProtoSessionType::Multicast => {
                 // For Multicast, force the destination to use DATA_CHANNEL_ID and control to use CONTROL_CHANNEL_ID
-                let data_destination = destination.clone().with_id(NameId::DATA_CHANNEL_ID);
-                let control_destination = destination.clone().with_id(NameId::CONTROL_CHANNEL_ID);
+                let data_destination = destination.clone().with_id(DATA_CHANNEL_ID);
+                let control_destination = destination.clone().with_id(CONTROL_CHANNEL_ID);
                 (data_destination, control_destination)
             }
             _ => {
@@ -1224,7 +1224,7 @@ mod tests {
         config.session_type = ProtoSessionType::Multicast;
 
         let dest = create_test_name("group");
-        let data_channel = dest.with_id(NameId::DATA_CHANNEL_ID);
+        let data_channel = dest.with_id(DATA_CHANNEL_ID);
         let builder =
             SessionBuilder::<MockTokenProvider, MockVerifier, ForController, NotReady>::for_controller()
                 .with_id(3)
@@ -1460,11 +1460,11 @@ mod tests {
         // Verify the builder forced the correct IDs
         assert_eq!(
             ready_builder.destination.unwrap().id(),
-            NameId::DATA_CHANNEL_ID
+            DATA_CHANNEL_ID
         );
         assert_eq!(
             ready_builder.control.unwrap().id(),
-            NameId::CONTROL_CHANNEL_ID
+            CONTROL_CHANNEL_ID
         );
     }
 

--- a/crates/session/src/session_builder.rs
+++ b/crates/session/src/session_builder.rs
@@ -1458,14 +1458,8 @@ mod tests {
         .unwrap();
 
         // Verify the builder forced the correct IDs
-        assert_eq!(
-            ready_builder.destination.unwrap().id(),
-            DATA_CHANNEL_ID
-        );
-        assert_eq!(
-            ready_builder.control.unwrap().id(),
-            CONTROL_CHANNEL_ID
-        );
+        assert_eq!(ready_builder.destination.unwrap().id(), DATA_CHANNEL_ID);
+        assert_eq!(ready_builder.control.unwrap().id(), CONTROL_CHANNEL_ID);
     }
 
     #[test]

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -43,8 +43,8 @@ where
     V: Verifier + Send + Sync,
 {
     let identity = msg.get_slim_header().get_identity();
-    if verifier.try_verify(&identity).is_err() {
-        verifier.verify(&identity).await?;
+    if verifier.try_verify(identity).is_err() {
+        verifier.verify(identity).await?;
     }
 
     if e2e_integrity_required && msg.get_session_message_type().is_command_message() {

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
     api::{
-        CommandPayload, Content, NameId, ProtoMessage as Message, ProtoName,
+        CommandPayload, Content, NULL_COMPONENT, ProtoMessage as Message, ProtoName,
         ProtoSessionMessageType, ProtoSessionType, SlimHeader,
     },
     messages::utils::SlimHeaderFlags,
@@ -725,7 +725,7 @@ impl SessionController {
                 }
                 let msg = Message::builder()
                     .source(self.source().clone())
-                    .destination(destination.clone().with_id(NameId::NULL_COMPONENT))
+                    .destination(destination.clone().with_id(NULL_COMPONENT))
                     .identity("")
                     .session_type(ProtoSessionType::Multicast)
                     .session_message_type(ProtoSessionMessageType::LeaveRequest)
@@ -1043,6 +1043,7 @@ mod tests {
     use crate::session_config::MlsSettings;
     use crate::subscription_manager::{SpySubscriptionManager, SubscriptionCall};
     use slim_auth::shared_secret::SharedSecret;
+    use slim_datapath::api::DATA_CHANNEL_ID;
 
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
@@ -1195,7 +1196,7 @@ mod tests {
         // For multicast sessions, destination uses DATA_CHANNEL_ID
         assert_eq!(
             controller.dst(),
-            &ProtoName::from_strings(["org", "ns", "dest"]).with_id(NameId::DATA_CHANNEL_ID)
+            &ProtoName::from_strings(["org", "ns", "dest"]).with_id(DATA_CHANNEL_ID)
         );
         assert_eq!(controller.session_type(), ProtoSessionType::Multicast);
         assert!(controller.is_initiator());

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -752,13 +752,13 @@ pub fn handle_channel_discovery_message(
     session_id: u32,
     session_type: ProtoSessionType,
 ) -> Result<Message, SessionError> {
-    let destination = message.get_slim_header().source.clone().unwrap();
+    let destination = message.get_slim_header().get_source();
 
     // the destination of the discovery message may be different from the name of
     // application itself. This can happen if the application subscribes to multiple
     // service names. So we can reply using as a source the destination name of
     // the discovery message but setting the application id
-    let mut source = message.get_slim_header().destination.clone().unwrap();
+    let mut source = message.get_slim_header().get_dst();
     source.set_id(app_name.id());
     let msg_id = message.get_id();
 

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -136,7 +136,7 @@ where
     };
     let aad = crate::mls_state::build_aad(msg);
     let signature = slim_auth::utils::sign_header_aad(&aad, &private_key, &public_key)?;
-    msg.get_slim_header_mut().e2e_header_sig = Some(signature);
+    msg.get_slim_header_mut().e2e_header_sig = Some(signature.into());
     Ok(())
 }
 

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -600,9 +600,10 @@ where
 
         let new_session = match session_type {
             ProtoSessionType::PointToPoint => {
+                let cp = message.extract_command_payload()?;
                 let conf = crate::SessionConfig::from_join_request(
                     ProtoSessionType::PointToPoint,
-                    message.extract_command_payload()?,
+                    &cp,
                     message.get_metadata_map(),
                     false,
                 )?;
@@ -619,9 +620,10 @@ where
                     .channel
                     .clone()
                     .ok_or(SessionError::MissingChannelName)?;
+                let cp = message.extract_command_payload()?;
                 let conf = crate::SessionConfig::from_join_request(
                     ProtoSessionType::Multicast,
-                    message.extract_command_payload()?,
+                    &cp,
                     message.get_metadata_map(),
                     false,
                 )?;

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -16,8 +16,8 @@ use tracing::{Instrument, debug, error, warn};
 
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::api::{
-    EncodedName, NameId, ParticipantSettings, ProtoMessage as Message, ProtoName,
-    ProtoSessionMessageType, ProtoSessionType,
+    ParticipantSettings, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
+    ProtoSessionType,
 };
 
 use crate::common::SessionMessage;
@@ -87,8 +87,8 @@ where
     /// Default name of the local app
     app_id: u128,
 
-    /// Names registered by local app, keyed by encoded name (null id) → subscription_id
-    app_names: SyncRwLock<HashMap<EncodedName, u64>>,
+    /// Names registered by local app, keyed by hash components (null id) → subscription_id
+    app_names: SyncRwLock<HashMap<[u64; 3], u64>>,
 
     /// Identity provider for the local app
     identity_provider: P,
@@ -192,15 +192,9 @@ where
         self.app_id
     }
 
-    /// Build the HashMap key (EncodedName with null component_3) from a ProtoName.
-    fn name_to_key(name: &ProtoName) -> EncodedName {
-        let enc = name.name.as_ref().unwrap();
-        EncodedName {
-            component_0: enc.component_0,
-            component_1: enc.component_1,
-            component_2: enc.component_2,
-            name_id: Some(NameId::from(NameId::NULL_COMPONENT)),
-        }
+    /// Build the HashMap key ([u64; 3] hash components, ignoring id) from a ProtoName.
+    fn name_to_key(name: &ProtoName) -> [u64; 3] {
+        name.components()
     }
 
     pub fn add_app_name(&self, name: ProtoName, subscription_id: u64) {
@@ -678,7 +672,7 @@ mod tests {
     use crate::test_utils::{MockTokenProvider, MockVerifier};
     use slim_auth::shared_secret::SharedSecret;
     use slim_datapath::Status;
-    use slim_datapath::api::{NameId, ProtoName, ProtoSessionType};
+    use slim_datapath::api::{NULL_COMPONENT, ProtoName, ProtoSessionType};
     use tokio::sync::mpsc;
 
     // --- Test Mocks -----------------------------------------------------------------------
@@ -1128,7 +1122,7 @@ mod tests {
         session_layer.remove_app_name(&name);
 
         // The name with NULL_COMPONENT should be removed
-        let name_null = name.with_id(NameId::NULL_COMPONENT);
+        let name_null = name.with_id(NULL_COMPONENT);
         assert!(
             !session_layer
                 .app_names

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -470,7 +470,6 @@ where
 
     /// Handle a message from the message processor, and pass it to the
     /// corresponding session
-    #[tracing::instrument(skip_all, fields(service_id = %self.service_id))]
     pub async fn handle_message_from_slim(
         self: &Arc<Self>,
         message: Message,

--- a/crates/session/src/session_moderator.rs
+++ b/crates/session/src/session_moderator.rs
@@ -11,8 +11,8 @@ use display_error_chain::ErrorChainExt;
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
     api::{
-        CommandPayload, MlsPayload, NameId, Participant, ProtoMessage as Message, ProtoMlsSettings,
-        ProtoName, ProtoSessionMessageType, ProtoSessionType,
+        CommandPayload, MlsPayload, NULL_COMPONENT, Participant, ProtoMessage as Message,
+        ProtoMlsSettings, ProtoName, ProtoSessionMessageType, ProtoSessionType,
     },
     messages::utils::{DELETE_GROUP, DISCONNECTION_DETECTED, LEAVING_SESSION, TRUE_VAL},
 };
@@ -302,7 +302,7 @@ where
                     .name
                     .as_ref()
                     .map(|n| n.id())
-                    .unwrap_or(NameId::NULL_COMPONENT); // the name should always be present
+                    .unwrap_or(NULL_COMPONENT); // the name should always be present
                 name.clone().with_id(id)
             })
             .collect()
@@ -1271,7 +1271,9 @@ mod tests {
     use crate::session_settings::{DEFAULT_MAX_SEEN_CONTROL_MESSAGE_IDS_SIZE, SessionSettings};
     use crate::test_utils::{MockInnerHandler, MockTokenProvider, MockVerifier};
     use slim_datapath::Status;
-    use slim_datapath::api::{CommandPayload, ParticipantSettings, ProtoSessionType};
+    use slim_datapath::api::{
+        CONTROL_CHANNEL_ID, CommandPayload, DATA_CHANNEL_ID, ParticipantSettings, ProtoSessionType,
+    };
     use tokio::sync::mpsc;
 
     // --- Test Helpers -----------------------------------------------------------------------
@@ -1310,8 +1312,8 @@ mod tests {
         mpsc::Receiver<Result<SessionMessage, SessionError>>,
     ) {
         let source = make_name(&["local", "moderator", "v1"]).with_id(100);
-        let destination = make_name(&["channel", "name", "v1"]).with_id(NameId::DATA_CHANNEL_ID);
-        let control = make_name(&["channel", "name", "v1"]).with_id(NameId::CONTROL_CHANNEL_ID);
+        let destination = make_name(&["channel", "name", "v1"]).with_id(DATA_CHANNEL_ID);
+        let control = make_name(&["channel", "name", "v1"]).with_id(CONTROL_CHANNEL_ID);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;
@@ -1758,7 +1760,7 @@ mod tests {
         let source = ProtoName::from_strings(["agntcy", "ns", "moderator"]).with_id(100);
         let destination = ProtoName::from_strings(["agntcy", "ns", "chat"]);
         let control =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(NameId::CONTROL_CHANNEL_ID);
+            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(CONTROL_CHANNEL_ID);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;
@@ -1907,9 +1909,9 @@ mod tests {
         // Create moderator with agntcy/ns/moderator naming
         let source = ProtoName::from_strings(["agntcy", "ns", "moderator"]).with_id(100);
         let destination =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(NameId::DATA_CHANNEL_ID);
+            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(DATA_CHANNEL_ID);
         let control =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(NameId::CONTROL_CHANNEL_ID);
+            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(CONTROL_CHANNEL_ID);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;

--- a/crates/session/src/session_moderator.rs
+++ b/crates/session/src/session_moderator.rs
@@ -298,11 +298,7 @@ where
         self.group_list
             .iter()
             .map(|(name, p)| {
-                let id = p
-                    .name
-                    .as_ref()
-                    .map(|n| n.id())
-                    .unwrap_or(NULL_COMPONENT); // the name should always be present
+                let id = p.name.as_ref().map(|n| n.id()).unwrap_or(NULL_COMPONENT); // the name should always be present
                 name.clone().with_id(id)
             })
             .collect()
@@ -1759,8 +1755,7 @@ mod tests {
         // Create moderator with agntcy/ns/moderator naming
         let source = ProtoName::from_strings(["agntcy", "ns", "moderator"]).with_id(100);
         let destination = ProtoName::from_strings(["agntcy", "ns", "chat"]);
-        let control =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(CONTROL_CHANNEL_ID);
+        let control = ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(CONTROL_CHANNEL_ID);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;
@@ -1910,8 +1905,7 @@ mod tests {
         let source = ProtoName::from_strings(["agntcy", "ns", "moderator"]).with_id(100);
         let destination =
             ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(DATA_CHANNEL_ID);
-        let control =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(CONTROL_CHANNEL_ID);
+        let control = ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(CONTROL_CHANNEL_ID);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;

--- a/crates/session/src/session_participant.rs
+++ b/crates/session/src/session_participant.rs
@@ -722,7 +722,9 @@ mod tests {
     use crate::session_settings::SessionSettings;
     use crate::test_utils::{MockInnerHandler, MockTokenProvider, MockVerifier};
     use slim_datapath::Status;
-    use slim_datapath::api::{CommandPayload, NameId, ProtoSessionType};
+    use slim_datapath::api::{
+        CONTROL_CHANNEL_ID, CommandPayload, DATA_CHANNEL_ID, ProtoSessionType,
+    };
     use tokio::sync::mpsc;
 
     // --- Test Helpers -----------------------------------------------------------------------
@@ -770,8 +772,8 @@ mod tests {
         let source = make_name(&["local", "participant", "v1"]);
         let (destination, control) = match session_type {
             ProtoSessionType::Multicast => (
-                make_name(&["channel", "name", "v1"]).with_id(NameId::DATA_CHANNEL_ID),
-                make_name(&["channel", "name", "v1"]).with_id(NameId::CONTROL_CHANNEL_ID),
+                make_name(&["channel", "name", "v1"]).with_id(DATA_CHANNEL_ID),
+                make_name(&["channel", "name", "v1"]).with_id(CONTROL_CHANNEL_ID),
             ),
             ProtoSessionType::PointToPoint => (
                 make_name(&["remote", "participant", "v1"]).with_id(100),

--- a/crates/session/src/session_participant.rs
+++ b/crates/session/src/session_participant.rs
@@ -448,13 +448,13 @@ where
 
         self.join(&msg).await?;
 
-        let list = &msg
+        let list = msg
             .get_payload()
             .unwrap()
-            .as_command_payload()?
-            .as_welcome_payload()?
+            .into_command_payload()?
+            .into_welcome_payload()?
             .participants;
-        for p in list {
+        for p in &list {
             let name = p.get_name()?;
             self.group_list.insert(name.clone(), *p.get_settings()?);
 
@@ -511,8 +511,8 @@ where
             let p = msg
                 .get_payload()
                 .unwrap()
-                .as_command_payload()?
-                .as_group_add_payload()?;
+                .into_command_payload()?
+                .into_group_add_payload()?;
             if let Some(ref new_participant) = p.new_participant {
                 let name = new_participant.get_name()?;
                 self.group_list
@@ -527,8 +527,8 @@ where
             let p = msg
                 .get_payload()
                 .unwrap()
-                .as_command_payload()?
-                .as_group_remove_payload()?;
+                .into_command_payload()?
+                .into_group_remove_payload()?;
             if let Some(ref removed_participant) = p.removed_participant {
                 let name = removed_participant.clone();
                 self.group_list.remove(&name);

--- a/crates/session/src/session_receiver.rs
+++ b/crates/session/src/session_receiver.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-use slim_datapath::api::{EncodedName, ProtoMessage as Message, ProtoName, ProtoSessionType};
+use slim_datapath::api::{ProtoMessage as Message, ProtoName, ProtoSessionType};
 use slim_datapath::messages::utils::{PUBLISH_TO, TRUE_VAL};
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
@@ -24,7 +24,7 @@ struct PendingRtxVal {
 }
 
 struct PendingRtxKey {
-    name: EncodedName,
+    name: [u64; 3],
     id: u32,
 }
 
@@ -52,9 +52,9 @@ enum ReceiverDrainStatus {
 }
 
 pub struct SessionReceiver {
-    /// buffer with received packets one per endpoint, keyed by EncodedName
+    /// buffer with received packets one per endpoint, keyed by [u64; 3] components
     /// for zero-alloc hot-path lookups
-    buffer: HashMap<EncodedName, ReceiverBuffer>,
+    buffer: HashMap<[u64; 3], ReceiverBuffer>,
 
     /// list of pending RTX requests per name/id
     pending_rtxs: HashMap<PendingRtxKey, PendingRtxVal>,
@@ -157,7 +157,7 @@ impl SessionReceiver {
 
         let source_proto = message.get_slim_header().source.clone().unwrap();
         let in_conn = message.get_incoming_conn();
-        let buffer = self.buffer.entry(source_proto.name.unwrap()).or_default();
+        let buffer = self.buffer.entry(source_proto.components()).or_default();
 
         let (recv_vec, rtx_vec) = buffer.on_received_message(message);
         self.handle_recv_and_rtx_vectors(&source_proto, in_conn, recv_vec, rtx_vec)
@@ -200,7 +200,7 @@ impl SessionReceiver {
     pub fn on_rtx_message(&mut self, message: Message) -> Result<SessionOutput, SessionError> {
         // in case we get the and RTX reply the session must be reliable
         let source_proto = message.get_slim_header().source.as_ref().unwrap();
-        let encoded_source = source_proto.name.unwrap();
+        let encoded_source = source_proto.components();
         let id = message.get_id();
         let in_conn = message.get_incoming_conn();
 
@@ -264,7 +264,7 @@ impl SessionReceiver {
         }
 
         if !rtx_vec.is_empty() {
-            let encoded = source.name.unwrap();
+            let encoded = source.components();
 
             for rtx_id in rtx_vec {
                 debug!(
@@ -317,7 +317,7 @@ impl SessionReceiver {
     pub fn on_timer_timeout(
         &mut self,
         id: u32,
-        name: EncodedName,
+        name: [u64; 3],
     ) -> Result<SessionOutput, SessionError> {
         debug!(%id, "timeout for message");
         let key = PendingRtxKey { name, id };
@@ -337,7 +337,7 @@ impl SessionReceiver {
     pub fn on_timer_failure(
         &mut self,
         id: u32,
-        name: EncodedName,
+        name: [u64; 3],
     ) -> Result<SessionOutput, SessionError> {
         debug!(
             %id,
@@ -364,7 +364,7 @@ impl SessionReceiver {
         // remove the buffer related to an endpoint so that if it is added again
         // the messages will not be dropped as duplicated
         tracing::debug!(%endpoint, "remove endpoint on the receiver");
-        self.buffer.remove(&endpoint.name.unwrap());
+        self.buffer.remove(&endpoint.components());
     }
 
     pub fn start_drain(&mut self) {

--- a/crates/session/src/session_receiver.rs
+++ b/crates/session/src/session_receiver.rs
@@ -155,7 +155,7 @@ impl SessionReceiver {
             return Ok(output);
         }
 
-        let source_proto = message.get_slim_header().source.clone().unwrap();
+        let source_proto = message.get_slim_header().get_source();
         let in_conn = message.get_incoming_conn();
         let buffer = self.buffer.entry(source_proto.components()).or_default();
 
@@ -176,7 +176,7 @@ impl SessionReceiver {
         });
 
         // Pass the source ProtoName directly as ACK destination — avoids ProtoName → Name → ProtoName roundtrip.
-        let source_proto = message.get_slim_header().source.clone().unwrap();
+        let source_proto = message.get_slim_header().get_source();
         let mut builder = Message::builder()
             .source(self.local_name.clone())
             .destination(source_proto)
@@ -199,7 +199,7 @@ impl SessionReceiver {
 
     pub fn on_rtx_message(&mut self, message: Message) -> Result<SessionOutput, SessionError> {
         // in case we get the and RTX reply the session must be reliable
-        let source_proto = message.get_slim_header().source.as_ref().unwrap();
+        let source_proto = message.get_slim_header().get_source();
         let encoded_source = source_proto.components();
         let id = message.get_id();
         let in_conn = message.get_incoming_conn();
@@ -230,7 +230,7 @@ impl SessionReceiver {
                     context: "receiver_buffer_rtx_reply",
                 })?;
         let recv_vec = buffer.on_lost_message(id);
-        self.handle_recv_and_rtx_vectors(source_proto, in_conn, recv_vec, vec![])
+        self.handle_recv_and_rtx_vectors(&source_proto, in_conn, recv_vec, vec![])
     }
 
     fn handle_recv_and_rtx_vectors(

--- a/crates/session/src/session_sender.rs
+++ b/crates/session/src/session_sender.rs
@@ -339,7 +339,7 @@ impl SessionSender {
     }
 
     fn on_rtx_message(&mut self, message: Message) -> Result<SessionOutput, SessionError> {
-        let source_proto = message.get_slim_header().source.clone();
+        let source_proto = message.get_slim_header().get_source();
         let message_id = message.get_id();
         let incoming_conn = message.get_incoming_conn();
 
@@ -352,7 +352,7 @@ impl SessionSender {
         let mut output = SessionOutput::new();
         if let Some(mut msg) = self.buffer.get(message_id as usize) {
             debug!("the message is still exists, send it as rtx reply");
-            msg.get_slim_header_mut().destination = source_proto;
+            msg.get_slim_header_mut().set_destination(source_proto.clone());
             msg.get_slim_header_mut()
                 .set_forward_to(Some(incoming_conn));
             msg.get_session_header_mut()
@@ -361,10 +361,10 @@ impl SessionSender {
             output.push_slim(msg);
         } else {
             debug!("the message does not exists anymore, send and error");
-            let dest_proto = message.get_slim_header().destination.clone().unwrap();
+            let dest_proto = message.get_slim_header().get_dst();
             let msg = Message::builder()
                 .source(dest_proto)
-                .destination(source_proto.unwrap())
+                .destination(source_proto)
                 .identity("")
                 .forward_to(incoming_conn)
                 .session_type(message.get_session_type())

--- a/crates/session/src/session_sender.rs
+++ b/crates/session/src/session_sender.rs
@@ -177,7 +177,11 @@ impl SessionSender {
     ) -> Result<SessionOutput, SessionError> {
         let is_publish_to = message.metadata.contains_key(PUBLISH_TO);
 
-        if is_publish_to && !self.endpoints_list.contains_key(&message.get_encoded_dst().0) {
+        if is_publish_to
+            && !self
+                .endpoints_list
+                .contains_key(&message.get_encoded_dst().0)
+        {
             let dst = message.get_dst();
             debug!(
                 %dst,
@@ -352,7 +356,8 @@ impl SessionSender {
         let mut output = SessionOutput::new();
         if let Some(mut msg) = self.buffer.get(message_id as usize) {
             debug!("the message is still exists, send it as rtx reply");
-            msg.get_slim_header_mut().set_destination(source_proto.clone());
+            msg.get_slim_header_mut()
+                .set_destination(source_proto.clone());
             msg.get_slim_header_mut()
                 .set_forward_to(Some(incoming_conn));
             msg.get_session_header_mut()

--- a/crates/session/src/session_sender.rs
+++ b/crates/session/src/session_sender.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 
 use rand::Rng;
-use slim_datapath::api::{EncodedName, Participant, ProtoSessionType};
+use slim_datapath::api::{Participant, ProtoSessionType};
 use slim_datapath::messages::utils::{MAX_PUBLISH_ID, PUBLISH_TO};
 use slim_datapath::{api::ProtoMessage as Message, api::ProtoName};
 use tokio::sync::mpsc::Sender;
@@ -29,7 +29,7 @@ enum SenderDrainStatus {
 
 struct GroupTimer {
     /// list of encoded names for which we did not get an ack yet
-    missing_timers: HashSet<EncodedName>,
+    missing_timers: HashSet<[u64; 3]>,
 
     /// the timer
     timer: Timer,
@@ -50,12 +50,12 @@ pub struct SessionSender {
     pending_acks: HashMap<u32, (GroupTimer, Option<Message>)>,
 
     /// list of timer ids associated for each endpoint
-    pending_acks_per_endpoint: HashMap<EncodedName, HashSet<u32>>,
+    pending_acks_per_endpoint: HashMap<[u64; 3], HashSet<u32>>,
 
-    /// list of the endpoints in the conversation, keyed by encoded name for
+    /// list of the endpoints in the conversation, keyed by [u64; 3] components for
     /// zero-alloc hot-path lookups; ProtoName value retained for retransmit
     /// set_destination calls (group retransmit must rewrite the destination).
-    endpoints_list: HashMap<EncodedName, ProtoName>,
+    endpoints_list: HashMap<[u64; 3], ProtoName>,
 
     /// message id, used to send sequential messages
     /// it goes from 0 to 2^16. higher ids are used for messages
@@ -177,7 +177,7 @@ impl SessionSender {
     ) -> Result<SessionOutput, SessionError> {
         let is_publish_to = message.metadata.contains_key(PUBLISH_TO);
 
-        if is_publish_to && !self.endpoints_list.contains_key(&message.get_encoded_dst()) {
+        if is_publish_to && !self.endpoints_list.contains_key(&message.get_encoded_dst().0) {
             let dst = message.get_dst();
             debug!(
                 %dst,
@@ -249,8 +249,8 @@ impl SessionSender {
 
         if let Some(timer_factory) = &self.timer_factory {
             debug!("reliable sender, set all timers");
-            let missing_timers: HashSet<EncodedName> = if is_publish_to {
-                HashSet::from([message.get_encoded_dst()])
+            let missing_timers: HashSet<[u64; 3]> = if is_publish_to {
+                HashSet::from([message.get_encoded_dst().0])
             } else {
                 self.endpoints_list.keys().copied().collect()
             };
@@ -264,10 +264,10 @@ impl SessionSender {
                 ),
             };
 
-            let endpoints_to_track: Vec<EncodedName> = if is_publish_to {
+            let endpoints_to_track: Vec<[u64; 3]> = if is_publish_to {
                 self.pending_acks
                     .insert(message_id, (gt, Some(message.clone())));
-                vec![message.get_encoded_dst()]
+                vec![message.get_encoded_dst().0]
             } else {
                 self.pending_acks.insert(message_id, (gt, None));
                 self.endpoints_list.keys().copied().collect()
@@ -292,7 +292,7 @@ impl SessionSender {
     }
 
     fn on_ack_message(&mut self, message: &Message) {
-        let encoded_source = message.get_encoded_source();
+        let encoded_source = message.get_encoded_source().0;
         let message_id = message.get_id();
         debug!(%message_id, source = %message.get_source(), "received ack message");
 
@@ -397,7 +397,7 @@ impl SessionSender {
             debug!("the message is still in the buffer, try to send it again to all the remotes");
             let mut output = SessionOutput::new();
             if let Some((gt, _)) = self.pending_acks.get(&id) {
-                let missing: Vec<EncodedName> = gt.missing_timers.iter().copied().collect();
+                let missing: Vec<[u64; 3]> = gt.missing_timers.iter().copied().collect();
                 for enc in &missing {
                     if let Some(name) = self.endpoints_list.get(enc) {
                         debug!(%id, dst = %name, "resend message");
@@ -474,7 +474,7 @@ impl SessionSender {
             return Ok(SessionOutput::new());
         }
 
-        self.endpoints_list.insert(name.name.unwrap(), name.clone());
+        self.endpoints_list.insert(name.components(), name.clone());
 
         debug!(
             %name,
@@ -502,7 +502,7 @@ impl SessionSender {
             list_len = %self.endpoints_list.len(),
             "remove endpoint",
         );
-        let key = endpoint.name.unwrap();
+        let key = endpoint.components();
         // remove endpoint from the list and remove all the ack state
         // notice that no ack state may be associated to the endpoint
         // (e.g. endpoint added but no message sent)

--- a/crates/session/src/timer_factory.rs
+++ b/crates/session/src/timer_factory.rs
@@ -4,7 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use slim_datapath::api::{EncodedName, ProtoSessionMessageType};
+use slim_datapath::api::ProtoSessionMessageType;
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
 
@@ -16,7 +16,7 @@ use crate::{
 struct ReliableTimerObserver {
     tx: Sender<SessionMessage>,
     message_type: ProtoSessionMessageType,
-    name: Option<EncodedName>,
+    name: Option<[u64; 3]>,
 }
 
 #[async_trait]
@@ -139,7 +139,7 @@ impl TimerFactory {
         &self,
         id: u32,
         message_type: ProtoSessionMessageType,
-        name: Option<EncodedName>,
+        name: Option<[u64; 3]>,
     ) -> Timer {
         let t = Timer::new(
             id,
@@ -156,7 +156,7 @@ impl TimerFactory {
         &self,
         timer: &Timer,
         message_type: ProtoSessionMessageType,
-        name: Option<EncodedName>,
+        name: Option<[u64; 3]>,
     ) {
         // start timer
         let observer = ReliableTimerObserver {
@@ -177,12 +177,9 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::time::timeout;
 
-    // Helper function to create a test EncodedName
-    fn test_encoded_name() -> EncodedName {
-        ProtoName::from_strings(["test", "org", "app"])
-            .with_id(1)
-            .name
-            .unwrap()
+    // Helper function to create a test [u64; 3] components
+    fn test_encoded_name() -> [u64; 3] {
+        ProtoName::from_strings(["test", "org", "app"]).components()
     }
 
     #[tokio::test]
@@ -469,14 +466,8 @@ mod tests {
             TimerType::Constant,
         );
         let factory = TimerFactory::new(settings, tx);
-        let name1 = ProtoName::from_strings(["test", "org", "app1"])
-            .with_id(1)
-            .name
-            .unwrap();
-        let name2 = ProtoName::from_strings(["test", "org", "app2"])
-            .with_id(2)
-            .name
-            .unwrap();
+        let name1 = ProtoName::from_strings(["test", "org", "app1"]).components();
+        let name2 = ProtoName::from_strings(["test", "org", "app2"]).components();
 
         // Act - create and start multiple timers
         let timer1 = factory.create_and_start_timer(

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -653,7 +653,7 @@ fn extract_payload(msg: &slim_datapath::api::ProtoMessage) -> Vec<u8> {
             .msg
             .as_ref()
             .and_then(|content| content.as_application_payload().ok())
-            .map(|payload| payload.blob.clone())
+            .map(|payload| payload.blob.to_vec())
             .unwrap_or_default(),
         _ => Vec::new(),
     }

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -650,9 +650,8 @@ async fn create_app_with_secret(
 fn extract_payload(msg: &slim_datapath::api::ProtoMessage) -> Vec<u8> {
     match msg.message_type.as_ref() {
         Some(ProtoPublishType(publish)) => publish
-            .msg
-            .as_ref()
-            .and_then(|content| content.as_application_payload().ok())
+            .get_payload()
+            .and_then(|content| content.into_application_payload().ok())
             .map(|payload| payload.blob.to_vec())
             .unwrap_or_default(),
         _ => Vec::new(),

--- a/crates/slimctl/src/utils.rs
+++ b/crates/slimctl/src/utils.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Result, bail};
 
-use slim_datapath::api::NameId;
+use slim_datapath::api::{NULL_COMPONENT, id_from_str};
 
 use crate::proto::controller::proto::v1::Connection;
 
@@ -13,7 +13,7 @@ pub const VIA_KEYWORD: &str = "via";
 /// Parse a route string `"org/namespace/agentname[/agentid]"` into its components.
 ///
 /// The fourth component (`agentid`) is optional; when omitted it defaults to
-/// [`NameId::NULL_COMPONENT`], matching the behaviour of the data-plane
+/// [`NULL_COMPONENT`], matching the behaviour of the data-plane
 /// when no specific instance is targeted.
 ///
 /// Returns `(organization, namespace, agent_type, agent_id)`.
@@ -38,13 +38,12 @@ pub fn parse_route(route: &str) -> Result<(String, String, String, u128)> {
                 route
             );
         }
-        NameId::try_from(id_str.to_string())
+        id_from_str(id_str)
             .map_err(|_| {
                 anyhow::anyhow!("invalid agent instance ID (must be a UUID): '{}'", id_str)
             })?
-            .into()
     } else {
-        NameId::NULL_COMPONENT
+        NULL_COMPONENT
     };
     Ok((
         parts[0].to_string(),
@@ -209,7 +208,7 @@ mod tests {
         assert_eq!(org, "myorg");
         assert_eq!(ns, "mynamespace");
         assert_eq!(agent, "myagent");
-        assert_eq!(id, NameId::NULL_COMPONENT);
+        assert_eq!(id, NULL_COMPONENT);
     }
 
     #[test]

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -39,7 +39,6 @@ path = "src/bin/receiver_app.rs"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 agntcy-slim = { workspace = true }
 agntcy-slim-auth = { workspace = true }
-bytes = { workspace = true }
 agntcy-slim-config = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-service = { workspace = true, features = ["session"] }
@@ -49,6 +48,7 @@ anyhow = { workspace = true }
 aws-lc-rs = { workspace = true }
 base64 = { workspace = true }
 bollard = { version = "0.17" }
+bytes = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -39,6 +39,7 @@ path = "src/bin/receiver_app.rs"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 agntcy-slim = { workspace = true }
 agntcy-slim-auth = { workspace = true }
+bytes = { workspace = true }
 agntcy-slim-config = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-service = { workspace = true, features = ["session"] }

--- a/crates/testing/src/bin/channel.rs
+++ b/crates/testing/src/bin/channel.rs
@@ -263,7 +263,7 @@ async fn main() {
                                 msg.message_type.as_ref()
                             {
                                 let p =
-                                    &publish.get_payload().as_application_payload().unwrap().blob;
+                                    publish.get_payload().unwrap().into_application_payload().unwrap().blob;
                                 if let Ok(payload) = String::from_utf8(p.to_vec()) {
                                     info!(%payload, "received message");
                                 }
@@ -332,7 +332,7 @@ async fn main() {
                                             let payload = if let Some(slim_datapath::api::ProtoPublishType(publish)) =
                                                 msg.message_type.as_ref()
                                             {
-                                                let blob = &publish.get_payload().as_application_payload().unwrap().blob;
+                                                let blob = publish.get_payload().unwrap().into_application_payload().unwrap().blob;
                                                 match String::from_utf8(blob.to_vec()) {
                                                     Ok(p) => p,
                                                     Err(e) => {

--- a/crates/testing/src/bin/channel.rs
+++ b/crates/testing/src/bin/channel.rs
@@ -262,8 +262,12 @@ async fn main() {
                             if let Some(slim_datapath::api::ProtoPublishType(publish)) =
                                 msg.message_type.as_ref()
                             {
-                                let p =
-                                    publish.get_payload().unwrap().into_application_payload().unwrap().blob;
+                                let p = publish
+                                    .get_payload()
+                                    .unwrap()
+                                    .into_application_payload()
+                                    .unwrap()
+                                    .blob;
                                 if let Ok(payload) = String::from_utf8(p.to_vec()) {
                                     info!(%payload, "received message");
                                 }

--- a/crates/testing/src/bin/receiver_app.rs
+++ b/crates/testing/src/bin/receiver_app.rs
@@ -161,12 +161,11 @@ async fn run_receiver(args: Args) -> Result<()> {
                     Ok(Some(Ok(msg))) => {
                         let payload = match msg.message_type.as_ref() {
                             Some(ProtoPublishType(publish)) => publish
-                                .msg
-                                .as_ref()
-                                .and_then(|content| content.as_application_payload().ok())
+                                .get_payload()
+                                .and_then(|content| content.into_application_payload().ok())
                                 .map(|p| p.blob.clone())
                                 .unwrap_or_default(),
-                            _ => Vec::new(),
+                            _ => bytes::Bytes::new(),
                         };
                         let source = msg.get_source();
                         let input_conn = msg.get_incoming_conn();

--- a/crates/testing/src/bin/sender_app.rs
+++ b/crates/testing/src/bin/sender_app.rs
@@ -269,12 +269,11 @@ async fn run_sender(args: Args) -> Result<()> {
                 Ok(Some(Ok(msg))) => {
                     let payload = match msg.message_type.as_ref() {
                         Some(ProtoPublishType(publish)) => publish
-                            .msg
-                            .as_ref()
-                            .and_then(|content| content.as_application_payload().ok())
+                            .get_payload()
+                            .and_then(|content| content.into_application_payload().ok())
                             .map(|p| p.blob.clone())
                             .unwrap_or_default(),
-                        _ => Vec::new(),
+                        _ => bytes::Bytes::new(),
                     };
                     let source = msg.get_source();
                     let payload_str = String::from_utf8_lossy(&payload);

--- a/crates/testing/src/bin/test_group.rs
+++ b/crates/testing/src/bin/test_group.rs
@@ -69,7 +69,7 @@ async fn run_participant_task(name: Name, port: u16) -> Result<(), ServiceError>
                                                     if let Some(slim_datapath::api::ProtoPublishType(publish)) = msg.message_type.as_ref() {
                                                         let publisher = msg.get_slim_header().get_source();
                                                         let msg_id = msg.get_id();
-                                                        let blob = &publish.get_payload().as_application_payload().unwrap().blob;
+                                                        let blob = publish.get_payload().unwrap().into_application_payload().unwrap().blob;
                                                         if let Ok(val) = String::from_utf8(blob.to_vec()) {
                                                             if publisher.str_components() == session_moderator_clone.str_components() {
                                                                 if val != *"hello there" { continue; }
@@ -235,7 +235,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             msg.message_type.as_ref()
                         {
                             let blob =
-                                &publish.get_payload().as_application_payload().unwrap().blob;
+                                publish.get_payload().unwrap().into_application_payload().unwrap().blob;
                             let _ = String::from_utf8(blob.to_vec())
                                 .expect("error while parsing received message");
                             if blob.len() >= 4 {

--- a/crates/testing/src/bin/test_group.rs
+++ b/crates/testing/src/bin/test_group.rs
@@ -234,8 +234,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         if let Some(slim_datapath::api::ProtoPublishType(publish)) =
                             msg.message_type.as_ref()
                         {
-                            let blob =
-                                publish.get_payload().unwrap().into_application_payload().unwrap().blob;
+                            let blob = publish
+                                .get_payload()
+                                .unwrap()
+                                .into_application_payload()
+                                .unwrap()
+                                .blob;
                             let _ = String::from_utf8(blob.to_vec())
                                 .expect("error while parsing received message");
                             if blob.len() >= 4 {

--- a/crates/testing/src/bin/test_p2p.rs
+++ b/crates/testing/src/bin/test_p2p.rs
@@ -364,8 +364,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 msg.message_type.as_ref()
                             {
                                 let sender = msg.get_source();
-                                let p =
-                                    publish.get_payload().unwrap().into_application_payload().unwrap().blob;
+                                let p = publish
+                                    .get_payload()
+                                    .unwrap()
+                                    .into_application_payload()
+                                    .unwrap()
+                                    .blob;
                                 let val = String::from_utf8(p.to_vec())
                                     .expect("error while parsing received message");
                                 if val != *"hello there" {

--- a/crates/testing/src/bin/test_p2p.rs
+++ b/crates/testing/src/bin/test_p2p.rs
@@ -116,7 +116,7 @@ async fn run_client_task(name: Name, moderator_name: Name, port: u16) -> Result<
                                                 if let Some(slim_datapath::api::ProtoPublishType(publish)) = msg.message_type.as_ref() {
                                                     let publisher = msg.get_slim_header().get_source();
                                                     let conn = msg.get_slim_header().recv_from.unwrap_or(conn_id);
-                                                    let blob = &publish.get_payload().as_application_payload().unwrap().blob;
+                                                    let blob = publish.get_payload().unwrap().into_application_payload().unwrap().blob;
                                                     match String::from_utf8(blob.to_vec()) {
                                                         Ok(val) => {
                                                             if val != *"hello there" { continue; }
@@ -365,7 +365,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             {
                                 let sender = msg.get_source();
                                 let p =
-                                    &publish.get_payload().as_application_payload().unwrap().blob;
+                                    publish.get_payload().unwrap().into_application_payload().unwrap().blob;
                                 let val = String::from_utf8(p.to_vec())
                                     .expect("error while parsing received message");
                                 if val != *"hello there" {


### PR DESCRIPTION
# Description

Performance improvements to the data-plane datapath focused on reducing allocation and decoding overhead on the hot forwarding path. Builds on top of the `feat/slimctl-bench-improvements` branch.

## Changes

### Data-plane throughput (profiling-driven)
- General throughput improvements based on profiling results
- Reverted server-side `OpenChannel` buffer from 1024 back to 128 (regression fix)

### Zero-copy proto field layout
- **`Name` proto**: replaced nested `EncodedName`/`NameId`/`StringName` message fields with flat `bytes encoded_name` (40 bytes: 3×u64 LE + u128 LE id) and `bytes str_name` (packed string components). Eliminates nested proto struct allocation on every name access.
- **`SLIMHeader` source/destination**: replaced `Name source = 1` / `Name destination = 2` message fields with flat `bytes source = 1` / `bytes destination = 2` (40-byte encoded name directly). The `str_name` parts move to new fields `source_str = 12` / `destination_str = 13`. Eliminates `Option<Name>` unwrap and nested struct indirection on every routing decision.
- **`Publish.msg`**: changed from `Content msg = 3` (message) to `bytes msg = 3`. Data-plane-only forwarding nodes now pass the application payload through without decoding it. Session-layer nodes decode on demand via `get_payload() -> Content`.

### Dead code removal
- Removed `ProtoPublish::is_command`, `get_application_payload`, `get_command_payload` (zero callers post-refactor)
- Removed duplicate `set_error_flag` (identical to `set_error`)
- Removed `ProtoName::name_id` (no callers)

> **Note:** The proto layout changes are wire-breaking. All SLIM nodes must be updated together.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass