### PR TITLE
feat(session): use uuid for channel ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "trait-variant",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1182,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/datapath/src/tables/subscription_table.rs
+++ b/crates/datapath/src/tables/subscription_table.rs
@@ -1601,4 +1601,56 @@ mod tests {
             .unwrap();
         assert_eq!(result, 20);
     }
+
+    #[test]
+    #[traced_test]
+    fn test_same_prefix_different_id_different_connections() {
+        let name = ProtoName::from_strings(["agntcy", "default", "channel"]);
+        let name_id1 = name.clone().with_id(1);
+        let name_id2 = name.clone().with_id(2);
+
+        let t = SubscriptionTableImpl::default();
+
+        // Subscribe channel with ID 1 on connections 10 and 11
+        assert!(
+            t.add_subscription(name_id1.clone(), 10, ConnType::Local, 1)
+                .is_ok()
+        );
+        assert!(
+            t.add_subscription(name_id1.clone(), 11, ConnType::Remote, 2)
+                .is_ok()
+        );
+
+        // Subscribe channel with ID 2 on connections 20, 21, and 22
+        assert!(
+            t.add_subscription(name_id2.clone(), 20, ConnType::Local, 3)
+                .is_ok()
+        );
+        assert!(
+            t.add_subscription(name_id2.clone(), 21, ConnType::Remote, 4)
+                .is_ok()
+        );
+        assert!(
+            t.add_subscription(name_id2.clone(), 22, ConnType::Remote, 5)
+                .is_ok()
+        );
+
+        // Message for ID 1 should only match connections 10 and 11
+        let result = t.match_all(&enc(&name_id1), 100, MatchFilter::ALL).unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&10));
+        assert!(result.contains(&11));
+        assert!(!result.contains(&20));
+        assert!(!result.contains(&21));
+        assert!(!result.contains(&22));
+
+        // Message for ID 2 should only match connections 20, 21, and 22
+        let result = t.match_all(&enc(&name_id2), 100, MatchFilter::ALL).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&20));
+        assert!(result.contains(&21));
+        assert!(result.contains(&22));
+        assert!(!result.contains(&10));
+        assert!(!result.contains(&11));
+    }
 }

--- a/crates/proto/proto/data-plane/v1/data_plane.proto
+++ b/crates/proto/proto/data-plane/v1/data_plane.proto
@@ -183,11 +183,14 @@ message DiscoveryReplyPayload {}
 message JoinRequestPayload {
   // settings for timers for rtx and acks
   optional TimerSettings timer_settings = 1;
-  // name where to send the messages
+  // name where to send the messages (data channel)
   // it can be a channel or none
   optional Name channel = 2;
+  // name where to send control messages (control channel)
+  // must be set if channel is set
+  optional Name control = 3;
   // MLS related settings
-  optional MlsSettings mls_settings = 3;
+  optional MlsSettings mls_settings = 4;
 }
 
 message TimerSettings {

--- a/crates/proto/src/gen/dataplane.proto.v1.rs
+++ b/crates/proto/src/gen/dataplane.proto.v1.rs
@@ -241,12 +241,16 @@ pub struct JoinRequestPayload {
     /// settings for timers for rtx and acks
     #[prost(message, optional, tag = "1")]
     pub timer_settings: ::core::option::Option<TimerSettings>,
-    /// name where to send the messages
+    /// name where to send the messages (data channel)
     /// it can be a channel or none
     #[prost(message, optional, tag = "2")]
     pub channel: ::core::option::Option<Name>,
-    /// MLS related settings
+    /// name where to send control messages (control channel)
+    /// must be set if channel is set
     #[prost(message, optional, tag = "3")]
+    pub control: ::core::option::Option<Name>,
+    /// MLS related settings
+    #[prost(message, optional, tag = "4")]
     pub mls_settings: ::core::option::Option<MlsSettings>,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/proto/src/impls.rs
+++ b/crates/proto/src/impls.rs
@@ -213,8 +213,6 @@ impl SlimHeaderFlags {
 
 impl NameId {
     pub const NULL_COMPONENT: u128 = u128::MAX;
-    pub const DATA_CHANNEL_ID: u128 = u128::MAX - 2;
-    pub const CONTROL_CHANNEL_ID: u128 = u128::MAX - 3;
     pub const RESERVED_IDS: u128 = 50;
 
     pub const fn is_reserved_id(id: u128) -> bool {
@@ -250,8 +248,6 @@ impl TryFrom<String> for NameId {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         match s.as_str() {
             "NULL_COMPONENT" => Ok(Self::from(Self::NULL_COMPONENT)),
-            "DATA_CHANNEL_ID" => Ok(Self::from(Self::DATA_CHANNEL_ID)),
-            "CONTROL_CHANNEL_ID" => Ok(Self::from(Self::CONTROL_CHANNEL_ID)),
             _ => {
                 if let Ok(uuid) = uuid::Uuid::parse_str(&s) {
                     return Ok(Self::from(uuid.as_u128()));
@@ -267,8 +263,6 @@ impl From<NameId> for String {
         let val: u128 = name_id.into();
         match val {
             NameId::NULL_COMPONENT => "NULL_COMPONENT".to_string(),
-            NameId::DATA_CHANNEL_ID => "DATA_CHANNEL_ID".to_string(),
-            NameId::CONTROL_CHANNEL_ID => "CONTROL_CHANNEL_ID".to_string(),
             id => uuid::Uuid::from_u128(id).to_string(),
         }
     }
@@ -1349,7 +1343,8 @@ impl CommandPayloadBuilder {
         self,
         max_retries: Option<u32>,
         timer_duration: Option<Duration>,
-        channel: Option<ProtoName>,
+        data_channel: Option<ProtoName>,
+        control_channel: Option<ProtoName>,
         mls_settings: Option<ProtoMlsSettings>,
     ) -> CommandPayload {
         let timer_settings = match (timer_duration, max_retries) {
@@ -1362,7 +1357,8 @@ impl CommandPayloadBuilder {
 
         let payload = JoinRequestPayload {
             timer_settings,
-            channel,
+            channel: data_channel,
+            control: control_channel,
             mls_settings,
         };
         CommandPayload {
@@ -1857,19 +1853,13 @@ mod name_tests {
 
     #[test]
     fn test_name_id_display_reserved() {
-        let mut str_nid: String = NameId::from(NameId::NULL_COMPONENT).into();
+        let str_nid: String = NameId::from(NameId::NULL_COMPONENT).into();
         assert_eq!(str_nid, "NULL_COMPONENT");
-        str_nid = NameId::from(NameId::DATA_CHANNEL_ID).into();
-        assert_eq!(str_nid, "DATA_CHANNEL_ID");
-        str_nid = NameId::from(NameId::CONTROL_CHANNEL_ID).into();
-        assert_eq!(str_nid, "CONTROL_CHANNEL_ID");
     }
 
     #[test]
     fn test_name_id_is_reserved() {
         assert!(NameId::is_reserved_id(NameId::NULL_COMPONENT));
-        assert!(NameId::is_reserved_id(NameId::DATA_CHANNEL_ID));
-        assert!(NameId::is_reserved_id(NameId::CONTROL_CHANNEL_ID));
         assert!(!NameId::is_reserved_id(0));
         assert!(!NameId::is_reserved_id(42));
     }
@@ -2325,6 +2315,7 @@ mod message_tests {
             Some(5),
             Some(Duration::from_secs(10)),
             Some(dest.clone()),
+            None,
             Some(ProtoMlsSettings::default()),
         );
         let extracted = payload.as_join_request_payload().unwrap();

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -8,6 +8,7 @@ pub use impls::*;
 
 pub mod dataplane {
     pub mod proto {
+        #[allow(clippy::large_enum_variant)]
         pub mod v1 {
             include!("gen/dataplane.proto.v1.rs");
         }

--- a/crates/service/src/app.rs
+++ b/crates/service/src/app.rs
@@ -451,8 +451,8 @@ mod tests {
     use crate::SubscriptionAckError;
     use slim_auth::shared_secret::SharedSecret;
     use slim_datapath::api::{
-        CommandPayload, NameId, Participant, ParticipantSettings, ProtoMessage,
-        ProtoSessionMessageType, ProtoSessionType,
+        CommandPayload, Participant, ParticipantSettings, ProtoMessage, ProtoSessionMessageType,
+        ProtoSessionType,
     };
     use slim_datapath::messages::utils::SlimHeaderFlags;
     use slim_session::session_config::MlsSettings;
@@ -807,7 +807,7 @@ mod tests {
 
         // send join_request message to create the session
         let payload = CommandPayload::builder()
-            .join_request(None, None, None, None)
+            .join_request(None, None, None, None, None)
             .as_content();
 
         let mut join_request = Message::builder()
@@ -1224,10 +1224,10 @@ mod tests {
             // Verify it's a multicast session
             assert_eq!(session_arc.session_type(), ProtoSessionType::Multicast);
 
-            // For multicast sessions, the destination is the channel name with DATA_CHANNEL_ID
+            // For multicast sessions, the destination is the channel name
             let dst = session_arc.dst();
-            let expected_dst = channel_name.clone().with_id(NameId::DATA_CHANNEL_ID);
-            assert_eq!(dst, &expected_dst);
+            let expected_dst = channel_name.clone();
+            assert!(dst.match_prefix(&expected_dst));
 
             total_received_sessions += 1;
         }

--- a/crates/service/src/app.rs
+++ b/crates/service/src/app.rs
@@ -1228,6 +1228,10 @@ mod tests {
             let dst = session_arc.dst();
             let expected_dst = channel_name.clone();
             assert!(dst.match_prefix(&expected_dst));
+            assert!(
+                dst.has_id(),
+                "destination should have a derived ID, not NULL_COMPONENT"
+            );
 
             total_received_sessions += 1;
         }

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 trait-variant = { workspace = true }
+twox-hash = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 maybe-async = { workspace = true, features = ["is_sync"] }

--- a/crates/session/src/controller_sender.rs
+++ b/crates/session/src/controller_sender.rs
@@ -8,8 +8,7 @@ use std::{
 
 use display_error_chain::ErrorChainExt;
 use slim_datapath::api::{
-    CommandPayload, NameId, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
-    ProtoSessionType,
+    CommandPayload, ProtoMessage as Message, ProtoName, ProtoSessionMessageType, ProtoSessionType,
 };
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
@@ -211,14 +210,14 @@ impl ControllerSender {
                     self.group_name = Some(message.get_dst());
                 } else {
                     // in multicast session the group name is specified in the
-                    // payload of the message
-                    let mut group_name = message
+                    // payload of the message, here we use only the control
+                    // channel name that must be set
+                    let group_name = message
                         .extract_join_request()?
-                        .channel
+                        .control
                         .as_ref()
                         .ok_or(SessionError::MissingGroupNameInJoinRequest)?
                         .clone();
-                    group_name.set_id(NameId::CONTROL_CHANNEL_ID);
                     debug!(
                         destination = %group_name,
                         "update group name on join request message for multicast session",
@@ -810,7 +809,8 @@ mod tests {
 
         let source = ProtoName::from_strings(["org", "ns", "source"]);
         let remote = ProtoName::from_strings(["org", "ns", "remote"]);
-        let channel = ProtoName::from_strings(["org", "ns", "channel"]);
+        let channel_data = ProtoName::from_strings(["org", "ns", "channel"]).with_id(1);
+        let channel_control = ProtoName::from_strings(["org", "ns", "channel"]).with_id(2);
         let session_id = 1;
 
         let mut sender = ControllerSender::new(
@@ -833,7 +833,13 @@ mod tests {
             .message_id(1)
             .payload(
                 CommandPayload::builder()
-                    .join_request(None, None, Some(channel.clone()), None)
+                    .join_request(
+                        None,
+                        None,
+                        Some(channel_data.clone()),
+                        Some(channel_control.clone()),
+                        None,
+                    )
                     .as_content(),
             )
             .build_publish()
@@ -1642,7 +1648,7 @@ mod tests {
             .message_id(1)
             .payload(
                 CommandPayload::builder()
-                    .join_request(None, None, None, None)
+                    .join_request(None, None, None, None, None)
                     .as_content(),
             )
             .build_publish()
@@ -1703,10 +1709,8 @@ mod tests {
         let (tx_signal, mut rx_signal) = tokio::sync::mpsc::channel(100);
 
         let source = ProtoName::from_strings(["org", "ns", "source"]);
-        let data_channel_name =
-            ProtoName::from_strings(["org", "ns", "channel"]).with_id(NameId::DATA_CHANNEL_ID);
-        let control_channel_name =
-            ProtoName::from_strings(["org", "ns", "channel"]).with_id(NameId::CONTROL_CHANNEL_ID);
+        let data_channel_name = ProtoName::from_strings(["org", "ns", "channel"]).with_id(1);
+        let control_channel_name = ProtoName::from_strings(["org", "ns", "channel"]).with_id(2);
         let participant = ProtoName::from_strings(["org", "ns", "participant"]);
         let session_id = 1;
 
@@ -1731,7 +1735,13 @@ mod tests {
             .fanout(256)
             .payload(
                 CommandPayload::builder()
-                    .join_request(None, None, Some(data_channel_name.clone()), None)
+                    .join_request(
+                        None,
+                        None,
+                        Some(data_channel_name.clone()),
+                        Some(control_channel_name.clone()),
+                        None,
+                    )
                     .as_content(),
             )
             .build_publish()

--- a/crates/session/src/session_builder.rs
+++ b/crates/session/src/session_builder.rs
@@ -176,6 +176,11 @@ where
         self
     }
 
+    pub fn with_control(mut self, control: ProtoName) -> Self {
+        self.control = Some(control);
+        self
+    }
+
     pub fn with_config(mut self, config: SessionConfig) -> Self {
         self.config = Some(config);
         self
@@ -275,8 +280,13 @@ where
             return Err(SessionError::SessionBuilderIncomplete);
         }
 
-        // Infer control name from destination based on session type
         let config = self.config.as_ref().unwrap();
+        if config.session_type == slim_datapath::api::ProtoSessionType::Multicast
+            && self.control.is_none()
+        {
+            return Err(SessionError::SessionBuilderIncomplete);
+        }
+
         let destination = self.destination.as_ref().unwrap();
         let (final_destination, control) = match config.session_type {
             slim_datapath::api::ProtoSessionType::PointToPoint => {
@@ -284,9 +294,16 @@ where
                 (destination.clone(), destination.clone())
             }
             slim_datapath::api::ProtoSessionType::Multicast => {
-                // For Multicast, force the destination to use DATA_CHANNEL_ID and control to use CONTROL_CHANNEL_ID
-                let data_destination = destination.clone().with_id(NameId::DATA_CHANNEL_ID);
-                let control_destination = destination.clone().with_id(NameId::CONTROL_CHANNEL_ID);
+                // For Multicast, validate that destination and control have valid, distinct IDs
+                let data_destination = destination.clone();
+                let control_destination = self.control.as_ref().unwrap().clone();
+                if data_destination.id() == NameId::NULL_COMPONENT
+                    || control_destination.id() == NameId::NULL_COMPONENT
+                    || data_destination.id() == control_destination.id()
+                    || !data_destination.match_prefix(&control_destination)
+                {
+                    return Err(SessionError::SessionBuilderIncomplete);
+                }
                 (data_destination, control_destination)
             }
             _ => {
@@ -1224,12 +1241,14 @@ mod tests {
         config.session_type = ProtoSessionType::Multicast;
 
         let dest = create_test_name("group");
-        let data_channel = dest.with_id(NameId::DATA_CHANNEL_ID);
+        let data_channel = dest.clone().with_id(1);
+        let ctrl_channel = dest.with_id(2);
         let builder =
             SessionBuilder::<MockTokenProvider, MockVerifier, ForController, NotReady>::for_controller()
                 .with_id(3)
                 .with_source(create_test_name("moderator"))
-                .with_destination(data_channel) // Multicast: use DATA_CHANNEL_ID
+                .with_destination(data_channel)
+                .with_control(ctrl_channel)
                 .with_config(config)
                 .with_identity_provider(MockTokenProvider)
                 .with_identity_verifier(MockVerifier)
@@ -1437,8 +1456,9 @@ mod tests {
         let mut config = create_test_config(true);
         config.session_type = ProtoSessionType::Multicast;
 
-        // Pass a destination with WRONG id (not DATA_CHANNEL_ID)
-        let dest = create_test_name("group").with_id(999);
+        // Pass destination and control with distinct IDs
+        let dest = create_test_name("group").with_id(1);
+        let ctrl = create_test_name("group").with_id(2);
 
         let ready_builder = SessionBuilder::<
             MockTokenProvider,
@@ -1449,6 +1469,7 @@ mod tests {
         .with_id(1)
         .with_source(create_test_name("source"))
         .with_destination(dest)
+        .with_control(ctrl)
         .with_config(config)
         .with_identity_provider(MockTokenProvider)
         .with_identity_verifier(MockVerifier)
@@ -1458,14 +1479,8 @@ mod tests {
         .unwrap();
 
         // Verify the builder forced the correct IDs
-        assert_eq!(
-            ready_builder.destination.unwrap().id(),
-            NameId::DATA_CHANNEL_ID
-        );
-        assert_eq!(
-            ready_builder.control.unwrap().id(),
-            NameId::CONTROL_CHANNEL_ID
-        );
+        assert_eq!(ready_builder.destination.unwrap().id(), 1);
+        assert_eq!(ready_builder.control.unwrap().id(), 2);
     }
 
     #[test]

--- a/crates/session/src/session_config.rs
+++ b/crates/session/src/session_config.rs
@@ -152,11 +152,13 @@ mod tests {
 
     #[test]
     fn test_from_join_request_with_timer_settings() {
-        let dest = Name::from_strings(["dest", "", ""]);
+        let dest = Name::from_strings(["org", "ns", "dst"]).with_id(1);
+        let ctrl = Name::from_strings(["org", "ns", "dst"]).with_id(2);
         let payload = CommandPayload::builder().join_request(
             Some(3),
             Some(Duration::from_millis(500)),
             Some(dest),
+            Some(ctrl),
             Some(slim_datapath::api::ProtoMlsSettings {
                 header_integrity_validation_percent: 100,
             }),
@@ -188,7 +190,7 @@ mod tests {
     #[test]
     fn test_from_join_request_without_timer_settings() {
         let dest = Name::from_strings(["dest", "", ""]);
-        let payload = CommandPayload::builder().join_request(None, None, Some(dest), None);
+        let payload = CommandPayload::builder().join_request(None, None, Some(dest), None, None);
 
         let metadata = HashMap::new();
 
@@ -210,11 +212,13 @@ mod tests {
 
     #[test]
     fn test_from_join_request_with_mls_enabled() {
-        let dest = Name::from_strings(["dest", "", ""]);
+        let dest = Name::from_strings(["ns", "org", "c"]).with_id(1);
+        let ctrl = Name::from_strings(["ns", "org", "c"]).with_id(2);
         let payload = CommandPayload::builder().join_request(
             Some(10),
             Some(Duration::from_secs(5)),
             Some(dest),
+            Some(ctrl),
             Some(slim_datapath::api::ProtoMlsSettings {
                 header_integrity_validation_percent: 100,
             }),
@@ -278,11 +282,13 @@ mod tests {
 
     #[test]
     fn test_from_join_request_with_large_timeout() {
-        let dest = Name::from_strings(["dest", "", ""]);
+        let dest = Name::from_strings(["ns", "org", "c"]).with_id(1);
+        let ctrl = Name::from_strings(["ns", "org", "c"]).with_id(2);
         let payload = CommandPayload::builder().join_request(
             Some(100),
             Some(Duration::from_secs(3600)), // 1 hour
             Some(dest),
+            Some(ctrl),
             None,
         );
 

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -1064,6 +1064,7 @@ mod tests {
         session_id: u32,
         source: ProtoName,
         destination: ProtoName,
+        control: ProtoName,
         session_type: ProtoSessionType,
         mls_settings: Option<MlsSettings>,
         initiator: bool,
@@ -1080,6 +1081,7 @@ mod tests {
                 session_id: 10,
                 source: ProtoName::from_strings(["org", "ns", "source"]).with_id(1),
                 destination: ProtoName::from_strings(["org", "ns", "dest"]).with_id(2),
+                control: ProtoName::from_strings(["org", "ns", "dest"]).with_id(2),
                 session_type: ProtoSessionType::PointToPoint,
                 mls_settings: None,
                 initiator: true,
@@ -1104,6 +1106,12 @@ mod tests {
         #[allow(dead_code)]
         fn with_destination(mut self, destination: ProtoName) -> Self {
             self.destination = destination;
+            self
+        }
+
+        #[allow(dead_code)]
+        fn with_control(mut self, control: ProtoName) -> Self {
+            self.control = control;
             self
         }
 
@@ -1160,6 +1168,7 @@ mod tests {
                 .with_id(self.session_id)
                 .with_source(self.source.clone())
                 .with_destination(self.destination.clone())
+                .with_control(self.control.clone())
                 .with_config(config)
                 .with_identity_provider(SharedSecret::new("test", SHARED_SECRET).unwrap())
                 .with_identity_verifier(SharedSecret::new("test", SHARED_SECRET).unwrap())
@@ -1183,6 +1192,8 @@ mod tests {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_id(42)
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .with_mls_enabled(true)
             .with_metadata(metadata)
             .build();
@@ -1192,10 +1203,10 @@ mod tests {
             controller.source(),
             &ProtoName::from_strings(["org", "ns", "source"]).with_id(1)
         );
-        // For multicast sessions, destination uses DATA_CHANNEL_ID
+        // For multicast sessions, destination uses the provided ID
         assert_eq!(
             controller.dst(),
-            &ProtoName::from_strings(["org", "ns", "dest"]).with_id(NameId::DATA_CHANNEL_ID)
+            &ProtoName::from_strings(["org", "ns", "group"]).with_id(2)
         );
         assert_eq!(controller.session_type(), ProtoSessionType::Multicast);
         assert!(controller.is_initiator());
@@ -1233,6 +1244,8 @@ mod tests {
     async fn test_publish_to_specific_connection() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .build();
 
         let target_name = ProtoName::from_strings(["org", "ns", "target"]);
@@ -1257,6 +1270,8 @@ mod tests {
     async fn test_publish_with_metadata() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .build();
 
         let target_name = ProtoName::from_strings(["org", "ns", "target"]);
@@ -1282,6 +1297,8 @@ mod tests {
     async fn test_invite_participant_in_multicast() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .build();
 
         let participant = ProtoName::from_strings(["org", "ns", "participant"]);
@@ -1298,6 +1315,8 @@ mod tests {
     async fn test_invite_participant_not_initiator_error() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .with_initiator(false)
             .build();
 
@@ -1323,6 +1342,8 @@ mod tests {
     async fn test_remove_participant_in_multicast() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .build();
 
         let participant = ProtoName::from_strings(["org", "ns", "participant"]);
@@ -1339,6 +1360,8 @@ mod tests {
     async fn test_remove_participant_not_initiator_error() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .with_initiator(false)
             .build();
 
@@ -1499,6 +1522,8 @@ mod tests {
     async fn test_create_discovery_request() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_session_type(ProtoSessionType::Multicast)
+            .with_destination(ProtoName::from_strings(["org", "ns", "group"]).with_id(2))
+            .with_control(ProtoName::from_strings(["org", "ns", "group"]).with_id(3))
             .build();
 
         let target = ProtoName::from_strings(["org", "ns", "target"]);

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -248,7 +248,40 @@ where
         let is_p2p = session_config.session_type == ProtoSessionType::PointToPoint;
         let destination_proto = destination.clone();
 
-        let session = self.create_session_internal(session_config, local_name, destination, id)?;
+        let (dest_with_id, control_with_id) =
+            if session_config.session_type == ProtoSessionType::Multicast {
+                let token_id = self
+                    .identity_provider
+                    .get_id()
+                    .map_err(|_| SessionError::SessionBuilderIncomplete)?;
+
+                let data_input = format!("{}/{}/data", token_id, destination);
+                let mut data_id = twox_hash::XxHash3_128::oneshot(data_input.as_bytes());
+                if NameId::is_reserved_id(data_id) {
+                    data_id %= u128::MAX - NameId::RESERVED_IDS;
+                }
+
+                let ctrl_input = format!("{}/{}/control", token_id, destination);
+                let mut ctrl_id = twox_hash::XxHash3_128::oneshot(ctrl_input.as_bytes());
+                if NameId::is_reserved_id(ctrl_id) {
+                    ctrl_id %= u128::MAX - NameId::RESERVED_IDS;
+                }
+
+                (
+                    destination.clone().with_id(data_id),
+                    destination.clone().with_id(ctrl_id),
+                )
+            } else {
+                (destination.clone(), destination.clone())
+            };
+
+        let session = self.create_session_internal(
+            session_config,
+            local_name,
+            dest_with_id,
+            control_with_id,
+            id,
+        )?;
 
         // If session is p2p, initiate the discovery request now and return the ack
         // Otherwise, return an immediately resolved future
@@ -280,6 +313,7 @@ where
         session_config: SessionConfig,
         local_name: ProtoName,
         destination: ProtoName,
+        control: ProtoName,
         id: Option<u32>,
     ) -> Result<SessionContext, SessionError> {
         // Retry loop to handle race conditions when generating random IDs
@@ -318,12 +352,12 @@ where
             // Create app channel for this session
             let (app_tx, app_rx) = tokio::sync::mpsc::unbounded_channel();
 
-            // Build the session controller (this is async, so no locks are held)
-            // The builder will automatically force DATA_CHANNEL_ID for multicast destinations
+            // Build the session controller with pre-computed destination and control names
             let builder = SessionController::builder()
                 .with_id(session_id)
                 .with_source(local_name.clone())
                 .with_destination(destination.clone())
+                .with_control(control.clone())
                 .with_config(session_config.clone())
                 .with_identity_provider(self.identity_provider.clone())
                 .with_identity_verifier(self.identity_verifier.clone())
@@ -613,7 +647,8 @@ where
                     message.get_metadata_map(),
                     false,
                 )?;
-                self.create_session_internal(conf, local_name, message.get_source(), Some(id))?
+                let dest = message.get_source();
+                self.create_session_internal(conf, local_name, dest.clone(), dest, Some(id))?
             }
             ProtoSessionType::Multicast => {
                 let payload = message.extract_join_request()?;
@@ -626,13 +661,17 @@ where
                     .channel
                     .clone()
                     .ok_or(SessionError::MissingChannelName)?;
+                let control = payload
+                    .control
+                    .clone()
+                    .ok_or(SessionError::MissingChannelName)?;
                 let conf = crate::SessionConfig::from_join_request(
                     ProtoSessionType::Multicast,
                     message.extract_command_payload()?,
                     message.get_metadata_map(),
                     false,
                 )?;
-                self.create_session_internal(conf, local_name, channel, Some(id))?
+                self.create_session_internal(conf, local_name, channel, control, Some(id))?
             }
             _ => {
                 warn!(
@@ -768,7 +807,13 @@ mod tests {
             metadata: Default::default(),
         };
 
-        let result = session_layer.create_session_internal(config, local_name, destination, None);
+        let result = session_layer.create_session_internal(
+            config,
+            local_name,
+            destination.clone(),
+            destination,
+            None,
+        );
 
         assert!(result.is_ok());
         assert_eq!(session_layer.pool_size(), 1);
@@ -793,7 +838,8 @@ mod tests {
         let result = session_layer.create_session_internal(
             config,
             local_name,
-            destination,
+            destination.clone(),
+            destination.clone(),
             Some(session_id),
         );
 
@@ -824,7 +870,8 @@ mod tests {
         let result = session_layer.create_session_internal(
             config,
             local_name,
-            destination,
+            destination.clone(),
+            destination.clone(),
             Some(invalid_id),
         );
 
@@ -857,6 +904,7 @@ mod tests {
             config.clone(),
             local_name.clone(),
             destination.clone(),
+            destination.clone(),
             Some(session_id),
         );
         assert!(result1.is_ok());
@@ -865,6 +913,7 @@ mod tests {
         let result2 = session_layer.create_session_internal(
             config,
             local_name,
+            destination.clone(),
             destination,
             Some(session_id),
         );
@@ -893,7 +942,13 @@ mod tests {
 
         let session_id = 100u32;
         let _context = session_layer
-            .create_session_internal(config, local_name, destination, Some(session_id))
+            .create_session_internal(
+                config,
+                local_name,
+                destination.clone(),
+                destination,
+                Some(session_id),
+            )
             .unwrap();
 
         assert_eq!(session_layer.pool_size(), 1);
@@ -1090,6 +1145,7 @@ mod tests {
             let result = session_layer.create_session_internal(
                 config.clone(),
                 local_name.clone(),
+                destination.clone(),
                 destination,
                 None,
             );

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -248,32 +248,49 @@ where
         let is_p2p = session_config.session_type == ProtoSessionType::PointToPoint;
         let destination_proto = destination.clone();
 
-        let (dest_with_id, control_with_id) =
-            if session_config.session_type == ProtoSessionType::Multicast {
-                let token_id = self
-                    .identity_provider
-                    .get_id()
-                    .map_err(|_| SessionError::SessionBuilderIncomplete)?;
+        let (dest_with_id, control_with_id) = if session_config.session_type
+            == ProtoSessionType::Multicast
+        {
+            let token_id = self.identity_provider.get_id()?;
 
-                let data_input = format!("{}/{}/data", token_id, destination);
-                let mut data_id = twox_hash::XxHash3_128::oneshot(data_input.as_bytes());
+            let (c0, c1, c2) = destination.str_components();
+            let data_input = format!("{}/{}/{}/{}/data", token_id, c0, c1, c2);
+            let ctrl_input = format!("{}/{}/{}/{}/control", token_id, c0, c1, c2);
+
+            let mut data_id;
+            let mut ctrl_id;
+            let mut salt = 0u64;
+            loop {
+                data_id = twox_hash::XxHash3_128::oneshot_with_seed(salt, data_input.as_bytes());
                 if NameId::is_reserved_id(data_id) {
-                    data_id %= u128::MAX - NameId::RESERVED_IDS;
+                    data_id = (data_id % (u128::MAX - NameId::RESERVED_IDS - 1)) + 1;
                 }
 
-                let ctrl_input = format!("{}/{}/control", token_id, destination);
-                let mut ctrl_id = twox_hash::XxHash3_128::oneshot(ctrl_input.as_bytes());
+                ctrl_id = twox_hash::XxHash3_128::oneshot_with_seed(salt, ctrl_input.as_bytes());
                 if NameId::is_reserved_id(ctrl_id) {
-                    ctrl_id %= u128::MAX - NameId::RESERVED_IDS;
+                    ctrl_id = (ctrl_id % (u128::MAX - NameId::RESERVED_IDS - 1)) + 1;
                 }
 
-                (
-                    destination.clone().with_id(data_id),
-                    destination.clone().with_id(ctrl_id),
-                )
-            } else {
-                (destination.clone(), destination.clone())
-            };
+                if data_id != ctrl_id {
+                    break;
+                }
+                warn!(
+                    salt,
+                    "data_id == ctrl_id hash collision, retrying with new salt"
+                );
+                salt += 1;
+                if salt > 10 {
+                    return Err(SessionError::SessionBuilderIncomplete);
+                }
+            }
+
+            (
+                destination.clone().with_id(data_id),
+                destination.clone().with_id(ctrl_id),
+            )
+        } else {
+            (destination.clone(), destination.clone())
+        };
 
         let session = self.create_session_internal(
             session_config,

--- a/crates/session/src/session_moderator.rs
+++ b/crates/session/src/session_moderator.rs
@@ -666,12 +666,16 @@ where
         // send a join message
         let msg_id = rand::random::<u32>();
 
-        let channel = if self.common.settings.config.session_type == ProtoSessionType::Multicast {
-            // using the destination as channel name, the control name can be recreated by the participants
-            Some(self.common.settings.destination.clone())
-        } else {
-            None
-        };
+        let (channel, control) =
+            if self.common.settings.config.session_type == ProtoSessionType::Multicast {
+                // using the destination as channel name, the control name can be recreated by the participants
+                (
+                    Some(self.common.settings.destination.clone()),
+                    Some(self.common.settings.control.clone()),
+                )
+            } else {
+                (None, None)
+            };
 
         let mls_settings =
             self.common
@@ -688,6 +692,7 @@ where
                 self.common.settings.config.max_retries,
                 self.common.settings.config.interval,
                 channel,
+                control,
                 mls_settings,
             )
             .as_content();
@@ -1310,8 +1315,8 @@ mod tests {
         mpsc::Receiver<Result<SessionMessage, SessionError>>,
     ) {
         let source = make_name(&["local", "moderator", "v1"]).with_id(100);
-        let destination = make_name(&["channel", "name", "v1"]).with_id(NameId::DATA_CHANNEL_ID);
-        let control = make_name(&["channel", "name", "v1"]).with_id(NameId::CONTROL_CHANNEL_ID);
+        let destination = make_name(&["channel", "name", "v1"]).with_id(1);
+        let control = make_name(&["channel", "name", "v1"]).with_id(2);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;
@@ -1476,7 +1481,13 @@ mod tests {
             .message_id(100)
             .payload(
                 CommandPayload::builder()
-                    .join_request(Some(3), Some(std::time::Duration::from_secs(1)), None, None)
+                    .join_request(
+                        Some(3),
+                        Some(std::time::Duration::from_secs(1)),
+                        None,
+                        None,
+                        None,
+                    )
                     .as_content(),
             )
             .build_publish()
@@ -1756,9 +1767,8 @@ mod tests {
 
         // Create moderator with agntcy/ns/moderator naming
         let source = ProtoName::from_strings(["agntcy", "ns", "moderator"]).with_id(100);
-        let destination = ProtoName::from_strings(["agntcy", "ns", "chat"]);
-        let control =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(NameId::CONTROL_CHANNEL_ID);
+        let destination = ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(1);
+        let control = ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(2);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;
@@ -1906,10 +1916,8 @@ mod tests {
 
         // Create moderator with agntcy/ns/moderator naming
         let source = ProtoName::from_strings(["agntcy", "ns", "moderator"]).with_id(100);
-        let destination =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(NameId::DATA_CHANNEL_ID);
-        let control =
-            ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(NameId::CONTROL_CHANNEL_ID);
+        let destination = ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(1);
+        let control = ProtoName::from_strings(["agntcy", "ns", "chat"]).with_id(2);
 
         let identity_provider = MockTokenProvider;
         let identity_verifier = MockVerifier;

--- a/crates/session/src/session_participant.rs
+++ b/crates/session/src/session_participant.rs
@@ -722,7 +722,7 @@ mod tests {
     use crate::session_settings::SessionSettings;
     use crate::test_utils::{MockInnerHandler, MockTokenProvider, MockVerifier};
     use slim_datapath::Status;
-    use slim_datapath::api::{CommandPayload, NameId, ProtoSessionType};
+    use slim_datapath::api::{CommandPayload, ProtoSessionType};
     use tokio::sync::mpsc;
 
     // --- Test Helpers -----------------------------------------------------------------------
@@ -770,8 +770,8 @@ mod tests {
         let source = make_name(&["local", "participant", "v1"]);
         let (destination, control) = match session_type {
             ProtoSessionType::Multicast => (
-                make_name(&["channel", "name", "v1"]).with_id(NameId::DATA_CHANNEL_ID),
-                make_name(&["channel", "name", "v1"]).with_id(NameId::CONTROL_CHANNEL_ID),
+                make_name(&["channel", "name", "v1"]).with_id(1),
+                make_name(&["channel", "name", "v1"]).with_id(2),
             ),
             ProtoSessionType::PointToPoint => (
                 make_name(&["remote", "participant", "v1"]).with_id(100),
@@ -866,7 +866,13 @@ mod tests {
             .message_id(100)
             .payload(
                 CommandPayload::builder()
-                    .join_request(Some(3), Some(std::time::Duration::from_secs(1)), None, None)
+                    .join_request(
+                        Some(3),
+                        Some(std::time::Duration::from_secs(1)),
+                        None,
+                        None,
+                        None,
+                    )
                     .as_content(),
             )
             .build_publish()
@@ -1157,7 +1163,13 @@ mod tests {
             .message_id(100)
             .payload(
                 CommandPayload::builder()
-                    .join_request(Some(3), Some(std::time::Duration::from_secs(1)), None, None)
+                    .join_request(
+                        Some(3),
+                        Some(std::time::Duration::from_secs(1)),
+                        None,
+                        None,
+                        None,
+                    )
                     .as_content(),
             )
             .build_publish()


### PR DESCRIPTION
# Description

Replace fixed `DATA_CHANNEL_ID` and `CONTROL_CHANNEL_ID` constants with identity-derived UUIDs for multicast channel names.

Previously, multicast channels used hardcoded sentinel IDs (`u128::MAX - 2` and `u128::MAX - 3`) which caused name collisions when two channels shared the same `org/ns/channel` prefix. This change derives unique data and control channel IDs by hashing the moderator's identity token together with the channel name using `XxHash3_128`, mirroring the approach already used for agent name IDs.

## Key changes

- **Moderator side**: Derives unique data/control channel IDs from `identity_token + destination_name` when creating a multicast session
- **JoinRequest proto**: Now carries both `channel` (data) and `control` names explicitly so participants use the exact same IDs
- **Participant side**: Extracts data/control names directly from the JoinRequest payload
- **SessionBuilder**: Validates that multicast sessions have distinct, non-null data and control IDs with matching prefixes

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
