### PR TITLE
fix: disable all-features by default for builds

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -61,7 +61,7 @@ tasks:
     cmds:
       - cargo build {{.RELEASE}} {{.TARGET_ARGS}} {{.ARGS}}
     vars:
-      ARGS: '{{.ARGS | default "--all-targets --locked --all-features"}}'
+      ARGS: '{{.ARGS | default "--all-targets --locked"}}'
 
   build:strip:
     desc: "Build the project and strip the debug symbols"


### PR DESCRIPTION
# Description

Remove `--all-features` from the default `build` task args in `Taskfile.yaml`. This keeps the setting opt-in for testing etc., preventing features like `otel_tracing` from being enabled automatically during standard builds where they are not needed and impact performance.

Reapplies the change from #1731 which was lost during the repo restructure.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass