### PR TITLE
ci: enable crate publish for control-plane and channel-manager

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -87,12 +87,12 @@ changelog_update = true
 
 [[package]]
 name = "agntcy-slim-control-plane"
-publish = false
+publish = true
 release = true
 changelog_update = true
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-publish = false
+publish = true
 release = true
 changelog_update = true


### PR DESCRIPTION
# Description

Enable publishing in crates.io for control-plane and channel-manager.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] CI

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
