### PR TITLE
feat(rpc): extract native agntcy-slim-rpc crate from the FFI bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prost-types",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest",
  "schemars 1.2.1",
  "serde",
@@ -167,7 +167,7 @@ dependencies = [
  "percent-encoding",
  "prost",
  "protoc-bin-vendored",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "rustls",
  "rustls-native-certs",
@@ -224,7 +224,7 @@ dependencies = [
  "petgraph",
  "prost",
  "prost-types",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rlimit",
  "serde",
  "serde_json",
@@ -359,12 +359,37 @@ dependencies = [
  "prost",
  "prost-types",
  "protoc-bin-vendored",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "agntcy-slim-rpc"
+version = "0.1.0"
+dependencies = [
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
+ "agntcy-slim-datapath",
+ "agntcy-slim-service",
+ "agntcy-slim-session",
+ "async-stream",
+ "async-trait",
+ "bincode",
+ "display-error-chain",
+ "drain",
+ "futures",
+ "futures-timer",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-test",
  "uuid",
 ]
 
@@ -415,7 +440,7 @@ dependencies = [
  "maybe-async",
  "parking_lot",
  "prost",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "smallvec",
@@ -459,7 +484,7 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -628,9 +653,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -785,15 +810,16 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.14"
+version = "0.13.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+checksum = "6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
  "regex",
 ]
 
@@ -1031,9 +1057,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
@@ -1075,9 +1101,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1102,9 +1128,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1327,9 +1353,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1346,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1526,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1536,12 +1562,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1568,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
  "der_derive",
@@ -1634,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.10"
+version = "2.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
+checksum = "e54d1f576cd3a3460f212a4615fd12ce1b6303c095b79a44449ffbe627753dc1"
 dependencies = [
  "diesel_derives",
  "downcast-rs",
@@ -1858,18 +1883,18 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,7 +1956,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "pin-project",
- "rand 0.8.6",
+ "rand 0.8.7",
  "sha1",
  "simdutf8",
  "thiserror 1.0.69",
@@ -2385,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2395,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2683,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -2694,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2779,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2793,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2804,19 +2829,19 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2837,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
+checksum = "4222e00941bfe18bf81b79fa23ad933e233bfa18f3ee27254c5dd9b1543b5d5f"
 dependencies = [
  "pest",
  "pest_derive",
@@ -3068,9 +3093,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3103,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "migrations_internals"
@@ -3152,9 +3177,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -3284,7 +3309,7 @@ checksum = "292a8e8a85689c029a6f6b0c7a7eef0f390a044ef176b80d0442b38948c66e35"
 dependencies = [
  "async-trait",
  "const-oid 0.10.2",
- "der 0.8.0",
+ "der 0.8.1",
  "js-sys",
  "maybe-async",
  "mls-rs-core",
@@ -3366,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3419,7 +3444,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.6",
+ "rand 0.8.7",
  "reqwest",
  "serde",
  "serde_json",
@@ -3549,7 +3574,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3623,9 +3648,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3633,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3643,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3656,12 +3681,11 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -3820,28 +3844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4013,9 +4015,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4024,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4034,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -4138,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4150,9 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4287,9 +4289,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4324,9 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4351,9 +4353,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -4372,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -4671,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4804,9 +4806,9 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4843,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "portable-atomic",
 ]
@@ -4898,9 +4900,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5043,18 +5045,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5072,9 +5074,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5102,9 +5104,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5150,7 +5152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -5259,14 +5261,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5275,7 +5277,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5557,7 +5559,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -5774,9 +5776,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5844,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5857,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5867,9 +5869,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5877,9 +5879,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5890,18 +5892,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
 dependencies = [
  "async-trait",
  "cast",
@@ -5921,9 +5923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5932,15 +5934,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6233,9 +6235,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6327,18 +6329,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6421,6 +6423,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/examples",
     "crates/mls",
     "crates/proto",
+    "crates/rpc",
     "crates/service",
     "crates/session",
     "crates/signal",
@@ -48,6 +49,7 @@ agntcy-slim-controller = { path = "crates/controller", version = "0.10.0" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.1" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.2.1" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.2.0" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "0.1.0" }
 agntcy-slim-service = { path = "crates/service", version = "0.11.0", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.5.0" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.10" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,0 +1,36 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "agntcy-slim-rpc"
+edition = { workspace = true }
+license = { workspace = true }
+version = "0.1.0"
+description = "SlimRPC: a gRPC-like RPC framework over SLIM (native Rust)."
+
+[lib]
+name = "slim_rpc"
+
+[dependencies]
+agntcy-slim-auth = { workspace = true }
+agntcy-slim-datapath = { workspace = true }
+agntcy-slim-service = { workspace = true, features = ["session"] }
+agntcy-slim-session = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+display-error-chain = { workspace = true }
+drain = { workspace = true }
+futures = { workspace = true }
+futures-timer = { workspace = true }
+parking_lot = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+agntcy-slim-config = { workspace = true }
+bincode = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tracing-test = { workspace = true }

--- a/crates/rpc/src/channel.rs
+++ b/crates/rpc/src/channel.rs
@@ -1,0 +1,1330 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client-side RPC channel implementation
+//!
+//! Provides a Channel type for making RPC calls to remote services.
+//! Supports all gRPC streaming patterns over SLIM sessions.
+//!
+//! All eight public RPC methods are built on top of `responses_from_stream_input`.
+//! Single-request callers wrap their request in `futures::stream::once`.
+//!
+//! Both core methods dispatch based on `self.is_group`:
+//! - P2P (`is_group = false`): uses a PointToPoint session; stream ends on server EOS
+//! - GROUP (`is_group = true`): uses a Multicast session; stream ends when all members
+//!   have sent their final response (EOS); member errors are yielded as stream items
+//!
+//! The "unary" variants are simply the streaming variants followed by `.next()`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_stream::stream;
+use display_error_chain::ErrorChainExt;
+use futures::StreamExt;
+use futures::future::join_all;
+use futures::stream::Stream;
+use futures_timer::Delay;
+use parking_lot::RwLock as ParkingRwLock;
+use slim_session::session_config::MlsSettings;
+use tokio::sync::mpsc::{self, unbounded_channel};
+use tokio::task::JoinHandle;
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::ProtoName as Name;
+use slim_datapath::api::ProtoSessionType;
+use slim_service::app::App as SlimApp;
+use slim_session::errors::SessionError;
+
+// ── Multicast response types ──────────────────────────────────────────────────
+
+/// Per-message context attached to every item in a multicast response stream.
+///
+/// Identifies which group member produced the response, allowing callers to
+/// correlate responses with their origin when multiple members are involved.
+#[derive(Debug, Clone)]
+pub struct MessageContext {
+    /// SLIM name of the member app that sent this message.
+    pub source: Name,
+}
+
+/// A single item in a multicast response stream: the decoded response together
+/// with the context identifying its origin.
+#[derive(Debug, Clone)]
+pub struct MulticastItem<T> {
+    /// Context identifying the member that produced this response.
+    pub context: MessageContext,
+    /// The decoded response message.
+    pub message: T,
+}
+
+use super::{
+    BidiStreamHandler, Context, METHOD_KEY, Metadata, MulticastBidiStreamHandler,
+    MulticastResponseReader, RPC_DIR_KEY, RPC_DIR_REQ, RPC_ID_KEY, ReceivedMessage,
+    RequestStreamWriter, ResponseStreamReader, RpcCode, RpcError, SERVICE_KEY, STATUS_CODE_KEY,
+    calculate_timeout_duration,
+    codec::{Decoder, Encoder},
+    send_eos,
+    session_wrapper::{SessionRx, SessionTx, new_session},
+};
+
+// ── ResponseDispatcher ────────────────────────────────────────────────────────
+
+/// Routes incoming response messages to the correct per-RPC mpsc channel.
+///
+/// The background `response_dispatcher_task` calls `dispatch()` for each
+/// message it receives from the shared `SessionRx`. RPC callers register
+/// before sending their request and unregister after receiving all responses.
+struct ResponseDispatcher {
+    pending: ParkingRwLock<HashMap<String, mpsc::UnboundedSender<ReceivedMessage>>>,
+}
+
+impl ResponseDispatcher {
+    fn new() -> Self {
+        Self {
+            pending: ParkingRwLock::new(HashMap::new()),
+        }
+    }
+
+    fn register(&self, rpc_id: &str) -> mpsc::UnboundedReceiver<ReceivedMessage> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.pending.write().insert(rpc_id.to_string(), tx);
+        rx
+    }
+
+    fn unregister(&self, rpc_id: &str) {
+        self.pending.write().remove(rpc_id);
+    }
+
+    /// Forward a message to the channel registered for `rpc_id`.
+    ///
+    /// Returns `true` on delivery to an active RPC caller, `false` if
+    /// no caller is registered for this rpc-id (message is dropped).
+    fn dispatch(&self, msg: ReceivedMessage, rpc_id: &str) -> bool {
+        let lock = self.pending.read();
+        if let Some(tx) = lock.get(rpc_id) {
+            tx.send(msg).is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Drop all pending registrations.
+    ///
+    /// Called when the underlying session closes. Dropping every sender causes
+    /// each waiting `rx.recv().await` to return `None`, cleanly ending the
+    /// response loop in all in-flight multicast callers.
+    fn close_all(&self) {
+        self.pending.write().clear();
+    }
+}
+
+// ── DispatcherGuard ───────────────────────────────────────────────────────────
+
+/// RAII guard that calls `dispatcher.unregister(rpc_id)` on drop.
+///
+/// Ensures the per-RPC channel is always removed from the dispatcher even
+/// when a stream is abandoned early (e.g. after a single `.next()` call).
+struct DispatcherGuard {
+    dispatcher: Arc<ResponseDispatcher>,
+    rpc_id: String,
+}
+
+impl Drop for DispatcherGuard {
+    fn drop(&mut self) {
+        self.dispatcher.unregister(&self.rpc_id);
+    }
+}
+
+// ── Dispatcher task ───────────────────────────────────────────────────────────
+
+/// Reads every message from `session_rx` and routes it by `rpc-id`.
+///
+/// On session close `close_all()` is called so any in-flight receive loop
+/// unblocks with `None`.
+async fn response_dispatcher_task(mut session_rx: SessionRx, dispatcher: Arc<ResponseDispatcher>) {
+    loop {
+        match session_rx.get_message(None).await {
+            Ok(msg) => {
+                let rpc_id = msg.metadata.get(RPC_ID_KEY).cloned().unwrap_or_default();
+                if !dispatcher.dispatch(msg, &rpc_id) {
+                    tracing::trace!(%rpc_id, "Received message for unknown rpc-id, dropping");
+                }
+            }
+            Err(SessionError::ParticipantDisconnected(name)) => {
+                tracing::debug!(%name, "Response dispatcher: group member disconnected, continuing");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "Response dispatcher: session closed");
+                dispatcher.close_all();
+                break;
+            }
+        }
+    }
+}
+
+// ── ChannelSession ────────────────────────────────────────────────────────────
+
+/// A live SLIM session together with its dispatcher, background task, and member set.
+struct ChannelSession {
+    tx: SessionTx,
+    dispatcher: Arc<ResponseDispatcher>,
+    /// Background task reading from the session. When finished the session
+    /// is considered dead and will be recreated on the next RPC call.
+    task: JoinHandle<()>,
+}
+
+impl ChannelSession {
+    fn is_alive(&self) -> bool {
+        !self.task.is_finished()
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn generate_rpc_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+async fn send_invite(session_tx: &SessionTx, member: &Name) -> Result<(), RpcError> {
+    tracing::debug!("Inviting member to rpc channel.. {}", member);
+    session_tx
+        .controller()
+        .invite_participant(member)
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to invite {member}: {e}")))?
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to invite {member}: {e}")))
+}
+
+/// Generate a random group session name derived from the client name.
+///
+/// Uses the first two components of `client_name` and a UUID as the third,
+/// so the group address lives in the same namespace as the client app.
+fn generate_group_name(client_name: &Name) -> Name {
+    let (c0, c1, _) = client_name.str_components();
+    Name::from_strings([c0, c1, &uuid::Uuid::new_v4().to_string()])
+}
+
+/// Metadata for the first message of an RPC call.
+fn first_msg_metadata(ctx: &Context, service: &str, method: &str, rpc_id: &str) -> Metadata {
+    let mut meta = ctx.metadata();
+    meta.insert(SERVICE_KEY.to_string(), service.to_string());
+    meta.insert(METHOD_KEY.to_string(), method.to_string());
+    meta.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
+    meta.insert(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string());
+    meta
+}
+
+/// Metadata for a stream continuation message (not the first).
+fn continuation_metadata(rpc_id: &str) -> Metadata {
+    let mut meta = HashMap::new();
+    meta.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
+    meta.insert(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string());
+    meta
+}
+
+// ── Channel ───────────────────────────────────────────────────────────────────
+
+/// Client-side channel for making RPC calls.
+///
+/// Manages a single persistent SLIM session: either a `PointToPoint` session
+/// to a single remote server, or a `Multicast` (GROUP) session shared across
+/// multiple remote servers. The session is lazily initialised and recreated
+/// when dead.
+///
+/// ## Constructor
+///
+/// - `new_with_members_internal(app, members)` — Smart constructor:
+///   - **1 member**: creates a P2P channel.
+///   - **Many members**: creates a GROUP channel with a generated session name
+///     and auto-invites all members on the first multicast call.
+#[derive(Clone)]
+pub struct Channel {
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+    /// Session destination: the remote server name for P2P channels, or a
+    /// generated group name (same org/namespace as the client, random UUID)
+    /// for GROUP channels.
+    remote: Name,
+    /// `true` for GROUP channels (`new_group` / `new_group_with_connection`),
+    /// `false` for P2P channels (`new` / `new_with_connection`).
+    is_group: bool,
+    /// Initial group members set at construction time. Used to seed a new
+    /// session on the first call. Dynamically invited members are stored
+    /// in `ChannelSession::members` and inherited across session recreations.
+    initial_members: HashSet<Name>,
+    connection_id: Option<u64>,
+    runtime: tokio::runtime::Handle,
+    /// Persistent session (lazily initialised, recreated when dead).
+    /// PointToPoint for P2P channels, Multicast for GROUP channels.
+    session: Arc<tokio::sync::Mutex<Option<ChannelSession>>>,
+}
+
+impl Channel {
+    /// Create a channel. This is the single construction point.
+    ///
+    /// - `is_group = false`: P2P channel; `members` must contain exactly one entry.
+    /// - `is_group = true`: GROUP channel; a random UUID session name is generated
+    ///   and all `members` are auto-invited on the first multicast call.
+    ///
+    /// Returns an error if `members` is empty.
+    pub fn new_with_members_internal(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Name>,
+        is_group: bool,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        if members.is_empty() {
+            return Err(RpcError::invalid_argument("members must not be empty"));
+        }
+        if !is_group && members.len() != 1 {
+            return Err(RpcError::invalid_argument(
+                "P2P channel requires exactly one member",
+            ));
+        }
+
+        let runtime = crate::get_runtime();
+
+        let members_set: HashSet<Name> = members.into_iter().collect();
+
+        let remote = if is_group {
+            generate_group_name(app.app_name())
+        } else {
+            members_set.iter().next().unwrap().clone()
+        };
+
+        Ok(Self {
+            app,
+            remote,
+            is_group,
+            initial_members: members_set,
+            connection_id,
+            runtime,
+            session: Arc::new(tokio::sync::Mutex::new(None)),
+        })
+    }
+
+    // ── Session management ────────────────────────────────────────────────────
+
+    /// Return the active session, creating it if needed.
+    ///
+    /// - Single-member channel (`is_group == false`): uses the P2P slot.
+    /// - Multi-member channel (`is_group == true`): uses the GROUP slot and
+    ///   auto-invites all members on every (re)creation under the session lock.
+    async fn get_or_create_session(
+        &self,
+    ) -> Result<(SessionTx, Arc<ResponseDispatcher>, HashMap<Name, bool>), RpcError> {
+        let mut guard = self.session.lock().await;
+        self.ensure_session(&mut guard).await?;
+        let cs = guard
+            .as_ref()
+            .ok_or_else(|| RpcError::internal("session missing after creation"))?;
+        let members = self
+            .initial_members
+            .iter()
+            .map(|m| {
+                let mut name = m.clone();
+                name.reset_id();
+                (name, false)
+            })
+            .collect();
+        Ok((cs.tx.clone(), cs.dispatcher.clone(), members))
+    }
+
+    /// Create (or recreate) the SLIM session inside an already-held lock guard.
+    ///
+    /// If the session is already alive this is a no-op. Members are always
+    /// taken from `self.initial_members` since the member set is fixed at
+    /// channel construction time.
+    async fn ensure_session(
+        &self,
+        guard: &mut tokio::sync::MutexGuard<'_, Option<ChannelSession>>,
+    ) -> Result<(), RpcError> {
+        if let Some(ref cs) = **guard
+            && cs.is_alive()
+        {
+            return Ok(());
+        }
+
+        let session_type = if self.is_group {
+            ProtoSessionType::Multicast
+        } else {
+            ProtoSessionType::PointToPoint
+        };
+
+        tracing::debug!(?session_type, "no persistent session — recreating");
+        let (session_tx, session_rx) = self.create_raw_session(session_type).await?;
+        let dispatcher = Arc::new(ResponseDispatcher::new());
+        let task = self
+            .runtime
+            .spawn(response_dispatcher_task(session_rx, dispatcher.clone()));
+
+        **guard = Some(ChannelSession {
+            tx: session_tx.clone(),
+            dispatcher: dispatcher.clone(),
+            task,
+        });
+
+        // Invite all members whenever the GROUP session is (re)created.
+        if self.is_group {
+            for member in &self.initial_members {
+                if let Some(conn_id) = self.connection_id {
+                    self.app.set_route(member, conn_id).await.map_err(|e| {
+                        RpcError::internal(format!(
+                            "Failed to set route for group member {member}: {e}"
+                        ))
+                    })?;
+                }
+                send_invite(&session_tx, member).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create a raw SLIM session to the remote peer.
+    async fn create_raw_session(
+        &self,
+        session_type: ProtoSessionType,
+    ) -> Result<(SessionTx, SessionRx), RpcError> {
+        let app = self.app.clone();
+        let remote = self.remote.clone();
+        let connection_id = self.connection_id;
+        let runtime = &self.runtime;
+
+        // Runs in a tokio task because create_session needs tokio runtime
+        let handle = runtime.spawn(async move {
+            if let Some(conn_id) = connection_id {
+                tracing::debug!(
+                    remote = %remote,
+                    connection_id = conn_id,
+                    "Setting route before creating session"
+                );
+                if let Err(e) = app.set_route(&remote, conn_id).await {
+                    tracing::warn!(
+                        remote = %remote,
+                        connection_id = conn_id,
+                        error = %e,
+                        "Failed to set route"
+                    );
+                }
+            }
+
+            tracing::debug!(remote = %remote, ?session_type, "Creating persistent session");
+
+            let slim_config = slim_session::session_config::SessionConfig {
+                session_type,
+                max_retries: Some(10),
+                interval: Some(Duration::from_secs(1)),
+                initiator: true,
+                metadata: HashMap::new(),
+                mls_settings: Some(MlsSettings::default()),
+            };
+
+            let (session_ctx, completion) = app
+                .create_session(slim_config, remote.clone(), None)
+                .await
+                .map_err(|e| RpcError::unavailable(format!("Failed to create session: {e}")))?;
+
+            completion
+                .await
+                .map_err(|e| RpcError::unavailable(format!("Session handshake failed: {e}")))?;
+
+            Ok(new_session(session_ctx))
+        });
+
+        handle
+            .await
+            .map_err(|e| RpcError::internal(format!("Session creation task failed: {e}")))?
+    }
+
+    // ── Send helpers ──────────────────────────────────────────────────────────
+
+    /// Send a stream of request messages.
+    async fn send_request_stream<Req>(
+        &self,
+        session: &SessionTx,
+        ctx: &Context,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        service_name: &str,
+        method_name: &str,
+        rpc_id: &str,
+    ) -> Result<(), RpcError>
+    where
+        Req: Encoder,
+    {
+        let mut request_stream = std::pin::pin!(request_stream);
+        let mut handles = vec![];
+        let mut first = true;
+        while let Some(request) = request_stream.next().await {
+            let request_bytes = request.encode()?;
+            let msg_meta = if first {
+                first = false;
+                first_msg_metadata(ctx, service_name, method_name, rpc_id)
+            } else {
+                continuation_metadata(rpc_id)
+            };
+            let handle = session
+                .publish(
+                    session.destination(),
+                    request_bytes,
+                    Some("msg".to_string()),
+                    Some(msg_meta),
+                )
+                .await?;
+            handles.push(handle);
+        }
+        // The client EOS always carries RPC_DIR_KEY so the server can distinguish
+        // it from an echoed server EOS.  When the request stream was empty we also
+        // include service + method so the server can dispatch without a data frame.
+        let mut eos_meta = HashMap::from([(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string())]);
+        if first {
+            eos_meta.insert(SERVICE_KEY.to_string(), service_name.to_string());
+            eos_meta.insert(METHOD_KEY.to_string(), method_name.to_string());
+        }
+        handles.push(send_eos(session, session.destination(), rpc_id, Some(eos_meta)).await?);
+
+        // Wait for all (data + EOS) acks in a single batch.
+        for result in join_all(handles).await {
+            result.map_err(|e| {
+                RpcError::internal(format!(
+                    "Failed to complete sending {}-{}: {}",
+                    service_name,
+                    method_name,
+                    ErrorChainExt::chain(&e)
+                ))
+            })?;
+        }
+
+        // When the stream was empty `first` is still true: the EOS must carry
+        // service + method so the server can dispatch without a preceding data frame.
+        let extra = if first {
+            Some(HashMap::from([
+                (SERVICE_KEY.to_string(), service_name.to_string()),
+                (METHOD_KEY.to_string(), method_name.to_string()),
+            ]))
+        } else {
+            None
+        };
+        send_eos(session, session.destination(), rpc_id, extra).await?;
+        Ok(())
+    }
+
+    // ── Core streaming methods ────────────────────────────────────────────────
+
+    /// Core streaming method for all interaction patterns (P2P and GROUP).
+    ///
+    /// Broadcasts `request_stream` concurrently while collecting responses.
+    /// For P2P (`num_members = 1`) the stream ends on the single server EOS.
+    /// For GROUP the stream ends when all members have sent their EOS.
+    /// Member errors are yielded as `Err` items and count as that member's EOS.
+    fn responses_from_stream_input<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        let service_name = service_name.to_string();
+        let method_name = method_name.to_string();
+        let channel = self.clone();
+
+        stream! {
+            let ctx = Context::for_rpc(timeout, metadata.clone());
+            let timeout_duration = calculate_timeout_duration(timeout);
+            let mut delay = Delay::new(timeout_duration);
+
+            let (session_tx, dispatcher, members) = match tokio::select! {
+                result = channel.get_or_create_session() => result,
+                _ = &mut delay => Err(RpcError::deadline_exceeded("Client deadline exceeded during session setup")),
+            } {
+                Ok(v) => v,
+                Err(e) => { yield Err(e); return; }
+            };
+
+            let rpc_id = generate_rpc_id();
+            let mut rx = dispatcher.register(&rpc_id);
+            let _guard = DispatcherGuard { dispatcher: dispatcher.clone(), rpc_id: rpc_id.clone() };
+
+            let session_tx_for_send = session_tx.clone();
+            let ctx_for_send = ctx.clone();
+            let service_for_send = service_name.clone();
+            let method_for_send = method_name.clone();
+            let rpc_id_for_send = rpc_id.clone();
+            let channel_for_send = channel.clone();
+            let mut send_handle = channel.runtime.spawn(async move {
+                channel_for_send
+                    .send_request_stream(
+                        &session_tx_for_send, &ctx_for_send, request_stream,
+                        &service_for_send, &method_for_send, &rpc_id_for_send,
+                    )
+                    .await
+            });
+            let mut members = members;
+            let num_members = members.len();
+            let mut num_completed = 0usize;
+            let mut send_completed = false;
+
+            loop {
+                let received_opt = tokio::select! {
+                    msg = rx.recv() => Ok(msg),
+                    send_result = &mut send_handle, if !send_completed => {
+                        send_completed = true;
+                        match send_result {
+                            Ok(Ok(_)) => continue,
+                            Ok(Err(e)) => Err(e),
+                            Err(e) => Err(RpcError::internal(format!("Send task panicked: {e}"))),
+                        }
+                    },
+                    _ = &mut delay => Err(RpcError::deadline_exceeded(
+                        "Client deadline exceeded while receiving response"
+                    )),
+                };
+
+                let received = match received_opt {
+                    Err(e) => { yield Err(e); break; }
+                    Ok(None) => {
+                        if num_completed < num_members {
+                            if channel.is_group {
+                                yield Err(RpcError::multicast_session_closed(
+                                    members.iter().map(|(m, done)| (m, *done))
+                                ));
+                            } else {
+                                yield Err(RpcError::internal(format!(
+                                    "Session closed after {num_completed}/{num_members} EOS markers"
+                                )));
+                            }
+                        }
+                        break;
+                    }
+                    Ok(Some(m)) => m,
+                };
+
+                let mut source = received.source.clone();
+                source.reset_id();
+
+                if received.is_eos() {
+                    if !*members.get(&source).unwrap_or(&true) {
+                        members.insert(source, true);
+                        num_completed += 1;
+                    }
+                    if num_completed >= num_members { break; }
+                    continue;
+                }
+                let code = RpcCode::from_metadata_str(
+                    received.metadata.get(STATUS_CODE_KEY).map(String::as_str)
+                );
+                if code != RpcCode::Ok {
+                    let msg_text = String::from_utf8_lossy(&received.payload).to_string();
+                    if !*members.get(&source).unwrap_or(&true) {
+                        members.insert(source.clone(), true);
+                        num_completed += 1;
+                    }
+                    let err = RpcError::new(code, msg_text);
+                    yield Err(if channel.is_group { err.with_origin(source.to_string()) } else { err });
+                    if num_completed >= num_members { break; }
+                    continue;
+                }
+
+                let response = match Res::decode(received.payload) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        if !*members.get(&source).unwrap_or(&true) {
+                            members.insert(source.clone(), true);
+                            num_completed += 1;
+                        }
+                        yield Err(if channel.is_group { e.with_origin(source.to_string()) } else { e });
+                        if num_completed >= num_members { break; }
+                        continue;
+                    }
+                };
+                yield Ok(MulticastItem { context: MessageContext { source }, message: response });
+            }
+        }
+    }
+
+    // ── RPC methods ───────────────────────────────────────────────────────────
+
+    /// Unary RPC: single request → single response.
+    ///
+    /// Equivalent to `unary_stream(...).next()`.
+    pub async fn unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Res, RpcError>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        let stream = self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        );
+        futures::pin_mut!(stream);
+        stream
+            .next()
+            .await
+            .unwrap_or_else(|| Err(RpcError::internal("No response received")))
+            .map(|item| item.message)
+    }
+
+    /// Unary-stream RPC: single request → stream of responses.
+    pub fn unary_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<Res, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        )
+        .map(|r| r.map(|item| item.message))
+    }
+
+    /// Stream-unary RPC: stream of requests → single response.
+    ///
+    /// Equivalent to `stream_stream(...).next()`.
+    pub async fn stream_unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Res, RpcError>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        let stream = self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        );
+        futures::pin_mut!(stream);
+        stream
+            .next()
+            .await
+            .unwrap_or_else(|| Err(RpcError::internal("No response received")))
+            .map(|item| item.message)
+    }
+
+    /// Stream-stream RPC: stream of requests → stream of responses.
+    pub fn stream_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<Res, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        )
+        .map(|r| r.map(|item| item.message))
+    }
+
+    /// Multicast unary: broadcast one request, receive one `MulticastItem` per member.
+    ///
+    /// Each item carries a `MessageContext` identifying the source member plus the
+    /// decoded response. The stream ends when all members have sent their response.
+    pub fn multicast_unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        )
+    }
+
+    /// Multicast unary-stream: broadcast one request, receive a stream of `MulticastItem`s.
+    ///
+    /// Each group member may return multiple responses. All responses from all
+    /// members are interleaved in arrival order, each tagged with its source.
+    /// The stream ends when all members have sent their final EOS.
+    ///
+    /// Transport is identical to `multicast_unary`; the semantic difference
+    /// (one vs many responses per member) lives in the server handler.
+    pub fn multicast_unary_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        )
+    }
+
+    /// Multicast stream-unary: broadcast a request stream, receive one `MulticastItem` per member.
+    ///
+    /// The request stream is broadcast to all members. Each member replies with
+    /// a single response tagged with its source. The stream ends when all members
+    /// have sent their response.
+    pub fn multicast_stream_unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        )
+    }
+
+    /// Multicast stream-stream: broadcast a request stream, receive a stream of `MulticastItem`s.
+    ///
+    /// The request stream is broadcast to all members. Each member replies with
+    /// its own response stream. All responses from all members are interleaved in
+    /// arrival order, each tagged with its source. The stream ends when all members
+    /// have sent their final EOS.
+    ///
+    /// Transport is identical to `multicast_stream_unary`; the semantic
+    /// difference lives in the server handler.
+    pub fn multicast_stream_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        )
+    }
+
+    pub fn app(&self) -> &Arc<SlimApp<AuthProvider, AuthVerifier>> {
+        &self.app
+    }
+
+    pub fn remote(&self) -> &Name {
+        &self.remote
+    }
+
+    pub fn connection_id(&self) -> Option<u64> {
+        self.connection_id
+    }
+}
+
+// ── UniFFI exports ────────────────────────────────────────────────────────────
+
+impl Channel {
+    pub fn new(app: Arc<SlimApp<AuthProvider, AuthVerifier>>, remote: Arc<Name>) -> Self {
+        Self::new_with_connection(app, remote, None)
+    }
+
+    pub fn new_with_connection(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        remote: Arc<Name>,
+        connection_id: Option<u64>,
+    ) -> Self {
+        let slim_app = app.clone();
+        let slim_name = remote.as_ref().clone();
+        Self::new_with_members_internal(slim_app, vec![slim_name], false, connection_id)
+            .expect("single non-empty member list is always valid")
+    }
+
+    pub fn new_group(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Arc<Name>>,
+    ) -> Result<Self, RpcError> {
+        Self::new_group_with_connection(app, members, None)
+    }
+
+    pub fn new_group_with_connection(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Arc<Name>>,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        let slim_app = app.clone();
+        let slim_names = members.iter().map(|n| n.as_ref().clone()).collect();
+        Self::new_with_members_internal(slim_app, slim_names, true, connection_id)
+    }
+
+    pub fn call_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Vec<u8>, RpcError> {
+        crate::get_runtime().block_on(self.call_unary_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    pub async fn call_unary_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Vec<u8>, RpcError> {
+        self.unary(&service_name, &method_name, request, timeout, metadata)
+            .await
+    }
+
+    pub fn call_unary_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<ResponseStreamReader>, RpcError> {
+        crate::get_runtime().block_on(self.call_unary_stream_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    pub async fn call_unary_stream_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<ResponseStreamReader>, RpcError> {
+        let channel = self.clone();
+        let (tx, rx) = unbounded_channel();
+        crate::get_runtime().spawn(async move {
+            let stream = channel.unary_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request,
+                timeout,
+                metadata,
+            );
+            futures::pin_mut!(stream);
+            while let Some(item) = futures::StreamExt::next(&mut stream).await {
+                if tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Arc::new(ResponseStreamReader::new(rx)))
+    }
+
+    pub fn call_stream_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Arc<RequestStreamWriter> {
+        Arc::new(RequestStreamWriter::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    pub fn call_stream_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Arc<BidiStreamHandler> {
+        Arc::new(BidiStreamHandler::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    // ── Multicast UniFFI methods ───────────────────────────────────────────────
+
+    /// Broadcast one request to all GROUP members and collect their responses.
+    ///
+    /// Returns a reader from which each member's response (wrapped in
+    /// `MulticastStreamMessage`) can be pulled one at a time (blocking).
+    pub fn call_multicast_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        crate::get_runtime().block_on(self.call_multicast_unary_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Broadcast one request to all GROUP members and collect their responses
+    /// (async).
+    pub async fn call_multicast_unary_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        let channel = self.clone();
+        let (tx, rx) = unbounded_channel();
+        crate::get_runtime().spawn(async move {
+            let stream = channel.multicast_unary::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request,
+                timeout,
+                metadata,
+            );
+            futures::pin_mut!(stream);
+            while let Some(item) = futures::StreamExt::next(&mut stream).await {
+                if tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Arc::new(MulticastResponseReader::new(rx)))
+    }
+
+    /// Broadcast one request to all GROUP members and stream their responses
+    /// (blocking).
+    ///
+    /// Semantically identical to `call_multicast_unary` at the transport level;
+    /// the difference is that each member may send multiple responses before its
+    /// EOS, which the server handler determines.
+    pub fn call_multicast_unary_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        crate::get_runtime().block_on(self.call_multicast_unary_stream_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Broadcast one request to all GROUP members and stream their responses
+    /// (async).
+    pub async fn call_multicast_unary_stream_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        let channel = self.clone();
+        let (tx, rx) = unbounded_channel();
+        crate::get_runtime().spawn(async move {
+            let stream = channel.multicast_unary_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request,
+                timeout,
+                metadata,
+            );
+            futures::pin_mut!(stream);
+            while let Some(item) = futures::StreamExt::next(&mut stream).await {
+                if tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Arc::new(MulticastResponseReader::new(rx)))
+    }
+
+    /// Broadcast a request stream to all GROUP members and collect their
+    /// responses.
+    ///
+    /// Returns a handler that lets you send requests and receive responses
+    /// concurrently. Use `send` / `send_async` to push request messages,
+    /// `close_send` / `close_send_async` to signal end-of-requests, and
+    /// `recv` / `recv_async` to pull response items.
+    pub fn call_multicast_stream_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Arc<MulticastBidiStreamHandler> {
+        Arc::new(MulticastBidiStreamHandler::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Broadcast a request stream to all GROUP members and stream their
+    /// responses.
+    ///
+    /// Semantically equivalent to `call_multicast_stream_unary` at the
+    /// transport level; the difference (one vs many responses per member) is
+    /// determined by the server handler.
+    pub fn call_multicast_stream_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Arc<MulticastBidiStreamHandler> {
+        Arc::new(MulticastBidiStreamHandler::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Close the persistent SLIM session held by this channel, if any.
+    ///
+    /// `timeout` optionally bounds how long to wait for the session layer to
+    /// confirm the close before giving up and proceeding with cleanup anyway.
+    /// Pass `None` to wait indefinitely.
+    ///
+    /// After this call the channel can still be used; a new session will be
+    /// created automatically on the next RPC call.
+    pub fn close(&self, timeout: Option<Duration>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_async(timeout))
+    }
+
+    /// Async version of [`close`](Self::close).
+    pub async fn close_async(&self, timeout: Option<Duration>) -> Result<(), RpcError> {
+        let mut guard = self.session.lock().await;
+        let Some(cs) = guard.take() else {
+            return Ok(());
+        };
+
+        let close_future = cs.tx.close(self.app.as_ref());
+        futures::pin_mut!(close_future);
+
+        if let Some(duration) = timeout {
+            // Bound the wait with a futures-timer delay so this works across
+            // all async runtimes exposed by the bindings.
+            let delay = Delay::new(duration);
+            futures::pin_mut!(delay);
+            match futures::future::select(close_future, delay).await {
+                futures::future::Either::Left((Err(e), _)) => {
+                    tracing::warn!(error = %e, "Error closing session");
+                }
+                futures::future::Either::Right(_) => {
+                    tracing::warn!("Timeout waiting for session close");
+                }
+                _ => {}
+            }
+        } else if let Err(e) = close_future.await {
+            tracing::warn!(error = %e, "Error closing session");
+        }
+
+        // Closing the session tx drops the underlying receive channel; the
+        // dispatcher task detects the closed channel and exits naturally.
+        let _ = cs.task.await;
+
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_status_code() {
+        assert_eq!(RpcCode::try_from(0), Ok(RpcCode::Ok));
+        assert_eq!(RpcCode::try_from(13), Ok(RpcCode::Internal));
+        assert!(RpcCode::try_from(999).is_err());
+    }
+
+    #[test]
+    fn test_generate_rpc_id() {
+        let id1 = generate_rpc_id();
+        let id2 = generate_rpc_id();
+        assert_eq!(id1.len(), 36);
+        assert_eq!(id2.len(), 36);
+        assert_ne!(id1, id2);
+    }
+
+    // ── ResponseDispatcher ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_response_dispatcher_close_all() {
+        let dispatcher = ResponseDispatcher::new();
+        let mut rx1 = dispatcher.register("rpc-a");
+        let mut rx2 = dispatcher.register("rpc-b");
+
+        dispatcher.close_all();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert!(
+                rx1.recv().await.is_none(),
+                "rx1 should see None after close_all"
+            );
+            assert!(
+                rx2.recv().await.is_none(),
+                "rx2 should see None after close_all"
+            );
+        });
+    }
+
+    #[test]
+    fn test_response_dispatcher_dispatch_and_unregister() {
+        let dispatcher = ResponseDispatcher::new();
+        let mut rx = dispatcher.register("rpc-x");
+
+        let dummy_name = Name::from_strings(["", "", ""]);
+        let msg = ReceivedMessage {
+            metadata: HashMap::new(),
+            payload: vec![1, 2, 3],
+            source: dummy_name.clone(),
+        };
+        assert!(dispatcher.dispatch(msg, "rpc-x"));
+        assert!(!dispatcher.dispatch(
+            ReceivedMessage {
+                metadata: HashMap::new(),
+                payload: vec![],
+                source: dummy_name.clone(),
+            },
+            "rpc-unknown"
+        ));
+
+        dispatcher.unregister("rpc-x");
+        assert!(!dispatcher.dispatch(
+            ReceivedMessage {
+                metadata: HashMap::new(),
+                payload: vec![],
+                source: dummy_name.clone(),
+            },
+            "rpc-x"
+        ));
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let received = rx.recv().await;
+            assert!(received.is_some());
+            assert_eq!(received.unwrap().payload, vec![1, 2, 3]);
+        });
+    }
+
+    // ── DispatcherGuard ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_dispatcher_guard_unregisters_on_drop() {
+        let dispatcher = Arc::new(ResponseDispatcher::new());
+        let _rx = dispatcher.register("rpc-guard");
+        {
+            let _guard = DispatcherGuard {
+                dispatcher: dispatcher.clone(),
+                rpc_id: "rpc-guard".to_string(),
+            };
+            // _guard dropped here → unregister called
+        }
+        // After guard drops, dispatch must fail.
+        assert!(!dispatcher.dispatch(
+            ReceivedMessage {
+                metadata: HashMap::new(),
+                payload: vec![],
+                source: Name::from_strings(["", "", ""]),
+            },
+            "rpc-guard"
+        ));
+    }
+}

--- a/crates/rpc/src/codec.rs
+++ b/crates/rpc/src/codec.rs
@@ -1,0 +1,79 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Codec traits for message serialization and deserialization
+//!
+//! Provides trait abstractions for encoding and decoding messages in SlimRPC.
+//! These traits are typically implemented by protobuf-generated code.
+
+use super::RpcError;
+
+/// Trait for encoding messages to bytes
+pub trait Encoder {
+    /// Encode a message to bytes
+    fn encode(self) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Trait for decoding messages from bytes
+pub trait Decoder: Default {
+    /// Decode a message from bytes
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError>;
+}
+
+/// Combined codec trait for types that can be both encoded and decoded
+pub trait Codec: Encoder + Decoder {}
+
+// Blanket implementation
+impl<T: Encoder + Decoder> Codec for T {}
+
+// Standard implementations for Vec<u8> (pass-through)
+impl Encoder for Vec<u8> {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        Ok(self)
+    }
+}
+
+impl Decoder for Vec<u8> {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        Ok(buf.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Simple test message type for codec tests
+    #[derive(Debug, Clone, Default, PartialEq)]
+    struct TestMessage {
+        data: Vec<u8>,
+    }
+
+    impl Encoder for TestMessage {
+        fn encode(self) -> Result<Vec<u8>, RpcError> {
+            Ok(self.data)
+        }
+    }
+
+    impl Decoder for TestMessage {
+        fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+            Ok(TestMessage { data: buf.into() })
+        }
+    }
+
+    #[test]
+    fn test_encode() {
+        let msg = TestMessage {
+            data: vec![1, 2, 3, 4],
+        };
+        let encoded = msg.encode().unwrap();
+        assert_eq!(encoded, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_decode() {
+        let buf = vec![1, 2, 3, 4];
+        let msg: TestMessage = TestMessage::decode(buf).unwrap();
+        assert_eq!(msg.data, vec![1, 2, 3, 4]);
+    }
+}

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -1,0 +1,323 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Context types for SlimRPC request handling
+//!
+//! Provides context information for RPC handlers including metadata, deadlines,
+//! session information, and message routing details.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
+
+use slim_datapath::api::ProtoName as Name;
+use slim_session::context::SessionContext as SlimSessionContext;
+
+use super::{DEADLINE_KEY, SessionTx, calculate_deadline};
+
+pub type Metadata = HashMap<String, String>;
+
+/// Context passed to RPC handlers
+///
+/// Contains all contextual information about an RPC call including:
+/// - Session information (source, destination, session ID)
+/// - Metadata (key-value pairs)
+/// - Deadline/timeout information
+/// - Message routing details
+#[derive(Debug, Clone)]
+pub struct Context {
+    /// Session context information
+    session: SessionContext,
+    /// Deadline for the RPC call (always set, defaults to now + MAX_TIMEOUT)
+    deadline: SystemTime,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Context {
+    /// Get the session ID
+    pub fn session_id(&self) -> String {
+        self.session.session_id().to_string()
+    }
+
+    /// Get the rpc session metadata
+    pub fn metadata(&self) -> HashMap<String, String> {
+        self.session.metadata.clone()
+    }
+
+    /// Get the deadline for this RPC call
+    pub fn deadline(&self) -> SystemTime {
+        self.deadline
+    }
+
+    /// Get the remaining time until deadline
+    ///
+    /// Returns Duration::ZERO if the deadline has already passed
+    pub fn remaining_time(&self) -> Duration {
+        self.deadline
+            .duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO)
+    }
+
+    /// Check if the deadline has been exceeded
+    pub fn is_deadline_exceeded(&self) -> bool {
+        SystemTime::now() > self.deadline
+    }
+}
+
+impl Context {
+    /// Create a context for an outbound RPC call.
+    ///
+    /// Sets the deadline from `timeout` (or the default max timeout if `None`)
+    /// and merges any caller-supplied `metadata`.
+    pub fn for_rpc(timeout: Option<Duration>, metadata: Option<Metadata>) -> Self {
+        let mut ctx = Self::new();
+        ctx.set_deadline(calculate_deadline(timeout));
+        if let Some(meta) = metadata {
+            ctx.metadata_mut().extend(meta);
+        }
+        ctx
+    }
+
+    /// Create a new empty context with default deadline (now + MAX_TIMEOUT)
+    pub fn new() -> Self {
+        Self::with_session(SessionContext {
+            session_id: String::new(),
+            source: Name::from_strings(["", "", ""]),
+            destination: Name::from_strings(["", "", ""]),
+            metadata: Metadata::new(),
+        })
+    }
+
+    /// Create a new context with a session context and default deadline
+    pub fn with_session(session: SessionContext) -> Self {
+        Self {
+            deadline: calculate_deadline(None),
+            session,
+        }
+    }
+
+    /// Create a new context from a session
+    pub fn from_session(session: &SlimSessionContext) -> Self {
+        let session_ctx = SessionContext::from_session(session);
+        let deadline =
+            Self::parse_deadline(&session_ctx.metadata).unwrap_or(calculate_deadline(None));
+
+        Self {
+            session: session_ctx,
+            deadline,
+        }
+    }
+
+    /// Create a new context from a SessionRx wrapper
+    pub fn from_session_tx(session: &SessionTx) -> Self {
+        let session_id = session.session_id().to_string();
+        let source = session.source().clone();
+        let destination = session.destination().clone();
+        let metadata = session.metadata();
+        let deadline = Self::parse_deadline(&metadata).unwrap_or(calculate_deadline(None));
+
+        Self {
+            session: SessionContext {
+                session_id,
+                source,
+                destination,
+                metadata,
+            },
+            deadline,
+        }
+    }
+
+    /// Create a new context with message metadata
+    pub fn with_message_metadata(
+        mut self,
+        msg_metadata: std::collections::HashMap<String, String>,
+    ) -> Self {
+        // Merge message metadata into context metadata
+        self.session.metadata.extend(msg_metadata);
+        // Re-parse deadline from merged metadata (message metadata takes precedence)
+        self.deadline =
+            Self::parse_deadline(&self.session.metadata).unwrap_or(calculate_deadline(None));
+        self
+    }
+
+    /// Get the session context
+    pub fn session(&self) -> &SessionContext {
+        &self.session
+    }
+
+    /// Get the request metadata
+    pub fn metadata_ref(&self) -> &Metadata {
+        &self.session.metadata
+    }
+
+    /// Get a mutable reference to metadata
+    pub fn metadata_mut(&mut self) -> &mut Metadata {
+        &mut self.session.metadata
+    }
+
+    /// Parse deadline from metadata
+    fn parse_deadline(metadata: &Metadata) -> Option<SystemTime> {
+        metadata.get(DEADLINE_KEY).and_then(|deadline_str| {
+            deadline_str.parse::<f64>().ok().and_then(|seconds| {
+                SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs_f64(seconds))
+            })
+        })
+    }
+
+    /// Set the deadline
+    pub fn set_deadline(&mut self, deadline: SystemTime) {
+        self.deadline = deadline;
+        let seconds = deadline
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64();
+        self.session
+            .metadata
+            .insert(DEADLINE_KEY.into(), seconds.to_string());
+    }
+
+    /// Set the deadline from a duration
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        let deadline = SystemTime::now()
+            .checked_add(timeout)
+            .unwrap_or(SystemTime::now());
+        self.set_deadline(deadline);
+    }
+}
+
+/// Session-level context information
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    /// Session ID
+    session_id: String,
+    /// Source name (sender)
+    source: Name,
+    /// Destination name (receiver)
+    destination: Name,
+    /// Session metadata
+    pub(crate) metadata: Metadata,
+}
+
+impl SessionContext {
+    /// Create from a SLIM session context
+    pub fn from_session(session: &SlimSessionContext) -> Self {
+        let session_arc = session.session_arc();
+        if let Some(controller) = session_arc {
+            Self {
+                session_id: controller.id().to_string(),
+                source: controller.source().clone(),
+                destination: controller.dst().clone(),
+                metadata: controller.metadata(),
+            }
+        } else {
+            // Fallback if session is already closed
+            Self {
+                session_id: session.session_id().to_string(),
+                source: Name::from_strings(["", "", ""]),
+                destination: Name::from_strings(["", "", ""]),
+                metadata: Metadata::new(),
+            }
+        }
+    }
+
+    /// Get the session ID
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Get the source name
+    pub fn source(&self) -> &Name {
+        &self.source
+    }
+
+    /// Get the destination name
+    pub fn destination(&self) -> &Name {
+        &self.destination
+    }
+
+    /// Get the session metadata
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_context_deadline_parsing() {
+        let mut metadata = Metadata::new();
+        let deadline_time = SystemTime::now()
+            .checked_add(Duration::from_secs(60))
+            .unwrap();
+        let seconds = deadline_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        metadata.insert(DEADLINE_KEY.into(), seconds.to_string());
+
+        let parsed = Context::parse_deadline(&metadata);
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn test_context_deadline_exceeded() {
+        let mut metadata = Metadata::new();
+        let past_deadline = SystemTime::now()
+            .checked_sub(Duration::from_secs(60))
+            .unwrap();
+        let seconds = past_deadline
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        metadata.insert(DEADLINE_KEY.into(), seconds.to_string());
+
+        let deadline = Context::parse_deadline(&metadata);
+        assert!(deadline.is_some());
+        if let Some(d) = deadline {
+            assert!(SystemTime::now() > d);
+        }
+    }
+
+    #[test]
+    fn test_context_set_timeout() {
+        let session_metadata = HashMap::new();
+        let ctx_session = SessionContext {
+            session_id: "test-session".to_string(),
+            source: Name::from_strings(["org", "ns", "app"]),
+            destination: Name::from_strings(["org", "ns", "dest"]),
+            metadata: session_metadata,
+        };
+
+        let mut ctx = Context::with_session(ctx_session);
+
+        ctx.set_timeout(Duration::from_secs(30));
+        assert!(!ctx.is_deadline_exceeded());
+    }
+
+    #[test]
+    fn test_remaining_time() {
+        let session_metadata = HashMap::new();
+        let ctx_session = SessionContext {
+            session_id: "test-session".to_string(),
+            source: Name::from_strings(["org", "ns", "app"]),
+            destination: Name::from_strings(["org", "ns", "dest"]),
+            metadata: session_metadata,
+        };
+
+        let mut ctx = Context::with_session(ctx_session);
+
+        ctx.set_timeout(Duration::from_secs(60));
+        let remaining = ctx.remaining_time();
+        // Should be close to 60 seconds, allow some margin
+        assert!(remaining.as_secs() >= 59 && remaining.as_secs() <= 60);
+    }
+}

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,0 +1,659 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Status codes and error handling for SlimRPC
+//!
+//! This module provides gRPC-compatible status codes and error types.
+
+use std::fmt;
+
+/// gRPC status codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(u16)]
+pub enum RpcCode {
+    /// Success
+    #[default]
+    Ok = 0,
+    /// The operation was cancelled
+    Cancelled = 1,
+    /// Unknown error
+    Unknown = 2,
+    /// Client specified an invalid argument
+    InvalidArgument = 3,
+    /// Deadline exceeded before operation could complete
+    DeadlineExceeded = 4,
+    /// Some requested entity was not found
+    NotFound = 5,
+    /// Some entity that we attempted to create already exists
+    AlreadyExists = 6,
+    /// The caller does not have permission to execute the specified operation
+    PermissionDenied = 7,
+    /// Some resource has been exhausted
+    ResourceExhausted = 8,
+    /// The system is not in a state required for the operation's execution
+    FailedPrecondition = 9,
+    /// The operation was aborted
+    Aborted = 10,
+    /// Operation was attempted past the valid range
+    OutOfRange = 11,
+    /// Operation is not implemented or not supported
+    Unimplemented = 12,
+    /// Internal errors
+    Internal = 13,
+    /// The service is currently unavailable
+    Unavailable = 14,
+    /// Unrecoverable data loss or corruption
+    DataLoss = 15,
+    /// The request does not have valid authentication credentials
+    Unauthenticated = 16,
+}
+
+impl RpcCode {
+    /// Returns true if this is a success code
+    pub fn is_ok(&self) -> bool {
+        matches!(self, RpcCode::Ok)
+    }
+
+    /// Returns true if this is an error code
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Parse an optional metadata value into an `RpcCode`.
+    ///
+    /// Returns `RpcCode::Ok` when the string is absent or cannot be parsed,
+    /// mirroring the wire convention where a missing status key means success.
+    pub fn from_metadata_str(s: Option<&str>) -> Self {
+        s.and_then(|s| s.parse::<i32>().ok())
+            .and_then(|code| RpcCode::try_from(code).ok())
+            .unwrap_or(RpcCode::Ok)
+    }
+}
+
+impl fmt::Display for RpcCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            RpcCode::Ok => "OK",
+            RpcCode::Cancelled => "CANCELLED",
+            RpcCode::Unknown => "UNKNOWN",
+            RpcCode::InvalidArgument => "INVALID_ARGUMENT",
+            RpcCode::DeadlineExceeded => "DEADLINE_EXCEEDED",
+            RpcCode::NotFound => "NOT_FOUND",
+            RpcCode::AlreadyExists => "ALREADY_EXISTS",
+            RpcCode::PermissionDenied => "PERMISSION_DENIED",
+            RpcCode::ResourceExhausted => "RESOURCE_EXHAUSTED",
+            RpcCode::FailedPrecondition => "FAILED_PRECONDITION",
+            RpcCode::Aborted => "ABORTED",
+            RpcCode::OutOfRange => "OUT_OF_RANGE",
+            RpcCode::Unimplemented => "UNIMPLEMENTED",
+            RpcCode::Internal => "INTERNAL",
+            RpcCode::Unavailable => "UNAVAILABLE",
+            RpcCode::DataLoss => "DATA_LOSS",
+            RpcCode::Unauthenticated => "UNAUTHENTICATED",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl From<RpcCode> for i32 {
+    fn from(code: RpcCode) -> i32 {
+        code as i32
+    }
+}
+
+impl TryFrom<i32> for RpcCode {
+    type Error = InvalidRpcCode;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(RpcCode::Ok),
+            1 => Ok(RpcCode::Cancelled),
+            2 => Ok(RpcCode::Unknown),
+            3 => Ok(RpcCode::InvalidArgument),
+            4 => Ok(RpcCode::DeadlineExceeded),
+            5 => Ok(RpcCode::NotFound),
+            6 => Ok(RpcCode::AlreadyExists),
+            7 => Ok(RpcCode::PermissionDenied),
+            8 => Ok(RpcCode::ResourceExhausted),
+            9 => Ok(RpcCode::FailedPrecondition),
+            10 => Ok(RpcCode::Aborted),
+            11 => Ok(RpcCode::OutOfRange),
+            12 => Ok(RpcCode::Unimplemented),
+            13 => Ok(RpcCode::Internal),
+            14 => Ok(RpcCode::Unavailable),
+            15 => Ok(RpcCode::DataLoss),
+            16 => Ok(RpcCode::Unauthenticated),
+            _ => Err(InvalidRpcCode(value)),
+        }
+    }
+}
+
+/// Error returned when trying to convert an invalid i32 to RpcCode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidRpcCode(pub i32);
+
+impl fmt::Display for InvalidRpcCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid RPC code: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidRpcCode {}
+
+/// UniFFI-compatible RPC error
+///
+/// This represents RPC errors with gRPC-compatible status codes.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum RpcError {
+    #[error("{message}")]
+    Rpc {
+        code: RpcCode,
+        message: String,
+        details: Option<Vec<u8>>,
+    },
+
+    #[error("[origin: {origin}] {message}")]
+    MulticastRpc {
+        origin: String,
+        code: RpcCode,
+        message: String,
+        details: Option<Vec<u8>>,
+    },
+
+    #[error("Session closed after {completed}/{total} members; received: [{}], missing: [{}]", received.join(", "), missing.join(", "))]
+    MulticastSessionClosed {
+        completed: u64,
+        total: u64,
+        received: Vec<String>,
+        missing: Vec<String>,
+    },
+}
+
+impl RpcError {
+    /// Create a new RPC error
+    pub fn new(code: RpcCode, message: impl Into<String>) -> Self {
+        Self::Rpc {
+            code,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Create a new multicast RPC error
+    pub fn new_multicast(
+        origin: impl Into<String>,
+        code: RpcCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::MulticastRpc {
+            origin: origin.into(),
+            code,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Create a multicast session-closed error from a member completion map.
+    ///
+    /// Partitions the members into received (done) and missing (not done) lists.
+    pub fn multicast_session_closed(
+        members: impl IntoIterator<Item = (impl ToString, bool)>,
+    ) -> Self {
+        let mut received = Vec::new();
+        let mut missing = Vec::new();
+        for (m, done) in members {
+            if done {
+                received.push(m.to_string());
+            } else {
+                missing.push(m.to_string());
+            }
+        }
+        let completed = received.len() as u64;
+        let total = (received.len() + missing.len()) as u64;
+        Self::MulticastSessionClosed {
+            completed,
+            total,
+            received,
+            missing,
+        }
+    }
+
+    /// Create a new multicast RPC error with details
+    pub fn multicast_with_details(
+        origin: impl Into<String>,
+        code: RpcCode,
+        message: impl Into<String>,
+        details: Vec<u8>,
+    ) -> Self {
+        Self::MulticastRpc {
+            origin: origin.into(),
+            code,
+            message: message.into(),
+            details: Some(details),
+        }
+    }
+
+    /// Create a new RPC error with details
+    pub fn with_details(code: RpcCode, message: impl Into<String>, details: Vec<u8>) -> Self {
+        Self::Rpc {
+            code,
+            message: message.into(),
+            details: Some(details),
+        }
+    }
+
+    /// Create a RPC error with just a code
+    pub fn with_code(code: RpcCode) -> Self {
+        Self::Rpc {
+            code,
+            message: String::new(),
+            details: None,
+        }
+    }
+
+    /// Create an OK status (for completeness, though typically not used as an error)
+    pub fn ok() -> Self {
+        Self::with_code(RpcCode::Ok)
+    }
+
+    /// Create a cancelled error
+    pub fn cancelled(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Cancelled, message)
+    }
+
+    /// Create an unknown error
+    pub fn unknown(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unknown, message)
+    }
+
+    /// Create an invalid argument error
+    pub fn invalid_argument(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::InvalidArgument, message)
+    }
+
+    /// Create a deadline exceeded error
+    pub fn deadline_exceeded(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::DeadlineExceeded, message)
+    }
+
+    /// Create a not found error
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::NotFound, message)
+    }
+
+    /// Create an already exists error
+    pub fn already_exists(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::AlreadyExists, message)
+    }
+
+    /// Create a permission denied error
+    pub fn permission_denied(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::PermissionDenied, message)
+    }
+
+    /// Create a resource exhausted error
+    pub fn resource_exhausted(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::ResourceExhausted, message)
+    }
+
+    /// Create a failed precondition error
+    pub fn failed_precondition(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::FailedPrecondition, message)
+    }
+
+    /// Create an aborted error
+    pub fn aborted(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Aborted, message)
+    }
+
+    /// Create an out of range error
+    pub fn out_of_range(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::OutOfRange, message)
+    }
+
+    /// Create an unimplemented error
+    pub fn unimplemented(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unimplemented, message)
+    }
+
+    /// Create an internal error
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Internal, message)
+    }
+
+    /// Create an unavailable error
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unavailable, message)
+    }
+
+    /// Create a data loss error
+    pub fn data_loss(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::DataLoss, message)
+    }
+
+    /// Create an unauthenticated error
+    pub fn unauthenticated(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unauthenticated, message)
+    }
+
+    /// Get the error code
+    pub fn code(&self) -> RpcCode {
+        match self {
+            Self::Rpc { code, .. } | Self::MulticastRpc { code, .. } => *code,
+            Self::MulticastSessionClosed { .. } => RpcCode::Internal,
+        }
+    }
+
+    /// Get the error message
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Rpc { message, .. } | Self::MulticastRpc { message, .. } => message,
+            Self::MulticastSessionClosed { .. } => "multicast session closed prematurely",
+        }
+    }
+
+    /// Get the error details
+    pub fn details(&self) -> Option<&[u8]> {
+        match self {
+            Self::Rpc { details, .. } | Self::MulticastRpc { details, .. } => details.as_deref(),
+            Self::MulticastSessionClosed { .. } => None,
+        }
+    }
+
+    /// Get the origin of the error (only available for multicast errors)
+    pub fn origin(&self) -> Option<&str> {
+        match self {
+            Self::MulticastRpc { origin, .. } => Some(origin),
+            _ => None,
+        }
+    }
+
+    /// Convert this error into a `MulticastRpc` variant, attaching the given origin.
+    ///
+    /// If the error is already a `MulticastRpc`, the origin is replaced.
+    /// `MulticastSessionClosed` is returned as-is since it has no single origin.
+    pub fn with_origin(self, origin: impl Into<String>) -> Self {
+        let origin = origin.into();
+        match self {
+            Self::Rpc {
+                code,
+                message,
+                details,
+            }
+            | Self::MulticastRpc {
+                code,
+                message,
+                details,
+                ..
+            } => Self::MulticastRpc {
+                origin,
+                code,
+                message,
+                details,
+            },
+            other @ Self::MulticastSessionClosed { .. } => other,
+        }
+    }
+
+    /// Returns true if this is a success status
+    pub fn is_ok(&self) -> bool {
+        self.code().is_ok()
+    }
+
+    /// Returns true if this is an error status
+    pub fn is_err(&self) -> bool {
+        self.code().is_err()
+    }
+
+    /// Add details to an existing error
+    pub fn with_details_added(mut self, details: Vec<u8>) -> Self {
+        match &mut self {
+            Self::Rpc { details: d, .. } | Self::MulticastRpc { details: d, .. } => {
+                *d = Some(details)
+            }
+            Self::MulticastSessionClosed { .. } => {}
+        }
+        self
+    }
+}
+
+impl Default for RpcError {
+    fn default() -> Self {
+        Self::ok()
+    }
+}
+
+impl From<RpcCode> for RpcError {
+    fn from(code: RpcCode) -> Self {
+        Self::with_code(code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_code_conversions() {
+        let ok_code: i32 = RpcCode::Ok.into();
+        let internal_code: i32 = RpcCode::Internal.into();
+        assert_eq!(ok_code, 0);
+        assert_eq!(internal_code, 13);
+        assert_eq!(RpcCode::try_from(0), Ok(RpcCode::Ok));
+        assert_eq!(RpcCode::try_from(13), Ok(RpcCode::Internal));
+        assert!(RpcCode::try_from(999).is_err());
+    }
+
+    #[test]
+    fn test_code_display() {
+        assert_eq!(RpcCode::Ok.to_string(), "OK");
+        assert_eq!(RpcCode::NotFound.to_string(), "NOT_FOUND");
+        assert_eq!(RpcCode::Internal.to_string(), "INTERNAL");
+    }
+
+    #[test]
+    fn test_code_is_ok() {
+        assert!(RpcCode::Ok.is_ok());
+        assert!(!RpcCode::Internal.is_ok());
+        assert!(!RpcCode::Ok.is_err());
+        assert!(RpcCode::Internal.is_err());
+    }
+
+    #[test]
+    fn test_error_creation() {
+        let error = RpcError::ok();
+        assert_eq!(error.code(), RpcCode::Ok);
+        assert!(error.is_ok());
+
+        let error = RpcError::internal("test error");
+        assert_eq!(error.code(), RpcCode::Internal);
+        assert!(error.is_err());
+        assert_eq!(error.message(), "test error");
+    }
+
+    #[test]
+    fn test_error_with_details() {
+        let details = vec![1, 2, 3, 4];
+        let error = RpcError::with_details(RpcCode::Internal, "error", details.clone());
+        assert_eq!(error.details(), Some(details.as_slice()));
+    }
+
+    #[test]
+    fn test_error_display() {
+        let error = RpcError::ok();
+        assert_eq!(error.to_string(), "");
+
+        let error = RpcError::internal("test");
+        assert_eq!(error.to_string(), "test");
+    }
+
+    #[test]
+    fn test_error_from_code() {
+        let error: RpcError = RpcCode::NotFound.into();
+        assert_eq!(error.code(), RpcCode::NotFound);
+        assert_eq!(error.message(), "");
+    }
+
+    #[test]
+    fn test_all_error_constructors() {
+        assert_eq!(RpcError::cancelled("msg").code(), RpcCode::Cancelled);
+        assert_eq!(RpcError::unknown("msg").code(), RpcCode::Unknown);
+        assert_eq!(
+            RpcError::invalid_argument("msg").code(),
+            RpcCode::InvalidArgument
+        );
+        assert_eq!(
+            RpcError::deadline_exceeded("msg").code(),
+            RpcCode::DeadlineExceeded
+        );
+        assert_eq!(RpcError::not_found("msg").code(), RpcCode::NotFound);
+        assert_eq!(
+            RpcError::already_exists("msg").code(),
+            RpcCode::AlreadyExists
+        );
+        assert_eq!(
+            RpcError::permission_denied("msg").code(),
+            RpcCode::PermissionDenied
+        );
+        assert_eq!(
+            RpcError::resource_exhausted("msg").code(),
+            RpcCode::ResourceExhausted
+        );
+        assert_eq!(
+            RpcError::failed_precondition("msg").code(),
+            RpcCode::FailedPrecondition
+        );
+        assert_eq!(RpcError::aborted("msg").code(), RpcCode::Aborted);
+        assert_eq!(RpcError::out_of_range("msg").code(), RpcCode::OutOfRange);
+        assert_eq!(
+            RpcError::unimplemented("msg").code(),
+            RpcCode::Unimplemented
+        );
+        assert_eq!(RpcError::internal("msg").code(), RpcCode::Internal);
+        assert_eq!(RpcError::unavailable("msg").code(), RpcCode::Unavailable);
+        assert_eq!(RpcError::data_loss("msg").code(), RpcCode::DataLoss);
+        assert_eq!(
+            RpcError::unauthenticated("msg").code(),
+            RpcCode::Unauthenticated
+        );
+    }
+
+    #[test]
+    fn test_with_origin_converts_rpc_to_multicast() {
+        let details = vec![1, 2, 3];
+        let err = RpcError::with_details(RpcCode::NotFound, "gone", details.clone());
+        let err = err.with_origin("org/ns/member-0");
+        match err {
+            RpcError::MulticastRpc {
+                origin,
+                code,
+                message,
+                details: d,
+            } => {
+                assert_eq!(origin, "org/ns/member-0");
+                assert_eq!(code, RpcCode::NotFound);
+                assert_eq!(message, "gone");
+                assert_eq!(d, Some(details));
+            }
+            other => panic!("expected MulticastRpc, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_with_origin_replaces_existing_origin() {
+        let err = RpcError::new_multicast("old-origin", RpcCode::Internal, "msg");
+        let err = err.with_origin("new-origin");
+        match err {
+            RpcError::MulticastRpc { origin, .. } => {
+                assert_eq!(origin, "new-origin");
+            }
+            other => panic!("expected MulticastRpc, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_constructor() {
+        let members = vec![
+            ("member-0".to_string(), true),
+            ("member-1".to_string(), false),
+            ("member-2".to_string(), true),
+            ("member-3".to_string(), false),
+        ];
+        let err = RpcError::multicast_session_closed(members);
+        match err {
+            RpcError::MulticastSessionClosed {
+                completed,
+                total,
+                received,
+                missing,
+            } => {
+                assert_eq!(completed, 2);
+                assert_eq!(total, 4);
+                let mut received = received;
+                received.sort();
+                assert_eq!(received, vec!["member-0", "member-2"]);
+                let mut missing = missing;
+                missing.sort();
+                assert_eq!(missing, vec!["member-1", "member-3"]);
+            }
+            other => panic!("expected MulticastSessionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_all_done() {
+        let members = vec![("a".to_string(), true), ("b".to_string(), true)];
+        let err = RpcError::multicast_session_closed(members);
+        match err {
+            RpcError::MulticastSessionClosed {
+                completed,
+                total,
+                missing,
+                ..
+            } => {
+                assert_eq!(completed, 2);
+                assert_eq!(total, 2);
+                assert!(missing.is_empty());
+            }
+            other => panic!("expected MulticastSessionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_none_done() {
+        let members = vec![("a".to_string(), false), ("b".to_string(), false)];
+        let err = RpcError::multicast_session_closed(members);
+        match err {
+            RpcError::MulticastSessionClosed {
+                completed,
+                total,
+                received,
+                ..
+            } => {
+                assert_eq!(completed, 0);
+                assert_eq!(total, 2);
+                assert!(received.is_empty());
+            }
+            other => panic!("expected MulticastSessionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_display() {
+        let members = vec![("alice".to_string(), true), ("bob".to_string(), false)];
+        let err = RpcError::multicast_session_closed(members);
+        let display = err.to_string();
+        assert!(
+            display.contains("1/2"),
+            "display should contain completed/total"
+        );
+        assert!(
+            display.contains("alice"),
+            "display should contain received member"
+        );
+        assert!(
+            display.contains("bob"),
+            "display should contain missing member"
+        );
+    }
+}

--- a/crates/rpc/src/handler_traits.rs
+++ b/crates/rpc/src/handler_traits.rs
@@ -1,0 +1,104 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Handler trait interface for SlimRPC UniFFI bindings
+//!
+//! Defines the callback traits that foreign language applications implement to handle RPC calls.
+//! UniFFI will generate foreign language interfaces for these traits.
+
+use std::sync::Arc;
+
+use super::{
+    Context, RpcError,
+    stream_types::{RequestStream, ResponseSink},
+};
+
+/// Unary-to-Unary RPC handler trait
+///
+/// Implement this trait to handle unary-to-unary RPC calls.
+/// The handler receives a single request and returns a single response.
+#[async_trait::async_trait]
+pub trait UnaryUnaryHandler: Send + Sync {
+    /// Handle a unary-to-unary RPC call
+    ///
+    /// # Arguments
+    /// * `request` - The request message bytes
+    /// * `context` - RPC context with metadata and session information
+    ///
+    /// # Returns
+    /// The response message bytes or an error
+    async fn handle(&self, request: Vec<u8>, context: Arc<Context>) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Unary-to-Stream RPC handler trait
+///
+/// Implement this trait to handle unary-to-stream RPC calls.
+/// The handler receives a single request and sends multiple responses via the sink.
+#[async_trait::async_trait]
+pub trait UnaryStreamHandler: Send + Sync {
+    /// Handle a unary-to-stream RPC call
+    ///
+    /// # Arguments
+    /// * `request` - The request message bytes
+    /// * `context` - RPC context with metadata and session information
+    /// * `sink` - Response sink to send streaming responses
+    ///
+    /// # Returns
+    /// Ok(()) if handling succeeded, or an error
+    ///
+    /// # Note
+    /// You must call `sink.close()` or `sink.send_error()` when done.
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError>;
+}
+
+/// Stream-to-Unary RPC handler trait
+///
+/// Implement this trait to handle stream-to-unary RPC calls.
+/// The handler receives multiple requests via the stream and returns a single response.
+#[async_trait::async_trait]
+pub trait StreamUnaryHandler: Send + Sync {
+    /// Handle a stream-to-unary RPC call
+    ///
+    /// # Arguments
+    /// * `stream` - Request stream to pull messages from
+    /// * `context` - RPC context with metadata and session information
+    ///
+    /// # Returns
+    /// The response message bytes or an error
+    async fn handle(
+        &self,
+        stream: Arc<RequestStream>,
+        context: Arc<Context>,
+    ) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Stream-to-Stream RPC handler trait
+///
+/// Implement this trait to handle stream-to-stream RPC calls.
+/// The handler receives multiple requests via the stream and sends multiple responses via the sink.
+#[async_trait::async_trait]
+pub trait StreamStreamHandler: Send + Sync {
+    /// Handle a stream-to-stream RPC call
+    ///
+    /// # Arguments
+    /// * `stream` - Request stream to pull messages from
+    /// * `context` - RPC context with metadata and session information
+    /// * `sink` - Response sink to send streaming responses
+    ///
+    /// # Returns
+    /// Ok(()) if handling succeeded, or an error
+    ///
+    /// # Note
+    /// You must call `sink.close()` or `sink.send_error()` when done.
+    async fn handle(
+        &self,
+        stream: Arc<RequestStream>,
+        context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError>;
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,0 +1,268 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! # SlimRPC - gRPC-like RPC framework over SLIM
+//!
+//! SlimRPC provides a gRPC-compatible RPC framework built on top of the SLIM messaging protocol.
+//! It supports all standard gRPC interaction patterns:
+//! - Unary-Unary: Single request, single response
+//! - Unary-Stream: Single request, streaming responses
+//! - Stream-Unary: Streaming requests, single response
+//! - Stream-Stream: Streaming requests, streaming responses
+//!
+//! ## Architecture
+//!
+//! SlimRPC uses SLIM sessions as the underlying transport mechanism. A persistent session
+//! is maintained per remote peer and shared across concurrent RPC calls. Each call is
+//! identified by a unique `rpc-id` in message metadata, which allows the server to
+//! demultiplex concurrent calls over the shared session.
+//!
+//! ## Core Types
+//!
+//! This crate works directly with core SLIM types:
+//! - `slim_service::app::App` - The SLIM application instance
+//! - `slim_session::context::SessionContext` - Session context for RPC calls
+//! - `slim_datapath::api::ProtoName` - SLIM names for service addressing
+//!
+//! ## Client Example
+//!
+//! ```ignore
+//! # use slim_bindings::{Channel, Context, RpcError, Encoder, Decoder};
+//! # use slim_bindings::Name;
+//! # use slim_service::app::App;
+//! # use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+//! # use std::sync::Arc;
+//! # async fn example(app: Arc<App<AuthProvider, AuthVerifier>>) -> Result<(), RpcError> {
+//! # #[derive(Default)]
+//! # struct Request {}
+//! # impl Encoder for Request {
+//! #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+//! # }
+//! # #[derive(Default)]
+//! # struct Response {}
+//! # impl Decoder for Response {
+//! #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Response::default()) }
+//! # }
+//! # let request = Request::default();
+//! // Create a channel
+//! let remote = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+//! let channel = Channel::new_with_members_internal(app.clone(), vec![remote.as_slim_name().clone()], false, None).unwrap();
+//!
+//! // Make an RPC call (typically through generated code)
+//! let response: Response = channel.unary("MyService", "MyMethod", request, None, None).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Server Example
+//!
+//! ```ignore
+//! # use slim_bindings::{Server, Context, RpcError, Encoder, Decoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+//! # use std::sync::Arc;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+//! # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+//! # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+//! # let app = App::new(app_name, provider, verifier)?;
+//! # let core_app = app.inner();
+//! # let notification_rx = app.notification_receiver();
+//! # #[derive(Default)]
+//! # struct Request {}
+//! # impl Decoder for Request {
+//! #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+//! # }
+//! # #[derive(Default)]
+//! # struct Response {}
+//! # impl Encoder for Response {
+//! #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+//! # }
+//! // Register and run server
+//! let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+//! let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+//!
+//! // Register a handler
+//! server.register_unary_unary_internal(
+//!     "MyService",
+//!     "MyMethod",
+//!     |request: Request, _ctx: Context| async move {
+//!         Ok(Response::default())
+//!     }
+//! );
+//! # Ok(())
+//! # }
+//! ```
+
+use slim_datapath::api::ProtoName as Name;
+
+/// Build a method-specific subscription name (base-service-method)
+///
+/// This creates a subscription name in the format: `org/namespace/app-service-method`
+/// matching the Python implementation's `handler_name_to_pyname`.
+///
+/// # Arguments
+/// * `base_name` - The base name (e.g., "org/namespace/app")
+/// * `service_name` - The service name (e.g., "MyService")
+/// * `method_name` - The method name (e.g., "MyMethod")
+///
+/// # Panics
+/// Panics if base_name doesn't have at least 3 components
+pub fn build_method_subscription_name(
+    base_name: &Name,
+    service_name: &str,
+    method_name: &str,
+) -> Name {
+    let (c0, c1, c2) = base_name.str_components();
+
+    // Create subscription name: org/namespace/app-service-method
+    let app_with_method = format!("{c2}-{service_name}-{method_name}");
+
+    Name::from_strings([c0, c1, &app_with_method])
+}
+
+mod channel;
+mod codec;
+mod context;
+mod error;
+mod rpc_session;
+mod server;
+mod session_wrapper;
+
+// UniFFI-specific modules
+mod handler_traits;
+mod stream_types;
+
+mod runtime;
+pub use runtime::get_runtime;
+
+pub use channel::{Channel, MessageContext, MulticastItem};
+pub use codec::{Codec, Decoder, Encoder};
+pub use context::{Context, Metadata, SessionContext};
+pub use error::{InvalidRpcCode, RpcCode, RpcError};
+pub use rpc_session::{
+    HandlerInfo, RpcSession, send_eos, send_error, send_error_for_rpc, send_response_stream,
+};
+pub use server::{HandlerType, RpcHandler, Server, StreamRpcHandler};
+pub use session_wrapper::{ReceivedMessage, SessionRx, SessionTx, new_session};
+
+// UniFFI handler traits and stream types
+pub use handler_traits::{
+    StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler,
+};
+pub use stream_types::{
+    BidiStreamHandler, DecodedStream, MulticastBidiStreamHandler, MulticastResponseReader,
+    MulticastStreamMessage, RawStream, RequestStream as UniffiRequestStream, RequestStreamWriter,
+    ResponseSink, ResponseStreamReader, RpcMessageContext, RpcMulticastItem, StreamMessage,
+    StreamSource,
+};
+
+/// Key used in metadata for RPC deadline/timeout
+pub const DEADLINE_KEY: &str = "slimrpc-timeout";
+
+/// Key used in metadata for RPC status code
+pub const STATUS_CODE_KEY: &str = "slimrpc-code";
+
+/// Key used in metadata for RPC call ID (used for session multiplexing)
+pub const RPC_ID_KEY: &str = "rpc-id";
+
+/// Key used in metadata for the RPC service name
+pub const SERVICE_KEY: &str = "service";
+
+/// Key used in metadata for the RPC method name
+pub const METHOD_KEY: &str = "method";
+
+/// Key used in metadata to mark a message as a client request.
+/// Present on all client-originated messages (data frames and EOS).
+/// Absent on server responses so the server can tell them apart.
+pub const RPC_DIR_KEY: &str = "slimrpc-dir";
+
+/// Value for [`RPC_DIR_KEY`] that marks a message as a client request.
+pub const RPC_DIR_REQ: &str = "req";
+
+/// Maximum timeout in seconds (10 hours)
+pub const MAX_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(36000);
+
+/// Calculate timeout duration from optional timeout
+///
+/// Returns the provided timeout or MAX_TIMEOUT if None.
+/// This is the single point of truth for timeout duration calculation in SlimRPC.
+pub fn calculate_timeout_duration(timeout: Option<std::time::Duration>) -> std::time::Duration {
+    timeout.unwrap_or(MAX_TIMEOUT)
+}
+
+/// Calculate deadline from optional timeout duration
+///
+/// Returns now + timeout_duration (or now + MAX_TIMEOUT if None).
+/// If overflow occurs, falls back to now + MAX_TIMEOUT.
+/// This is the single point of truth for deadline calculation in SlimRPC.
+pub fn calculate_deadline(timeout: Option<std::time::Duration>) -> std::time::SystemTime {
+    let timeout_duration = timeout.unwrap_or(MAX_TIMEOUT);
+    std::time::SystemTime::now()
+        .checked_add(timeout_duration)
+        .unwrap_or_else(|| std::time::SystemTime::now() + MAX_TIMEOUT)
+}
+
+/// Result type for SlimRPC operations
+pub type Result<T> = std::result::Result<T, RpcError>;
+
+/// Type alias for request streams in stream-based RPC handlers
+///
+/// This represents a pinned, boxed stream of requests that can be used
+/// in stream-unary and stream-stream RPC handlers.
+///
+/// # Example
+///
+/// ```ignore
+/// # use slim_bindings::{RpcError, Decoder, Encoder};
+/// # use futures::StreamExt;
+/// # use futures::stream::BoxStream;
+/// # #[derive(Default)]
+/// # struct MyRequest {}
+/// # impl Decoder for MyRequest {
+/// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(MyRequest::default()) }
+/// # }
+/// # #[derive(Default)]
+/// # struct MyResponse {}
+/// # impl Encoder for MyResponse {
+/// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+/// # }
+/// async fn handler(mut stream: BoxStream<'static, Result<MyRequest, RpcError>>) -> Result<MyResponse, RpcError> {
+///     while let Some(request) = stream.next().await {
+///         let req = request?;
+///         // Process request
+///     }
+///     Ok(MyResponse::default())
+/// }
+/// ```
+pub type RequestStream<T> = futures::stream::BoxStream<'static, Result<T>>;
+
+/// Type alias for response streams in stream-based RPC handlers
+///
+/// This represents a stream of responses that can be returned from
+/// unary-stream and stream-stream RPC handlers.
+///
+/// Note: While this type can represent the return value, handlers typically
+/// return concrete stream types (like those from `futures::stream::iter`) which
+/// are then automatically converted.
+///
+/// # Example
+///
+/// ```ignore
+/// # use slim_bindings::{RpcError, Decoder, Encoder};
+/// # type Result<T> = std::result::Result<T, RpcError>;
+/// # use futures::stream::{self, Stream};
+/// # #[derive(Default, Clone)]
+/// # struct MyRequest {}
+/// # impl Decoder for MyRequest {
+/// #     fn decode(_buf: impl Into<Vec<u8>>) -> std::result::Result<Self, RpcError> { Ok(MyRequest::default()) }
+/// # }
+/// # #[derive(Default, Clone)]
+/// # struct MyResponse {}
+/// # impl Encoder for MyResponse {
+/// #     fn encode(self) -> std::result::Result<Vec<u8>, RpcError> { Ok(vec![]) }
+/// # }
+/// async fn handler(request: MyRequest) -> std::result::Result<impl Stream<Item = Result<MyResponse>>, RpcError> {
+///     let responses = vec![MyResponse::default(), MyResponse::default(), MyResponse::default()];
+///     Ok(stream::iter(responses.into_iter().map(Ok)))
+/// }
+/// ```
+pub type ResponseStream<T> = futures::stream::BoxStream<'static, Result<T>>;

--- a/crates/rpc/src/rpc_session.rs
+++ b/crates/rpc/src/rpc_session.rs
@@ -1,0 +1,242 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! RPC session handling implementation
+//!
+//! This module contains the logic for handling individual RPC sessions,
+//! including message sending/receiving, timeout handling, and stream processing.
+
+use std::{collections::HashMap, sync::Arc};
+
+use futures::StreamExt;
+use slim_session::CompletionHandle;
+use tokio::sync::mpsc;
+
+use slim_datapath::api::ProtoName as Name;
+
+use super::{
+    Context, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError, RpcHandler, STATUS_CODE_KEY,
+    SessionTx, StreamRpcHandler, StreamSource,
+};
+
+/// Handler information retrieved from registry
+pub enum HandlerInfo {
+    Stream(StreamRpcHandler),
+    Unary(RpcHandler),
+}
+
+/// RPC session handler for all four interaction patterns.
+///
+/// For stream-input methods (stream-unary, stream-stream), construct with
+/// [`RpcSession::new_stream`]. For unary-input methods (unary-unary,
+/// unary-stream), construct with [`RpcSession::new_unary`].
+pub struct RpcSession<'a> {
+    session_tx: &'a SessionTx,
+    /// Present for stream-input handlers; absent for unary-input handlers.
+    session_rx: Option<mpsc::UnboundedReceiver<ReceivedMessage>>,
+    method_path: &'a str,
+    /// First message read from the wire, carrying the request payload and metadata.
+    first_message: ReceivedMessage,
+}
+
+impl<'a> RpcSession<'a> {
+    /// Create a session for a unary-input RPC (unary-unary, unary-stream).
+    pub fn new_unary(
+        session_tx: &'a SessionTx,
+        method_path: &'a str,
+        first_message: ReceivedMessage,
+    ) -> Self {
+        Self {
+            session_tx,
+            session_rx: None,
+            method_path,
+            first_message,
+        }
+    }
+
+    /// Create a session for a stream-input RPC (stream-unary, stream-stream).
+    pub fn new_stream(
+        session_tx: &'a SessionTx,
+        channel_rx: mpsc::UnboundedReceiver<ReceivedMessage>,
+        method_path: &'a str,
+        first_message: ReceivedMessage,
+    ) -> Self {
+        Self {
+            session_tx,
+            session_rx: Some(channel_rx),
+            method_path,
+            first_message,
+        }
+    }
+
+    /// Handle the session, dispatching to the appropriate interaction pattern.
+    pub async fn handle(self, handler_info: HandlerInfo, rpc_id: Arc<str>) -> Result<(), RpcError> {
+        let Self {
+            session_tx,
+            session_rx,
+            method_path,
+            first_message,
+        } = self;
+
+        tracing::debug!(%method_path, "Processing RPC");
+
+        // Pre-compute first-message status before moving fields into ctx / stream.
+        let first_is_eos = first_message.is_eos();
+        let first_code = RpcCode::from_metadata_str(
+            first_message
+                .metadata
+                .get(STATUS_CODE_KEY)
+                .map(String::as_str),
+        );
+        let ReceivedMessage {
+            metadata,
+            payload,
+            source,
+        } = first_message;
+        let ctx = Context::from_session_tx(session_tx).with_message_metadata(metadata);
+
+        if ctx.is_deadline_exceeded() {
+            return Err(RpcError::deadline_exceeded("Deadline exceeded"));
+        }
+
+        let deadline = tokio::time::Instant::now() + ctx.remaining_time();
+
+        let result = tokio::select! {
+            result = async move {
+                match &handler_info {
+                    HandlerInfo::Unary(handler) => {
+                        handler(payload, ctx, session_tx.clone(), source, rpc_id).await
+                    }
+                    HandlerInfo::Stream(handler) => {
+                        let stream_source = StreamSource { session_rx, payload, first_is_eos, first_code };
+                        handler(stream_source, ctx, session_tx.clone(), source, rpc_id).await
+                    }
+                }
+            } => result,
+            _ = tokio::time::sleep_until(deadline) => {
+                tracing::debug!("RPC handler execution exceeded deadline");
+                Err(RpcError::deadline_exceeded("Deadline exceeded during RPC execution"))
+            }
+        };
+
+        if let Err(e) = &result {
+            tracing::error!(%method_path, error = %e, "Error handling RPC");
+        } else {
+            tracing::debug!(%method_path, "RPC completed successfully");
+        }
+
+        result
+    }
+}
+
+/// Send a session-level error response (no rpc_id — used before dispatch)
+pub async fn send_error(session: &SessionTx, error: RpcError) -> Result<(), RpcError> {
+    send_error_for_rpc(session, error, "").await
+}
+
+/// Send an RPC-level error response including the rpc_id so the client can
+/// route it back to the correct waiting caller over the shared session.
+pub async fn send_error_for_rpc(
+    session: &SessionTx,
+    error: RpcError,
+    rpc_id: &str,
+) -> Result<(), RpcError> {
+    let message = error.message().to_string();
+    let metadata = create_status_metadata(error.code(), rpc_id);
+    let handle = session
+        .publish(
+            session.destination(),
+            message.into_bytes(),
+            Some("msg".to_string()),
+            Some(metadata),
+        )
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to send error: {e}")))?;
+    handle.await.map_err(|e| {
+        tracing::warn!(error = %e, "Failed to send error response");
+        RpcError::internal(format!("Failed to complete error send: {e}"))
+    })
+}
+
+/// Send an end-of-stream marker to `target`.
+///
+/// An EOS is an empty-payload message with `slimrpc-code = Ok`. Every server
+/// handler must send one after its final response so GROUP/multicast callers
+/// can count per-member stream ends. P2P callers discard it harmlessly.
+///
+/// `extra` is merged into the EOS metadata after the status code. Pass
+/// `None` for the common case where no additional metadata is needed.
+/// When the EOS is also the first message (empty request stream), pass
+/// service + method so the server can dispatch without a preceding data frame.
+pub async fn send_eos(
+    session_tx: &SessionTx,
+    target: &Name,
+    rpc_id: &str,
+    extra: Option<HashMap<String, String>>,
+) -> Result<CompletionHandle, RpcError> {
+    let mut metadata = create_status_metadata(RpcCode::Ok, rpc_id);
+    if let Some(extra) = extra {
+        metadata.extend(extra);
+    }
+    session_tx
+        .publish(target, Vec::new(), Some("msg".to_string()), Some(metadata))
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to send EOS: {e}")))
+}
+
+fn create_status_metadata(code: RpcCode, rpc_id: &str) -> HashMap<String, String> {
+    let mut metadata = HashMap::new();
+    let code_i32: i32 = code.into();
+    metadata.insert(STATUS_CODE_KEY.to_string(), code_i32.to_string());
+    if !rpc_id.is_empty() {
+        metadata.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
+    }
+    metadata
+}
+
+pub async fn send_response_stream<S>(
+    session_tx: &SessionTx,
+    stream: S,
+    rpc_id: &str,
+    target: &Name,
+) -> Result<(), RpcError>
+where
+    S: futures::Stream<Item = Result<Vec<u8>, RpcError>>,
+{
+    futures::pin_mut!(stream);
+
+    // Publish every response message without awaiting its CompletionHandle,
+    // collecting all handles so we can wait for them in a single batch once
+    // the stream is exhausted.  This avoids a per-message round-trip delay
+    // caused by the session layer's reliable-delivery acknowledgement protocol.
+    let mut handles: Vec<CompletionHandle> = Vec::new();
+
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(response_bytes) => {
+                handles.push(
+                    session_tx
+                        .publish(
+                            target,
+                            response_bytes,
+                            Some("msg".to_string()),
+                            Some(create_status_metadata(RpcCode::Ok, rpc_id)),
+                        )
+                        .await
+                        .map_err(|e| RpcError::internal(format!("Failed to send response: {e}")))?,
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Queue the EOS marker and collect its handle too.
+    handles.push(send_eos(session_tx, target, rpc_id, None).await?);
+
+    // Wait for all in-flight sends to be acknowledged by the session layer.
+    futures::future::try_join_all(handles)
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to complete sending: {e}")))?;
+
+    Ok(())
+}

--- a/crates/rpc/src/runtime.rs
+++ b/crates/rpc/src/runtime.rs
@@ -1,0 +1,22 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process-global Tokio runtime for the synchronous convenience wrappers.
+//!
+//! Async callers should prefer the `*_async` methods and drive them on their own
+//! runtime; the blocking wrappers exist only for callers without an ambient one.
+
+use std::sync::OnceLock;
+
+use tokio::runtime::{Handle, Runtime};
+
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+/// Returns a handle to the process-global multi-threaded runtime, building it on
+/// first use.
+pub fn get_runtime() -> Handle {
+    RUNTIME
+        .get_or_init(|| Runtime::new().expect("failed to build the slimrpc runtime"))
+        .handle()
+        .clone()
+}

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -1,0 +1,1419 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-side RPC handling implementation
+//!
+//! Provides a Server type for handling incoming RPC requests and dispatching
+//! them to registered service implementations.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::join_all;
+use futures::stream::Stream;
+use futures::{FutureExt, StreamExt, future::BoxFuture, stream};
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::app::App as SlimApp;
+use slim_session::errors::SessionError;
+use slim_session::notification::Notification;
+
+use super::{RPC_DIR_KEY, RPC_DIR_REQ};
+use crate::STATUS_CODE_KEY;
+
+use super::{
+    Context, HandlerInfo, METHOD_KEY, RPC_ID_KEY, ReceivedMessage, ResponseSink, RpcCode, RpcError,
+    RpcSession, SERVICE_KEY, StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler,
+    UnaryUnaryHandler, UniffiRequestStream,
+    codec::{Decoder, Encoder},
+    send_error_for_rpc, send_response_stream,
+    session_wrapper::{SessionRx, SessionTx, new_session},
+    stream_types::{DecodedStream, StreamSource},
+};
+
+pub type Item = Vec<u8>;
+pub type ResponseStream = BoxFuture<'static, Result<(), RpcError>>;
+
+/// Handler function type for RPC methods (unary input)
+pub type RpcHandler =
+    Arc<dyn Fn(Item, Context, SessionTx, Name, Arc<str>) -> ResponseStream + Send + Sync>;
+
+/// Handler function type for stream-input RPC methods
+pub type StreamRpcHandler =
+    Arc<dyn Fn(StreamSource, Context, SessionTx, Name, Arc<str>) -> ResponseStream + Send + Sync>;
+
+/// Type of RPC handler
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandlerType {
+    /// Unary request, unary response
+    UnaryUnary,
+    /// Unary request, streaming response
+    UnaryStream,
+    /// Streaming request, unary response
+    StreamUnary,
+    /// Streaming request, streaming response
+    StreamStream,
+}
+
+/// Registry for RPC service methods (internal implementation detail)
+#[derive(Clone)]
+struct ServiceRegistry {
+    /// Map of method paths to handlers (for unary-input methods)
+    handlers: HashMap<String, RpcHandler>,
+    /// Map of method paths to stream handlers (for stream-input methods)
+    stream_handlers: HashMap<String, StreamRpcHandler>,
+}
+
+impl ServiceRegistry {
+    /// Create a new service registry
+    fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+            stream_handlers: HashMap::new(),
+        }
+    }
+
+    /// Register a unary-unary handler
+    fn register_unary_unary<F, Req, Res, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |bytes: Vec<u8>,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  source: Name,
+                  rpc_id: Arc<str>| {
+                let fut = Req::decode(bytes).map(|req| handler(req, ctx));
+                async move {
+                    let encoded = fut?.await?.encode()?;
+                    send_response_stream(
+                        &session_tx,
+                        stream::once(std::future::ready(Ok(encoded))),
+                        &rpc_id,
+                        &source,
+                    )
+                    .await
+                }
+                .boxed()
+            },
+        );
+
+        self.handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a unary-stream handler
+    pub fn register_unary_stream<F, Req, Res, S, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |bytes: Vec<u8>,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  source: Name,
+                  rpc_id: Arc<str>| {
+                let fut = Req::decode(bytes).map(|req| handler(req, ctx));
+                async move {
+                    let response_stream = fut?.await?;
+                    let byte_mapped = response_stream.map(|res| res.and_then(|r| r.encode()));
+                    send_response_stream(&session_tx, byte_mapped, &rpc_id, &source).await
+                }
+                .boxed()
+            },
+        );
+
+        self.handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a stream-unary handler
+    pub fn register_stream_unary<F, Req, Res, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |source: StreamSource,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  target: Name,
+                  rpc_id: Arc<str>| {
+                let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
+                    |res| res.and_then(|bytes| Req::decode(bytes));
+                let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
+                let fut = handler(decoded, ctx);
+                async move {
+                    let encoded = fut.await?.encode()?;
+                    send_response_stream(
+                        &session_tx,
+                        stream::once(std::future::ready(Ok(encoded))),
+                        &rpc_id,
+                        &target,
+                    )
+                    .await
+                }
+                .boxed()
+            },
+        );
+
+        self.stream_handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a stream-stream handler
+    pub fn register_stream_stream<F, Req, Res, S, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |source: StreamSource,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  target: Name,
+                  rpc_id: Arc<str>| {
+                let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
+                    |res| res.and_then(|bytes| Req::decode(bytes));
+                let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
+                let fut = handler(decoded, ctx);
+                async move {
+                    let response_stream = fut.await?;
+                    let byte_mapped = response_stream.map(|res| res.and_then(|r| r.encode()));
+                    send_response_stream(&session_tx, byte_mapped, &rpc_id, &target).await
+                }
+                .boxed()
+            },
+        );
+
+        self.stream_handlers.insert(method_path, wrapper);
+    }
+
+    /// Get handler info (either stream or unary) in one lookup
+    fn get_handler_info(&self, method_path: &str) -> Option<HandlerInfo> {
+        self.stream_handlers
+            .get(method_path)
+            .cloned()
+            .map(HandlerInfo::Stream)
+            .or_else(|| {
+                self.handlers
+                    .get(method_path)
+                    .cloned()
+                    .map(HandlerInfo::Unary)
+            })
+    }
+
+    /// Get all registered method paths
+    fn methods(&self) -> Vec<String> {
+        let mut methods: Vec<String> = self.handlers.keys().cloned().collect();
+        methods.extend(self.stream_handlers.keys().cloned());
+        methods
+    }
+}
+
+impl Default for ServiceRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Enum to hold either an owned or shared notification receiver
+enum NotificationReceiver {
+    Owned(mpsc::Receiver<Result<Notification, SessionError>>),
+    Shared(Arc<tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>>),
+}
+
+/// Result handed back from the spawned `serve_handle` task: the notification
+/// receiver (so the caller can keep consuming after shutdown) plus the run
+/// outcome.
+type ServeHandleResult = (NotificationReceiver, Result<(), RpcError>);
+
+/// RPC Server
+///
+/// Handles incoming RPC requests by creating sessions and dispatching
+/// to registered service handlers.
+///
+/// # Example
+///
+/// ```ignore
+/// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name};
+/// # use std::sync::Arc;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # use slim_bindings::{IdentityProviderConfig, IdentityVerifierConfig};
+/// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+/// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+/// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+/// # let app = App::new(app_name, provider, verifier)?;
+/// # let core_app = app.inner();
+/// # let notification_rx = app.notification_receiver();
+/// # #[derive(Default)]
+/// # struct Request {}
+/// # impl Decoder for Request {
+/// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+/// # }
+/// # #[derive(Default)]
+/// # struct Response {}
+/// # impl Encoder for Response {
+/// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+/// # }
+/// let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+/// let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+///
+/// // Register handlers
+/// server.register_unary_unary_internal(
+///     "MyService",
+///     "MyMethod",
+///     |request: Request, _ctx: Context| async move {
+///         Ok(Response::default())
+///     }
+/// );
+/// # Ok(())
+/// # }
+/// ```
+pub struct Server {
+    /// The SLIM app instance
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+    /// Service registry containing all registered handlers
+    registry: RwLock<ServiceRegistry>,
+    /// Base service name
+    base_name: Name,
+    /// Optional connection ID for subscription propagation
+    connection_id: Option<u64>,
+    /// Notification receiver for incoming sessions (either owned or shared)
+    notification_rx: parking_lot::Mutex<Option<NotificationReceiver>>,
+    /// Drain signal for graceful shutdown
+    drain_signal: RwLock<Option<drain::Signal>>,
+    /// Drain watch for session handlers
+    drain_watch: RwLock<Option<drain::Watch>>,
+    /// Runtime handle for spawning tasks (resolved at construction)
+    runtime: tokio::runtime::Handle,
+}
+
+/// Spawn a handler task for a new RPC call and, for stream-input handlers, register the mpsc
+/// sender in `pending_streams` so that subsequent messages can be routed to the same task.
+fn spawn_handler_task(
+    handler_info: HandlerInfo,
+    msg: ReceivedMessage,
+    rpc_id: Arc<str>,
+    method_path: String,
+    session_tx: SessionTx,
+    pending_streams: &mut HashMap<Arc<str>, mpsc::UnboundedSender<ReceivedMessage>>,
+    session_drain_watch: drain::Watch,
+) {
+    // For stream-input handlers, create the mpsc channel and register the sender
+    // so that subsequent messages can be routed to the same handler task.
+    // Only register if the first message is not already terminal; otherwise drop
+    // stream_tx immediately so the handler's channel closes after the first message.
+    let stream_rx = match &handler_info {
+        HandlerInfo::Stream(_) => {
+            let (stream_tx, stream_rx) = mpsc::unbounded_channel();
+            if !msg.is_eos() {
+                pending_streams.insert(rpc_id.clone(), stream_tx);
+            }
+            Some(stream_rx)
+        }
+        HandlerInfo::Unary(_) => None,
+    };
+
+    tokio::spawn(async move {
+        let session = match stream_rx {
+            Some(rx) => RpcSession::new_stream(&session_tx, rx, &method_path, msg),
+            None => RpcSession::new_unary(&session_tx, &method_path, msg),
+        };
+        let handler_fut = async {
+            match session.handle(handler_info, rpc_id.clone()).await {
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::error!(%method_path, error = %e, "Error in RPC handler");
+                    Some(e)
+                }
+            }
+        };
+        let error = tokio::select! {
+            err = handler_fut => err,
+            _ = session_drain_watch.signaled() => {
+                tracing::debug!(%method_path, %rpc_id, "Session closed, aborting handler");
+                Some(RpcError::cancelled("Server shutting down"))
+            }
+        };
+        if let Some(e) = error {
+            let _ = send_error_for_rpc(&session_tx, e, &rpc_id).await;
+        }
+    });
+}
+
+/// Per-session demultiplexer: routes incoming messages by `rpc-id` and dispatches each new
+/// RPC call to a dedicated handler task.  Runs until the drain signal fires or the session
+/// closes, then aborts any still-running handler tasks and cleans up the session.
+async fn run_session_demux(
+    session_tx: SessionTx,
+    mut session_rx: SessionRx,
+    registry: ServiceRegistry,
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+    drain_watch: drain::Watch,
+) {
+    // Map rpc_id → mpsc sender for live stream-input handlers.
+    let mut pending_streams: HashMap<Arc<str>, mpsc::UnboundedSender<ReceivedMessage>> =
+        HashMap::new();
+
+    // Per-session drain: signals all active handler tasks when the session closes.
+    // drain().await serves as a barrier — it resolves once every task has dropped its Watch.
+    let (session_drain_signal, session_drain_watch) = drain::channel();
+
+    let mut drain_fut = std::pin::pin!(drain_watch.signaled());
+
+    loop {
+        let msg = tokio::select! {
+            _ = &mut drain_fut => {
+                tracing::info!("Session demux task: server shutdown");
+                break;
+            }
+            result = session_rx.get_message(None) => match result {
+                Ok(m) => m,
+                Err(SessionError::ParticipantDisconnected(name)) => {
+                    tracing::warn!(%name, "Participant disconnected, closing session");
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "Session closed by peer");
+                    break;
+                }
+            }
+        };
+
+        let Some(rpc_id_str) = msg.metadata.get(RPC_ID_KEY).filter(|s| !s.is_empty()) else {
+            tracing::trace!("Skipping message with missing or empty rpc-id");
+            continue;
+        };
+
+        if let Some(tx) = pending_streams.get(rpc_id_str.as_str()).cloned() {
+            // Route client request messages (data or EOS) to the existing stream-input handler.
+            //
+            // All client-originated messages carry RPC_DIR_KEY="req".  Server responses
+            // (data frames, EOSes, and error replies — including echoes of this server's own
+            // responses in a GROUP session and responses from peer servers) do not carry
+            // this key.  Drop anything that isn't tagged as a client request.
+            if msg.metadata.get(RPC_DIR_KEY).map(String::as_str) != Some(RPC_DIR_REQ) {
+                tracing::trace!(%rpc_id_str, "Skipping server response for active stream");
+                continue;
+            }
+            // Remove before send so rpc_id_str (borrows msg.metadata) is last used
+            // before msg is moved — NLL lets the borrow end here.
+            let is_terminal = msg.is_eos();
+            if is_terminal {
+                pending_streams.remove(rpc_id_str.as_str());
+            }
+            let _ = tx.send(msg);
+            continue;
+        }
+
+        // No active stream for this rpc_id.
+        // Drop server responses: they have STATUS_CODE_KEY but are NOT tagged as client
+        // requests.  An empty-stream client EOS also has STATUS_CODE_KEY but carries
+        // RPC_DIR_KEY="req", so it passes through and is dispatched as a new RPC call.
+        if msg.metadata.contains_key(STATUS_CODE_KEY)
+            && msg.metadata.get(RPC_DIR_KEY).map(String::as_str) != Some(RPC_DIR_REQ)
+        {
+            tracing::trace!("Skipping server response (no pending stream)");
+            continue;
+        }
+
+        // New RPC call — create Arc now that we know we need it.
+        let rpc_id: Arc<str> = Arc::from(rpc_id_str.as_str());
+
+        let (Some(service), Some(method)) = (
+            msg.metadata
+                .get(SERVICE_KEY)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.as_str()),
+            msg.metadata
+                .get(METHOD_KEY)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.as_str()),
+        ) else {
+            tracing::trace!(%rpc_id, "Skipping message missing service or method key");
+            continue;
+        };
+
+        let method_path = format!("{service}/{method}");
+
+        tracing::debug!(%method_path, %rpc_id, "Dispatching new RPC call");
+
+        let Some(handler_info) = registry.get_handler_info(&method_path) else {
+            tracing::error!(%method_path, "No handler registered");
+            let _ = send_error_for_rpc(
+                &session_tx,
+                RpcError::unimplemented(format!("Method not found: {method_path}")),
+                &rpc_id,
+            )
+            .await;
+            continue;
+        };
+
+        spawn_handler_task(
+            handler_info,
+            msg,
+            rpc_id,
+            method_path,
+            session_tx.clone(),
+            &mut pending_streams,
+            session_drain_watch.clone(),
+        );
+    }
+
+    // Drop mpsc senders so stream-input handlers see channel close at their next recv.
+    drop(pending_streams);
+    // Drop watch otherwise next call to drain would also wait for this
+    drop(session_drain_watch);
+    // Fire the session drain and wait: resolves once every handler task drops its Watch,
+    // so when each task completes
+    session_drain_signal.drain().await;
+
+    // Close session_tx. This might fail if session was already dropped by the channel endpoint
+    let _ = tokio::time::timeout(Duration::from_secs(10), session_tx.close(app.as_ref())).await;
+}
+
+impl Server {
+    /// Create a new RPC server
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `notification_rx` - Receiver for session notifications
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_internal(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        notification_rx: mpsc::Receiver<Result<Notification, SessionError>>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            None,
+            NotificationReceiver::Owned(notification_rx),
+            None,
+        )
+    }
+
+    /// Create a new RPC server with optional connection ID
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `connection_id` - Optional connection ID for subscription propagation to next SLIM node
+    /// * `notification_rx` - Receiver for session notifications
+    /// * `runtime` - Optional tokio runtime handle for spawning tasks
+    pub fn new_with_connection_and_runtime(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: mpsc::Receiver<Result<Notification, SessionError>>,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            connection_id,
+            NotificationReceiver::Owned(notification_rx),
+            runtime,
+        )
+    }
+
+    /// Create a new RPC server with shared notification receiver
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `notification_rx` - Shared Arc to the notification receiver
+    pub fn new_with_shared_rx(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        notification_rx: Arc<
+            tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>,
+        >,
+    ) -> Self {
+        Self::new_with_shared_rx_and_connection(app, base_name, None, notification_rx, None)
+    }
+
+    /// Create a new RPC server with shared notification receiver and connection ID
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `connection_id` - Optional connection ID for subscription propagation to next SLIM node
+    /// * `notification_rx` - Shared Arc to the notification receiver
+    /// * `runtime` - Optional tokio runtime handle for spawning tasks
+    pub fn new_with_shared_rx_and_connection(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: Arc<
+            tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>,
+        >,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            connection_id,
+            NotificationReceiver::Shared(notification_rx),
+            runtime,
+        )
+    }
+
+    /// Internal constructor - single point of truth for Server construction
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server
+    /// * `connection_id` - Optional connection ID for subscription propagation
+    /// * `notification_rx` - Notification receiver (owned or shared)
+    /// * `runtime` - Optional tokio runtime handle for spawning tasks
+    fn construct_internal(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: NotificationReceiver,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        let (drain_signal, drain_watch) = drain::channel();
+
+        // Resolve runtime handle: use provided or try to get current
+        let runtime = runtime.unwrap_or_else(|| {
+            tokio::runtime::Handle::try_current()
+                .expect("No tokio runtime found. Either provide a runtime handle or call from within a tokio runtime context")
+        });
+
+        Self {
+            app,
+            registry: RwLock::new(ServiceRegistry::new()),
+            base_name,
+            connection_id,
+            notification_rx: parking_lot::Mutex::new(Some(notification_rx)),
+            drain_signal: RwLock::new(Some(drain_signal)),
+            drain_watch: RwLock::new(Some(drain_watch)),
+            runtime,
+        }
+    }
+
+    /// Register a unary-unary RPC handler
+    ///
+    /// Handles a single request and returns a single response.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request and context, returns a response
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { name: String }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { greeting: String }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// server.register_unary_unary_internal(
+    ///     "GreeterService",
+    ///     "SayHello",
+    ///     |request: Request, _ctx: Context| async move {
+    ///         Ok(Response {
+    ///             greeting: format!("Hello, {}", request.name)
+    ///         })
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_unary_unary_internal<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_unary_unary(service_name, method_name, handler);
+    }
+
+    /// Register a unary-stream RPC handler
+    ///
+    /// Handles a single request and returns a stream of responses.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request and returns a stream of responses
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # use futures::stream;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { count: i32 }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { value: i32 }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// server.register_unary_stream_internal(
+    ///     "NumberService",
+    ///     "GenerateNumbers",
+    ///     |request: Request, _ctx: Context| async move {
+    ///         let numbers: Vec<Result<Response, RpcError>> = (0..request.count)
+    ///             .map(|i| Ok(Response { value: i }))
+    ///             .collect();
+    ///         Ok(stream::iter(numbers))
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_unary_stream_internal<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_unary_stream(service_name, method_name, handler);
+    }
+
+    /// Register a stream-unary RPC handler
+    ///
+    /// Handles a stream of requests and returns a single response.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request stream and returns a response
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # use futures::StreamExt;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { value: i32 }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { sum: i32 }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// # use slim_bindings::DecodedStream;
+    /// server.register_stream_unary_internal(
+    ///     "AggregateService",
+    ///     "SumNumbers",
+    ///     |mut request_stream: DecodedStream<Request>, _ctx: Context| async move {
+    ///         let mut sum = 0;
+    ///         while let Some(result) = request_stream.next().await {
+    ///             let request = result?;
+    ///             sum += request.value;
+    ///         }
+    ///         Ok(Response { sum })
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_stream_unary_internal<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_stream_unary(service_name, method_name, handler);
+    }
+
+    /// Register a stream-stream RPC handler
+    ///
+    /// Handles a stream of requests and returns a stream of responses.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request stream and returns a response stream
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # use futures::StreamExt;
+    /// # use async_stream::stream;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { message: String }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { reply: String }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// # use slim_bindings::DecodedStream;
+    /// server.register_stream_stream_internal(
+    ///     "EchoService",
+    ///     "Echo",
+    ///     |mut request_stream: DecodedStream<Request>, _ctx: Context| async move {
+    ///         let responses = stream! {
+    ///             while let Some(result) = request_stream.next().await {
+    ///                 match result {
+    ///                     Ok(request) => {
+    ///                         yield Ok(Response {
+    ///                             reply: format!("Echo: {}", request.message)
+    ///                         });
+    ///                     }
+    ///                     Err(e) => {
+    ///                         yield Err(e);
+    ///                         break;
+    ///                     }
+    ///                 }
+    ///             }
+    ///         };
+    ///         Ok(responses)
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_stream_stream_internal<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_stream_stream(service_name, method_name, handler);
+    }
+
+    /// Get all registered method paths
+    ///
+    /// Returns a list of all registered service/method paths in the format "Service/Method".
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// let methods = server.methods();
+    /// for method in methods {
+    ///     println!("Registered: {}", method);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn methods(&self) -> Vec<String> {
+        self.registry.read().methods()
+    }
+
+    /// Start the server and listen for incoming RPC requests in a separate task
+    ///
+    /// This method spawns a background task that listens for incoming sessions and
+    /// dispatches them to registered handlers. The service/method routing is determined
+    /// by metadata in the session.
+    ///
+    /// The spawned task runs indefinitely until [`shutdown`](Self::shutdown) is called
+    /// or an error occurs.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `JoinHandle` for the spawned server task. The task result is `Result<(), RpcError>`.
+    ///
+    /// # Example
+    ///
+    /// This is a private internal method. Use the public `serve()` or `serve_async()` methods instead:
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// // Register handlers first...
+    ///
+    /// // For async contexts, use serve_async():
+    /// // server.serve_async().await?;
+    ///
+    /// // For blocking contexts, use serve():
+    /// // server.serve()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn serve_handle(&self) -> Result<JoinHandle<ServeHandleResult>, RpcError> {
+        let notification = self
+            .notification_rx
+            .lock()
+            .take()
+            .ok_or(RpcError::internal("server already running"))?;
+
+        let registry = self.registry.read().clone();
+        let base_name = self.base_name.clone();
+        let app = self.app.clone();
+        let connection_id = self.connection_id;
+        let drain_watch = self
+            .drain_watch
+            .read()
+            .clone()
+            .ok_or_else(|| RpcError::internal("drain_watch not available"))?;
+
+        let ret = self.runtime.spawn(Server::serve_internal(
+            notification,
+            registry,
+            connection_id,
+            base_name,
+            app,
+            drain_watch,
+        ));
+
+        Ok(ret)
+    }
+
+    /// Internal server loop implementation
+    ///
+    /// This method contains the actual server loop logic and is called by [`serve`](Self::serve)
+    /// in a spawned task.
+    async fn serve_internal(
+        mut rx: NotificationReceiver,
+        registry: ServiceRegistry,
+        connection_id: Option<u64>,
+        base_name: Name,
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        drain_watch: drain::Watch,
+    ) -> (NotificationReceiver, Result<(), RpcError>) {
+        tracing::info!(
+            %base_name,
+            "SlimRPC server starting"
+        );
+
+        // Subscribe to the base name so that the SLIM network routes incoming
+        // sessions to this server.
+        tracing::info!(%base_name, "Subscribing");
+        if let Err(e) = app.subscribe(&base_name, connection_id).await {
+            let status = RpcError::internal(format!("Failed to subscribe to {base_name}: {e}"));
+            return (rx, Err(status));
+        }
+
+        // Save spawned tasks
+        let mut tasks = vec![];
+
+        // Pin the drain watch for use in select (clone to avoid moving)
+        let mut drain_signaled = std::pin::pin!(drain_watch.clone().signaled());
+
+        // Main server loop - listen for sessions
+        loop {
+            tokio::select! {
+                // Handle shutdown signal via drain
+                _ = &mut drain_signaled => {
+                    tracing::info!("Server received drain signal, waiting for {} tasks to complete", tasks.len());
+                    break;
+                }
+                // Handle incoming sessions
+                session_result = Server::listen_for_session(&mut rx) => {
+                    tracing::debug!("Received session notification");
+
+                    let session_ctx = match session_result {
+                        Ok(ctx) => ctx,
+                        Err(e) => {
+                            tracing::error!("Error receiving session: {}", e);
+                            return (rx, Err(e));
+                        }
+                    };
+
+                    tracing::debug!("Received new session — starting per-session demux task");
+
+                    let (session_tx, session_rx) = new_session(session_ctx);
+                    tasks.push(tokio::spawn(run_session_demux(
+                        session_tx,
+                        session_rx,
+                        registry.clone(),
+                        app.clone(),
+                        drain_watch.clone(),
+                    )));
+                }
+            }
+        }
+
+        // Wait for all tasks to finish
+        tracing::debug!("Waiting for {} session tasks to complete", tasks.len());
+        let results = join_all(tasks).await;
+
+        // Log any panicked tasks
+        let mut panicked_count = 0;
+        for (idx, result) in results.iter().enumerate() {
+            if let Err(e) = result {
+                tracing::error!(task_index = idx, error = %e, "Session task panicked");
+                panicked_count += 1;
+            }
+        }
+
+        if panicked_count > 0 {
+            tracing::warn!("{} session tasks panicked during shutdown", panicked_count);
+        } else {
+            tracing::info!("All session tasks completed successfully");
+        }
+
+        (rx, Ok(()))
+    }
+
+    /// Shutdown the server gracefully
+    ///
+    /// This signals all active session handlers to terminate and waits for them to drain.
+    /// After shutdown completes, the server can be restarted by calling [`serve`](Self::serve) again.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// // In another task or signal handler:
+    /// # slim_bindings::get_runtime().block_on(async {
+    /// server.shutdown_internal().await;
+    /// # });
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn shutdown_internal(&self) {
+        tracing::info!("Shutting down SlimRPC server");
+
+        // Take the drain signal and watch
+        let drain_signal = self.drain_signal.write().take();
+        let drain_watch = self.drain_watch.write().take();
+
+        // Drop the watch to complete the drain
+        drop(drain_watch);
+
+        // Signal all session handlers to terminate
+        if let Some(signal) = drain_signal {
+            signal.drain().await;
+        }
+
+        // Recreate drain signal and watch so the server can be restarted
+        let (new_signal, new_watch) = drain::channel();
+        *self.drain_signal.write() = Some(new_signal);
+        *self.drain_watch.write() = Some(new_watch);
+
+        tracing::debug!("Server shutdown complete, ready to restart");
+    }
+
+    /// Listen for an incoming session from the notification receiver
+    async fn listen_for_session(
+        notification_rx: &mut NotificationReceiver,
+    ) -> Result<slim_session::context::SessionContext, RpcError> {
+        tracing::debug!("Waiting for incoming session notification");
+        let notification_opt = match notification_rx {
+            NotificationReceiver::Owned(rx) => rx.recv().await,
+            NotificationReceiver::Shared(rx_arc) => {
+                // For shared receiver, put it back immediately and work with the Arc
+                tracing::debug!("Acquiring shared notification receiver");
+
+                // Now lock and receive from the shared receiver
+                let mut rx = rx_arc.write().await;
+                tracing::debug!("Receiving from shared notification receiver");
+                rx.recv().await
+            }
+        };
+
+        if notification_opt.is_none() {
+            return Err(RpcError::internal("notification channel closed"));
+        }
+
+        let notification = notification_opt
+            .unwrap()
+            .map_err(|e| RpcError::internal(format!("Session error: {e}")))?;
+
+        match notification {
+            Notification::NewSession(session_ctx) => Ok(session_ctx),
+            _ => Err(RpcError::internal("Unexpected notification type")),
+        }
+    }
+}
+
+// UniFFI-compatible methods for foreign language bindings
+impl Server {
+    /// Register a unary-to-unary RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name (e.g., "MyService")
+    /// * `method_name` - The method name (e.g., "GetUser")
+    /// * `handler` - Implementation of the UnaryUnaryHandler trait
+    pub fn register_unary_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn UnaryUnaryHandler>,
+    ) {
+        let service_clone = service_name.clone();
+        let method_clone = method_name.clone();
+
+        tracing::debug!(service = %service_clone, method = %method_clone, "Registering unary-unary handler");
+
+        self.register_unary_unary_internal(
+            &service_name,
+            &method_name,
+            move |request: Vec<u8>, context: Context| {
+                let handler = handler.clone();
+                tracing::debug!(service = %service_clone, method = %method_clone, "Handling unary-unary request");
+
+                async move { handler.handle(request, Arc::new(context)).await }
+            },
+        );
+    }
+
+    /// Register a unary-to-stream RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name
+    /// * `method_name` - The method name
+    /// * `handler` - Implementation of the UnaryStreamHandler trait
+    pub fn register_unary_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn UnaryStreamHandler>,
+    ) {
+        self.register_unary_stream_internal(
+            &service_name,
+            &method_name,
+            move |request: Vec<u8>, context: Context| {
+                let handler = handler.clone();
+
+                async move {
+                    let (sink, rx) = ResponseSink::receiver();
+                    let sink_arc = Arc::new(sink);
+
+                    // Spawn a task to run the handler
+                    let handler_task = {
+                        let sink = sink_arc.clone();
+                        crate::get_runtime().spawn(async move {
+                            if let Err(e) = handler
+                                .handle(request, Arc::new(context), sink.clone())
+                                .await
+                            {
+                                let _ = sink.send_error_async(e).await;
+                            }
+                        })
+                    };
+
+                    // Detach the task - it will run independently
+                    drop(handler_task);
+
+                    // Convert the receiver to a stream
+                    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+                    Ok(stream)
+                }
+            },
+        );
+    }
+
+    /// Register a stream-to-unary RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name
+    /// * `method_name` - The method name
+    /// * `handler` - Implementation of the StreamUnaryHandler trait
+    pub fn register_stream_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn StreamUnaryHandler>,
+    ) {
+        self.register_stream_unary_internal(
+            &service_name,
+            &method_name,
+            move |stream: DecodedStream<Vec<u8>>, context: Context| {
+                let handler = handler.clone();
+                let request_stream = Arc::new(UniffiRequestStream::new(stream));
+
+                async move { handler.handle(request_stream, Arc::new(context)).await }
+            },
+        );
+    }
+
+    /// Register a stream-to-stream RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name
+    /// * `method_name` - The method name
+    /// * `handler` - Implementation of the StreamStreamHandler trait
+    pub fn register_stream_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn StreamStreamHandler>,
+    ) {
+        self.register_stream_stream_internal(
+            &service_name,
+            &method_name,
+            move |stream: DecodedStream<Vec<u8>>, context: Context| {
+                let handler = handler.clone();
+                let request_stream = Arc::new(UniffiRequestStream::new(stream));
+
+                async move {
+                    let (sink, rx) = ResponseSink::receiver();
+                    let sink_arc = Arc::new(sink);
+
+                    // Spawn a task to run the handler
+                    let handler_task = {
+                        let sink = sink_arc.clone();
+                        crate::get_runtime().spawn(async move {
+                            if let Err(e) = handler
+                                .handle(request_stream, Arc::new(context), sink.clone())
+                                .await
+                            {
+                                let _ = sink.send_error_async(e).await;
+                            }
+                        })
+                    };
+
+                    // Detach the task - it will run independently
+                    drop(handler_task);
+
+                    // Convert the receiver to a stream
+                    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+                    Ok(stream)
+                }
+            },
+        );
+    }
+
+    /// Start serving RPC requests (blocking version)
+    ///
+    /// This is a blocking method that runs until the server is shut down.
+    /// It listens for incoming RPC calls and dispatches them to registered handlers.
+    pub fn serve(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.serve_async())
+    }
+
+    /// Start serving RPC requests (async version)
+    ///
+    /// This is an async method that runs until the server is shut down.
+    /// It listens for incoming RPC calls and dispatches them to registered handlers.
+    pub async fn serve_async(&self) -> Result<(), RpcError> {
+        let handle = self.serve_handle()?;
+
+        // Wait for the server task to complete and restore the NotificationReceiver
+        let (notification_rx, result) = handle
+            .await
+            .map_err(|e| RpcError::new(RpcCode::Internal, format!("Server task panicked: {e}")))?;
+
+        // Restore the NotificationReceiver back to the server
+        *self.notification_rx.lock() = Some(notification_rx);
+
+        // Return the result from the server task
+        result.map_err(|e| RpcError::new(RpcCode::Internal, e.to_string()))
+    }
+
+    /// Shutdown the server gracefully (blocking version)
+    ///
+    /// This signals the server to stop accepting new requests and wait for
+    /// in-flight requests to complete.
+    pub fn shutdown(&self) {
+        crate::get_runtime().block_on(self.shutdown_async())
+    }
+
+    /// Shutdown the server gracefully (async version)
+    ///
+    /// This signals the server to stop accepting new requests and wait for
+    /// in-flight requests to complete.
+    pub async fn shutdown_async(&self) {
+        self.shutdown_internal().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_registry_new() {
+        let registry = ServiceRegistry::new();
+        assert_eq!(registry.methods().len(), 0);
+    }
+
+    #[test]
+    fn test_build_method_name() {
+        // Test name building logic without requiring full App setup
+        let base_name = Name::from_strings(["org", "namespace", "app"]);
+        let (_, _, c2) = base_name.str_components();
+        let expected = format!("{}-{}-{}", c2, "MyService", "MyMethod");
+
+        assert_eq!(expected, "app-MyService-MyMethod");
+    }
+
+    #[test]
+    fn test_parse_method_from_destination() {
+        // Test parsing logic
+        let full_method = "app-MyService-MyMethod";
+        let base_app = "app";
+
+        if let Some(suffix) = full_method.strip_prefix(&format!("{base_app}-")) {
+            let parts: Vec<&str> = suffix.splitn(2, '-').collect();
+            assert_eq!(parts.len(), 2);
+            assert_eq!(parts[0], "MyService");
+            assert_eq!(parts[1], "MyMethod");
+        } else {
+            panic!("Failed to parse method name");
+        }
+    }
+
+    #[test]
+    fn test_handler_type_equality() {
+        assert_eq!(HandlerType::UnaryUnary, HandlerType::UnaryUnary);
+        assert_ne!(HandlerType::UnaryUnary, HandlerType::UnaryStream);
+    }
+}

--- a/crates/rpc/src/session_wrapper.rs
+++ b/crates/rpc/src/session_wrapper.rs
@@ -1,0 +1,194 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session wrapper for SlimRPC operations
+//!
+//! Provides a lightweight wrapper around SessionContext that exposes the
+//! publish and receive operations needed for RPC communication.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use display_error_chain::ErrorChainExt;
+
+use futures_timer::Delay;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::app::App as SlimApp;
+use slim_session::context::SessionContext;
+use slim_session::errors::SessionError;
+use slim_session::{AppChannelReceiver, CompletionHandle};
+
+use super::{RpcCode, RpcError, STATUS_CODE_KEY};
+
+/// Received message from a session
+#[derive(Debug, Clone)]
+pub struct ReceivedMessage {
+    /// Message metadata
+    pub metadata: std::collections::HashMap<String, String>,
+    /// Message payload
+    pub payload: Vec<u8>,
+    /// Name of the app that sent this message (extracted from the SLIM header)
+    pub source: Name,
+}
+
+impl ReceivedMessage {
+    /// Returns `true` when this message is an end-of-stream marker:
+    /// status code is `Ok` **and** the payload is empty.
+    pub fn is_eos(&self) -> bool {
+        RpcCode::from_metadata_str(self.metadata.get(STATUS_CODE_KEY).map(String::as_str))
+            == RpcCode::Ok
+            && self.payload.is_empty()
+    }
+}
+
+/// Session transmitter - used only for sending messages
+#[derive(Clone)]
+pub struct SessionTx {
+    /// The underlying session controller
+    controller: Arc<slim_session::session_controller::SessionController>,
+}
+
+/// Session receiver - used only for receiving messages
+pub struct SessionRx {
+    /// Receiver for incoming messages
+    rx: AppChannelReceiver,
+}
+
+impl SessionTx {
+    /// Get the session ID
+    pub fn session_id(&self) -> u32 {
+        self.controller.id()
+    }
+
+    /// Get the source name
+    pub fn source(&self) -> &Name {
+        self.controller.source()
+    }
+
+    /// Get the destination name
+    pub fn destination(&self) -> &Name {
+        self.controller.dst()
+    }
+
+    /// Get session metadata
+    pub fn metadata(&self) -> std::collections::HashMap<String, String> {
+        self.controller.metadata()
+    }
+
+    /// Publish a message to `target` through this session.
+    ///
+    /// Pass `self.destination()` for broadcast behaviour, or pass the
+    /// requester's source name to unicast a reply directly to the caller.
+    pub async fn publish(
+        &self,
+        target: &Name,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Result<CompletionHandle, RpcError> {
+        self.controller
+            .publish(target, data, payload_type, metadata)
+            .await
+            .map_err(|e| RpcError::internal(e.chain().to_string()))
+    }
+
+    /// Get a clone of the underlying session controller
+    pub fn controller(&self) -> Arc<slim_session::session_controller::SessionController> {
+        self.controller.clone()
+    }
+
+    /// Close the session and delete it from the app
+    ///
+    /// This properly cleans up the session resources by calling app.delete_session().
+    /// After calling this, the session should not be used anymore.
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app instance to delete the session from
+    pub async fn close(&self, app: &SlimApp<AuthProvider, AuthVerifier>) -> Result<(), RpcError> {
+        tracing::debug!(session_id = %self.controller.id(), "Closing session");
+
+        match app.delete_session(self.controller.as_ref()) {
+            Ok(handle) => {
+                handle.await.map_err(|e| {
+                    RpcError::internal(format!("Failed to delete session: {}", e.chain()))
+                })?;
+                tracing::debug!(session_id = %self.controller.id(), "Successfully deleted session");
+            }
+            Err(e) => {
+                tracing::warn!(session_id = %self.controller.id(), error = %e, "Failed to delete session");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SessionRx {
+    /// Receive a message from the session with optional timeout.
+    ///
+    /// Returns `Err(SessionError::SessionClosed)` when the channel is gone,
+    /// `Err(SessionError::ReceiveTimeout)` on timeout, and the raw
+    /// `SessionError` for all other session-level errors (e.g.
+    /// `ParticipantDisconnected`).  Callers can therefore distinguish
+    /// transient membership events from fatal failures.
+    pub async fn get_message(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<ReceivedMessage, SessionError> {
+        let recv_future = async {
+            let msg = self.rx.recv().await.ok_or(SessionError::SessionClosed)??;
+
+            // Extract payload from the proto message
+            let payload = if let Some(content) = msg.get_payload() {
+                if let Ok(app_payload) = content.as_application_payload() {
+                    app_payload.blob.clone()
+                } else {
+                    Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
+
+            let source = msg.get_source();
+            Ok(ReceivedMessage {
+                metadata: msg.metadata,
+                payload,
+                source,
+            })
+        };
+
+        if let Some(timeout_duration) = timeout {
+            futures::pin_mut!(recv_future);
+            let delay = Delay::new(timeout_duration);
+            futures::pin_mut!(delay);
+
+            match futures::future::select(recv_future, delay).await {
+                futures::future::Either::Left((result, _)) => result,
+                futures::future::Either::Right(_) => Err(SessionError::ReceiveTimeout),
+            }
+        } else {
+            recv_future.await
+        }
+    }
+}
+
+/// Create session transmitter and receiver from a SessionContext
+///
+/// Returns a tuple of (SessionTx, SessionRx) where:
+/// - SessionTx is used only for sending messages
+/// - SessionRx is used only for receiving messages
+pub fn new_session(ctx: SessionContext) -> (SessionTx, SessionRx) {
+    let (session_weak, rx) = ctx.into_parts();
+    let controller = session_weak
+        .upgrade()
+        .expect("Session controller should be available");
+
+    let tx = SessionTx {
+        controller: controller.clone(),
+    };
+
+    let rx_wrapper = SessionRx { rx };
+
+    (tx, rx_wrapper)
+}

--- a/crates/rpc/src/stream_types.rs
+++ b/crates/rpc/src/stream_types.rs
@@ -1,0 +1,832 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stream wrapper types for SlimRPC UniFFI bindings
+//!
+//! Provides UniFFI-compatible wrappers for streaming operations.
+//! Since UniFFI doesn't support Rust async streams, we provide synchronous
+//! pull/push interfaces backed by async channels.
+
+use slim_datapath::api::ProtoName as Name;
+use std::pin::Pin;
+use std::task::Poll;
+
+use futures::StreamExt;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tokio::sync::{
+    Mutex as TokioMutex,
+    mpsc::{self, UnboundedReceiver, UnboundedSender, unbounded_channel},
+};
+
+use super::{Channel, MulticastItem, ReceivedMessage, RpcCode, RpcError, STATUS_CODE_KEY};
+
+/// Result type for raw byte payloads flowing through the RPC streams.
+type RpcBytesResult = Result<Vec<u8>, RpcError>;
+/// Sender end of a channel carrying RPC byte results.
+type RpcBytesSender = UnboundedSender<RpcBytesResult>;
+/// Tokio JoinHandle producing a final RPC byte result.
+type RpcBytesJoinHandle = tokio::task::JoinHandle<RpcBytesResult>;
+
+/// Raw byte stream for a stream-input RPC call.
+///
+/// Implements [`Stream`] directly using `poll_recv` — no heap allocation.
+/// All fields are [`Unpin`], so this type is `Unpin` too.
+///
+/// Yielded values:
+/// - `Ok(payload)` — normal message bytes
+/// - `Err(e)` — protocol error (bad status code, channel closed)
+///
+/// The stream ends (returns `None`) on EOS or after yielding an error.
+pub struct RawStream {
+    session_rx: Option<mpsc::UnboundedReceiver<ReceivedMessage>>,
+    payload: Vec<u8>,
+    first_is_eos: bool,
+    first_code: RpcCode,
+    /// `true` once the first message has been yielded or skipped.
+    first_done: bool,
+    /// `true` once the stream has permanently ended (EOS, error, or channel close).
+    done: bool,
+}
+
+impl futures::Stream for RawStream {
+    type Item = Result<Vec<u8>, RpcError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        // ── First message ────────────────────────────────────────────────────
+        if !self.first_done {
+            self.first_done = true;
+
+            if self.first_is_eos {
+                self.done = true;
+                return Poll::Ready(None);
+            }
+
+            let first_code = self.first_code;
+            if first_code != RpcCode::Ok {
+                let payload = std::mem::take(&mut self.payload);
+                self.done = true;
+                return Poll::Ready(Some(Err(RpcError::new(
+                    first_code,
+                    String::from_utf8_lossy(&payload).into_owned(),
+                ))));
+            }
+
+            let payload = std::mem::take(&mut self.payload);
+            return Poll::Ready(Some(Ok(payload)));
+        }
+
+        // ── Continuation messages ────────────────────────────────────────────
+        let Some(ref mut rx) = self.session_rx else {
+            self.done = true;
+            return Poll::Ready(None);
+        };
+
+        match rx.poll_recv(cx) {
+            Poll::Ready(Some(msg)) => {
+                tracing::debug!("Received message in stream-based method");
+
+                if msg.is_eos() {
+                    self.done = true;
+                    return Poll::Ready(None);
+                }
+
+                let code = RpcCode::from_metadata_str(
+                    msg.metadata.get(STATUS_CODE_KEY).map(String::as_str),
+                );
+                if code != RpcCode::Ok {
+                    let message = String::from_utf8_lossy(&msg.payload).into_owned();
+                    self.done = true;
+                    return Poll::Ready(Some(Err(RpcError::new(code, message))));
+                }
+
+                Poll::Ready(Some(Ok(msg.payload)))
+            }
+            Poll::Ready(None) => {
+                self.done = true;
+                Poll::Ready(Some(Err(RpcError::internal("Stream channel closed"))))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// A decoded request stream: `RawStream` items mapped through `Req::decode`.
+///
+/// Using a concrete named type (instead of `BoxStream`) lets the compiler
+/// stack-allocate the stream combinator and eliminates the `BoxStream`
+/// allocation that `RequestStream<Req>` required.
+///
+/// Handlers registered via `register_stream_unary_internal` /
+/// `register_stream_stream_internal` receive `DecodedStream<Req>` directly.
+pub type DecodedStream<Req> =
+    futures::stream::Map<RawStream, fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError>>;
+
+/// Raw stream components passed to stream-input handlers.
+///
+/// Holding the raw components avoids boxing at the dispatch level. Each typed
+/// wrapper calls [`StreamSource::into_raw_stream`] to get a [`RawStream`], then
+/// maps it to the decoded type — with zero heap allocations.
+pub struct StreamSource {
+    pub session_rx: Option<mpsc::UnboundedReceiver<ReceivedMessage>>,
+    pub payload: Vec<u8>,
+    pub first_is_eos: bool,
+    pub first_code: RpcCode,
+}
+
+impl StreamSource {
+    /// Consume `self` and produce an allocation-free [`RawStream`].
+    pub fn into_raw_stream(self) -> RawStream {
+        RawStream {
+            session_rx: self.session_rx,
+            payload: self.payload,
+            first_is_eos: self.first_is_eos,
+            first_code: self.first_code,
+            first_done: false,
+            done: false,
+        }
+    }
+}
+
+/// Request stream reader
+///
+/// Allows pulling messages from a client request stream.
+/// This wraps the underlying async stream and provides a blocking interface
+/// suitable for UniFFI callback traits.
+pub struct RequestStream {
+    /// Inner stream wrapped in a mutex for interior mutability
+    inner: TokioMutex<DecodedStream<Vec<u8>>>,
+}
+
+impl RequestStream {
+    /// Create a new request stream wrapper
+    pub fn new(stream: DecodedStream<Vec<u8>>) -> Self {
+        Self {
+            inner: TokioMutex::new(stream),
+        }
+    }
+}
+
+impl RequestStream {
+    /// Pull the next message from the stream (blocking version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub fn next(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next message from the stream (async version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub async fn next_async(&self) -> StreamMessage {
+        let mut stream = self.inner.lock().await;
+        match stream.next().await {
+            Some(Ok(data)) => StreamMessage::Data(data),
+            Some(Err(e)) => StreamMessage::Error(e),
+            None => StreamMessage::End,
+        }
+    }
+}
+
+/// Message from a stream
+pub enum StreamMessage {
+    /// Successfully received data
+    Data(Vec<u8>),
+    /// Stream error occurred
+    Error(RpcError),
+    /// Stream has ended
+    End,
+}
+
+/// Response stream writer
+///
+/// Allows pushing messages to a client response stream.
+/// This wraps an async channel sender and provides a blocking interface
+/// suitable for UniFFI callback traits.
+pub struct ResponseSink {
+    /// Channel sender for streaming responses (None when closed)
+    sender: Mutex<Option<RpcBytesSender>>,
+}
+
+impl ResponseSink {
+    /// Create a new response sink wrapper
+    pub fn new(sender: UnboundedSender<Result<Vec<u8>, RpcError>>) -> Self {
+        Self {
+            sender: Mutex::new(Some(sender)),
+        }
+    }
+
+    /// Get the receiver side of the channel
+    pub fn receiver() -> (Self, UnboundedReceiver<Result<Vec<u8>, RpcError>>) {
+        let (tx, rx) = unbounded_channel();
+        let sink = Self::new(tx);
+        (sink, rx)
+    }
+}
+
+impl ResponseSink {
+    /// Send a message to the response stream (blocking version)
+    ///
+    /// Returns an error if the stream has been closed or if sending fails.
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a message to the response stream (async version)
+    ///
+    /// Returns an error if the stream has been closed or if sending fails.
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock();
+        match sender.as_ref() {
+            Some(s) => s.send(Ok(data)).map_err(|_| {
+                RpcError::new(RpcCode::Unavailable, "Failed to send response".to_string())
+            }),
+            None => Err(RpcError::new(
+                RpcCode::FailedPrecondition,
+                "Response sink is closed".to_string(),
+            )),
+        }
+    }
+
+    /// Send an error to the response stream and close it (blocking version)
+    ///
+    /// This terminates the stream with an error status.
+    pub fn send_error(&self, error: RpcError) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_error_async(error))
+    }
+
+    /// Send an error to the response stream and close it (async version)
+    ///
+    /// This terminates the stream with an error status.
+    pub async fn send_error_async(&self, error: RpcError) -> Result<(), RpcError> {
+        let mut sender_guard = self.sender.lock();
+        match sender_guard.take() {
+            Some(sender) => sender.send(Err(error)).map_err(|_| {
+                RpcError::new(RpcCode::Unavailable, "Failed to send error".to_string())
+            }),
+            None => Err(RpcError::new(
+                RpcCode::FailedPrecondition,
+                "Response sink is already closed".to_string(),
+            )),
+        }
+    }
+
+    /// Close the response stream (blocking version)
+    ///
+    /// Signals that no more messages will be sent.
+    /// The stream will end gracefully.
+    pub fn close(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_async())
+    }
+
+    /// Close the response stream (async version)
+    ///
+    /// Signals that no more messages will be sent.
+    /// The stream will end gracefully.
+    pub async fn close_async(&self) -> Result<(), RpcError> {
+        let mut sender = self.sender.lock();
+        sender.take(); // Drop the sender to signal stream end
+        Ok(())
+    }
+
+    /// Check if the sink has been closed (blocking version)
+    pub fn is_closed(&self) -> bool {
+        crate::get_runtime().block_on(self.is_closed_async())
+    }
+
+    /// Check if the sink has been closed (async version)
+    pub async fn is_closed_async(&self) -> bool {
+        self.sender.lock().is_none()
+    }
+}
+
+/// Response stream reader for unary-to-stream RPC calls
+///
+/// Allows pulling messages from a server response stream one at a time.
+pub struct ResponseStreamReader {
+    /// Inner receiver channel for stream messages
+    inner: TokioMutex<UnboundedReceiver<Result<Vec<u8>, RpcError>>>,
+}
+
+impl ResponseStreamReader {
+    /// Create a new response stream reader
+    pub fn new(rx: UnboundedReceiver<Result<Vec<u8>, RpcError>>) -> Self {
+        Self {
+            inner: TokioMutex::new(rx),
+        }
+    }
+}
+
+impl ResponseStreamReader {
+    /// Pull the next message from the response stream (blocking version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub fn next(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next message from the response stream (async version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub async fn next_async(&self) -> StreamMessage {
+        let mut rx = self.inner.lock().await;
+        match rx.recv().await {
+            Some(Ok(data)) => StreamMessage::Data(data),
+            Some(Err(e)) => StreamMessage::Error(e),
+            None => StreamMessage::End,
+        }
+    }
+}
+
+/// Request stream writer for stream-to-unary RPC calls
+///
+/// Allows sending multiple request messages and getting a final response.
+pub struct RequestStreamWriter {
+    sender: TokioMutex<Option<UnboundedSender<Vec<u8>>>>,
+    response: TokioMutex<Option<RpcBytesJoinHandle>>,
+}
+
+impl RequestStreamWriter {
+    pub fn new(
+        channel: Channel,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        let (tx, mut rx) = unbounded_channel();
+
+        let channel_clone = channel;
+        let service_name_clone = service_name;
+        let method_name_clone = method_name;
+
+        // Spawn task to handle the stream_unary call
+        let response_handle = crate::get_runtime().spawn(async move {
+            use async_stream::stream;
+
+            let stream = stream! {
+                while let Some(data) = rx.recv().await {
+                    yield data;
+                }
+            };
+
+            channel_clone
+                .stream_unary::<Vec<u8>, Vec<u8>>(
+                    &service_name_clone,
+                    &method_name_clone,
+                    stream,
+                    timeout,
+                    metadata,
+                )
+                .await
+        });
+
+        Self {
+            sender: TokioMutex::new(Some(tx)),
+            response: TokioMutex::new(Some(response_handle)),
+        }
+    }
+}
+
+impl RequestStreamWriter {
+    /// Send a request message to the stream (blocking version)
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a request message to the stream (async version)
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock().await;
+        if let Some(tx) = sender.as_ref() {
+            tx.send(data)
+                .map_err(|_| RpcError::new(RpcCode::Internal, "Stream closed".to_string()))
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already finalized".to_string(),
+            ))
+        }
+    }
+
+    /// Finalize the stream and get the response (blocking version)
+    pub fn finalize_stream(&self) -> Result<Vec<u8>, RpcError> {
+        crate::get_runtime().block_on(self.finalize_stream_async())
+    }
+
+    /// Finalize the stream and get the response (async version)
+    pub async fn finalize_stream_async(&self) -> Result<Vec<u8>, RpcError> {
+        // Drop the sender to signal end of stream
+        {
+            let mut sender = self.sender.lock().await;
+            *sender = None;
+        }
+
+        // Wait for response
+        let mut response_guard = self.response.lock().await;
+        if let Some(handle) = response_guard.take() {
+            handle
+                .await
+                .map_err(|e| RpcError::new(RpcCode::Internal, format!("Task failed: {e}")))?
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already finalized".to_string(),
+            ))
+        }
+    }
+}
+
+impl RequestStreamWriter {
+    /// Finalize the stream and get the response (async version)
+    ///
+    /// **Deprecated**: Use [`finalize_stream_async`](Self::finalize_stream_async) instead.
+    pub async fn finalize_async(&self) -> Result<Vec<u8>, RpcError> {
+        self.finalize_stream_async().await
+    }
+}
+
+/// Bidirectional stream handler for stream-to-stream RPC calls
+///
+/// Allows sending and receiving messages concurrently.
+pub struct BidiStreamHandler {
+    sender: TokioMutex<Option<UnboundedSender<Vec<u8>>>>,
+    receiver: TokioMutex<UnboundedReceiver<Result<Vec<u8>, RpcError>>>,
+}
+
+impl BidiStreamHandler {
+    pub fn new(
+        channel: Channel,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        let (req_tx, mut req_rx) = unbounded_channel();
+        let (resp_tx, resp_rx) = unbounded_channel();
+
+        // Spawn task to handle the stream_stream call
+        crate::get_runtime().spawn(async move {
+            use async_stream::stream;
+
+            let request_stream = stream! {
+                while let Some(data) = req_rx.recv().await {
+                    yield data;
+                }
+            };
+
+            let response_stream = channel.stream_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request_stream,
+                timeout,
+                metadata,
+            );
+
+            futures::pin_mut!(response_stream);
+            while let Some(item) = futures::StreamExt::next(&mut response_stream).await {
+                if resp_tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            sender: TokioMutex::new(Some(req_tx)),
+            receiver: TokioMutex::new(resp_rx),
+        }
+    }
+}
+
+impl BidiStreamHandler {
+    /// Send a request message to the stream (blocking version)
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a request message to the stream (async version)
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock().await;
+        if let Some(tx) = sender.as_ref() {
+            tx.send(data)
+                .map_err(|_| RpcError::new(RpcCode::Internal, "Stream closed".to_string()))
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already closed".to_string(),
+            ))
+        }
+    }
+
+    /// Close the request stream (no more messages will be sent)
+    pub fn close_send(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_send_async())
+    }
+
+    /// Close the request stream (async version)
+    pub async fn close_send_async(&self) -> Result<(), RpcError> {
+        let mut sender = self.sender.lock().await;
+        *sender = None;
+        Ok(())
+    }
+
+    /// Receive the next response message (blocking version)
+    pub fn recv(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.recv_async())
+    }
+
+    /// Receive the next response message (async version)
+    pub async fn recv_async(&self) -> StreamMessage {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(Ok(data)) => StreamMessage::Data(data),
+            Some(Err(e)) => StreamMessage::Error(e),
+            None => StreamMessage::End,
+        }
+    }
+}
+
+// ── Multicast stream types ────────────────────────────────────────────────────
+
+/// Per-message context for a multicast RPC response — identifies which group
+/// member sent the response.
+#[derive(Clone, Debug)]
+pub struct RpcMessageContext {
+    /// The SLIM name of the group member that sent this response.
+    pub source: Arc<Name>,
+}
+
+/// A single item in a multicast response stream, pairing the response payload
+/// with the identity of the member that produced it.
+#[derive(Clone, Debug)]
+pub struct RpcMulticastItem {
+    /// Context identifying the source member.
+    pub context: RpcMessageContext,
+    /// The encoded response payload (raw bytes).
+    pub message: Vec<u8>,
+}
+
+/// Message from a multicast response stream.
+pub enum MulticastStreamMessage {
+    /// Successfully received response item with source context.
+    Data { item: RpcMulticastItem },
+    /// Error from one member — other members may still be active.
+    Error { error: RpcError },
+    /// All members have finished — the stream has ended.
+    End,
+}
+
+/// Response stream reader for multicast RPC calls.
+///
+/// Allows pulling `RpcMulticastItem`s from a GROUP response stream one at a
+/// time. Each item carries the source member's identity alongside the payload.
+pub struct MulticastResponseReader {
+    inner: TokioMutex<UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>>,
+}
+
+impl MulticastResponseReader {
+    /// Create a new reader backed by the given mpsc receiver.
+    pub fn new(rx: UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>) -> Self {
+        Self {
+            inner: TokioMutex::new(rx),
+        }
+    }
+
+    /// Convert one channel item into a `MulticastStreamMessage`.
+    pub(crate) fn convert_item(
+        item: Result<MulticastItem<Vec<u8>>, RpcError>,
+    ) -> MulticastStreamMessage {
+        match item {
+            Ok(mi) => MulticastStreamMessage::Data {
+                item: RpcMulticastItem {
+                    context: RpcMessageContext {
+                        source: Arc::new(mi.context.source),
+                    },
+                    message: mi.message,
+                },
+            },
+            Err(e) => MulticastStreamMessage::Error { error: e },
+        }
+    }
+}
+
+impl MulticastResponseReader {
+    /// Pull the next item from the multicast response stream (blocking).
+    pub fn next(&self) -> MulticastStreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next item from the multicast response stream (async).
+    pub async fn next_async(&self) -> MulticastStreamMessage {
+        let mut rx = self.inner.lock().await;
+        match rx.recv().await {
+            Some(item) => Self::convert_item(item),
+            None => MulticastStreamMessage::End,
+        }
+    }
+}
+
+/// Bidirectional stream handler for multicast stream-to-unary and
+/// stream-to-stream RPC calls.
+///
+/// Send request messages via [`send`](Self::send) / [`send_async`](Self::send_async),
+/// close the request stream via [`close_send`](Self::close_send), and receive
+/// responses via [`recv`](Self::recv) / [`recv_async`](Self::recv_async). Each
+/// response item carries the source member's identity.
+pub struct MulticastBidiStreamHandler {
+    sender: TokioMutex<Option<UnboundedSender<Vec<u8>>>>,
+    receiver: TokioMutex<UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>>,
+}
+
+impl MulticastBidiStreamHandler {
+    /// Create a new handler that pipes a request stream through a multicast
+    /// `stream_stream` call on `channel`.
+    pub fn new(
+        channel: Channel,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        let (req_tx, mut req_rx) = unbounded_channel();
+        let (resp_tx, resp_rx) = unbounded_channel();
+
+        crate::get_runtime().spawn(async move {
+            use async_stream::stream;
+
+            let request_stream = stream! {
+                while let Some(data) = req_rx.recv().await {
+                    yield data;
+                }
+            };
+
+            let response_stream = channel.multicast_stream_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request_stream,
+                timeout,
+                metadata,
+            );
+
+            futures::pin_mut!(response_stream);
+            while let Some(item) = futures::StreamExt::next(&mut response_stream).await {
+                if resp_tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            sender: TokioMutex::new(Some(req_tx)),
+            receiver: TokioMutex::new(resp_rx),
+        }
+    }
+}
+
+impl MulticastBidiStreamHandler {
+    /// Send a request message to the stream (blocking).
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a request message to the stream (async).
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock().await;
+        if let Some(tx) = sender.as_ref() {
+            tx.send(data)
+                .map_err(|_| RpcError::new(RpcCode::Internal, "Stream closed".to_string()))
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already closed".to_string(),
+            ))
+        }
+    }
+
+    /// Close the request stream — signals that no more messages will be sent
+    /// (blocking).
+    pub fn close_send(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_send_async())
+    }
+
+    /// Close the request stream (async).
+    pub async fn close_send_async(&self) -> Result<(), RpcError> {
+        let mut sender = self.sender.lock().await;
+        *sender = None;
+        Ok(())
+    }
+
+    /// Receive the next response item (blocking).
+    pub fn recv(&self) -> MulticastStreamMessage {
+        crate::get_runtime().block_on(self.recv_async())
+    }
+
+    /// Receive the next response item (async).
+    pub async fn recv_async(&self) -> MulticastStreamMessage {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(item) => MulticastResponseReader::convert_item(item),
+            None => MulticastStreamMessage::End,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_request_stream() {
+        use crate::{ReceivedMessage, StreamSource};
+        use futures::StreamExt;
+        use slim_datapath::api::ProtoName as Name;
+
+        let dummy_name = Name::from_strings(["", "", ""]);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ReceivedMessage>();
+
+        // Second message
+        tx.send(ReceivedMessage {
+            metadata: std::collections::HashMap::new(),
+            payload: vec![4, 5, 6],
+            source: dummy_name.clone(),
+        })
+        .unwrap();
+        // EOS: empty payload with default (Ok) status code
+        tx.send(ReceivedMessage {
+            metadata: std::collections::HashMap::new(),
+            payload: vec![],
+            source: dummy_name,
+        })
+        .unwrap();
+
+        let source = StreamSource {
+            session_rx: Some(rx),
+            payload: vec![1, 2, 3],
+            first_is_eos: false,
+            first_code: RpcCode::Ok,
+        };
+        let decode_fn: fn(RpcBytesResult) -> RpcBytesResult = |res| res;
+        let stream: DecodedStream<Vec<u8>> = source.into_raw_stream().map(decode_fn);
+        let request_stream = RequestStream::new(stream);
+
+        let msg1 = request_stream.next_async().await;
+        match msg1 {
+            StreamMessage::Data(d) => assert_eq!(d, vec![1, 2, 3]),
+            _ => panic!("Expected data"),
+        }
+
+        let msg2 = request_stream.next_async().await;
+        match msg2 {
+            StreamMessage::Data(d) => assert_eq!(d, vec![4, 5, 6]),
+            _ => panic!("Expected data"),
+        }
+
+        let msg3 = request_stream.next_async().await;
+        match msg3 {
+            StreamMessage::End => {}
+            _ => panic!("Expected end"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_response_sink() {
+        let (sink, mut rx) = ResponseSink::receiver();
+
+        sink.send_async(vec![1, 2, 3]).await.unwrap();
+        sink.send_async(vec![4, 5, 6]).await.unwrap();
+        sink.close_async().await.unwrap();
+
+        let msg1 = rx.recv().await.unwrap();
+        assert_eq!(msg1.unwrap(), vec![1, 2, 3]);
+
+        let msg2 = rx.recv().await.unwrap();
+        assert_eq!(msg2.unwrap(), vec![4, 5, 6]);
+
+        // After close, no more messages
+        assert!(sink.is_closed_async().await);
+    }
+
+    #[tokio::test]
+    async fn test_response_sink_error() {
+        let (sink, mut rx) = ResponseSink::receiver();
+
+        sink.send_async(vec![1, 2, 3]).await.unwrap();
+
+        let error = RpcError::new(RpcCode::Internal, "Test error".to_string());
+        sink.send_error_async(error).await.unwrap();
+
+        let msg1 = rx.recv().await.unwrap();
+        assert_eq!(msg1.unwrap(), vec![1, 2, 3]);
+
+        let msg2 = rx.recv().await.unwrap();
+        assert!(msg2.is_err());
+
+        assert!(sink.is_closed_async().await);
+    }
+}

--- a/crates/rpc/tests/core.rs
+++ b/crates/rpc/tests/core.rs
@@ -1,0 +1,2738 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for SlimRPC
+//!
+//! These tests verify the four RPC interaction patterns:
+//! - Unary-Unary: Single request, single response
+//! - Stream-Unary: Streaming requests, single response
+//! - Unary-Stream: Single request, streaming responses
+//! - Stream-Stream: Streaming requests, streaming responses
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use futures::pin_mut;
+use futures::stream::{self, StreamExt};
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::shared_secret::SharedSecret;
+use slim_config::component::id::{ID, Kind};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::service::Service;
+use tokio::sync::Mutex;
+
+const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+use slim_rpc::{Channel, Context, DecodedStream, Decoder, Encoder, RpcCode, RpcError, Server};
+
+// ============================================================================
+// Test Message Types
+// ============================================================================
+
+/// Simple request message for testing
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestRequest {
+    pub message: String,
+    pub value: i32,
+}
+
+impl Encoder for TestRequest {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        let encoded = bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))?;
+        Ok(encoded)
+    }
+}
+
+impl Decoder for TestRequest {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (decoded, _len): (TestRequest, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(decoded)
+    }
+}
+
+/// Simple response message for testing
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestResponse {
+    pub result: String,
+    pub count: i32,
+}
+
+impl Encoder for TestResponse {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        let encoded = bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))?;
+        Ok(encoded)
+    }
+}
+
+impl Decoder for TestResponse {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (decoded, _len): (TestResponse, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(decoded)
+    }
+}
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/// Test environment containing service, server, and client components
+struct TestEnv {
+    service: Arc<Service>,
+    server: Arc<Server>,
+    channel: Channel,
+}
+
+impl TestEnv {
+    /// Create a new test environment with server and client (server not started yet)
+    async fn new(test_name: &str) -> Self {
+        let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+        let service = Arc::new(Service::new(id));
+
+        let server_name = Name::from_strings(["org", "ns", "server"]);
+        let secret = SharedSecret::new("server", TEST_VALID_SECRET).unwrap();
+
+        let (server_app, server_notifications) = service
+            .create_app(
+                &server_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret.clone()),
+            )
+            .unwrap();
+        let server_app = Arc::new(server_app);
+
+        let server = Arc::new(Server::new_internal(
+            server_app.clone(),
+            server_app.app_name().clone(),
+            server_notifications,
+        ));
+
+        // Create client
+        let client_name = Name::from_strings(["org", "ns", "client"]);
+        let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+        let (client_app, _) = service
+            .create_app(
+                &client_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        let client_app = Arc::new(client_app);
+
+        let channel = Channel::new_with_members_internal(
+            client_app.clone(),
+            vec![server_app.app_name().clone()],
+            false,
+            None,
+        )
+        .expect("single non-empty member list is always valid");
+
+        Self {
+            service,
+            server,
+            channel,
+        }
+    }
+
+    /// Start the server in the background
+    async fn start_server(&self) {
+        let server = self.server.clone();
+
+        // Spawn task to run the server
+        tokio::spawn(async move {
+            if let Err(e) = server.serve_async().await {
+                tracing::error!("Server error: {:?}", e);
+            }
+        });
+
+        // Give server time to start and subscribe
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    /// Clean shutdown of the test environment
+    async fn shutdown(&mut self) {
+        tracing::info!("Shutting down server...");
+        self.server.shutdown_internal().await;
+
+        tracing::info!("Shutting down service...");
+        self.service.shutdown().await.unwrap();
+    }
+}
+
+// ============================================================================
+// Test Helper Functions
+// ============================================================================
+
+/// Collect all responses from a stream into a vector
+async fn collect_stream_responses<T>(
+    mut stream: impl futures::Stream<Item = Result<T, RpcError>> + Unpin,
+) -> Vec<T> {
+    let mut responses = Vec::new();
+    while let Some(result) = stream.next().await {
+        responses.push(result.expect("Stream item failed"));
+    }
+    responses
+}
+
+/// Collect responses from a stream until an error occurs
+async fn collect_stream_until_error<T>(
+    mut stream: impl futures::Stream<Item = Result<T, RpcError>> + Unpin,
+) -> (Vec<T>, Option<RpcError>) {
+    let mut responses = Vec::new();
+    let mut error = None;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(response) => responses.push(response),
+            Err(e) => {
+                error = Some(e);
+                break;
+            }
+        }
+    }
+    (responses, error)
+}
+
+/// Register a unary-unary handler that counts calls and tracks session IDs
+fn register_counting_handler(
+    server: &Arc<Server>,
+    service: &str,
+    method: &str,
+    call_count: Arc<Mutex<i32>>,
+    session_ids: Option<Arc<Mutex<Vec<String>>>>,
+) {
+    server.register_unary_unary_internal(
+        service,
+        method,
+        move |request: TestRequest, ctx: Context| {
+            let count = call_count.clone();
+            let ids = session_ids.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                let current = *c;
+                drop(c);
+
+                if let Some(ids) = ids {
+                    let session_id = ctx.session().session_id().to_string();
+                    tracing::info!(
+                        "RPC '{}' (call #{}) handled by session ID: {}",
+                        request.message,
+                        current,
+                        session_id
+                    );
+                    let mut id_list = ids.lock().await;
+                    id_list.push(session_id);
+                    drop(id_list);
+                }
+
+                Ok(TestResponse {
+                    result: format!("Echo: {}", request.message),
+                    count: current,
+                })
+            }
+        },
+    );
+}
+
+/// Assert that a result is an error with the expected code and optional message substring
+fn assert_error_with_code(
+    result: Result<impl std::fmt::Debug, RpcError>,
+    code: RpcCode,
+    msg_contains: Option<&str>,
+) {
+    assert!(result.is_err(), "Expected an error");
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), code, "Error code mismatch");
+    if let Some(expected_msg) = msg_contains {
+        let actual_msg = err.message();
+        assert!(
+            actual_msg.contains(expected_msg),
+            "Error message '{actual_msg}' does not contain '{expected_msg}'"
+        );
+    }
+}
+
+// ============================================================================
+// Test 1: Unary-Unary RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_rpc() {
+    let mut env = TestEnv::new("test-service-unary").await;
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        |request: TestRequest, _ctx: Context| async move {
+            Ok(TestResponse {
+                result: format!("Echo: {}", request.message),
+                count: request.value * 2,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "Hello".to_string(),
+        value: 42,
+    };
+
+    let response: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request, None, None)
+        .await
+        .expect("Unary call failed");
+
+    // Verify response
+    assert_eq!(response.result, "Echo: Hello");
+    assert_eq!(response.count, 84);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_error_handling() {
+    let mut env = TestEnv::new("test-service-error").await;
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "ErrorMethod",
+        |_request: TestRequest, _ctx: Context| async move {
+            Err::<TestResponse, _>(RpcError::invalid_argument("Invalid input"))
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 1,
+    };
+
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary("TestService", "ErrorMethod", request, None, None)
+        .await;
+
+    assert_error_with_code(result, RpcCode::InvalidArgument, Some("Invalid input"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 2: Stream-Unary RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_rpc() {
+    let mut env = TestEnv::new("test-service-stream-unary").await;
+
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "Sum",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            let mut total = 0;
+            let mut messages = Vec::new();
+
+            while let Some(req_result) = request_stream.next().await {
+                let req: TestRequest = req_result?;
+                total += req.value;
+                messages.push(req.message);
+            }
+
+            Ok(TestResponse {
+                result: messages.join(", "),
+                count: total,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "one".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "two".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "three".to_string(),
+            value: 3,
+        },
+    ];
+    let request_stream = stream::iter(requests);
+
+    let response: TestResponse = env
+        .channel
+        .stream_unary("TestService", "Sum", request_stream, None, None)
+        .await
+        .expect("Stream-unary call failed");
+
+    // Verify response
+    assert_eq!(response.result, "one, two, three");
+    assert_eq!(response.count, 6);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 2b: Stream-Unary RPC with Error Handling
+// ============================================================================
+//
+// This test verifies that errors in the request stream are properly handled.
+// Note: RequestStream<T> = Pin<Box<dyn Stream<Item = Result<T, RpcError>> + Send>>
+// Each item in the stream is a Result that can contain:
+// - Ok(T): Successfully received and deserialized message
+// - Err(Status): Network error, deserialization error, or transport issue
+//
+// In this test, we simulate an error condition by having the handler validate
+// input and return an error when invalid data is encountered.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_error_handling() {
+    let mut env = TestEnv::new("test-service-stream-unary-error").await;
+
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "SumWithValidation",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            let mut total = 0;
+            let mut messages = Vec::new();
+
+            // Iterate over the stream of Results
+            while let Some(req_result) = request_stream.next().await {
+                // Each item is a Result<TestRequest, RpcError>
+                // Use ? to propagate any errors from the stream (network, deserialization, etc.)
+                let req = req_result?;
+
+                // Validate input - return error if value is negative
+                if req.value < 0 {
+                    tracing::info!("Received invalid value: {}", req.value);
+                    return Err(RpcError::invalid_argument(format!(
+                        "Negative values not allowed: {}",
+                        req.value
+                    )));
+                }
+
+                total += req.value;
+                messages.push(req.message);
+            }
+
+            Ok(TestResponse {
+                result: messages.join(", "),
+                count: total,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    // Note: The client sends Stream<Item = TestRequest>, not Stream<Item = Result<...>>
+    // The Result wrapper is added by the transport layer on the server side
+    let requests = vec![
+        TestRequest {
+            message: "one".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "two".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "invalid".to_string(),
+            value: -5, // This invalid value will cause the handler to return an error
+        },
+        TestRequest {
+            message: "three".to_string(),
+            value: 3, // This won't be processed due to the error above
+        },
+    ];
+    let request_stream = stream::iter(requests);
+
+    let response: Result<TestResponse, RpcError> = env
+        .channel
+        .stream_unary(
+            "TestService",
+            "SumWithValidation",
+            request_stream,
+            None,
+            None,
+        )
+        .await;
+
+    // Verify that the error was propagated back
+    assert!(response.is_err(), "Expected an error response");
+    let err = response.unwrap_err();
+    assert_eq!(err.code(), RpcCode::InvalidArgument);
+    let msg = err.message();
+    assert!(
+        msg.contains("Negative values not allowed"),
+        "Error message was: {msg}"
+    );
+    assert!(msg.contains("-5"), "Error message was: {msg}");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 3: Unary-Stream RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_rpc() {
+    let mut env = TestEnv::new("test-service-unary-stream").await;
+
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "Generate",
+        |request: TestRequest, _ctx: Context| async move {
+            let count = request.value;
+            let message = request.message.clone();
+
+            // Create an async stream that generates responses incrementally
+
+            // register current time
+            let response_stream = async_stream::stream! {
+                for i in 1..=count {
+                    // Simulate some async work (optional)
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+
+                    yield Ok(TestResponse {
+                        result: format!("{message}-{i}"),
+                        count: i,
+                    });
+                }
+            };
+
+            Ok(response_stream)
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 5,
+    };
+
+    let responses: Vec<TestResponse> = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Generate",
+            request,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_responses(response_stream).await
+    };
+
+    // Verify responses
+    assert_eq!(responses.len(), 5);
+    assert_eq!(responses[0].result, "item-1");
+    assert_eq!(responses[0].count, 1);
+    assert_eq!(responses[4].result, "item-5");
+    assert_eq!(responses[4].count, 5);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 3b: Unary-Stream RPC with Error Handling
+// ============================================================================
+//
+// This test verifies that errors in the response stream are properly propagated.
+// The handler generates several responses successfully, then encounters an error
+// condition and yields an error in the stream. The client should receive the
+// successful responses followed by the error.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_error_handling() {
+    let mut env = TestEnv::new("test-service-unary-stream-error").await;
+
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "GenerateWithError",
+        |request: TestRequest, _ctx: Context| async move {
+            let count = request.value;
+            let message = request.message.clone();
+
+            // Create an async stream that generates some responses then an error
+            let response_stream = async_stream::stream! {
+                for i in 1..=count {
+                    // After 3 items, simulate an error condition
+                    if i > 3 {
+                        tracing::info!("Simulating error after {} responses", i - 1);
+                        yield Err(RpcError::internal(
+                            format!("Failed to generate item {i}")
+                        ));
+                        break;
+                    }
+
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+
+                    yield Ok(TestResponse {
+                        result: format!("{message}-{i}"),
+                        count: i,
+                    });
+                }
+            };
+
+            Ok(response_stream)
+        },
+    );
+
+    env.start_server().await;
+
+    // Request 10 items, but handler will error after 3
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 10,
+    };
+
+    let (responses, error_received) = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "GenerateWithError",
+            request,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+
+    // Verify we received 3 successful responses before the error
+    assert_eq!(responses.len(), 3);
+    assert_eq!(responses[0].result, "item-1");
+    assert_eq!(responses[1].result, "item-2");
+    assert_eq!(responses[2].result, "item-3");
+
+    // Verify the error was received
+    assert!(error_received.is_some(), "Expected an error in the stream");
+    let err = error_received.unwrap();
+    assert_eq!(err.code(), RpcCode::Internal);
+    assert!(err.message().contains("Failed to generate item 4"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 4: Stream-Stream RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_rpc() {
+    let mut env = TestEnv::new("test-service-stream-stream").await;
+
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "Transform",
+        |request_stream, _ctx: Context| async move {
+            // Using .map() processes items as they arrive (lazy/incremental)
+            // For more complex async processing, use async_stream or spawn a task
+            // with a channel (see the SlimRPC examples for the channel pattern)
+            Ok(request_stream.map(|req_result| {
+                req_result.map(|req: TestRequest| TestResponse {
+                    result: req.message.to_uppercase(),
+                    count: req.value * 10,
+                })
+            }))
+        },
+    );
+
+    env.start_server().await;
+
+    // Create request stream
+    let requests = vec![
+        TestRequest {
+            message: "hello".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "world".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "rpc".to_string(),
+            value: 3,
+        },
+    ];
+
+    let responses: Vec<TestResponse> = {
+        let request_stream = stream::iter(requests);
+
+        let response_stream = env.channel.stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Transform",
+            request_stream,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_responses(response_stream).await
+    };
+
+    // Verify responses
+    assert_eq!(responses.len(), 3);
+    assert_eq!(responses[0].result, "HELLO");
+    assert_eq!(responses[0].count, 10);
+    assert_eq!(responses[1].result, "WORLD");
+    assert_eq!(responses[1].count, 20);
+    assert_eq!(responses[2].result, "RPC");
+    assert_eq!(responses[2].count, 30);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 4b: Stream-Stream RPC with Channel Pattern (Async Processing)
+// ============================================================================
+//
+// This test demonstrates an alternative pattern for stream-stream handlers
+// where complex async processing is needed. It uses a channel to decouple
+// request processing from response generation, allowing true bidirectional
+// streaming with async operations.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_with_async_processing() {
+    let mut env = TestEnv::new("test-service-stream-stream-async").await;
+
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "ProcessAsync",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            // Create channel for responses
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+            // Spawn task to process requests asynchronously
+            tokio::spawn(async move {
+                while let Some(req_result) = request_stream.next().await {
+                    match req_result {
+                        Ok(req) => {
+                            // Simulate some async processing work
+                            tokio::time::sleep(Duration::from_millis(5)).await;
+
+                            let response = TestResponse {
+                                result: format!("Processed: {}", req.message),
+                                count: req.value * 100,
+                            };
+
+                            if tx.send(Ok(response)).is_err() {
+                                tracing::warn!("Response channel closed");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(e));
+                            break;
+                        }
+                    }
+                }
+            });
+
+            // Return stream from the receiver
+            Ok(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "alpha".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "beta".to_string(),
+            value: 2,
+        },
+    ];
+
+    let responses: Vec<TestResponse> = {
+        let request_stream = stream::iter(requests);
+
+        let response_stream = env.channel.stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "ProcessAsync",
+            request_stream,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_responses(response_stream).await
+    };
+
+    // Verify responses
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0].result, "Processed: alpha");
+    assert_eq!(responses[0].count, 100);
+    assert_eq!(responses[1].result, "Processed: beta");
+    assert_eq!(responses[1].count, 200);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Additional Edge Case Tests
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_empty_stream_unary() {
+    let mut env = TestEnv::new("test-service-empty-stream").await;
+
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "EmptySum",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            println!("Processing empty stream...");
+
+            let mut count = 0;
+            while (request_stream.next().await).is_some() {
+                count += 1;
+            }
+
+            Ok(TestResponse {
+                result: "empty".to_string(),
+                count,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    // Empty stream
+    let request_stream = stream::iter(Vec::<TestRequest>::new());
+
+    let response: TestResponse = env
+        .channel
+        .stream_unary("TestService", "EmptySum", request_stream, None, None)
+        .await
+        .expect("Empty stream-unary call failed");
+
+    assert_eq!(response.result, "empty");
+    assert_eq!(response.count, 0);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_concurrent_unary_calls() {
+    let mut env = TestEnv::new("test-service-concurrent").await;
+
+    let call_counter = Arc::new(Mutex::new(0));
+    let counter_clone = call_counter.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Count",
+        move |request: TestRequest, _ctx: Context| {
+            let counter = counter_clone.clone();
+            async move {
+                let mut count = counter.lock().await;
+                *count += 1;
+                let current = *count;
+                drop(count);
+
+                Ok(TestResponse {
+                    result: request.message,
+                    count: current,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let channel = Arc::new(env.channel.clone());
+    let mut handles = vec![];
+    for i in 0..5 {
+        let channel_clone = channel.clone();
+        let handle = tokio::spawn(async move {
+            let request = TestRequest {
+                message: format!("call-{i}"),
+                value: i,
+            };
+            channel_clone
+                .unary::<TestRequest, TestResponse>("TestService", "Count", request, None, None)
+                .await
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all calls to complete
+    let mut results = vec![];
+    for handle in handles {
+        let result = handle.await.unwrap().unwrap();
+        results.push(result);
+    }
+
+    // All calls should succeed
+    assert_eq!(results.len(), 5);
+
+    // Counter should have been incremented 5 times
+    let final_count = *call_counter.lock().await;
+    assert_eq!(final_count, 5);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Session Reuse Tests
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_session_reused_across_rpcs() {
+    let mut env = TestEnv::new("test-session-reused-across-rpcs").await;
+
+    let call_count = Arc::new(Mutex::new(0));
+    let session_ids = Arc::new(Mutex::new(Vec::new()));
+
+    register_counting_handler(
+        &env.server,
+        "TestService",
+        "Echo",
+        call_count.clone(),
+        Some(session_ids.clone()),
+    );
+
+    env.start_server().await;
+
+    // First call — establishes the persistent session
+    let request1 = TestRequest {
+        message: "first".to_string(),
+        value: 1,
+    };
+    let response1: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request1, None, None)
+        .await
+        .expect("First RPC call failed");
+    assert_eq!(response1.count, 1);
+
+    // Second call — reuses the same session
+    let request2 = TestRequest {
+        message: "second".to_string(),
+        value: 2,
+    };
+    let response2: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request2, None, None)
+        .await
+        .expect("Second RPC call failed");
+    assert_eq!(response2.count, 2);
+
+    // Third call — still reuses the same session
+    let request3 = TestRequest {
+        message: "third".to_string(),
+        value: 3,
+    };
+    let response3: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request3, None, None)
+        .await
+        .expect("Third RPC call failed");
+    assert_eq!(response3.count, 3);
+
+    // All 3 calls should have been processed
+    let final_count = *call_count.lock().await;
+    assert_eq!(final_count, 3);
+
+    // All calls share the same persistent session
+    let id_list = session_ids.lock().await;
+    assert_eq!(id_list.len(), 3, "Should have 3 session IDs recorded");
+    let first_session_id = &id_list[0];
+    let second_session_id = &id_list[1];
+    let third_session_id = &id_list[2];
+
+    assert_eq!(
+        first_session_id, second_session_id,
+        "Session should be reused: first and second calls should share the same session"
+    );
+    assert_eq!(
+        second_session_id, third_session_id,
+        "Session should be reused: second and third calls should share the same session"
+    );
+    tracing::info!("✓ All three RPC calls reused session: {}", first_session_id);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_session_reused_after_handler_error() {
+    let mut env = TestEnv::new("test-session-reused-after-error").await;
+
+    let call_count = Arc::new(Mutex::new(0));
+    let session_ids = Arc::new(Mutex::new(Vec::new()));
+
+    let count_clone = call_count.clone();
+    let ids_clone = session_ids.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "FlakyMethod",
+        move |request: TestRequest, ctx: Context| {
+            let count = count_clone.clone();
+            let ids = ids_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                let current = *c;
+                drop(c);
+
+                let session_id = ctx.session().session_id().to_string();
+                tracing::info!(
+                    "RPC '{}' (call #{}) handled by session ID: {}",
+                    request.message,
+                    current,
+                    session_id
+                );
+
+                let mut id_list = ids.lock().await;
+                id_list.push(session_id.clone());
+                drop(id_list);
+
+                // Fail on first call
+                if current == 1 {
+                    return Err(RpcError::internal("Simulated error"));
+                }
+
+                Ok(TestResponse {
+                    result: request.message,
+                    count: current,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // First call fails
+    let request1 = TestRequest {
+        message: "first".to_string(),
+        value: 1,
+    };
+    let result1 = env
+        .channel
+        .unary::<TestRequest, TestResponse>("TestService", "FlakyMethod", request1, None, None)
+        .await;
+    assert!(result1.is_err());
+    assert_eq!(result1.unwrap_err().code(), RpcCode::Internal);
+
+    // Second call should succeed — the session is reused even after a handler error
+    let request2 = TestRequest {
+        message: "second".to_string(),
+        value: 2,
+    };
+    let response2: TestResponse = env
+        .channel
+        .unary("TestService", "FlakyMethod", request2, None, None)
+        .await
+        .expect("Second RPC call should succeed");
+    assert_eq!(response2.count, 2);
+
+    // Both calls should have been attempted
+    let final_count = *call_count.lock().await;
+    assert_eq!(final_count, 2);
+
+    // Both calls should share the same persistent session
+    let id_list = session_ids.lock().await;
+    assert_eq!(id_list.len(), 2, "Should have 2 session IDs recorded");
+    let first_session_id = &id_list[0];
+    let second_session_id = &id_list[1];
+
+    assert_eq!(
+        first_session_id, second_session_id,
+        "Session should be reused even after a handler error"
+    );
+    tracing::info!(
+        "✓ Session reused after error: first={}, second={}",
+        first_session_id,
+        second_session_id
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_different_methods_different_sessions() {
+    let mut env = TestEnv::new("test-different-sessions").await;
+
+    let method1_count = Arc::new(Mutex::new(0));
+    let method2_count = Arc::new(Mutex::new(0));
+
+    let m1_clone = method1_count.clone();
+    let m2_clone = method2_count.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Method1",
+        move |request: TestRequest, _ctx: Context| {
+            let count = m1_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                drop(c);
+
+                Ok(TestResponse {
+                    result: format!("M1: {}", request.message),
+                    count: request.value + 100,
+                })
+            }
+        },
+    );
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Method2",
+        move |request: TestRequest, _ctx: Context| {
+            let count = m2_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                drop(c);
+
+                Ok(TestResponse {
+                    result: format!("M2: {}", request.message),
+                    count: request.value + 200,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Call both methods multiple times
+    for i in 0..3 {
+        let req1 = TestRequest {
+            message: format!("call-{i}"),
+            value: i,
+        };
+        let req2 = TestRequest {
+            message: format!("call-{i}"),
+            value: i,
+        };
+
+        let resp1: TestResponse = env
+            .channel
+            .unary("TestService", "Method1", req1, None, None)
+            .await
+            .expect("Method1 call failed");
+
+        let resp2: TestResponse = env
+            .channel
+            .unary("TestService", "Method2", req2, None, None)
+            .await
+            .expect("Method2 call failed");
+
+        assert_eq!(resp1.result, format!("M1: call-{i}"));
+        assert_eq!(resp1.count, i + 100);
+
+        assert_eq!(resp2.result, format!("M2: call-{i}"));
+        assert_eq!(resp2.count, i + 200);
+    }
+
+    // Each method should have been called 3 times
+    assert_eq!(*method1_count.lock().await, 3);
+    assert_eq!(*method2_count.lock().await, 3);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_session_reused_for_streaming() {
+    let mut env = TestEnv::new("test-session-reused-streaming").await;
+
+    let call_count = Arc::new(Mutex::new(0));
+    let session_ids = Arc::new(Mutex::new(Vec::new()));
+
+    let count_clone = call_count.clone();
+    let ids_clone = session_ids.clone();
+
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "GenerateNumbers",
+        move |request: TestRequest, ctx: Context| {
+            let count = count_clone.clone();
+            let ids = ids_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                let current = *c;
+                drop(c);
+
+                let session_id = ctx.session().session_id().to_string();
+                tracing::info!(
+                    "Streaming RPC '{}' (call #{}) handled by session ID: {}",
+                    request.message,
+                    current,
+                    session_id
+                );
+
+                let mut id_list = ids.lock().await;
+                id_list.push(session_id.clone());
+                drop(id_list);
+
+                let n = request.value;
+                let stream = stream::iter((0..n).map(|i| {
+                    Ok(TestResponse {
+                        result: format!("item-{i}"),
+                        count: i,
+                    })
+                }));
+                Ok(stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // First streaming call in a scope
+    {
+        let request1 = TestRequest {
+            message: "first".to_string(),
+            value: 3,
+        };
+        let stream1 = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "GenerateNumbers",
+            request1,
+            None,
+            None,
+        );
+        pin_mut!(stream1);
+
+        let results1 = collect_stream_responses(stream1).await;
+        assert_eq!(results1.len(), 3);
+    } // stream1 dropped here
+
+    // Second streaming call in a scope - reuses the same session
+    {
+        let request2 = TestRequest {
+            message: "second".to_string(),
+            value: 2,
+        };
+        let stream2 = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "GenerateNumbers",
+            request2,
+            None,
+            None,
+        );
+        pin_mut!(stream2);
+
+        let results2 = collect_stream_responses(stream2).await;
+        assert_eq!(results2.len(), 2);
+    } // stream2 dropped here
+
+    // Both calls should have been processed
+    let final_count = *call_count.lock().await;
+    assert_eq!(final_count, 2);
+
+    // Get all session IDs
+    let id_list = session_ids.lock().await;
+    assert_eq!(id_list.len(), 2, "Should have 2 session IDs recorded");
+    let first_session_id = id_list[0].clone();
+    let second_session_id = id_list[1].clone();
+    drop(id_list);
+
+    // Both calls share the same persistent session
+    assert_eq!(
+        first_session_id, second_session_id,
+        "Streaming RPCs should share the same persistent session"
+    );
+    tracing::info!(
+        "✓ Both streaming RPCs reused the same session: {}",
+        first_session_id
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_concurrent_calls_independent() {
+    let mut env = TestEnv::new("test-concurrent-calls").await;
+
+    // Track concurrent execution (now multiple calls can run concurrently since no session lock)
+    let active_count = Arc::new(Mutex::new(0));
+    let max_concurrent = Arc::new(Mutex::new(0));
+
+    let active_clone = active_count.clone();
+    let max_clone = max_concurrent.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowEcho",
+        move |request: TestRequest, _ctx: Context| {
+            let active = active_clone.clone();
+            let max = max_clone.clone();
+            async move {
+                // Increment active count
+                let mut a = active.lock().await;
+                *a += 1;
+                let current = *a;
+                drop(a);
+
+                // Update max
+                let mut m = max.lock().await;
+                if current > *m {
+                    *m = current;
+                }
+                drop(m);
+
+                // Simulate slow processing
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
+                // Decrement active count
+                let mut a = active.lock().await;
+                *a -= 1;
+                drop(a);
+
+                Ok(TestResponse {
+                    result: request.message,
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Launch concurrent calls - they should run concurrently since each RPC gets its own session
+    let channel = Arc::new(env.channel.clone());
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let mut handles = vec![];
+    for i in 0..3 {
+        let ch = channel.clone();
+        let b = barrier.clone();
+        let handle = tokio::spawn(async move {
+            // Wait for all tasks to be ready
+            b.wait().await;
+
+            let req = TestRequest {
+                message: format!("call-{i}"),
+                value: i + 1,
+            };
+            ch.unary::<TestRequest, TestResponse>("TestService", "SlowEcho", req, None, None)
+                .await
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all to complete
+    for handle in handles {
+        handle.await.unwrap().expect("RPC should succeed");
+    }
+
+    // Max concurrent should be 3 (all calls run concurrently, no session lock)
+    let max = *max_concurrent.lock().await;
+    assert_eq!(
+        max, 3,
+        "Calls should run concurrently since each RPC gets its own session"
+    );
+
+    env.shutdown().await;
+}
+
+/// Test that multiple calls to the same server from the same client
+/// towards different gRPC handler types all work correctly
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multiple_handler_types_same_client() {
+    let mut env = TestEnv::new("test-multi-handlers").await;
+
+    // Counters to track calls to each handler
+    let unary_count = Arc::new(Mutex::new(0));
+    let stream_unary_count = Arc::new(Mutex::new(0));
+    let unary_stream_count = Arc::new(Mutex::new(0));
+    let stream_stream_count = Arc::new(Mutex::new(0));
+
+    // Register unary-unary handler
+    let uu_counter = unary_count.clone();
+    env.server.register_unary_unary_internal(
+        "MultiService",
+        "UnaryUnary",
+        move |request: TestRequest, _ctx: Context| {
+            let counter = uu_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                Ok(TestResponse {
+                    result: format!("UnaryUnary: {}", request.message),
+                    count: request.value * 10,
+                })
+            }
+        },
+    );
+
+    // Register stream-unary handler
+    let su_counter = stream_unary_count.clone();
+    env.server.register_stream_unary_internal(
+        "MultiService",
+        "StreamUnary",
+        move |mut stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let counter = su_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                let mut sum = 0;
+                let mut messages = vec![];
+                while let Some(result) = stream.next().await {
+                    let req = result?;
+                    sum += req.value;
+                    messages.push(req.message);
+                }
+
+                Ok(TestResponse {
+                    result: format!("StreamUnary: {}", messages.join(",")),
+                    count: sum,
+                })
+            }
+        },
+    );
+
+    // Register unary-stream handler
+    let us_counter = unary_stream_count.clone();
+    env.server.register_unary_stream_internal(
+        "MultiService",
+        "UnaryStream",
+        move |request: TestRequest, _ctx: Context| {
+            let counter = us_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                let responses = (0..request.value).map(move |i| {
+                    Ok(TestResponse {
+                        result: format!("UnaryStream-{}: {}", i, request.message.clone()),
+                        count: i,
+                    })
+                });
+
+                Ok(stream::iter(responses))
+            }
+        },
+    );
+
+    // Register stream-stream handler
+    let ss_counter = stream_stream_count.clone();
+    env.server.register_stream_stream_internal(
+        "MultiService",
+        "StreamStream",
+        move |mut stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let counter = ss_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                let response_stream = async_stream::stream! {
+                    while let Some(result) = stream.next().await {
+                        match result {
+                            Ok(req) => {
+                                yield Ok(TestResponse {
+                                    result: format!("StreamStream: {}", req.message),
+                                    count: req.value * 100,
+                                });
+                            }
+                            Err(e) => {
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+                };
+
+                Ok(response_stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Now test calling each handler multiple times from the same client
+
+    // Test 1: Call unary-unary handler twice
+    for i in 0..2 {
+        let req = TestRequest {
+            message: format!("uu-call-{i}"),
+            value: i + 1,
+        };
+        let resp: TestResponse = env
+            .channel
+            .unary("MultiService", "UnaryUnary", req, None, None)
+            .await
+            .expect("UnaryUnary call failed");
+
+        assert_eq!(resp.result, format!("UnaryUnary: uu-call-{i}"));
+        assert_eq!(resp.count, (i + 1) * 10);
+    }
+
+    // Test 2: Call stream-unary handler twice
+    for i in 0..2 {
+        let requests = vec![
+            TestRequest {
+                message: format!("su-msg-{i}-1"),
+                value: 1,
+            },
+            TestRequest {
+                message: format!("su-msg-{i}-2"),
+                value: 2,
+            },
+            TestRequest {
+                message: format!("su-msg-{i}-3"),
+                value: 3,
+            },
+        ];
+
+        let resp: TestResponse = env
+            .channel
+            .stream_unary(
+                "MultiService",
+                "StreamUnary",
+                stream::iter(requests),
+                None,
+                None,
+            )
+            .await
+            .expect("StreamUnary call failed");
+
+        assert_eq!(
+            resp.result,
+            format!("StreamUnary: su-msg-{i}-1,su-msg-{i}-2,su-msg-{i}-3")
+        );
+        assert_eq!(resp.count, 6);
+    }
+
+    // Test 3: Call unary-stream handler twice
+    for i in 0..2 {
+        let req = TestRequest {
+            message: format!("us-call-{i}"),
+            value: 3,
+        };
+
+        let response_stream =
+            env.channel
+                .unary_stream("MultiService", "UnaryStream", req, None, None);
+
+        pin_mut!(response_stream);
+
+        let responses: Vec<TestResponse> = collect_stream_responses(response_stream).await;
+        assert_eq!(responses.len(), 3);
+        for (count, resp) in responses.iter().enumerate() {
+            assert_eq!(resp.result, format!("UnaryStream-{count}: us-call-{i}"));
+            assert_eq!(resp.count, count as i32);
+        }
+    }
+
+    // Test 4: Call stream-stream handler twice
+    for i in 0..2 {
+        let requests = vec![
+            TestRequest {
+                message: format!("ss-msg-{i}-1"),
+                value: 1,
+            },
+            TestRequest {
+                message: format!("ss-msg-{i}-2"),
+                value: 2,
+            },
+        ];
+
+        let response_stream = env.channel.stream_stream(
+            "MultiService",
+            "StreamStream",
+            stream::iter(requests),
+            None,
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        let received: Vec<TestResponse> = collect_stream_responses(response_stream).await;
+
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0].result, format!("StreamStream: ss-msg-{i}-1"));
+        assert_eq!(received[0].count, 100);
+        assert_eq!(received[1].result, format!("StreamStream: ss-msg-{i}-2"));
+        assert_eq!(received[1].count, 200);
+    }
+
+    // Verify each handler was called the expected number of times
+    assert_eq!(*unary_count.lock().await, 2);
+    assert_eq!(*stream_unary_count.lock().await, 2);
+    assert_eq!(*unary_stream_count.lock().await, 2);
+    assert_eq!(*stream_stream_count.lock().await, 2);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Client-side deadline enforcement (timeout)
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_client_deadline_unary_unary() {
+    let mut env = TestEnv::new("test-client-deadline-unary").await;
+
+    // Register a handler that takes longer than the timeout
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowMethod",
+        |request: TestRequest, _ctx: Context| async move {
+            // Sleep for 2 seconds
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Ok(TestResponse {
+                result: format!("Processed: {}", request.message),
+                count: request.value,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with a very short timeout (100ms)
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "SlowMethod",
+            request,
+            Some(Duration::from_millis(100)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the client side
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_client_deadline_unary_stream() {
+    let mut env = TestEnv::new("test-client-deadline-unary-stream").await;
+
+    // Register a handler that streams slowly
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "SlowStream",
+        |request: TestRequest, _ctx: Context| async move {
+            Ok(stream::iter((0..5).map(move |i| {
+                let msg = request.message.clone();
+                async move {
+                    // Each item takes 500ms
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    Ok::<_, RpcError>(TestResponse {
+                        result: format!("{msg}-{i}"),
+                        count: i,
+                    })
+                }
+            }))
+            .then(|fut| fut))
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 0,
+    };
+
+    // Call with a timeout of 1 second (should only get 2 items before timeout)
+    let (responses, last_error) = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStream",
+            request,
+            Some(Duration::from_secs(1)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+    let count = responses.len();
+
+    // Should have received some items but then timed out
+    assert!(count < 5, "Expected timeout before all items, got {count}");
+    assert!(last_error.is_some());
+    let err = last_error.unwrap();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Server-side deadline enforcement
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_unary_unary() {
+    let mut env = TestEnv::new("test-server-deadline-unary").await;
+
+    // Register a handler that takes longer than the deadline
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowHandler",
+        |request: TestRequest, _ctx: Context| async move {
+            // Handler takes 2 seconds
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Ok(TestResponse {
+                result: format!("Processed: {}", request.message),
+                count: request.value,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with a short timeout (500ms) - server should enforce this
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "SlowHandler",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the server side (handler execution)
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_unary_stream() {
+    let mut env = TestEnv::new("test-server-deadline-unary-stream").await;
+
+    // Register a handler that takes too long to start streaming
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "SlowStreamHandler",
+        |request: TestRequest, _ctx: Context| async move {
+            // Handler setup takes 2 seconds before returning stream
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Ok(stream::iter((0..3).map(move |i| {
+                Ok::<_, RpcError>(TestResponse {
+                    result: format!("{}-{}", request.message, i),
+                    count: i,
+                })
+            })))
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 0,
+    };
+
+    // Call with a short timeout (500ms)
+    let err = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStreamHandler",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        // Should get a deadline exceeded error
+        let result = response_stream.next().await;
+        assert!(result.is_some());
+        let item_result = result.unwrap();
+        assert!(item_result.is_err());
+        item_result.unwrap_err()
+    };
+
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_stream_unary() {
+    let mut env = TestEnv::new("test-server-deadline-stream-unary").await;
+
+    // Register a handler that takes too long to process the stream
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "SlowStreamUnary",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            // Collect all requests
+            let mut messages = Vec::new();
+            while let Some(req_result) = request_stream.next().await {
+                let req = req_result?;
+                messages.push(req.message);
+            }
+
+            // Then take too long to process
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            Ok(TestResponse {
+                result: messages.join(","),
+                count: messages.len() as i32,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "msg1".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "msg2".to_string(),
+            value: 2,
+        },
+    ];
+
+    // Call with a short timeout (500ms)
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .stream_unary(
+            "TestService",
+            "SlowStreamUnary",
+            stream::iter(requests),
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the server side
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_stream_stream() {
+    let mut env = TestEnv::new("test-server-deadline-stream-stream").await;
+
+    // Register a handler that takes too long to setup
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "SlowStreamStream",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            // Consume one request
+            if let Some(req_result) = request_stream.next().await {
+                let _ = req_result?;
+            }
+
+            // Then take too long before returning stream
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            Ok(stream::iter((0..3).map(|i| {
+                Ok::<_, RpcError>(TestResponse {
+                    result: format!("response-{i}"),
+                    count: i,
+                })
+            })))
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "msg1".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "msg2".to_string(),
+            value: 2,
+        },
+    ];
+
+    // Call with a short timeout (500ms)
+    let err = {
+        let response_stream = env.channel.stream_stream(
+            "TestService",
+            "SlowStreamStream",
+            stream::iter(requests),
+            Some(Duration::from_millis(500)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        // Should get a deadline exceeded error
+        let result = response_stream.next().await;
+        assert!(result.is_some());
+        let item_result: Result<TestResponse, RpcError> = result.unwrap();
+        assert!(item_result.is_err());
+        item_result.unwrap_err()
+    };
+
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Server checks deadline before handler execution
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_already_exceeded() {
+    let mut env = TestEnv::new("test-server-deadline-already-exceeded").await;
+
+    let handler_called = Arc::new(Mutex::new(false));
+    let handler_called_clone = handler_called.clone();
+
+    // Register a handler
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "CheckDeadline",
+        move |request: TestRequest, _ctx: Context| {
+            let called = handler_called_clone.clone();
+            async move {
+                *called.lock().await = true;
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with an already expired deadline (1ms and then wait)
+    let channel_clone = env.channel.clone();
+    let result: Result<TestResponse, RpcError> = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        channel_clone
+            .unary(
+                "TestService",
+                "CheckDeadline",
+                request,
+                Some(Duration::from_millis(1)),
+                None,
+            )
+            .await
+    })
+    .await
+    .unwrap();
+
+    // Should fail with deadline exceeded
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    // Handler should not have been called (deadline checked before execution)
+    // Note: There's a race condition here, but with 50ms delay + network time,
+    // the deadline should be exceeded before the handler is called
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // We can't reliably assert this due to timing, but the test verifies
+    // that deadline exceeded is returned
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Deadline propagation from client to server
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_deadline_propagation() {
+    let mut env = TestEnv::new("test-deadline-propagation").await;
+
+    let deadline_from_handler: Arc<Mutex<Option<SystemTime>>> = Arc::new(Mutex::new(None));
+    let deadline_clone = deadline_from_handler.clone();
+
+    // Register a handler that captures the deadline from context
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "CaptureDeadline",
+        move |request: TestRequest, ctx: Context| {
+            let deadline = deadline_clone.clone();
+            async move {
+                *deadline.lock().await = Some(ctx.deadline());
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with a specific timeout
+    let timeout = Duration::from_secs(30);
+    let start = std::time::SystemTime::now();
+
+    let _: TestResponse = env
+        .channel
+        .unary(
+            "TestService",
+            "CaptureDeadline",
+            request,
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Check that the handler received a deadline
+    let captured_deadline = deadline_from_handler.lock().await;
+    assert!(
+        captured_deadline.is_some(),
+        "Handler should receive a deadline"
+    );
+
+    let deadline = captured_deadline.unwrap();
+    let expected_deadline = start + timeout;
+
+    // The deadline should be approximately the expected value (within 1 second tolerance)
+    let diff = if deadline > expected_deadline {
+        deadline.duration_since(expected_deadline).unwrap()
+    } else {
+        expected_deadline.duration_since(deadline).unwrap()
+    };
+
+    assert!(
+        diff < Duration::from_secs(1),
+        "Deadline should match expected value within tolerance, diff: {diff:?}"
+    );
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Server-side deadline enforcement (infrastructure checks, not handler)
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_rejects_already_expired_deadline() {
+    let mut env = TestEnv::new("test-expired-deadline").await;
+
+    let handler_called = Arc::new(Mutex::new(false));
+    let handler_called_clone = handler_called.clone();
+
+    // Register a handler that should never be called
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "ShouldNotBeCalled",
+        move |request: TestRequest, _ctx: Context| {
+            let called = handler_called_clone.clone();
+            async move {
+                tracing::error!("Handler was called when it should have been rejected!");
+                *called.lock().await = true;
+
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Use a very short deadline (1ms) and wait before making the call
+    // to ensure the deadline is already expired when the server receives it
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "ShouldNotBeCalled",
+            request,
+            Some(Duration::from_nanos(1)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded or timing-related error
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+
+    // The error might be DeadlineExceeded or Internal depending on timing
+    // (if the deadline check happens before or after session setup)
+    assert!(
+        err.code() == RpcCode::DeadlineExceeded || err.code() == RpcCode::Internal,
+        "Expected DeadlineExceeded or Internal, got {:?}",
+        err.code()
+    );
+
+    // Give some time for any potential handler execution to occur
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the handler was NOT called (server rejected the request before handler execution)
+    let was_called = *handler_called.lock().await;
+    assert!(
+        !was_called,
+        "Handler should not have been called for expired deadline"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_during_handler_execution() {
+    let mut env = TestEnv::new("test-server-enforces-deadline").await;
+
+    let handler_started = Arc::new(Mutex::new(false));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let started_clone = handler_started.clone();
+    let completed_clone = handler_completed.clone();
+
+    // Register a handler that takes a long time (ignores deadline)
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "LongRunningIgnoresDeadline",
+        move |request: TestRequest, _ctx: Context| {
+            let started = started_clone.clone();
+            let completed = completed_clone.clone();
+            async move {
+                *started.lock().await = true;
+                tracing::info!("Handler started, will run for 5 seconds");
+
+                // Handler intentionally ignores the deadline and runs for a long time
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                *completed.lock().await = true;
+                tracing::info!("Handler completed (this should not happen due to deadline)");
+
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Set a short deadline (500ms) while handler takes 5 seconds
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "LongRunningIgnoresDeadline",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded (enforced by server, not handler)
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete (but it shouldn't)
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the handler started but did not complete
+    // (server infrastructure cancelled it due to deadline)
+    let was_started = *handler_started.lock().await;
+    let was_completed = *handler_completed.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_for_stream_unary() {
+    let mut env = TestEnv::new("test-server-deadline-stream-unary").await;
+
+    let messages_received = Arc::new(Mutex::new(0));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let message_received_clone = messages_received.clone();
+    let handler_completed_clone = handler_completed.clone();
+
+    // Register a stream-unary handler that processes messages slowly
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "SlowStreamProcessor",
+        move |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let received = message_received_clone.clone();
+            let completed = handler_completed_clone.clone();
+            async move {
+                // Process incoming messages slowly (ignores deadline)
+                while let Some(req_result) = request_stream.next().await {
+                    let req = req_result?;
+                    *received.lock().await += 1;
+
+                    tracing::info!(
+                        "Processing message {}: {}",
+                        *received.lock().await,
+                        req.message
+                    );
+
+                    // Slow processing (200ms per message)
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+
+                *completed.lock().await = true;
+
+                let count = *received.lock().await;
+
+                tracing::info!("Handler completed processing {} messages", count);
+
+                Ok(TestResponse {
+                    result: format!("Processed {count} messages"),
+                    count,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Create a stream of 10 messages (would take 2 seconds to process)
+    let requests = (0..10)
+        .map(|i| TestRequest {
+            message: format!("msg-{i}"),
+            value: i,
+        })
+        .collect::<Vec<_>>();
+
+    // Set a deadline of 500ms (server should enforce this)
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .stream_unary(
+            "TestService",
+            "SlowStreamProcessor",
+            stream::iter(requests),
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded (enforced by server infrastructure)
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let was_completed = *handler_completed.lock().await;
+    let received = *messages_received.lock().await;
+
+    assert!(!was_completed, "Server should not have completed");
+
+    // Handler should not have completed due to server-enforced deadline
+    assert!(
+        received < 10,
+        "Handler should not have processed all messages due to deadline, got {received}"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_for_unary_stream() {
+    let mut env = TestEnv::new("test-server-deadline-unary-stream").await;
+
+    let messages_sent = Arc::new(Mutex::new(0));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let sent_clone = messages_sent.clone();
+    let completed_clone = handler_completed.clone();
+
+    // Register a unary-stream handler that generates messages slowly
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "SlowStreamGenerator",
+        move |request: TestRequest, _ctx: Context| {
+            let sent = sent_clone.clone();
+            let completed = completed_clone.clone();
+            async move {
+                let response_stream = async_stream::stream! {
+                    // Try to generate many messages slowly (ignores deadline)
+                    for i in 0..10 {
+                        tracing::info!("Generating message {}", i);
+
+                        // Slow generation (200ms per message)
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+
+                        let mut count = sent.lock().await;
+                        *count += 1;
+                        drop(count);
+
+                        yield Ok(TestResponse {
+                            result: format!("{}-{}", request.message, i),
+                            count: i,
+                        });
+                    }
+
+                    *completed.lock().await = true;
+                    tracing::info!("Handler completed generating all messages");
+                };
+
+                Ok(response_stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 0,
+    };
+
+    // Set a deadline of 500ms (would take 2 seconds to generate all 10 messages)
+    let (responses, error) = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStreamGenerator",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+    let responses_received = responses.len();
+
+    // Should have received some messages but not all due to deadline
+    assert!(
+        responses_received < 10,
+        "Should not have received all messages due to deadline, got {responses_received}"
+    );
+
+    // Should get a deadline exceeded error
+    assert!(error.is_some(), "Expected deadline exceeded error");
+    let err = error.unwrap();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let was_completed = *handler_completed.lock().await;
+    let sent = *messages_sent.lock().await;
+
+    assert!(!was_completed, "Handler should not have completed");
+    assert!(
+        sent < 10,
+        "Handler should not have sent all messages due to deadline, sent {sent}"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_for_stream_stream() {
+    let mut env = TestEnv::new("test-server-deadline-stream-stream").await;
+
+    let messages_received = Arc::new(Mutex::new(0));
+    let messages_sent = Arc::new(Mutex::new(0));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let received_clone = messages_received.clone();
+    let sent_clone = messages_sent.clone();
+    let completed_clone = handler_completed.clone();
+
+    // Register a stream-stream handler that processes slowly
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "SlowStreamTransform",
+        move |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let received = received_clone.clone();
+            let sent = sent_clone.clone();
+            let completed = completed_clone.clone();
+            async move {
+                let response_stream = async_stream::stream! {
+                    // Process incoming messages slowly (ignores deadline)
+                    while let Some(req_result) = request_stream.next().await {
+                        match req_result {
+                            Ok(req) => {
+                                let mut recv_count = received.lock().await;
+                                *recv_count += 1;
+                                drop(recv_count);
+
+                                tracing::info!("Processing message: {}", req.message);
+
+                                // Slow processing (300ms per message)
+                                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                                let mut send_count = sent.lock().await;
+                                *send_count += 1;
+                                drop(send_count);
+
+                                yield Ok(TestResponse {
+                                    result: format!("Processed: {}", req.message),
+                                    count: req.value * 10,
+                                });
+                            }
+                            Err(e) => {
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+
+                    *completed.lock().await = true;
+                    tracing::info!("Handler completed processing all messages");
+                };
+
+                Ok(response_stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Create a stream of 10 messages (would take 3 seconds to process)
+    let requests = (0..10)
+        .map(|i| TestRequest {
+            message: format!("msg-{i}"),
+            value: i,
+        })
+        .collect::<Vec<_>>();
+
+    // Set a deadline of 800ms (server should enforce this)
+    let (responses, error) = {
+        let response_stream = env.channel.stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStreamTransform",
+            stream::iter(requests),
+            Some(Duration::from_millis(800)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+    let responses_received = responses.len();
+
+    // Should have received some messages but not all due to deadline
+    assert!(
+        responses_received < 10,
+        "Should not have received all messages due to deadline, got {responses_received}"
+    );
+
+    // Should get a deadline exceeded error
+    assert!(error.is_some(), "Expected deadline exceeded error");
+    let err = error.unwrap();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let was_completed = *handler_completed.lock().await;
+    let sent = *messages_sent.lock().await;
+
+    assert!(!was_completed, "Handler should not have completed");
+    assert!(
+        sent < 10,
+        "Handler should not have sent all messages due to deadline, sent {sent}"
+    );
+
+    env.shutdown().await;
+}
+
+/// Test that verifies a server can be shut down and restarted successfully
+#[tokio::test]
+async fn test_server_restart() {
+    let mut env = TestEnv::new("test-server-restart").await;
+
+    // Register a handler that counts calls
+    let call_count = Arc::new(Mutex::new(0u32));
+    let count_clone = call_count.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Counter",
+        move |request: TestRequest, _ctx: Context| {
+            let count = count_clone.clone();
+            async move {
+                let mut counter = count.lock().await;
+                *counter += 1;
+                let current_count = *counter;
+                drop(counter);
+
+                Ok(TestResponse {
+                    result: format!(
+                        "Call count: {}, Message: {}",
+                        current_count, request.message
+                    ),
+                    count: current_count as i32,
+                })
+            }
+        },
+    );
+
+    // Start server first time
+    env.start_server().await;
+
+    // Make first call
+    let request1 = TestRequest {
+        message: "First call".to_string(),
+        value: 1,
+    };
+
+    let response1: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request1, None, None)
+        .await
+        .expect("First unary call failed");
+
+    assert_eq!(response1.count, 1);
+    assert!(response1.result.contains("Call count: 1"));
+    assert!(response1.result.contains("First call"));
+
+    // Make second call before shutdown
+    let request2 = TestRequest {
+        message: "Second call".to_string(),
+        value: 2,
+    };
+
+    let response2: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request2, None, None)
+        .await
+        .expect("Second unary call failed");
+
+    assert_eq!(response2.count, 2);
+    assert!(response2.result.contains("Call count: 2"));
+
+    // Shutdown the server
+    tracing::info!("Shutting down server for restart test...");
+    env.server.shutdown_async().await;
+
+    // Give a brief moment for cleanup
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Restart the server
+    tracing::info!("Restarting server...");
+    env.start_server().await;
+
+    // Make third call after restart
+    let request3 = TestRequest {
+        message: "Third call after restart".to_string(),
+        value: 3,
+    };
+
+    let response3: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request3, None, None)
+        .await
+        .expect("Third unary call after restart failed");
+
+    // The counter should continue from where it left off (state is preserved)
+    assert_eq!(response3.count, 3);
+    assert!(response3.result.contains("Call count: 3"));
+    assert!(response3.result.contains("Third call after restart"));
+
+    // Make fourth call to ensure server is fully functional
+    let request4 = TestRequest {
+        message: "Fourth call".to_string(),
+        value: 4,
+    };
+
+    let response4: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request4, None, None)
+        .await
+        .expect("Fourth unary call failed");
+
+    assert_eq!(response4.count, 4);
+    assert!(response4.result.contains("Call count: 4"));
+
+    // Final shutdown
+    env.shutdown().await;
+}
+
+/// Test that verifies shutting down the server while a handler is executing
+/// The handler is cancelled and the client receives an error
+#[tokio::test]
+async fn test_server_shutdown_during_handler_execution() {
+    let mut env = TestEnv::new("test-shutdown-during-handler").await;
+
+    let handler_started = Arc::new(Mutex::new(false));
+    let started_clone = handler_started.clone();
+
+    // Register a handler that takes some time to execute
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowHandler",
+        move |request: TestRequest, _ctx: Context| {
+            let started = started_clone.clone();
+            async move {
+                *started.lock().await = true;
+
+                // Simulate a long-running handler (5 seconds)
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "Test".to_string(),
+        value: 42,
+    };
+
+    // Start the RPC call in a separate task
+    let channel = env.channel.clone();
+    let call_handle = tokio::spawn(async move {
+        channel
+            .unary::<TestRequest, TestResponse>("TestService", "SlowHandler", request, None, None)
+            .await
+    });
+
+    // Wait for handler to start
+    for _ in 0..100 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if *handler_started.lock().await {
+            break;
+        }
+    }
+
+    assert!(*handler_started.lock().await, "Handler should have started");
+
+    // Give the handler more time to be deep in execution
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Now shut down the server while the handler is still executing
+    env.server.shutdown_async().await;
+
+    // The RPC call should return an error since the handler was cancelled
+    let result = call_handle.await.expect("Task should not panic");
+
+    assert!(
+        result.is_err(),
+        "Expected an error when server shuts down during handler execution"
+    );
+
+    let error = result.unwrap_err();
+
+    // The error should be Cancelled since the handler was cancelled during shutdown
+    assert_eq!(
+        error.code(),
+        RpcCode::Cancelled,
+        "Expected Cancelled error when server shuts down during handler execution, got: {:?}",
+        error.code()
+    );
+
+    env.shutdown().await;
+}

--- a/crates/rpc/tests/handlers.rs
+++ b/crates/rpc/tests/handlers.rs
@@ -1,0 +1,1111 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for SlimRPC using the native trait-object handler
+//! registration API and the raw-bytes client call API.
+//!
+//! These tests exercise code paths that the typed `*_internal` tests in
+//! `core.rs` do not cover:
+//! - the public `Server::register_*` trait methods (trait-object handlers),
+//! - the `handler_traits.rs` traits,
+//! - the `stream_types.rs` wrappers `RequestStream`/`ResponseSink`/
+//!   `ResponseStreamReader`/`RequestStreamWriter`/`BidiStreamHandler`, and
+//! - the raw-bytes `Channel::call_*` methods.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::shared_secret::SharedSecret;
+use slim_config::component::id::{ID, Kind};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::service::Service;
+use tokio::sync::Mutex;
+
+use slim_rpc::{
+    Channel, Context, ResponseSink, RpcCode, RpcError, Server, StreamMessage, StreamStreamHandler,
+    StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler, UniffiRequestStream,
+};
+
+const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+// ============================================================================
+// Test Handlers (ported from the FFI e2e tests, using native types)
+// ============================================================================
+
+/// Simple echo handler for unary-unary
+struct EchoHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for EchoHandler {
+    async fn handle(&self, request: Vec<u8>, _context: Arc<Context>) -> Result<Vec<u8>, RpcError> {
+        Ok(request)
+    }
+}
+
+/// Handler that returns an error for unary-unary
+struct ErrorHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for ErrorHandler {
+    async fn handle(&self, _request: Vec<u8>, _context: Arc<Context>) -> Result<Vec<u8>, RpcError> {
+        Err(RpcError::new(
+            RpcCode::InvalidArgument,
+            "Intentional error".to_string(),
+        ))
+    }
+}
+
+/// Handler that streams responses for unary-stream
+struct CounterHandler;
+
+#[async_trait::async_trait]
+impl UnaryStreamHandler for CounterHandler {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        _context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError> {
+        let count = if request.len() >= 4 {
+            u32::from_le_bytes([request[0], request[1], request[2], request[3]])
+        } else {
+            3
+        };
+
+        for i in 0..count {
+            let response = i.to_le_bytes().to_vec();
+            sink.send_async(response).await?;
+        }
+
+        sink.close_async().await?;
+        Ok(())
+    }
+}
+
+/// Handler that streams responses with an error for unary-stream
+struct StreamErrorHandler;
+
+#[async_trait::async_trait]
+impl UnaryStreamHandler for StreamErrorHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        _context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError> {
+        sink.send_async(vec![1, 2, 3]).await?;
+        sink.send_async(vec![4, 5, 6]).await?;
+
+        sink.send_error_async(RpcError::new(
+            RpcCode::Internal,
+            "Stream error after 2 messages".to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+}
+
+/// Handler that accumulates stream input for stream-unary
+struct AccumulatorHandler;
+
+#[async_trait::async_trait]
+impl StreamUnaryHandler for AccumulatorHandler {
+    async fn handle(
+        &self,
+        stream: Arc<UniffiRequestStream>,
+        _context: Arc<Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        let mut total = 0u32;
+        let mut count = 0u32;
+
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    count += 1;
+                    if data.len() >= 4 {
+                        let value = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+                        total += value;
+                    }
+                }
+                StreamMessage::Error(e) => return Err(e),
+                StreamMessage::End => break,
+            }
+        }
+
+        let mut result = total.to_le_bytes().to_vec();
+        result.extend_from_slice(&count.to_le_bytes());
+        Ok(result)
+    }
+}
+
+/// Handler that detects error in stream input for stream-unary
+struct StreamInputErrorHandler;
+
+#[async_trait::async_trait]
+impl StreamUnaryHandler for StreamInputErrorHandler {
+    async fn handle(
+        &self,
+        stream: Arc<UniffiRequestStream>,
+        _context: Arc<Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        let mut count = 0u32;
+
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    count += 1;
+                    if !data.is_empty() && data[0] == 255 {
+                        return Err(RpcError::new(
+                            RpcCode::InvalidArgument,
+                            format!("Invalid data at message {count}"),
+                        ));
+                    }
+                }
+                StreamMessage::Error(e) => return Err(e),
+                StreamMessage::End => break,
+            }
+        }
+
+        Ok(count.to_le_bytes().to_vec())
+    }
+}
+
+/// Handler that echoes stream for stream-stream
+struct StreamEchoHandler;
+
+#[async_trait::async_trait]
+impl StreamStreamHandler for StreamEchoHandler {
+    async fn handle(
+        &self,
+        stream: Arc<UniffiRequestStream>,
+        _context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError> {
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    sink.send_async(data).await?;
+                }
+                StreamMessage::Error(e) => {
+                    sink.send_error_async(e).await?;
+                    return Ok(());
+                }
+                StreamMessage::End => {
+                    sink.close_async().await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+/// Handler that transforms stream data for stream-stream
+struct TransformHandler;
+
+#[async_trait::async_trait]
+impl StreamStreamHandler for TransformHandler {
+    async fn handle(
+        &self,
+        stream: Arc<UniffiRequestStream>,
+        _context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError> {
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    let transformed: Vec<u8> = data.iter().map(|&b| b.wrapping_mul(2)).collect();
+                    sink.send_async(transformed).await?;
+                }
+                StreamMessage::Error(e) => {
+                    sink.send_error_async(e).await?;
+                    return Ok(());
+                }
+                StreamMessage::End => {
+                    sink.close_async().await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Context Handlers
+// ============================================================================
+
+/// Handler that returns context information (session id)
+struct ContextInfoHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for ContextInfoHandler {
+    async fn handle(&self, _request: Vec<u8>, context: Arc<Context>) -> Result<Vec<u8>, RpcError> {
+        let session_id = context.session_id();
+        Ok(session_id.as_bytes().to_vec())
+    }
+}
+
+/// Handler that captures and validates all context information
+struct ContextValidationHandler {
+    captured_session_id: Arc<Mutex<Option<String>>>,
+    captured_metadata: Arc<Mutex<Option<HashMap<String, String>>>>,
+    captured_deadline: Arc<Mutex<Option<std::time::SystemTime>>>,
+    captured_remaining: Arc<Mutex<Option<Duration>>>,
+    captured_is_exceeded: Arc<Mutex<Option<bool>>>,
+}
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for ContextValidationHandler {
+    async fn handle(&self, _request: Vec<u8>, context: Arc<Context>) -> Result<Vec<u8>, RpcError> {
+        *self.captured_session_id.lock().await = Some(context.session_id());
+        *self.captured_metadata.lock().await = Some(context.metadata());
+        *self.captured_deadline.lock().await = Some(context.deadline());
+        *self.captured_remaining.lock().await = Some(context.remaining_time());
+        *self.captured_is_exceeded.lock().await = Some(context.is_deadline_exceeded());
+
+        Ok(b"ok".to_vec())
+    }
+}
+
+// ============================================================================
+// Test Environment Setup (copied from tests/core.rs)
+// ============================================================================
+
+struct TestEnv {
+    service: Arc<Service>,
+    server: Arc<Server>,
+    channel: Channel,
+}
+
+impl TestEnv {
+    async fn new(test_name: &str) -> Self {
+        let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+        let service = Arc::new(Service::new(id));
+
+        let server_name = Name::from_strings(["org", "ns", "server"]);
+        let secret = SharedSecret::new("server", TEST_VALID_SECRET).unwrap();
+
+        let (server_app, server_notifications) = service
+            .create_app(
+                &server_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret.clone()),
+            )
+            .unwrap();
+        let server_app = Arc::new(server_app);
+
+        let server = Arc::new(Server::new_internal(
+            server_app.clone(),
+            server_app.app_name().clone(),
+            server_notifications,
+        ));
+
+        // Create client
+        let client_name = Name::from_strings(["org", "ns", "client"]);
+        let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+        let (client_app, _) = service
+            .create_app(
+                &client_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        let client_app = Arc::new(client_app);
+
+        let channel = Channel::new_with_members_internal(
+            client_app.clone(),
+            vec![server_app.app_name().clone()],
+            false,
+            None,
+        )
+        .expect("single non-empty member list is always valid");
+
+        Self {
+            service,
+            server,
+            channel,
+        }
+    }
+
+    async fn start_server(&self) {
+        let server = self.server.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = server.serve_async().await {
+                tracing::error!("Server error: {:?}", e);
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    async fn shutdown(&mut self) {
+        tracing::info!("Shutting down server...");
+        self.server.shutdown_internal().await;
+
+        tracing::info!("Shutting down service...");
+        self.service.shutdown().await.unwrap();
+    }
+}
+
+// ============================================================================
+// Unary-Unary via trait handlers
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_rpc_trait() {
+    let mut env = TestEnv::new("trait-unary-echo").await;
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Echo".to_string(),
+        Arc::new(EchoHandler),
+    );
+
+    env.start_server().await;
+
+    let request = vec![1, 2, 3, 4, 5];
+    let response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "Echo".to_string(),
+            request.clone(),
+            Some(Duration::from_secs(5)),
+            None,
+        )
+        .await
+        .expect("Unary call failed");
+
+    assert_eq!(response, request);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_error_handling_trait() {
+    let mut env = TestEnv::new("trait-unary-error").await;
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Error".to_string(),
+        Arc::new(ErrorHandler),
+    );
+
+    env.start_server().await;
+
+    let result = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "Error".to_string(),
+            vec![1, 2, 3],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await;
+
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), RpcCode::InvalidArgument);
+    assert!(error.message().contains("Intentional error"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Unary-Stream via trait handlers
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_rpc_trait() {
+    let mut env = TestEnv::new("trait-unary-stream").await;
+
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "Counter".to_string(),
+        Arc::new(CounterHandler),
+    );
+
+    env.start_server().await;
+
+    let count = 5u32;
+    let request = count.to_le_bytes().to_vec();
+
+    let reader = env
+        .channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "Counter".to_string(),
+            request,
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Unary stream call failed");
+
+    let mut responses = Vec::new();
+    loop {
+        match reader.next_async().await {
+            StreamMessage::Data(data) => responses.push(data),
+            StreamMessage::Error(e) => panic!("Unexpected error: {e:?}"),
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(responses.len(), 5);
+    for (i, response) in responses.iter().enumerate() {
+        let value = u32::from_le_bytes([response[0], response[1], response[2], response[3]]);
+        assert_eq!(value, i as u32);
+    }
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_error_handling_trait() {
+    let mut env = TestEnv::new("trait-unary-stream-error").await;
+
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "StreamError".to_string(),
+        Arc::new(StreamErrorHandler),
+    );
+
+    env.start_server().await;
+
+    let reader = env
+        .channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "StreamError".to_string(),
+            vec![1],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Unary stream call failed");
+
+    let mut responses = Vec::new();
+    let mut got_error = false;
+
+    loop {
+        match reader.next_async().await {
+            StreamMessage::Data(data) => responses.push(data),
+            StreamMessage::Error(e) => {
+                assert_eq!(e.code(), RpcCode::Internal);
+                assert!(e.message().contains("Stream error after 2 messages"));
+                got_error = true;
+                break;
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(responses.len(), 2);
+    assert!(got_error);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Stream-Unary via trait handlers
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_rpc_trait() {
+    let mut env = TestEnv::new("trait-stream-unary").await;
+
+    env.server.register_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Arc::new(AccumulatorHandler),
+    );
+
+    env.start_server().await;
+
+    let writer = env.channel.call_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    let values = vec![10u32, 20u32, 30u32, 40u32];
+    for value in &values {
+        writer
+            .send_async(value.to_le_bytes().to_vec())
+            .await
+            .expect("Failed to send");
+    }
+
+    let response = writer
+        .finalize_stream_async()
+        .await
+        .expect("Failed to finalize");
+
+    assert_eq!(response.len(), 8);
+    let total = u32::from_le_bytes([response[0], response[1], response[2], response[3]]);
+    let count = u32::from_le_bytes([response[4], response[5], response[6], response[7]]);
+
+    assert_eq!(total, 100);
+    assert_eq!(count, 4);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_error_handling_trait() {
+    let mut env = TestEnv::new("trait-stream-unary-error").await;
+
+    env.server.register_stream_unary(
+        "TestService".to_string(),
+        "StreamInputError".to_string(),
+        Arc::new(StreamInputErrorHandler),
+    );
+
+    env.start_server().await;
+
+    let writer = env.channel.call_stream_unary(
+        "TestService".to_string(),
+        "StreamInputError".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    writer
+        .send_async(vec![1, 2, 3])
+        .await
+        .expect("Failed to send");
+    writer
+        .send_async(vec![255, 0, 0])
+        .await
+        .expect("Failed to send");
+
+    let result = writer.finalize_stream_async().await;
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), RpcCode::InvalidArgument);
+    assert!(error.message().contains("Invalid data"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Stream-Stream via trait handlers
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_echo_trait() {
+    let mut env = TestEnv::new("trait-stream-stream-echo").await;
+
+    env.server.register_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Arc::new(StreamEchoHandler),
+    );
+
+    env.start_server().await;
+
+    let handler = env.channel.call_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    let messages = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    for msg in &messages {
+        handler
+            .send_async(msg.clone())
+            .await
+            .expect("Failed to send");
+    }
+
+    handler.close_send_async().await.expect("Failed to close");
+
+    let mut received = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            StreamMessage::Data(data) => received.push(data),
+            StreamMessage::Error(e) => panic!("Unexpected error: {e:?}"),
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(received.len(), 3);
+    assert_eq!(received, messages);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_transform_trait() {
+    let mut env = TestEnv::new("trait-stream-stream-transform").await;
+
+    env.server.register_stream_stream(
+        "TestService".to_string(),
+        "Transform".to_string(),
+        Arc::new(TransformHandler),
+    );
+
+    env.start_server().await;
+
+    let handler = env.channel.call_stream_stream(
+        "TestService".to_string(),
+        "Transform".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    let handler_clone = handler.clone();
+    let send_handle = tokio::spawn(async move {
+        let messages = vec![vec![1, 2, 3], vec![10, 20, 30], vec![100]];
+        for msg in messages {
+            handler_clone.send_async(msg).await.expect("Failed to send");
+        }
+        handler_clone
+            .close_send_async()
+            .await
+            .expect("Failed to close");
+    });
+
+    let mut received = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            StreamMessage::Data(data) => received.push(data),
+            StreamMessage::Error(e) => panic!("Unexpected error: {e:?}"),
+            StreamMessage::End => break,
+        }
+    }
+
+    send_handle.await.expect("Send task failed");
+
+    assert_eq!(received.len(), 3);
+    assert_eq!(received[0], vec![2, 4, 6]);
+    assert_eq!(received[1], vec![20, 40, 60]);
+    assert_eq!(received[2], vec![200]);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Context tests
+// ============================================================================
+
+// Returns the handler plus clones of its capture handles so tests can assert on
+// what the handler saw after it's been moved into the server registration.
+#[allow(clippy::type_complexity)]
+fn new_validation_handler() -> (
+    ContextValidationHandler,
+    Arc<Mutex<Option<String>>>,
+    Arc<Mutex<Option<HashMap<String, String>>>>,
+    Arc<Mutex<Option<std::time::SystemTime>>>,
+    Arc<Mutex<Option<Duration>>>,
+    Arc<Mutex<Option<bool>>>,
+) {
+    let session_id = Arc::new(Mutex::new(None));
+    let metadata = Arc::new(Mutex::new(None));
+    let deadline = Arc::new(Mutex::new(None));
+    let remaining = Arc::new(Mutex::new(None));
+    let is_exceeded = Arc::new(Mutex::new(None));
+
+    let handler = ContextValidationHandler {
+        captured_session_id: session_id.clone(),
+        captured_metadata: metadata.clone(),
+        captured_deadline: deadline.clone(),
+        captured_remaining: remaining.clone(),
+        captured_is_exceeded: is_exceeded.clone(),
+    };
+
+    (
+        handler,
+        session_id,
+        metadata,
+        deadline,
+        remaining,
+        is_exceeded,
+    )
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_access_trait() {
+    let mut env = TestEnv::new("trait-context-access").await;
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ContextInfo".to_string(),
+        Arc::new(ContextInfoHandler),
+    );
+
+    env.start_server().await;
+
+    let response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ContextInfo".to_string(),
+            vec![],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Context call failed");
+
+    assert!(!response.is_empty());
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_session_id_trait() {
+    let mut env = TestEnv::new("trait-context-session-id").await;
+
+    let (handler, session_id, ..) = new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            None,
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    let session_id = session_id.lock().await;
+    assert!(session_id.is_some(), "Session ID should be captured");
+    assert!(
+        !session_id.as_ref().unwrap().is_empty(),
+        "Session ID should not be empty"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_metadata_trait() {
+    let mut env = TestEnv::new("trait-context-metadata").await;
+
+    let (handler, _sid, metadata, ..) = new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            None,
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    let metadata = metadata.lock().await;
+    assert!(metadata.is_some(), "Metadata should be captured");
+
+    let metadata_map = metadata.as_ref().unwrap();
+    assert!(
+        metadata_map.contains_key("slimrpc-timeout"),
+        "Metadata should contain deadline"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_custom_metadata_trait() {
+    let mut env = TestEnv::new("trait-context-custom-metadata").await;
+
+    let (handler, _sid, metadata, ..) = new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let mut custom_metadata = HashMap::new();
+    custom_metadata.insert("authorization".to_string(), "Bearer token123".to_string());
+    custom_metadata.insert("request-id".to_string(), "abc-123-xyz".to_string());
+    custom_metadata.insert("user-agent".to_string(), "test-client/1.0".to_string());
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(Duration::from_secs(30)),
+            Some(custom_metadata.clone()),
+        )
+        .await
+        .expect("Call failed");
+
+    let metadata = metadata.lock().await;
+    assert!(metadata.is_some(), "Metadata should be captured");
+
+    let metadata_map = metadata.as_ref().unwrap();
+    assert_eq!(
+        metadata_map.get("authorization"),
+        Some(&"Bearer token123".to_string()),
+        "Authorization metadata should match"
+    );
+    assert_eq!(
+        metadata_map.get("request-id"),
+        Some(&"abc-123-xyz".to_string()),
+        "Request ID metadata should match"
+    );
+    assert_eq!(
+        metadata_map.get("user-agent"),
+        Some(&"test-client/1.0".to_string()),
+        "User agent metadata should match"
+    );
+    assert!(
+        metadata_map.contains_key("slimrpc-timeout"),
+        "Metadata should contain deadline"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_deadline_trait() {
+    let mut env = TestEnv::new("trait-context-deadline").await;
+
+    let (handler, _sid, _meta, deadline, ..) = new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let timeout = Duration::from_secs(30);
+    let start = std::time::SystemTime::now();
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    let deadline = deadline.lock().await;
+    assert!(deadline.is_some(), "Deadline should be captured");
+
+    let captured = deadline.unwrap();
+    let expected = start + timeout;
+
+    let diff = if captured > expected {
+        captured.duration_since(expected).unwrap()
+    } else {
+        expected.duration_since(captured).unwrap()
+    };
+
+    assert!(
+        diff < Duration::from_secs(2),
+        "Deadline should be close to expected value"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_remaining_time_trait() {
+    let mut env = TestEnv::new("trait-context-remaining-time").await;
+
+    let (handler, _sid, _meta, _deadline, remaining, _exc) = new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let timeout = Duration::from_secs(60);
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    let remaining = remaining.lock().await;
+    assert!(remaining.is_some(), "Remaining time should be captured");
+
+    let remaining_duration = remaining.unwrap();
+    assert!(
+        remaining_duration > Duration::ZERO,
+        "Remaining time should be positive"
+    );
+    assert!(
+        remaining_duration <= timeout,
+        "Remaining time should not exceed timeout"
+    );
+    assert!(
+        remaining_duration >= timeout - Duration::from_secs(5),
+        "Remaining time should be close to timeout"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_deadline_not_exceeded_trait() {
+    let mut env = TestEnv::new("trait-context-not-exceeded").await;
+
+    let (handler, _sid, _meta, _deadline, _remaining, is_exceeded) = new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(Duration::from_secs(60)),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    let is_exceeded = is_exceeded.lock().await;
+    assert!(
+        is_exceeded.is_some(),
+        "Deadline exceeded status should be captured"
+    );
+    assert!(
+        !is_exceeded.unwrap(),
+        "Deadline should not be exceeded for normal calls"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_all_fields_trait() {
+    let mut env = TestEnv::new("trait-context-all-fields").await;
+
+    let (handler, session_id, metadata, deadline, remaining, is_exceeded) =
+        new_validation_handler();
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let _response = env
+        .channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    {
+        let session_id = session_id.lock().await;
+        assert!(session_id.is_some(), "Session ID should be captured");
+        assert!(
+            !session_id.as_ref().unwrap().is_empty(),
+            "Session ID should not be empty"
+        );
+    }
+    {
+        let metadata = metadata.lock().await;
+        assert!(metadata.is_some(), "Metadata should be captured");
+        assert!(
+            metadata.as_ref().unwrap().contains_key("slimrpc-timeout"),
+            "Metadata should contain deadline"
+        );
+    }
+    {
+        let deadline = deadline.lock().await;
+        assert!(deadline.is_some(), "Deadline should be captured");
+    }
+    {
+        let remaining = remaining.lock().await;
+        assert!(remaining.is_some(), "Remaining time should be captured");
+        assert!(
+            remaining.unwrap() > Duration::ZERO,
+            "Remaining time should be positive"
+        );
+    }
+    {
+        let is_exceeded = is_exceeded.lock().await;
+        assert!(
+            is_exceeded.is_some(),
+            "Deadline exceeded status should be captured"
+        );
+        assert!(!is_exceeded.unwrap(), "Deadline should not be exceeded");
+    }
+
+    env.shutdown().await;
+}

--- a/crates/rpc/tests/multicast.rs
+++ b/crates/rpc/tests/multicast.rs
@@ -1,0 +1,1091 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for SlimRPC multicast / GROUP RPC patterns
+//!
+//! Tests the four multicast interaction patterns plus the group-inbox observer:
+//! - multicast_unary:        one request broadcast to all members, one response per member
+//! - multicast_unary_stream: one request, each member streams multiple responses
+//! - multicast_stream_unary: client streams requests, one response per member
+//! - multicast_stream_stream: client streams requests, each member streams responses
+//! - group_inbox:            a member can observe other members' responses via subscribe_group_inbox()
+//!
+//! Topology
+//! --------
+//! All tests share the same shape:
+//!   - A shared in-process SLIM `Service` acts as the message bus.
+//!   - Multiple "member" apps are registered under the SAME name ("org/ns/member").
+//!     Each has a `Server` that handles incoming requests.
+//!   - A separate "client" app holds a `Channel` that broadcasts multicast RPCs.
+//!   - (group_inbox test only) An "observer" app also opens a multicast Channel
+//!     to the same group name and subscribes to the group inbox.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures::pin_mut;
+use futures::stream;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::shared_secret::SharedSecret;
+use slim_config::component::id::{ID, Kind};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::service::Service;
+
+const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+use slim_rpc::{
+    Channel, Context, DecodedStream, Decoder, Encoder, MulticastItem, RpcError, Server,
+};
+
+// ============================================================================
+// Test message types
+// ============================================================================
+
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestRequest {
+    pub message: String,
+    pub value: i32,
+}
+
+impl Encoder for TestRequest {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))
+    }
+}
+
+impl Decoder for TestRequest {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (v, _): (TestRequest, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(v)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestResponse {
+    pub member_id: usize,
+    pub result: String,
+    pub count: i32,
+}
+
+impl Encoder for TestResponse {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))
+    }
+}
+
+impl Decoder for TestResponse {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (v, _): (TestResponse, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(v)
+    }
+}
+
+// ============================================================================
+// MulticastTestEnv
+// ============================================================================
+
+/// Test environment with `num_members` servers and one broadcaster channel.
+struct MulticastTestEnv {
+    service: Arc<Service>,
+    /// Member servers — each registered under its own unique app name.
+    member_servers: Vec<Arc<Server>>,
+    /// Channel used as the multicast broadcaster.
+    ///
+    /// Created with `Channel::new_with_members_internal` so the GROUP session
+    /// name is randomly generated and members are auto-invited on the first
+    /// multicast call.
+    channel: Channel,
+}
+
+impl MulticastTestEnv {
+    async fn new(test_name: &str, num_members: usize) -> Self {
+        let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+        let service = Arc::new(Service::new(id));
+
+        // Create N member apps, each with a UNIQUE name ("org/ns/member-{i}").
+        // Each app auto-subscribes to its own unique name via process_messages,
+        // making it reachable for the invite discovery-request sent by the Channel.
+        let mut member_servers = Vec::new();
+        let mut member_app_names = Vec::new();
+        for i in 0..num_members {
+            let member_app_name = Name::from_strings(["org", "ns", &format!("member-{i}")]);
+            let secret = SharedSecret::new("test", TEST_VALID_SECRET).unwrap();
+            let (app, notifications) = service
+                .create_app(
+                    &member_app_name,
+                    AuthProvider::shared_secret(secret.clone()),
+                    AuthVerifier::shared_secret(secret),
+                )
+                .unwrap();
+            let app = Arc::new(app);
+            let server = Arc::new(Server::new_internal(
+                app.clone(),
+                member_app_name.clone(),
+                notifications,
+            ));
+            member_app_names.push(member_app_name);
+            member_servers.push(server);
+        }
+
+        // Broadcaster app — uses new_with_members_internal so the Channel
+        // generates a random UUID group name and auto-invites all members on
+        // the first multicast call.
+        let client_name = Name::from_strings(["org", "ns", "client"]);
+        let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+        let (client_app, _) = service
+            .create_app(
+                &client_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        let channel =
+            Channel::new_with_members_internal(Arc::new(client_app), member_app_names, true, None)
+                .expect("failed to create channel");
+
+        Self {
+            service,
+            member_servers,
+            channel,
+        }
+    }
+
+    /// Start all member servers in background tasks.
+    async fn start_all_servers(&self) {
+        for server in &self.member_servers {
+            let s = server.clone();
+            tokio::spawn(async move {
+                if let Err(e) = s.serve_async().await {
+                    tracing::error!("Member server error: {:?}", e);
+                }
+            });
+        }
+        // Give all servers time to subscribe before the first invite is sent.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    async fn shutdown(&mut self) {
+        self.channel.close_async(None).await.unwrap();
+
+        for server in &self.member_servers {
+            server.shutdown_internal().await;
+        }
+
+        self.service.shutdown().await.unwrap();
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Collect exactly `n` items (successes or errors) from a multicast stream.
+///
+/// Unlike `collect_n_multicast`, this does NOT panic on errors — it stores them
+/// so tests can assert on the mix of successes and failures.
+async fn collect_n_mixed<T>(
+    stream: impl futures::Stream<Item = Result<MulticastItem<T>, RpcError>>,
+    n: usize,
+    timeout: Duration,
+    label: &str,
+) -> Vec<Result<MulticastItem<T>, RpcError>> {
+    pin_mut!(stream);
+    let mut results: Vec<Result<MulticastItem<T>, RpcError>> = Vec::with_capacity(n);
+    tokio::time::timeout(timeout, async {
+        for _ in 0..n {
+            match stream.next().await {
+                Some(item) => results.push(item),
+                None => break,
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "{label}: timed out after collecting {}/{n} items",
+            results.len()
+        )
+    });
+    results
+}
+
+/// Collect exactly `n` responses from a multicast stream, failing if:
+/// - the stream ends before `n` items arrive, or
+/// - any item is an error, or
+/// - the operation does not complete within `timeout`.
+async fn collect_n_multicast<T>(
+    stream: impl futures::Stream<Item = Result<MulticastItem<T>, RpcError>>,
+    n: usize,
+    timeout: Duration,
+    label: &str,
+) -> Vec<MulticastItem<T>> {
+    pin_mut!(stream);
+    let mut responses = Vec::with_capacity(n);
+    tokio::time::timeout(timeout, async {
+        for i in 0..n {
+            match stream.next().await {
+                Some(Ok(r)) => responses.push(r),
+                Some(Err(e)) => panic!("{label}: item {i} failed: {e:?}"),
+                None => panic!("{label}: stream ended after {i} items, expected {n}"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "{label}: timed out after collecting {}/{n} items",
+            responses.len()
+        )
+    });
+    responses
+}
+
+// ============================================================================
+// Test 1 — multicast_unary
+// ============================================================================
+
+/// Broadcast one request; each member returns one response.
+/// The client collects one `TestResponse` per member.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_unary() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-multicast-unary", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", req.message),
+                    count: req.value + i as i32,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let mut responses = collect_n_multicast(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "multicast_unary",
+    )
+    .await;
+    responses.sort_by_key(|r| r.message.member_id);
+
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    assert_eq!(responses[0].message.result, "M0: hello");
+    assert_eq!(responses[0].message.count, 10);
+    assert_eq!(responses[1].message.result, "M1: hello");
+    assert_eq!(responses[1].message.count, 11);
+    // Source should identify each member by name.
+    assert_eq!(
+        responses[0].context.source,
+        Name::from_strings(["org", "ns", "member-0"])
+    );
+    assert_eq!(
+        responses[1].context.source,
+        Name::from_strings(["org", "ns", "member-1"])
+    );
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 2 — multicast_unary_stream
+// ============================================================================
+
+/// Broadcast one request; each member returns a stream of responses.
+/// The client interleaves all per-member streams into one stream.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_unary_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const ITEMS_PER_MEMBER: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-unary-stream", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_stream_internal(
+            "TestService",
+            "Expand",
+            move |req: TestRequest, _ctx: Context| async move {
+                let items: Vec<Result<TestResponse, RpcError>> = (0..ITEMS_PER_MEMBER)
+                    .map(|j| {
+                        Ok(TestResponse {
+                            member_id: i,
+                            result: format!("M{i}-item{j}: {}", req.message),
+                            count: req.value * 10 + j as i32,
+                        })
+                    })
+                    .collect();
+                Ok(stream::iter(items))
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env
+        .channel
+        .multicast_unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Expand",
+            TestRequest {
+                message: "x".to_string(),
+                value: 1,
+            },
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let total = NUM_MEMBERS * ITEMS_PER_MEMBER;
+    let responses = collect_n_multicast(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "multicast_unary_stream",
+    )
+    .await;
+
+    assert_eq!(responses.len(), total);
+    // Each member contributed exactly ITEMS_PER_MEMBER items.
+    for mid in 0..NUM_MEMBERS {
+        let count = responses
+            .iter()
+            .filter(|r| r.message.member_id == mid)
+            .count();
+        assert_eq!(
+            count, ITEMS_PER_MEMBER,
+            "member {mid} should have sent {ITEMS_PER_MEMBER} items"
+        );
+        // Every item from this member should carry the expected source name.
+        let expected_src = Name::from_strings(["org", "ns", &format!("member-{mid}")]);
+        assert!(
+            responses
+                .iter()
+                .filter(|r| r.message.member_id == mid)
+                .all(|r| r.context.source == expected_src),
+            "member {mid} items have wrong source"
+        );
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 3 — multicast_stream_unary
+// ============================================================================
+
+/// Client streams requests to all members; each member aggregates and replies once.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_stream_unary() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-multicast-stream-unary", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_stream_unary_internal(
+            "TestService",
+            "Sum",
+            move |mut req_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+                let mut total = 0i32;
+                let mut msgs = Vec::new();
+                while let Some(item) = req_stream.next().await {
+                    let req = item?;
+                    total += req.value;
+                    msgs.push(req.message.clone());
+                }
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", msgs.join("+")),
+                    count: total,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let requests = stream::iter(vec![
+        TestRequest {
+            message: "a".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "b".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "c".to_string(),
+            value: 3,
+        },
+    ]);
+
+    let stream = env
+        .channel
+        .multicast_stream_unary::<TestRequest, TestResponse>(
+            "TestService",
+            "Sum",
+            requests,
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let mut responses = collect_n_multicast(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "multicast_stream_unary",
+    )
+    .await;
+    responses.sort_by_key(|r| r.message.member_id);
+
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    for r in &responses {
+        assert_eq!(
+            r.message.count, 6,
+            "member {} should sum to 6",
+            r.message.member_id
+        );
+        assert!(
+            r.message.result.contains("a+b+c"),
+            "member {} got: {}",
+            r.message.member_id,
+            r.message.result
+        );
+        let expected_src =
+            Name::from_strings(["org", "ns", &format!("member-{}", r.message.member_id)]);
+        assert_eq!(r.context.source, expected_src, "wrong source for member");
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 4 — multicast_stream_stream
+// ============================================================================
+
+/// Client streams requests; each member streams one response per request item.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_stream_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const NUM_REQUESTS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-stream-stream", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_stream_stream_internal(
+            "TestService",
+            "Echo",
+            move |mut req_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+                let responses: Vec<Result<TestResponse, RpcError>> = {
+                    let mut v = Vec::new();
+                    while let Some(item) = req_stream.next().await {
+                        let req = item?;
+                        v.push(Ok(TestResponse {
+                            member_id: i,
+                            result: format!("M{i}: {}", req.message),
+                            count: req.value,
+                        }));
+                    }
+                    v
+                };
+                Ok(stream::iter(responses))
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let requests = stream::iter(vec![
+        TestRequest {
+            message: "x".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "y".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "z".to_string(),
+            value: 3,
+        },
+    ]);
+
+    let stream = env
+        .channel
+        .multicast_stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Echo",
+            requests,
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let total = NUM_MEMBERS * NUM_REQUESTS;
+    let responses = collect_n_multicast(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "multicast_stream_stream",
+    )
+    .await;
+
+    assert_eq!(responses.len(), total);
+    for mid in 0..NUM_MEMBERS {
+        let member_responses: Vec<_> = responses
+            .iter()
+            .filter(|r| r.message.member_id == mid)
+            .collect();
+        assert_eq!(member_responses.len(), NUM_REQUESTS);
+        let values: Vec<i32> = member_responses.iter().map(|r| r.message.count).collect();
+        // Each member should have echoed all 3 request values.
+        for v in [1, 2, 3] {
+            assert!(values.contains(&v), "member {mid} missing value {v}");
+        }
+        let expected_src = Name::from_strings(["org", "ns", &format!("member-{mid}")]);
+        assert!(
+            member_responses
+                .iter()
+                .all(|r| r.context.source == expected_src),
+            "member {mid} items have wrong source"
+        );
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 5 — partial error, unary pattern
+// ============================================================================
+
+/// One member returns an error; the other members' successes must still arrive.
+///
+/// Uses `multicast_unary` (unary-unary). The server sends one data message per
+/// member — no EOS marker. The caller collects exactly NUM_MEMBERS items
+/// (mix of Ok and Err) and then drops the stream.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_partial_error_unary() {
+    const NUM_MEMBERS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-partial-error-unary", NUM_MEMBERS).await;
+
+    // Member 0 returns an error.
+    env.member_servers[0].register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        move |_req: TestRequest, _ctx: Context| async move {
+            Err::<TestResponse, _>(RpcError::internal("member 0 failed"))
+        },
+    );
+    // Members 1 and 2 succeed.
+    for i in 1..NUM_MEMBERS {
+        env.member_servers[i].register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", req.message),
+                    count: req.value + i as i32,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let results = collect_n_mixed(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "partial_error_unary",
+    )
+    .await;
+
+    assert_eq!(results.len(), NUM_MEMBERS);
+    let errors: Vec<_> = results.iter().filter(|r| r.is_err()).collect();
+    let successes: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error");
+    assert_eq!(successes.len(), 2, "expected 2 successes");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 6 — partial error, streaming pattern
+// ============================================================================
+
+/// One member errors mid-stream; the other member's full response stream must
+/// still arrive and the combined stream must terminate cleanly.
+///
+/// Uses `multicast_unary_stream`. Member 0 yields two items then an error;
+/// member 1 yields three items then EOS. The client should receive:
+///   - 2 Ok items from member 0
+///   - 1 Err from member 0 (counted as its EOS)
+///   - 3 Ok items from member 1
+///   - stream terminates after member 1's EOS
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_partial_error_unary_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const M0_OK_ITEMS: usize = 2;
+    const M1_OK_ITEMS: usize = 3;
+    let mut env =
+        MulticastTestEnv::new("test-multicast-partial-error-unary-stream", NUM_MEMBERS).await;
+
+    // Member 0: 2 ok items then an error (no server-side EOS follows the error).
+    env.member_servers[0].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M0_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 0,
+                        result: format!("M0-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .chain(std::iter::once(Err(RpcError::internal("M0 stream error"))))
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    // Member 1: 3 ok items, server sends EOS after the last one.
+    env.member_servers[1].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M1_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 1,
+                        result: format!("M1-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    env.start_all_servers().await;
+
+    let stream = env
+        .channel
+        .multicast_unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Expand",
+            TestRequest {
+                message: "x".to_string(),
+                value: 1,
+            },
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    // M0 yields M0_OK_ITEMS Ok + 1 Err; M1 yields M1_OK_ITEMS Ok.
+    // The stream terminates after M1's EOS (M0's error is counted as its EOS),
+    // so the total item count is known up front.
+    let total = M0_OK_ITEMS + 1 + M1_OK_ITEMS;
+    let results = collect_n_mixed(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "partial_error_stream",
+    )
+    .await;
+
+    let errors: Vec<_> = results.iter().filter(|r| r.is_err()).collect();
+    let successes: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error (from M0)");
+    assert_eq!(
+        successes.len(),
+        M0_OK_ITEMS + M1_OK_ITEMS,
+        "expected all ok items from both members"
+    );
+    let m1_items: Vec<_> = successes
+        .iter()
+        .filter(|r| r.as_ref().unwrap().message.member_id == 1)
+        .collect();
+    assert_eq!(m1_items.len(), M1_OK_ITEMS, "M1 should deliver all items");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 7 — MulticastRpc error carries origin (unary)
+// ============================================================================
+
+/// When a member returns an error in a multicast unary call, the yielded
+/// `RpcError` must be the `MulticastRpc` variant with the `origin` field set
+/// to the failing member's name.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_error_origin_unary() {
+    const NUM_MEMBERS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-error-origin-unary", NUM_MEMBERS).await;
+
+    // Member 0 returns an error.
+    env.member_servers[0].register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        move |_req: TestRequest, _ctx: Context| async move {
+            Err::<TestResponse, _>(RpcError::internal("member 0 exploded"))
+        },
+    );
+    // Members 1 and 2 succeed.
+    for i in 1..NUM_MEMBERS {
+        env.member_servers[i].register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", req.message),
+                    count: req.value + i as i32,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let results = collect_n_mixed(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "error_origin_unary",
+    )
+    .await;
+
+    assert_eq!(results.len(), NUM_MEMBERS);
+
+    let errors: Vec<_> = results.iter().filter_map(|r| r.as_ref().err()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error");
+
+    let err = &errors[0];
+    let expected_origin = Name::from_strings(["org", "ns", "member-0"]).to_string();
+    match err {
+        RpcError::MulticastRpc {
+            origin,
+            code,
+            message,
+            ..
+        } => {
+            assert_eq!(
+                origin, &expected_origin,
+                "origin must identify the failing member"
+            );
+            assert_eq!(*code, slim_rpc::RpcCode::Internal);
+            assert!(
+                message.contains("member 0 exploded"),
+                "message should be preserved"
+            );
+        }
+        other => panic!("expected MulticastRpc, got: {other:?}"),
+    }
+
+    // Successes should still be plain Ok items with correct context.
+    let successes: Vec<_> = results.iter().filter_map(|r| r.as_ref().ok()).collect();
+    assert_eq!(successes.len(), 2, "expected 2 successes");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 8 — MulticastRpc error carries origin (streaming)
+// ============================================================================
+
+/// When a member errors mid-stream, the yielded error must be `MulticastRpc`
+/// with the correct `origin`.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_error_origin_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const M0_OK_ITEMS: usize = 1;
+    const M1_OK_ITEMS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-multicast-error-origin-stream", NUM_MEMBERS).await;
+
+    // Member 0: 1 ok item then an error.
+    env.member_servers[0].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M0_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 0,
+                        result: format!("M0-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .chain(std::iter::once(Err(RpcError::internal("M0 broke"))))
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    // Member 1: 2 ok items, normal completion.
+    env.member_servers[1].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M1_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 1,
+                        result: format!("M1-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    env.start_all_servers().await;
+
+    let stream = env
+        .channel
+        .multicast_unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Expand",
+            TestRequest {
+                message: "x".to_string(),
+                value: 1,
+            },
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let total = M0_OK_ITEMS + 1 + M1_OK_ITEMS;
+    let results = collect_n_mixed(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "error_origin_stream",
+    )
+    .await;
+
+    let errors: Vec<_> = results.iter().filter_map(|r| r.as_ref().err()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error (from M0)");
+
+    let err = &errors[0];
+    let expected_origin = Name::from_strings(["org", "ns", "member-0"]).to_string();
+    match err {
+        RpcError::MulticastRpc { origin, code, .. } => {
+            assert_eq!(origin, &expected_origin, "origin must identify M0");
+            assert_eq!(*code, slim_rpc::RpcCode::Internal);
+        }
+        other => panic!("expected MulticastRpc, got: {other:?}"),
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 9 — MulticastRpc error carries origin for all failing members
+// ============================================================================
+
+/// When multiple members fail, each error must carry its own origin.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_error_origin_multiple_failures() {
+    const NUM_MEMBERS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-error-origin-multi", NUM_MEMBERS).await;
+
+    // All members return errors with distinct messages.
+    for i in 0..NUM_MEMBERS {
+        env.member_servers[i].register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |_req: TestRequest, _ctx: Context| async move {
+                Err::<TestResponse, _>(RpcError::internal(format!("fail-{i}")))
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let results = collect_n_mixed(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "error_origin_multi",
+    )
+    .await;
+
+    assert_eq!(results.len(), NUM_MEMBERS);
+
+    // Every result should be a MulticastRpc error.
+    let mut origins: Vec<String> = Vec::new();
+    for result in &results {
+        match result {
+            Err(RpcError::MulticastRpc { origin, .. }) => {
+                origins.push(origin.clone());
+            }
+            Err(other) => panic!("expected MulticastRpc, got: {other:?}"),
+            Ok(item) => panic!("expected error, got success: {:?}", item.message),
+        }
+    }
+
+    // Each member should appear exactly once.
+    origins.sort();
+    let mut expected: Vec<String> = (0..NUM_MEMBERS)
+        .map(|i| Name::from_strings(["org", "ns", &format!("member-{i}")]).to_string())
+        .collect();
+    expected.sort();
+    assert_eq!(
+        origins, expected,
+        "each failing member must appear as an origin"
+    );
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 10 — channel close: idle (no session)
+// ============================================================================
+
+/// `close_async` on a channel that has never been used must succeed immediately
+/// without panicking or blocking.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_channel_close_no_session() {
+    let mut env = MulticastTestEnv::new("test-channel-close-no-session", 1).await;
+
+    env.member_servers[0].register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        move |req: TestRequest, _ctx: Context| async move {
+            Ok(TestResponse {
+                member_id: 0,
+                result: req.message,
+                count: req.value,
+            })
+        },
+    );
+    env.start_all_servers().await;
+
+    // No RPC has been made — no underlying session exists yet.
+    env.channel
+        .close_async(None)
+        .await
+        .expect("close on idle channel must succeed");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 11 — channel close: active session, then reuse
+// ============================================================================
+
+/// After `close_async` on a channel with an active session the channel must
+/// still be usable: the next RPC call re-creates the session transparently.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_channel_close_after_rpc() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-channel-close-after-rpc", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: req.message,
+                    count: req.value,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    // First call — establishes the persistent GROUP session.
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "first".to_string(),
+            value: 1,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses =
+        collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "first call").await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+
+    // Close the session — the dispatcher task must exit naturally.
+    env.channel
+        .close_async(None)
+        .await
+        .expect("close must succeed with an active session");
+
+    // Second call — channel must re-create the session transparently.
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "second".to_string(),
+            value: 2,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses =
+        collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "second call").await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    assert!(responses.iter().all(|r| r.message.result == "second"));
+
+    env.shutdown().await;
+}


### PR DESCRIPTION
Moves the SlimRPC engine (gRPC-like RPC over SLIM, ~5.5k LOC) out of the UniFFI `slim-bindings` repo into a native crate here, so Rust consumers (`a2a-slimrpc`, SHADI) stop depending on the FFI shim.

- UniFFI annotations stripped; self-contained runtime module; native `App`/`ProtoName` instead of the FFI wrapper types.
- `Server::new` convenience constructors (which needed the wrapper's rx) dropped in favor of `new_with_shared_rx_and_connection`.
- Design + rationale: `crates/rpc/DESIGN.md`.

Draft — follow-ups: rewire `slim-bindings` to wrap this crate; repoint `a2a-slimrpc` onto it.