### PR TITLE
ci: stabilize rust-cache shared key to warm-start on dependency changes

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -36,7 +36,14 @@ runs:
         cache: ${{ inputs.cache-enabled }}
         cache-workspaces: ${{ inputs.workspace }}
         cache-on-failure: false
-        cache-shared-key: ${{runner.os}}-rust-${{hashFiles('**/Cargo.lock')}}
+        # Keep the shared key STABLE (no Cargo.lock hash). rust-cache already
+        # appends a lockfile/toolchain hash to the full cache key and derives
+        # restore-keys from this prefix, so a stable prefix lets a Cargo.lock
+        # change warm-start from the previous cache (rebuilding only changed
+        # crates) instead of cold-starting. Embedding the lockfile hash here made
+        # the prefix change on every dependency bump, defeating the restore-key
+        # fallback and inflating "Setup Rust" from ~45s to ~30m on such PRs.
+        cache-shared-key: ${{ runner.os }}-rust
         cache-all-crates: true
         cache-bin: false # cache-bin has a bug at the swatinem cache level, if it's enabled, it will cause the bin cache to be cleared
         cache-directories: ${{ inputs.cache-directories }}


### PR DESCRIPTION
`setup-rust`'s `cache-shared-key` embedded `hashFiles('**/Cargo.lock')`, so any `Cargo.lock` change altered the cache-key **prefix** and defeated rust-cache's restore-key fallback → a full cold start.

**Measured:** the coverage job's `Setup Rust` step went from ~45s to **~34m** (job 12m → 45m) on dependency PRs — and every crate-adding PR (e.g. #1830) hits it.

rust-cache already appends a lockfile/toolchain hash to the *full* key and derives restore-keys from the prefix. Making the prefix stable (`${{ runner.os }}-rust`) lets a `Cargo.lock` change restore the previous cache and rebuild only what changed.

Note: the first run after merge seeds the new key (one cold miss); subsequent runs — and dependency-bump PRs especially — warm-start.