### PR TITLE
ci: move wasm test suites off the PR path to nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,11 @@ jobs:
   build-and-test:
     name: Build & test
     uses: ./.github/workflows/reusable-rust-build-and-test.yaml
+    with:
+      # wasm suites run nightly (ci-nightly): the browser suite is flaky
+      # (headless Chrome) and neither is on the PR critical path.
+      rust-test-wasm: false
+      rust-test-wasm-browser: false
 
   docker-build:
     name: Build SLIM docker image

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,15 +17,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release-cross-build:
-    name: Nightly release build
+  build-and-wasm:
+    name: Nightly release build + wasm
     uses: ./.github/workflows/reusable-rust-build-and-test.yaml
     with:
       rust-lint: true
       rust-vuln: false
       rust-test: false
-      rust-test-wasm: false
-      rust-test-wasm-browser: false
+      # wasm suites moved off the PR path; the wasm jobs need the lint job,
+      # so they share this call's single lint run.
+      rust-test-wasm: true
+      rust-test-wasm-browser: true
       rust-cross-build: true
       rust-cross-build-profiles: '["release"]'
       rust-cross-build-arches: '["aarch64","x86_64"]'


### PR DESCRIPTION
`wasm-test` (node) and `wasm-browser-test` (headless Chrome) ran on every PR. The browser suite is flaky and neither is on the PR critical path — both finish well before `build-and-test`/docker. They now run nightly via `ci-nightly`, sharing its existing lint job (the wasm jobs depend on `lint`).

Tradeoff: wasm build validation moves from PR-time to nightly. Frees two runners per PR and removes a flake source; PR wall-clock is unchanged (still bounded by docker + unittest-matrix). actionlint clean.