### PR TITLE
ci: fix docker bake set block broken by inline comments

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yaml
+++ b/.github/workflows/reusable-docker-build-push.yaml
@@ -98,10 +98,6 @@ jobs:
           provenance: false
           set: |
             *.cache-from=type=gha
-            # mode=min exports only the final image layers (not every
-            # intermediate stage). mode=max was producing ~167 layer blobs
-            # (~6 GB) and pinning the repo at the 10 GB Actions-cache ceiling,
-            # forcing constant LRU eviction that churned the rust caches too.
             *.cache-to=type=gha,mode=min
         env:
           IMAGE_REPO: ${{ inputs.image-repo }}


### PR DESCRIPTION
**Hotfix for a regression in #1833.** The bake-action `set:` is a literal block scalar — each line becomes a `--set` arg. The explanatory comment lines I added landed *inside* the block, so bake received `--set # mode=min...` and failed:

```
ERROR: invalid override key # mode, expected target.name
```

This broke the docker-build job on `main` and every PR. Fix: move the note above the `set:` key so the block contains only the two `--set` lines. YAML validated.