### PR TITLE
ci: drop benchmark concurrency block that breaks the nightly reusable call

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -53,10 +53,6 @@ on:
         default: '3'
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   benchmark:
     name: Data plane benchmark


### PR DESCRIPTION
The manual nightly run [failed](https://github.com/agntcy/slim/actions/runs/29349471997) with no `benchmark` job created.

`benchmark.yaml` became a reusable workflow in #1840 but kept its top-level `concurrency` block. When `ci-nightly` calls it, `github.workflow` resolves to the **caller**, so the group becomes `ci-nightly-refs/heads/main` — identical to ci-nightly's own group. GitHub rejects a reusable workflow whose concurrency group collides with its caller, so the call failed before creating a job and failed the whole run.

The block was only needed for the old PR trigger. Removing it; the caller's concurrency governs the scheduled run. actionlint clean.