### PR TITLE
fix: remove csit integration test triggering for release

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -63,19 +63,19 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  test-integration:
-    name: Run integration tests
-    permissions:
-      contents: read
-    needs: [ release ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Trigger CSIT integration CI
-        uses: ./.github/actions/trigger-integrations
-        with:
-          github-token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
+  # test-integration:
+  #   name: Run integration tests
+  #   permissions:
+  #     contents: read
+  #   needs: [ release ]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         persist-credentials: false
+  #         fetch-depth: 0
+  #     - name: Trigger CSIT integration CI
+  #       uses: ./.github/actions/trigger-integrations
+  #       with:
+  #         github-token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -90,19 +90,19 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  test-integration:
-    name: Run integration tests
-    needs: [ build-push ]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Trigger CSIT integration CI
-        uses: ./.github/actions/trigger-integrations
-        with:
-          github-token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
+  # test-integration:
+  #   name: Run integration tests
+  #   needs: [ build-push ]
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         persist-credentials: false
+  #         fetch-depth: 0
+  #     - name: Trigger CSIT integration CI
+  #       uses: ./.github/actions/trigger-integrations
+  #       with:
+  #         github-token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}


### PR DESCRIPTION
# Description

[test-slim-integration](https://github.com/agntcy/csit/blob/main/.github/workflows/test-slim-integration.yaml) tests if a given slim data-plane / controller, image, helm chart and slim bindings python package version works together deployed on Kind.
It makes no sense to invoke after an image or helm chart build, cause you need to have new compatible versions released first.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
