### PR TITLE
fix(config): use RetryIf::spawn instead of non-existent RetryIf::start

### DIFF
--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -547,7 +547,7 @@ impl ClientConfig {
         use tokio_retry::RetryIf;
 
         let strategy = self.backoff.get_strategy();
-        RetryIf::start(strategy, attempt, |e: &ConfigError| {
+        RetryIf::spawn(strategy, attempt, |e: &ConfigError| {
             let retry = e.is_retryable_connect_error();
             if retry {
                 tracing::warn!(error = %e.chain(), "transient connect error, retrying");


### PR DESCRIPTION
## Summary

`agntcy-slim-config` calls `tokio_retry::RetryIf::start(...)`, which does **not
exist** in `tokio-retry 0.3` — the version the workspace pins
(`tokio-retry = "0.3"`). The constructor is `RetryIf::spawn`, with an identical
signature. This one-line change switches to it.

```diff
-        RetryIf::start(strategy, attempt, |e: &ConfigError| {
+        RetryIf::spawn(strategy, attempt, |e: &ConfigError| {
```
(`crates/config/src/client.rs`, `ClientConfig::retry_connect`)

## Why this matters

Because the call references a non-existent associated item, `agntcy-slim-config`
fails to compile against its declared `tokio-retry = "0.3"` dependency **when
built outside this workspace** — i.e. as a published crate consumed from
crates.io. That breaks the entire v2 dependency chain for downstream Rust
consumers:

```
slim-config → slim-datapath → slim-controller → slim-service
            → slim → slim-bindings → a2a-slimrpc
```

As a result, **no crate can currently build on the `2.0.0-alpha` line from
crates.io.**

## Reproduction

Depending on `agntcy-slim-bindings = "2.0.0-alpha.2"` from a separate workspace
and running `cargo build` fails while compiling `agntcy-slim-config` (both
`0.11.1` and `0.12.0` are pulled in transitively):

```
error[E0599]: no function or associated item named `start` found for struct
`RetryIf<I, A, C>` in the current scope
   --> agntcy-slim-config-0.12.0/src/client.rs:448:18
    |
    |         RetryIf::start(strategy, attempt, |e: &ConfigError| {
    |                  ^^^^^ function or associated item not found in `RetryIf<_, _, _>`
note: consider using `RetryIf::<I, A, C>::spawn` which returns `RetryIf<_, _, _>`
```

## Fix

`RetryIf::spawn` takes the same `(strategy, action, condition)` arguments and
returns the same awaitable `RetryIf` future, so the change is behavior-preserving
and builds against stock `tokio-retry 0.3`.

## Follow-up

This unblocks cutting a **buildable stable `2.0.0`** release from crates.io — the
current `2.0.0-alpha.*` artifacts do not compile standalone because of this bug.
Recommend a green CI job that builds the published crates from a clean external
workspace (not just the monorepo) to catch this class of "compiles in-workspace,
breaks when published" regressions going forward.
