### PR TITLE
chore: fixing link checker

### DIFF
--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -1,6 +1,10 @@
 # https://github.com/lycheeverse/lychee
 max_concurrency = 10
 timeout = 10
+# MkDocs/Material pretty URLs in raw HTML omit .md; resolve against source files.
+fallback_extensions = ["md"]
+# Validate in-page anchors (e.g. slim/slim-howto/#slim-node).
+include_fragments = true
 # Include transient gateway / origin errors so flaky GitHub (502) does not fail the docs job.
 accept = [200, 201, 204, 403, 429, 502, 503, 504]
 


### PR DESCRIPTION
# Description

The PR updates the link checker: lychee and mkdocs were treating file paths differently, causing the link checker to fail on good links.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
