### PR TITLE
ci: run coverage once, move release builds and e2e tests to nightly

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -41,6 +42,6 @@ jobs:
           files: lcov.info
           flags: rust
           name: rust-coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,41 +2,41 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-name: ci-integration-tests
+name: ci-nightly
 
 on:
-  push:
-    paths:
-      - 'tests/**'
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-    branches:
-      - main
-  pull_request:
-    paths:
-      - 'tests/**'
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  release-cross-build:
+    name: Nightly release build
+    uses: ./.github/workflows/reusable-rust-build-and-test.yaml
+    with:
+      rust-lint: true
+      rust-vuln: false
+      rust-test: false
+      rust-test-wasm: false
+      rust-test-wasm-browser: false
+      rust-cross-build: true
+      rust-cross-build-profiles: '["release"]'
+      rust-cross-build-arches: '["aarch64","x86_64"]'
+
   integration-tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     defaults:
       run:
         shell: bash
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,11 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     defaults:
       run:
         shell: bash
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-rust-build-and-test.yaml
+++ b/.github/workflows/reusable-rust-build-and-test.yaml
@@ -37,11 +37,6 @@ on:
         required: false
         type: boolean
         default: true
-      rust-test-coverage:
-        description: Whether to run "task coverage"
-        required: false
-        type: boolean
-        default: true
       rust-test-wasm:
         description: Whether to run "task test:wasm" (wasm32 browser unit tests)
         required: false
@@ -57,6 +52,16 @@ on:
         required: false
         type: boolean
         default: true
+      rust-cross-build-profiles:
+        description: JSON array of cargo profiles to cross-build
+        required: false
+        type: string
+        default: '["debug"]'
+      rust-cross-build-arches:
+        description: JSON array of target arches to cross-build
+        required: false
+        type: string
+        default: '["x86_64"]'
       working-directory:
         description: Directory to run the task in
         required: false
@@ -92,33 +97,6 @@ jobs:
           TASK_PREFIX: ${{ inputs.task-prefix }}
         run: |
           task "${TASK_PREFIX:+${TASK_PREFIX}:}lint"
-
-  test-coverage:
-    runs-on: ${{ inputs.runner }}
-    defaults:
-      run:
-        shell: bash
-        working-directory: ${{ inputs.working-directory }}
-
-    if: ${{ inputs.rust-test-coverage }}
-    needs: [lint]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          workspace: ${{ inputs.working-directory }}
-
-      - name: Run `coverage`
-        env:
-          TASK_PREFIX: ${{ inputs.task-prefix }}
-        run: |
-          task "${TASK_PREFIX:+${TASK_PREFIX}:}test:coverage"
 
   unittest-matrix:
     runs-on: ${{ inputs.runner }}
@@ -314,8 +292,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux]
-        profile: [release, debug]
-        arch: [aarch64, x86_64]
+        profile: ${{ fromJSON(inputs.rust-cross-build-profiles) }}
+        arch: ${{ fromJSON(inputs.rust-cross-build-arches) }}
 
     steps:
       - name: Checkout Repo

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -291,7 +291,6 @@ tasks:
     desc: "Run the tests"
     cmds:
       - ulimit -n 4096 2>/dev/null || true; cargo test {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}}
-      - task: core:test
     vars:
       ARGS: '{{.ARGS | default "--all-targets --locked --all-features"}}'
 
@@ -349,7 +348,6 @@ tasks:
       - task: test:coverage
         vars:
           ARGS: "--all-targets --locked --all-features"
-      - task: core:test
 
   core:test:
     desc: "Run core end to end tests"


### PR DESCRIPTION
Keep the PR pipeline to fast, deterministic checks; run the heavy/flaky integration and e2e suites nightly.

**Coverage** — remove the duplicate `test-coverage` gate (llvm-cov ran twice per PR). `ci-publish-project-coverage` is the single run, now `continue-on-error` + Codecov `fail_ci_if_error: false` → informational, can't block a merge.

**Cross-build** — profile/arch are inputs; PRs build **debug for the native arch only** (x86_64, one job). Release builds are workspace-crate-bound (rust-cache doesn't cache workspace crates), so they move to nightly (full arch matrix).

**E2E / integration** — the session e2e (`core:test` = group + point-to-point) ran on every PR three ways (`task test`, `coverage-full`, and the `ci-integration-tests` workflow) — triple exposure to the same flaky session tests (`test_group`/`test_p2p`, `MessageSendRetryFailed`). Dropped `core:test` from `task test`/`coverage-full` and folded the integration + sessions jobs into a consolidated **`ci-nightly`** workflow (deleting `ci-integration-tests`).

PRs now gate on: lint, unit + control-plane cargo tests, wasm, one native debug cross-build, docker. Integration/e2e + release run nightly (+ manual dispatch) and via the `release-*` pipeline before shipping.

⚠️ **Branch protection:** the `integration-tests` and `sessions-test` checks no longer run on PRs — remove them from required status checks, or PRs will wait on checks that never report.

actionlint clean; workflows + Taskfile parse.