### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -458,11 +458,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,21 +38,21 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.2" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.11.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.12.0" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.2" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.10.0" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.1" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.2.1" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.2.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.11.0", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.5.0" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.10" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.3" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.12.0" }
+agntcy-slim-config = { path = "crates/config", version = "0.12.1" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.3" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.11.0" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.2" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.2.2" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.3.0" }
+agntcy-slim-service = { path = "crates/service", version = "0.11.1", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.5.1" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.11" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.2" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.2" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.2" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.3" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.3" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.3" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -213,7 +213,7 @@ wiremock = "0.6"
 x25519-dalek = { version = "2", default-features = false, features = ["static_secrets"] }
 
 [workspace.package]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/agntcy/slim/compare/slim-auth-v0.11.0...slim-auth-v0.12.0) - 2026-07-14
+
+### Added
+
+- *(mls)* share one signing identity across an app and its sessions ([#1825](https://github.com/agntcy/slim/pull/1825))
+- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
+
 ## [0.11.0](https://github.com/agntcy/slim/compare/slim-auth-v0.10.0...slim-auth-v0.11.0) - 2026-07-01
 
 ### Added

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.11.0"
+version = "0.12.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.2...slim-channel-manager-v2.0.0-alpha.3) - 2026-07-14
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-channel-manager-v2.0.0-alpha.2) - 2026-07-06
 
 ### Added

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/agntcy/slim/compare/slim-config-v0.12.0...slim-config-v0.12.1) - 2026-07-14
+
+### Added
+
+- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
+
+### Fixed
+
+- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
+
 ## [0.12.0](https://github.com/agntcy/slim/compare/slim-config-v0.11.1...slim-config-v0.12.0) - 2026-07-06
 
 ### Added

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.2...slim-control-plane-v2.0.0-alpha.3) - 2026-07-14
+
+### Added
+
+- group registration via slimctl ([#1795](https://github.com/agntcy/slim/pull/1795))
+
+### Fixed
+
+- *(control-plane)* re-expand routes when a node reconnects over a claimed link ([#1836](https://github.com/agntcy/slim/pull/1836))
+- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
+
+### Other
+
+- *(control-plane)* fix auth-link flake by making the connector dialer-only ([#1831](https://github.com/agntcy/slim/pull/1831))
+- *(control-plane)* de-flake integration tests ([#1829](https://github.com/agntcy/slim/pull/1829))
+
 ## [2.0.0-alpha.2](https://github.com/agntcy/slim/releases/tag/slim-control-plane-v2.0.0-alpha.2) - 2026-07-01
 
 ### Added

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/agntcy/slim/compare/slim-controller-v0.10.0...slim-controller-v0.11.0) - 2026-07-14
+
+### Fixed
+
+- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
+
 ## [0.10.0](https://github.com/agntcy/slim/compare/slim-controller-v0.9.0...slim-controller-v0.10.0) - 2026-07-06
 
 ### Added

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.1...slim-datapath-v0.16.2) - 2026-07-14
+
+### Added
+
+- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
+- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
+
 ## [0.16.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.0...slim-datapath-v0.16.1) - 2026-07-06
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.16.1"
+version = "0.16.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/agntcy/slim/compare/slim-mls-v0.2.1...slim-mls-v0.2.2) - 2026-07-14
+
+### Added
+
+- *(mls)* share one signing identity across an app and its sessions ([#1825](https://github.com/agntcy/slim/pull/1825))
+
 ## [0.2.1](https://github.com/agntcy/slim/compare/slim-mls-v0.2.0...slim-mls-v0.2.1) - 2026-07-01
 
 ### Added

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.2.2"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/agntcy/slim/compare/slim-proto-v0.2.0...slim-proto-v0.3.0) - 2026-07-14
+
+### Added
+
+- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
+- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
+- group registration via slimctl ([#1795](https://github.com/agntcy/slim/pull/1795))
+
+### Fixed
+
+- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
+
 ## [0.2.0](https://github.com/agntcy/slim/compare/slim-proto-v0.1.0...slim-proto-v0.2.0) - 2026-07-06
 
 ### Added

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/agntcy/slim/compare/slim-service-v0.11.0...slim-service-v0.11.1) - 2026-07-14
+
+### Added
+
+- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
+
 ## [0.11.0](https://github.com/agntcy/slim/compare/slim-service-v0.10.1...slim-service-v0.11.0) - 2026-07-06
 
 ### Added

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.11.0"
+version = "0.11.1"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/agntcy/slim/compare/slim-session-v0.5.0...slim-session-v0.5.1) - 2026-07-14
+
+### Added
+
+- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
+- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
+
 ## [0.5.0](https://github.com/agntcy/slim/compare/slim-session-v0.4.0...slim-session-v0.5.0) - 2026-07-06
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.0"
+version = "0.5.1"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/agntcy/slim/compare/slim-signal-v0.1.10...slim-signal-v0.1.11) - 2026-07-14
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.10](https://github.com/agntcy/slim/compare/slim-signal-v0.1.9...slim-signal-v0.1.10) - 2026-06-17
 
 ### Added

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.10"
+version = "0.1.11"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.2...slim-tracing-v0.4.3) - 2026-07-14
+
+### Added
+
+- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
+
 ## [0.4.2](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.1...slim-tracing-v0.4.2) - 2026-07-06
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.2"
+version = "0.4.3"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.2 -> 2.0.0-alpha.3
* `agntcy-slim-auth`: 0.11.0 -> 0.12.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `agntcy-slim-proto`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.16.1 -> 0.16.2 (✓ API compatible changes)
* `agntcy-slim-mls`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `agntcy-slim-session`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `agntcy-slim`: 2.0.0-alpha.2 -> 2.0.0-alpha.3 (✓ API compatible changes)
* `agntcy-slim-channel-manager`: 2.0.0-alpha.2 -> 2.0.0-alpha.3 (✓ API compatible changes)
* `agntcy-slim-control-plane`: 2.0.0-alpha.2 -> 2.0.0-alpha.3 (✓ API compatible changes)
* `agntcy-slimctl`: 2.0.0-alpha.2 -> 2.0.0-alpha.3
* `agntcy-slim-signal`: 0.1.10 -> 0.1.11

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  SharedSecret::with_replay_cache_enabled, previously in file /tmp/.tmp07kuqk/agntcy-slim-auth/src/shared_secret.rs:263
  SharedSecret::with_replay_cache_disabled, previously in file /tmp/.tmp07kuqk/agntcy-slim-auth/src/shared_secret.rs:269
  SharedSecret::with_validity_window, previously in file /tmp/.tmp07kuqk/agntcy-slim-auth/src/shared_secret.rs:274
  SharedSecret::with_clock_skew, previously in file /tmp/.tmp07kuqk/agntcy-slim-auth/src/shared_secret.rs:279
  SharedSecret::with_replay_cache_max, previously in file /tmp/.tmp07kuqk/agntcy-slim-auth/src/shared_secret.rs:284
```

### ⚠ `agntcy-slim-proto` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConnectionDetails.tls_required in /tmp/.tmpeojNrS/slim/crates/proto/src/gen/controller.proto.v1.rs:166
  field ConnectionDetails.auth_method in /tmp/.tmpeojNrS/slim/crates/proto/src/gen/controller.proto.v1.rs:168
  field ConnectionDetails.spire_trust_domain in /tmp/.tmpeojNrS/slim/crates/proto/src/gen/controller.proto.v1.rs:170
  field JoinRequestPayload.control in /tmp/.tmpeojNrS/slim/crates/proto/src/gen/dataplane.proto.v1.rs:251

--- failure inherent_associated_pub_const_missing: inherent impl's associated pub const removed ---

Description:
An inherent impl's associated public constant is removed or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_associated_pub_const_missing.ron

Failed in:
  NameId::DATA_CHANNEL_ID, previously at /tmp/.tmp07kuqk/agntcy-slim-proto/src/impls.rs:216
  NameId::CONTROL_CHANNEL_ID, previously at /tmp/.tmp07kuqk/agntcy-slim-proto/src/impls.rs:217

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  agntcy_slim_proto::CommandPayloadBuilder::join_request now takes 5 parameters instead of 4, in /tmp/.tmpeojNrS/slim/crates/proto/src/impls.rs:1341

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod agntcy_slim_proto::controller::proto::v1::connection_details, previously in file /tmp/.tmp07kuqk/agntcy-slim-proto/src/gen/controller.proto.v1.rs:171

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct agntcy_slim_proto::controller::proto::v1::connection_details::SpireMtls, previously in file /tmp/.tmp07kuqk/agntcy-slim-proto/src/gen/controller.proto.v1.rs:173

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field spire_mtls of struct ConnectionDetails, previously in file /tmp/.tmp07kuqk/agntcy-slim-proto/src/gen/controller.proto.v1.rs:166

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method agntcy_slim_proto::controlplane::proto::v1::control_plane_service_server::ControlPlaneService::list_groups in file /tmp/.tmpeojNrS/slim/crates/proto/src/gen/controlplane.proto.v1.rs:938
  trait method agntcy_slim_proto::controlplane::proto::v1::control_plane_service_server::ControlPlaneService::add_group in file /tmp/.tmpeojNrS/slim/crates/proto/src/gen/controlplane.proto.v1.rs:948
  trait method agntcy_slim_proto::controlplane::proto::v1::control_plane_service_server::ControlPlaneService::remove_group in file /tmp/.tmpeojNrS/slim/crates/proto/src/gen/controlplane.proto.v1.rs:957
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ControlPlaneSettings.outbound_clients in /tmp/.tmpeojNrS/slim/crates/controller/src/service.rs:71
  field Config.outbound_clients in /tmp/.tmpeojNrS/slim/crates/controller/src/config.rs:28
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.12.0](https://github.com/agntcy/slim/compare/slim-auth-v0.11.0...slim-auth-v0.12.0) - 2026-07-14

### Added

- *(mls)* share one signing identity across an app and its sessions ([#1825](https://github.com/agntcy/slim/pull/1825))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.12.1](https://github.com/agntcy/slim/compare/slim-config-v0.12.0...slim-config-v0.12.1) - 2026-07-14

### Added

- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))

### Fixed

- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.3.0](https://github.com/agntcy/slim/compare/slim-proto-v0.2.0...slim-proto-v0.3.0) - 2026-07-14

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
- group registration via slimctl ([#1795](https://github.com/agntcy/slim/pull/1795))

### Fixed

- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.3](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.2...slim-tracing-v0.4.3) - 2026-07-14

### Added

- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.1...slim-datapath-v0.16.2) - 2026-07-14

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.2](https://github.com/agntcy/slim/compare/slim-mls-v0.2.1...slim-mls-v0.2.2) - 2026-07-14

### Added

- *(mls)* share one signing identity across an app and its sessions ([#1825](https://github.com/agntcy/slim/pull/1825))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.5.1](https://github.com/agntcy/slim/compare/slim-session-v0.5.0...slim-session-v0.5.1) - 2026-07-14

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.11.0](https://github.com/agntcy/slim/compare/slim-controller-v0.10.0...slim-controller-v0.11.0) - 2026-07-14

### Fixed

- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.11.1](https://github.com/agntcy/slim/compare/slim-service-v0.11.0...slim-service-v0.11.1) - 2026-07-14

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.2...slim-v2.0.0-alpha.3) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-service, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.2...slim-channel-manager-v2.0.0-alpha.3) - 2026-07-14

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.2...slim-control-plane-v2.0.0-alpha.3) - 2026-07-14

### Added

- group registration via slimctl ([#1795](https://github.com/agntcy/slim/pull/1795))

### Fixed

- *(control-plane)* re-expand routes when a node reconnects over a claimed link ([#1836](https://github.com/agntcy/slim/pull/1836))
- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))

### Other

- *(control-plane)* fix auth-link flake by making the connector dialer-only ([#1831](https://github.com/agntcy/slim/pull/1831))
- *(control-plane)* de-flake integration tests ([#1829](https://github.com/agntcy/slim/pull/1829))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.2...slimctl-v2.0.0-alpha.3) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-session, agntcy-slim-service, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.11](https://github.com/agntcy/slim/compare/slim-signal-v0.1.10...slim-signal-v0.1.11) - 2026-07-14

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).