### PR TITLE
chore: upgrade Rust toolchain from 1.93 to 1.95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build container
-FROM --platform=${BUILDPLATFORM} rust:1.93-slim-bookworm AS rust
+FROM --platform=${BUILDPLATFORM} rust:1.95-slim-bookworm AS rust
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.95.0"
 components = ["rustc", "clippy", "rustfmt", "rust-std", "cargo"]


### PR DESCRIPTION
# Description

The latest version of cargo-binstall (v1.20.1) depends on vergen@10.0.0, vergen-gitcl@10.0.0, and vergen-lib@10.0.0, which require a minimum of rustc 1.95.0. This broke the ci-build-and-test workflow since our toolchain was pinned to 1.93.0.

 - Updated rust-toolchain.toml from 1.93.0 to 1.95.0
 - Updated Dockerfile base image from rust:1.93-slim-bookworm to rust:1.95-slim-bookworm

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
