### PR TITLE
ci: move coverage and benchmark off the PR path

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,15 +4,32 @@
 ---
 name: benchmark
 
+# Runs nightly (via ci-nightly, which calls this workflow) and on manual
+# dispatch. Not a PR gate: there is no regression comparison, so per-PR runs
+# produced no actionable signal while costing a runner on every PR.
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/benchmark.yaml'
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'scripts/run-benchmark.sh'
-      - 'scripts/flamegraph-profile.sh'
+  workflow_call:
+    inputs:
+      senders:
+        description: 'Comma-separated sender counts'
+        required: false
+        default: '1,2,4,8'
+        type: string
+      messages:
+        description: 'Messages per sender'
+        required: false
+        default: '1000000'
+        type: string
+      payload-sizes:
+        description: 'Comma-separated payload sizes in bytes'
+        required: false
+        default: '8,16,64,256,1024,4096'
+        type: string
+      runs:
+        description: 'Repetitions per configuration'
+        required: false
+        default: '3'
+        type: string
   workflow_dispatch:
     inputs:
       senders:
@@ -38,7 +55,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   benchmark:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,16 +4,13 @@
 ---
 name: ci-publish-project-coverage
 
+# Coverage is informational (continue-on-error + fail_ci_if_error: false) and
+# cannot gate a PR, so it runs only post-merge on main to track the trend
+# without burning a runner on every PR. Nightly/manual coverage is unnecessary
+# since main is the tracked baseline.
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs-ci.yaml'
-      - '.github/workflows/docs-deploy.yml'
-      - '.github/workflows/reusable-docs.yml'
 
 jobs:
   coverage:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,6 +30,10 @@ jobs:
       rust-cross-build-profiles: '["release"]'
       rust-cross-build-arches: '["aarch64","x86_64"]'
 
+  benchmark:
+    name: Data plane benchmark
+    uses: ./.github/workflows/benchmark.yaml
+
   integration-tests:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Both jobs ran on every PR without gating it:

- **coverage** is informational (`continue-on-error` + `fail_ci_if_error: false`) so it can't block a merge. Now runs post-merge on `main` only, still tracking the trend.
- **benchmark** has no regression comparison, so per-PR runs gave no actionable signal. Now a reusable workflow called nightly by `ci-nightly` (manual `workflow_dispatch` kept).

Frees two runners per PR; drops nothing from the merge gate (ruleset gates on review, not status checks). actionlint clean.