### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,17 +41,17 @@ resolver = "2"
 # Local dependencies
 agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.2" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.11.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.11.1" }
+agntcy-slim-config = { path = "crates/config", version = "0.12.0" }
 agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.2" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.9.0" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.0" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.10.0" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.1" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.2.1" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.1.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.10.1", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.4.0" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.2.0" }
+agntcy-slim-service = { path = "crates/service", version = "0.11.0", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.5.0" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.10" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.1" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.2" }
 agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.2" }
 agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.2" }
 anyhow = "1.0.103"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,20 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0](https://github.com/agntcy/slim/compare/slim-proto-v0.1.0...slim-proto-v0.2.0) - 2026-07-06
+## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-channel-manager-v2.0.0-alpha.2) - 2026-07-06
 
 ### Added
 
 - authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
-
-## [0.1.0](https://github.com/agntcy/slim/releases/tag/slim-proto-v0.1.0) - 2026-07-01
-
-### Added
-
-- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
 - add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))
 
 ### Other
 
-- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
+- align channel manager version with workspace ([#1798](https://github.com/agntcy/slim/pull/1798))
 - restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/agntcy/slim/compare/slim-config-v0.11.1...slim-config-v0.12.0) - 2026-07-06
+
+### Added
+
+- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
+
 ## [0.11.1](https://github.com/agntcy/slim/compare/slim-config-v0.11.0...slim-config-v0.11.1) - 2026-07-01
 
 ### Added

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.11.1"
+version = "0.12.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/agntcy/slim/compare/slim-controller-v0.9.0...slim-controller-v0.10.0) - 2026-07-06
+
+### Added
+
+- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
+
 ## [0.9.0](https://github.com/agntcy/slim/compare/slim-controller-v0.8.0...slim-controller-v0.9.0) - 2026-07-01
 
 ### Added

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.9.0"
+version = "0.10.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.0...slim-datapath-v0.16.1) - 2026-07-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
+
 ## [0.16.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.15.0...slim-datapath-v0.16.0) - 2026-07-01
 
 ### Added

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.16.0"
+version = "0.16.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/agntcy/slim/compare/slim-service-v0.10.1...slim-service-v0.11.0) - 2026-07-06
+
+### Added
+
+- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
+
 ## [0.10.1](https://github.com/agntcy/slim/compare/slim-service-v0.10.0...slim-service-v0.10.1) - 2026-07-01
 
 ### Added

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.10.1"
+version = "0.11.0"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/slim/compare/slim-session-v0.4.0...slim-session-v0.5.0) - 2026-07-06
+
+### Other
+
+- *(session)* optimise ProducerBuffer — swap field roles ([#1674](https://github.com/agntcy/slim/pull/1674))
+
 ## [0.4.0](https://github.com/agntcy/slim/compare/slim-session-v0.3.0...slim-session-v0.4.0) - 2026-07-01
 
 ### Added

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.0"
+version = "0.5.0"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.2...slim-v2.0.0-alpha.3) - 2026-07-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-service, agntcy-slim-tracing
+
 ## [2.0.0-alpha.2](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.1...slim-v2.0.0-alpha.2) - 2026-07-01
 
 ### Other

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.2...slimctl-v2.0.0-alpha.3) - 2026-07-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-session, agntcy-slim-service, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim
+
 ## [2.0.0-alpha.2](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.1...slimctl-v2.0.0-alpha.2) - 2026-07-01
 
 ### Added

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.1...slim-tracing-v0.4.2) - 2026-07-06
+
+### Other
+
+- updated the following local packages: agntcy-slim-config
+
 ## [0.4.1](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.0...slim-tracing-v0.4.1) - 2026-07-01
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.1"
+version = "0.4.2"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-config`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)
* `agntcy-slim-proto`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `agntcy-slim-session`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `agntcy-slim-controller`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)
* `agntcy-slim-channel-manager`: 2.0.0-alpha.2
* `agntcy-slim-control-plane`: 2.0.0-alpha.2
* `agntcy-slim-tracing`: 0.4.1 -> 0.4.2
* `agntcy-slim-datapath`: 0.16.0 -> 0.16.1
* `agntcy-slim`: 2.0.0-alpha.2 -> 2.0.0-alpha.3
* `agntcy-slimctl`: 2.0.0-alpha.2 -> 2.0.0-alpha.3

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigAuthError:AuthSecretEmpty in /tmp/.tmpBUrXI4/slim/crates/config/src/auth.rs:34
  variant ConfigAuthError:AuthSpireSocketPathMissing in /tmp/.tmpBUrXI4/slim/crates/config/src/auth.rs:36
```

### ⚠ `agntcy-slim-proto` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RegisterNodeRequest.credentials in /tmp/.tmpBUrXI4/slim/crates/proto/src/gen/controller.proto.v1.rs:198
```

### ⚠ `agntcy-slim-session` breaking changes

```text
--- failure inherent_method_now_returns_unit: inherent method now returns unit ---

Description:
A publicly-visible method that used to return a value now returns `()`.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_now_returns_unit.ron
Failed in:
  slim_session::producer_buffer::ProducerBuffer::push in /tmp/.tmpBUrXI4/slim/crates/session/src/producer_buffer.rs:45
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ControlPlaneSettings.auth_provider in /tmp/.tmpBUrXI4/slim/crates/controller/src/service.rs:73

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_controller::config::Config::into_service now takes 5 parameters instead of 4, in /tmp/.tmpBUrXI4/slim/crates/controller/src/config.rs:58
```

### ⚠ `agntcy-slim-service` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ServiceConfiguration.auth in /tmp/.tmpBUrXI4/slim/crates/service/src/service.rs:90
  field ServiceConfiguration.auth in /tmp/.tmpBUrXI4/slim/crates/service/src/service.rs:90
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-config`

<blockquote>

## [0.12.0](https://github.com/agntcy/slim/compare/slim-config-v0.11.1...slim-config-v0.12.0) - 2026-07-06

### Added

- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.2.0](https://github.com/agntcy/slim/compare/slim-proto-v0.1.0...slim-proto-v0.2.0) - 2026-07-06

### Added

- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.5.0](https://github.com/agntcy/slim/compare/slim-session-v0.4.0...slim-session-v0.5.0) - 2026-07-06

### Other

- *(session)* optimise ProducerBuffer — swap field roles ([#1674](https://github.com/agntcy/slim/pull/1674))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.10.0](https://github.com/agntcy/slim/compare/slim-controller-v0.9.0...slim-controller-v0.10.0) - 2026-07-06

### Added

- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.11.0](https://github.com/agntcy/slim/compare/slim-service-v0.10.1...slim-service-v0.11.0) - 2026-07-06

### Added

- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-channel-manager-v2.0.0-alpha.2) - 2026-07-06

### Added

- authenticate node group membership on registration ([#1782](https://github.com/agntcy/slim/pull/1782))
- add header integrity check and replay protection to control messages ([#1740](https://github.com/agntcy/slim/pull/1740))

### Other

- align channel manager version with workspace ([#1798](https://github.com/agntcy/slim/pull/1798))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-control-plane-v2.0.0-alpha.2) - 2026-07-01

### Added

- config mode vs api mode for topology management ([#1772](https://github.com/agntcy/slim/pull/1772))
- network segmentation ([#1761](https://github.com/agntcy/slim/pull/1761))

### Other

- release 2.0.0 alpha 2 ([#1783](https://github.com/agntcy/slim/pull/1783))
- `slimctl` CLI commands for group-based routing ([#1769](https://github.com/agntcy/slim/pull/1769))
- restructure repo as pure Rust workspace ([#1693](https://github.com/agntcy/slim/pull/1693))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.1...slim-tracing-v0.4.2) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.0...slim-datapath-v0.16.1) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.2...slim-v2.0.0-alpha.3) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-service, agntcy-slim-tracing
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.2...slimctl-v2.0.0-alpha.3) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-session, agntcy-slim-service, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).