### PR TITLE
ci: disable docker build on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,8 @@ jobs:
   docker-build:
     name: Build SLIM docker image
     uses: ./.github/workflows/reusable-docker-build-push.yaml
+    # Run only on pushes to main, not on PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     with:
       bake-targets: slim
       image-tag: ${{ github.sha }}

--- a/.github/workflows/reusable-rust-build-and-test.yaml
+++ b/.github/workflows/reusable-rust-build-and-test.yaml
@@ -106,7 +106,6 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
     if: ${{ inputs.rust-test }}
-    needs: [lint]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -152,7 +151,6 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
     if: ${{ inputs.rust-test-wasm }}
-    needs: [lint]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -205,7 +203,6 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
     if: ${{ inputs.rust-test-wasm-browser }}
-    needs: [lint]
 
     timeout-minutes: 30
     steps:
@@ -282,8 +279,6 @@ jobs:
       run:
         shell: bash
         working-directory: ${{ inputs.working-directory }}
-
-    needs: [lint]
 
     if: ${{ inputs.rust-cross-build }}
 


### PR DESCRIPTION
# Description

Run docker build only on push events, not on each PR.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] CI

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
