### PR TITLE
ci: cut docker cache bloat and warm-start release cross-builds

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -24,6 +24,14 @@ inputs:
     description: 'Enable rust cache'
     required: false
     default: 'true'
+  cache-key-suffix:
+    description: >-
+      Optional suffix appended to the cache shared-key. Use it to give jobs that
+      build DIFFERENT artifacts (e.g. cross-compiled targets or a specific
+      profile) their own cache, so they do not restore/overwrite the shared
+      host cache. Leave empty for host jobs that should share one cache.
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -43,7 +51,7 @@ runs:
         # crates) instead of cold-starting. Embedding the lockfile hash here made
         # the prefix change on every dependency bump, defeating the restore-key
         # fallback and inflating "Setup Rust" from ~45s to ~30m on such PRs.
-        cache-shared-key: ${{ runner.os }}-rust
+        cache-shared-key: ${{ format('{0}-rust{1}', runner.os, inputs.cache-key-suffix) }}
         cache-all-crates: true
         cache-bin: false # cache-bin has a bug at the swatinem cache level, if it's enabled, it will cause the bin cache to be cleared
         cache-directories: ${{ inputs.cache-directories }}

--- a/.github/workflows/reusable-docker-build-push.yaml
+++ b/.github/workflows/reusable-docker-build-push.yaml
@@ -98,6 +98,10 @@ jobs:
           provenance: false
           set: |
             *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            # mode=min exports only the final image layers (not every
+            # intermediate stage). mode=max was producing ~167 layer blobs
+            # (~6 GB) and pinning the repo at the 10 GB Actions-cache ceiling,
+            # forcing constant LRU eviction that churned the rust caches too.
+            *.cache-to=type=gha,mode=min
         env:
           IMAGE_REPO: ${{ inputs.image-repo }}

--- a/.github/workflows/reusable-rust-build-and-test.yaml
+++ b/.github/workflows/reusable-rust-build-and-test.yaml
@@ -328,7 +328,11 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           workspace: ${{ inputs.working-directory }}
-          cache-enabled: ${{ matrix.profile != 'release' }}
+          # Each cell compiles distinct artifacts (target triple × profile), so
+          # give each its own cache rather than sharing/overwriting the host
+          # cache. This also warm-starts release builds — caching was previously
+          # disabled for release, forcing a full ~24m cold recompile every run.
+          cache-key-suffix: "-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}"
 
       - name: Build
         env:


### PR DESCRIPTION
The Actions cache sits at the **10 GB ceiling** (measured 9.99 GB), so GitHub LRU-evicts continuously — churning even the rust caches. Breakdown: **docker buildkit ~6.3 GB (167 blobs)** vs rust ~3.1 GB.

**Two changes:**
- **docker `cache-to` `mode=max` → `mode=min`** — `max` exports a blob per intermediate layer; `min` keeps only final layers, reclaiming several GB. docker-build isn't on the critical path, so the lower layer-hit-rate is acceptable.
- **cross-build: enable caching for the release profile.** Caching was disabled for release → each ran a full cold recompile (~24m vs ~5.5m cached debug). Now every matrix cell (os × arch × profile) gets its **own** cache key via a new `setup-rust` `cache-key-suffix` input, so cross-targets don't restore/overwrite the shared host cache. Host jobs keep the stable `${{ runner.os }}-rust` key (suffix defaults to empty).

**Expected:** release cross-build **~24m → ~6–10m** warm; cache pressure relieved. First run per new key seeds it (one cold miss); the `mode=min` reclaim is gradual as old `max` blobs age out.

Follow-up to #1832.