### PR TITLE
chore: move slim-bindings back to slim core

### DIFF
--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -20,9 +20,10 @@ jobs:
       contents: write
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          name: "${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG"
 
   build-binaries:
     name: "${{ matrix.platform.target }}"

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -96,3 +96,10 @@ name = "agntcy-slim-channel-manager"
 publish = true
 release = true
 changelog_update = true
+
+[[package]]
+name = "agntcy-slim-bindings"
+publish = true
+release = true
+changelog_update = true
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "agntcy-slim-bindings"
+version = "2.0.0-alpha.2"
+dependencies = [
+ "agntcy-slim",
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
+ "agntcy-slim-controller",
+ "agntcy-slim-datapath",
+ "agntcy-slim-service",
+ "agntcy-slim-session",
+ "agntcy-slim-signal",
+ "agntcy-slim-tracing",
+ "agntcy-slim-version",
+ "async-stream",
+ "async-trait",
+ "bincode",
+ "clap",
+ "display-error-chain",
+ "drain",
+ "futures",
+ "futures-timer",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "test-fork",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-test",
+ "tracing",
+ "tracing-test",
+ "uniffi",
+ "uuid",
+]
+
+[[package]]
 name = "agntcy-slim-channel-manager"
 version = "2.0.0-alpha.2"
 dependencies = [
@@ -600,6 +636,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +901,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1034,38 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cast"
@@ -1856,6 +1995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2208,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -3560,6 +3719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4444,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,6 +4514,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -4568,6 +4757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4600,6 +4795,12 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -4678,6 +4879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4752,6 +4959,46 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-fork"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f6630ff809074fa1c60cb3ef18829a2bc9eb81cdaaffc7530082ce8024fecf"
+dependencies = [
+ "test-fork-core",
+ "test-fork-macros",
+]
+
+[[package]]
+name = "test-fork-core"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8597f6b65c2c328b5c1f2f0c0a0f0b77c1d2eaec95ace746438ce1db0e9195e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-fork-macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538d31f35d5795e671f34748cb8541cf6606587a8f3bb61e8214a06eb0545814"
+dependencies = [
+ "syn",
+ "test-fork-core",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -4983,10 +5230,12 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 0.7.15",
 ]
 
@@ -5028,6 +5277,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -5330,6 +5585,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "uniffi"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap 2.14.0",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744fe15bcd3e2b1712a4573a45ce749af19cf28d69027ca5789619014955668c"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,6 +5734,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -5407,6 +5801,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"
@@ -5554,6 +5954,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -5818,6 +6227,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/session",
     "crates/signal",
     "crates/slim",
+    "crates/slim-bindings",
     "crates/slimctl",
     "crates/testing",
     "crates/tracing",
@@ -40,6 +41,7 @@ resolver = "2"
 # Local dependencies
 agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.2" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.11.0" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.2" }
 agntcy-slim-config = { path = "crates/config", version = "0.12.0" }
 agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.2" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.10.0" }
@@ -202,6 +204,7 @@ tracing-subscriber = "0.3.19"
 tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 trait-variant = "0.1"
 twox-hash = "2.1.1"
+uniffi = "0.31.1"
 url = "2.5.0"
 uuid = { version = "1.15.1", features = ["v4"] }
 wasm-bindgen-futures = "0.4"

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "agntcy-slim-bindings"
+version = "2.0.0-alpha.2"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "UniFFI bindings and FFI adapter for SLIM data plane - enables language integrations (Go, Swift, Kotlin, etc.)"
+
+[lib]
+name = "slim_bindings"
+crate-type = ["lib", "staticlib", "cdylib"]
+
+[dependencies]
+agntcy-slim = { workspace = true }
+agntcy-slim-auth = { workspace = true }
+agntcy-slim-config = { workspace = true }
+agntcy-slim-controller = { workspace = true }
+agntcy-slim-datapath = { workspace = true }
+agntcy-slim-service = { workspace = true, features = ["session"] }
+agntcy-slim-session = { workspace = true }
+agntcy-slim-signal = { workspace = true }
+agntcy-slim-tracing = { workspace = true }
+agntcy-slim-version = { workspace = true }
+
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+display-error-chain = { workspace = true }
+drain = { workspace = true }
+futures = { workspace = true }
+futures-timer = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+uniffi = { workspace = true, features = ["cli"] }
+uuid = { workspace = true }
+
+[build-dependencies]
+agntcy-slim-version = { workspace = true }
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+bincode = { workspace = true }
+clap = { workspace = true }
+test-fork = { workspace = true }
+tokio-test = { workspace = true }
+tracing-test = { workspace = true }
+
+[[example]]
+name = "receiver"
+path = "examples/receiver.rs"
+
+[[example]]
+name = "sender"
+path = "examples/sender.rs"

--- a/crates/slim-bindings/build.rs
+++ b/crates/slim-bindings/build.rs
@@ -1,0 +1,8 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    slim_version::build::set_git_sha();
+    slim_version::build::set_build_date();
+    slim_version::build::set_profile();
+}

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -1,0 +1,155 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! # SLIM Receiver App
+//!
+//! This app demonstrates a passive listener that:
+//! 1. Creates a SLIM application with specified identity and shared secret
+//! 2. Waits for an incoming session
+//! 3. Receives messages from that session
+//! 4. Replies to each message using publish_to
+//!
+//! Usage:
+//! ```bash
+//! cargo run --example receiver -- \
+//!   --local agntcy/ns/alice \
+//!   --shared-secret a-very-long-shared-secret-abcdef1234567890
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Parser;
+use slim_bindings::{
+    Name, get_global_service, initialize_with_defaults, new_insecure_client_config, shutdown,
+};
+use tokio::signal;
+
+/// Command-line arguments for the receiver application
+#[derive(Parser, Debug)]
+struct Args {
+    /// Local identity in format: organization/namespace/application
+    #[arg(long)]
+    local: String,
+
+    /// Shared secret for authentication
+    #[arg(long)]
+    shared_secret: String,
+
+    /// SLIM control plane endpoint
+    #[arg(long, default_value = "http://localhost:46357")]
+    slim: String,
+}
+
+/// Parse a name string in format "org/namespace/app" into a Name object
+fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
+    let parts: Vec<&str> = id.split('/').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "Invalid name format '{id}'. Expected format: organization/namespace/application"
+        )
+        .into());
+    }
+
+    Ok(Name::new(
+        parts[0].to_string(),
+        parts[1].to_string(),
+        parts[2].to_string(),
+    ))
+}
+
+/// Main receiver loop
+async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Parse the local identity
+    let local_name = parse_name(&args.local)?;
+    let local_name_arc = Arc::new(local_name);
+
+    // Initialize SLIM with default configuration
+    initialize_with_defaults();
+
+    // Get the global service and connect to the control plane
+    let service = get_global_service();
+    let client_config = new_insecure_client_config(args.slim);
+    let conn_id = service.connect_async(client_config).await?;
+
+    println!("Connected to control plane with connection ID: {conn_id}");
+
+    // Create the slim application using global service with shared secret
+    let app = service
+        .create_app_with_secret_async(local_name_arc.clone(), args.shared_secret)
+        .await?;
+
+    let full_name = app.name();
+
+    // Subscribe to local name
+    app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+
+    println!("[{full_name}] Waiting for incoming session...");
+
+    // Wait for one incoming session (no timeout)
+    let session = app.listen_for_session_async(None).await?;
+
+    let session_id = session.session_id()?;
+    let destination = session.destination()?;
+    println!("[{full_name}] New session {session_id} established from {destination}");
+
+    // Loop to receive messages and reply
+    loop {
+        tokio::select! {
+            result = session.get_message_async(Some(Duration::from_secs(5))) => {
+                match result {
+                    Ok(received_msg) => {
+                        let payload = String::from_utf8_lossy(&received_msg.payload);
+                        let source = &received_msg.context.source_name;
+
+                        println!(
+                            "[{full_name}] Received from {source}: {payload}"
+                        );
+
+                        // Reply to the sender using publish_to
+                        let reply = format!("{payload} from {full_name}");
+                        session
+                            .publish_to_and_wait_async(
+                                received_msg.context,
+                                reply.as_bytes().to_vec(),
+                                None,
+                                None,
+                            )
+                            .await?;
+
+                        println!("[{full_name}] Sent reply: {reply}");
+                    }
+                    Err(e) => {
+                        let error_msg = e.to_string().to_lowercase();
+                        if error_msg.contains("timeout") {
+                            // Timeout is expected, just continue waiting
+                            continue;
+                        } else {
+                            println!("[{full_name}] Error receiving message: {e}");
+                            break;
+                        }
+                    }
+                }
+            },
+            _ = signal::ctrl_c() => {
+                println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
+                break;
+            }
+        }
+    }
+
+    // Cleanup
+    shutdown().await?;
+    println!("[{full_name}] Receiver stopped");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command-line arguments
+    let args = Args::parse();
+
+    // Run the receiver
+    run_receiver(args).await
+}

--- a/crates/slim-bindings/examples/sender.rs
+++ b/crates/slim-bindings/examples/sender.rs
@@ -1,0 +1,305 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! # SLIM Sender App
+//!
+//! This app demonstrates an active sender that:
+//! 1. Creates a SLIM application with specified identity and shared secret
+//! 2. Creates a session (point-to-point or group)
+//! 3. Sends messages at regular intervals
+//! 4. Receives and validates replies from participants
+//!
+//! Usage:
+//! ```bash
+//! # Point-to-point
+//! cargo run --example sender -- \
+//!   --local agntcy/ns/bob \
+//!   --shared-secret a-very-long-shared-secret-abcdef1234567890 \
+//!   --session-type p2p \
+//!   --participants agntcy/ns/alice
+//!
+//! # Group
+//! cargo run --example sender -- \
+//!   --local agntcy/ns/bob \
+//!   --shared-secret a-very-long-shared-secret-abcdef1234567890 \
+//!   --session-type group \
+//!   --participants agntcy/ns/alice agntcy/ns/charlie
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Parser;
+use slim_bindings::{
+    MlsSettings, Name, SessionConfig, SessionType, get_global_service, initialize_with_defaults,
+    new_insecure_client_config, shutdown,
+};
+
+/// Command-line arguments for the sender application
+#[derive(Parser, Debug)]
+struct Args {
+    /// Local identity in format: organization/namespace/application
+    #[arg(long)]
+    local: String,
+
+    /// Shared secret for authentication
+    #[arg(long)]
+    shared_secret: String,
+
+    /// SLIM control plane endpoint
+    #[arg(long, default_value = "http://localhost:46357")]
+    slim: String,
+
+    /// Session type: "p2p" or "group"
+    #[arg(long)]
+    session_type: String,
+
+    /// List of participant identities (format: organization/namespace/application)
+    /// For p2p: exactly 1 participant
+    /// For group: at least 1 participant
+    #[arg(long, required = true, num_args = 1..)]
+    participants: Vec<String>,
+
+    /// Number of messages to send
+    #[arg(long, default_value = "10")]
+    count: usize,
+
+    /// Interval between messages in milliseconds
+    #[arg(long, default_value = "100")]
+    interval_ms: u64,
+}
+
+/// Parse a name string in format "org/namespace/app" into a Name object
+fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
+    let parts: Vec<&str> = id.split('/').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "Invalid name format '{id}'. Expected format: organization/namespace/application"
+        )
+        .into());
+    }
+
+    Ok(Name::new(
+        parts[0].to_string(),
+        parts[1].to_string(),
+        parts[2].to_string(),
+    ))
+}
+
+/// Parse session type from string
+fn parse_session_type(s: &str) -> Result<SessionType, Box<dyn std::error::Error>> {
+    match s.to_lowercase().as_str() {
+        "p2p" | "point-to-point" | "pointtopoint" => Ok(SessionType::PointToPoint),
+        "group" | "multicast" => Ok(SessionType::Group),
+        _ => Err(format!("Invalid session type '{s}'. Expected 'p2p' or 'group'").into()),
+    }
+}
+
+/// Main sender loop
+async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate arguments
+    let session_type = parse_session_type(&args.session_type)?;
+
+    if session_type == SessionType::PointToPoint && args.participants.len() != 1 {
+        return Err("Point-to-point sessions require exactly 1 participant".into());
+    }
+
+    if args.participants.is_empty() {
+        return Err("At least 1 participant is required".into());
+    }
+
+    // Parse the local identity
+    let local_name = parse_name(&args.local)?;
+    let local_name_arc = Arc::new(local_name);
+
+    // Parse participant names
+    let participant_names: Result<Vec<Name>, _> =
+        args.participants.iter().map(|s| parse_name(s)).collect();
+    let participant_names = participant_names?;
+
+    // Initialize SLIM with default configuration
+    initialize_with_defaults();
+
+    // Get the global service and connect to the control plane
+    let service = get_global_service();
+    let client_config = new_insecure_client_config(args.slim);
+    let conn_id = service.connect_async(client_config).await?;
+
+    println!("Connected to control plane with connection ID: {conn_id}");
+
+    // Create the slim application using global service with shared secret
+    let app = service
+        .create_app_with_secret_async(local_name_arc.clone(), args.shared_secret)
+        .await?;
+
+    let full_name = app.name();
+    println!("[{full_name}] Application created");
+
+    // Subscribe to local name
+    app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+
+    // Create session configuration
+    let session_config = SessionConfig {
+        session_type: session_type.clone(),
+        max_retries: Some(5),
+        interval: Some(Duration::from_secs(1)),
+        metadata: HashMap::new(),
+        mls_settings: Some(MlsSettings::default()),
+    };
+
+    // For p2p, destination is the single participant
+    // For group, destination is the group channel name
+    let destination = if session_type == SessionType::Group {
+        Arc::new(parse_name("agntcy/slim/test-app-channel")?)
+    } else {
+        Arc::new(participant_names[0].clone())
+    };
+
+    println!("[{full_name}] Creating {session_type:?} session with destination {destination}...");
+
+    // Set routes for all participants to ensure they can receive the session invite
+    for participant in &participant_names {
+        println!("[{full_name}] Setting route for {participant}");
+        app.set_route_async(Arc::new(participant.clone()), conn_id)
+            .await?;
+    }
+
+    let session_with_completion = app
+        .create_session_async(session_config, destination)
+        .await?;
+
+    // Wait for session establishment
+    session_with_completion.completion.wait_async().await?;
+    let session = session_with_completion.session;
+
+    let session_id = session.session_id()?;
+    println!("[{full_name}] Session {session_id} established");
+
+    // For group sessions, invite all participants
+    if session_type == SessionType::Group {
+        for participant in &participant_names {
+            println!("[{full_name}] Inviting {participant} to session...");
+            session
+                .invite_and_wait_async(Arc::new(participant.clone()))
+                .await?;
+            println!("[{full_name}] {participant} joined session");
+        }
+    }
+
+    let interval = Duration::from_millis(args.interval_ms);
+    let expected_replies_per_message = participant_names.len();
+    let total_expected_replies = args.count * expected_replies_per_message;
+
+    println!(
+        "[{}] Sending {} messages with {}ms interval...",
+        full_name, args.count, args.interval_ms
+    );
+
+    // Spawn a background task to collect replies
+    let session_clone = session.clone();
+    let full_name_clone = full_name.clone();
+    let reply_task = tokio::spawn(async move {
+        let mut total_replies_received = 0;
+
+        loop {
+            match session_clone
+                .get_message_async(Some(Duration::from_secs(10)))
+                .await
+            {
+                Ok(received_msg) => {
+                    let payload = String::from_utf8_lossy(&received_msg.payload);
+                    let source = received_msg.context.source_name.to_string();
+
+                    println!("[{full_name_clone}] Reply from {source}: {payload}");
+
+                    total_replies_received += 1;
+
+                    // Stop if we've received all expected replies
+                    if total_replies_received >= total_expected_replies {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let error_msg = e.to_string().to_lowercase();
+                    if error_msg.contains("timeout") {
+                        // Continue waiting
+                        continue;
+                    } else {
+                        println!("[{full_name_clone}] Error receiving reply: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        total_replies_received
+    });
+
+    // Send messages at fixed intervals
+    for i in 0..args.count {
+        let message = format!("Message {}", i + 1);
+        println!("[{full_name}] Sending: {message}");
+
+        if let Err(e) = session
+            .publish_and_wait_async(message.as_bytes().to_vec(), None, None)
+            .await
+        {
+            println!("[{full_name}] Error sending message: {e}");
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+
+    println!("[{full_name}] Finished sending messages, waiting for remaining replies...");
+
+    // Wait for reply collection task to finish or timeout
+    let total_replies_received = tokio::select! {
+        result = reply_task => {
+            match result {
+                Ok(data) => data,
+                Err(e) => {
+                    println!("[{full_name}] Reply collection task error: {e}");
+                    0
+                }
+            }
+        }
+        _ = tokio::time::sleep(Duration::from_secs(30)) => {
+            println!("[{full_name}] Timeout waiting for replies");
+            0
+        }
+    };
+
+    // Summary
+    println!("\n[{full_name}] === Summary ===");
+    println!("[{full_name}] Replies received: {total_replies_received}/{total_expected_replies}");
+
+    if total_replies_received == total_expected_replies {
+        println!("[{full_name}] ✓ All participants replied correctly");
+    } else {
+        println!(
+            "[{}] ✗ Missing {} replies",
+            full_name,
+            total_expected_replies - total_replies_received
+        );
+    }
+
+    // Delete session
+    println!("[{full_name}] Deleting session...");
+    app.delete_session_and_wait_async(session).await?;
+
+    // Cleanup
+    shutdown().await?;
+    println!("[{full_name}] Sender stopped");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command-line arguments
+    let args = Args::parse();
+
+    // Run the sender
+    run_sender(args).await
+}

--- a/crates/slim-bindings/src/app.rs
+++ b/crates/slim-bindings/src/app.rs
@@ -1,0 +1,1529 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! # SLIM Bindings Adapter (UniFFI-Compatible)
+//!
+//! This module provides a language-agnostic FFI interface to SLIM using a hybrid approach
+//! that exposes both synchronous (blocking) and asynchronous versions of operations.
+//!
+//! ## Architecture
+//! - **Flexible Authentication**: Uses `AuthProvider`/`AuthVerifier` enums supporting multiple auth types
+//!   (SharedSecret, JWT, SPIRE, StaticToken) instead of generics (UniFFI requirement)
+//! - **Hybrid API**: Both sync (FFI-exposed) and async (internal) methods
+//! - **Runtime management**: Manages Tokio runtime for blocking operations
+
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, mpsc};
+
+use crate::errors::SlimError;
+use crate::name::Name;
+use crate::{get_global_service, get_runtime};
+
+use crate::session::SessionConfig;
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+
+use crate::identity_config::{IdentityProviderConfig, IdentityVerifierConfig};
+
+use futures_timer::Delay;
+use slim_datapath::api::ProtoName as SlimName;
+use slim_service::Service as SlimService;
+use slim_service::app::App as SlimApp;
+use slim_session::Direction as CoreDirection;
+
+use slim_session::SessionConfig as SlimSessionConfig;
+use slim_session::session_controller::SessionController;
+use slim_session::{Notification, SessionError as SlimSessionError};
+
+/// Direction enum
+/// Indicates whether the App can send, receive, both, or neither.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum Direction {
+    Send,          // Can only send data messages (shutdown_send: false, shutdown_receive: true)
+    Recv,          // Can only receive data messages (shutdown_send: true, shutdown_receive: false)
+    Bidirectional, // Can send and receive data messages (shutdown_send: false, shutdown_receive: false)
+    None, // Neither send nor receive data messages (shutdown_send: true, shutdown_receive: true)
+}
+
+impl From<Direction> for CoreDirection {
+    fn from(direction: Direction) -> Self {
+        match direction {
+            Direction::Send => CoreDirection::Send,
+            Direction::Recv => CoreDirection::Recv,
+            Direction::Bidirectional => CoreDirection::Bidirectional,
+            Direction::None => CoreDirection::None,
+        }
+    }
+}
+
+impl From<CoreDirection> for Direction {
+    fn from(direction: CoreDirection) -> Self {
+        match direction {
+            CoreDirection::Send => Direction::Send,
+            CoreDirection::Recv => Direction::Recv,
+            CoreDirection::Bidirectional => Direction::Bidirectional,
+            CoreDirection::None => Direction::None,
+        }
+    }
+}
+
+// ============================================================================
+// Return Types
+// ============================================================================
+
+/// Result of creating a session, containing the session context and a completion handle
+///
+/// The completion handle should be awaited to ensure the session is fully established.
+#[derive(uniffi::Record)]
+pub struct SessionWithCompletion {
+    /// The session context for performing operations
+    pub session: Arc<crate::Session>,
+    /// Completion handle to wait for session establishment
+    pub completion: Arc<crate::CompletionHandle>,
+}
+
+/// Adapter that bridges the App API with language-bindings interface
+///
+/// This adapter uses enum-based auth types (`AuthProvider`/`AuthVerifier`) instead of generics
+/// to be compatible with UniFFI, supporting multiple authentication mechanisms (SharedSecret,
+/// JWT, SPIRE, StaticToken). It provides both synchronous (blocking) and asynchronous methods
+/// for flexibility.
+#[derive(uniffi::Object)]
+pub struct App {
+    /// The underlying App instance with enum-based auth types (supports SharedSecret, JWT, SPIRE)
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+
+    /// Channel receiver for notifications from the app
+    notification_rx: Arc<RwLock<mpsc::Receiver<Result<Notification, SlimSessionError>>>>,
+
+    /// Service instance for lifecycle management (Arc to inner SlimService)
+    service: Arc<SlimService>,
+}
+
+impl App {
+    /// Internal constructor from parts
+    ///
+    /// Used by Service::create_adapter_async to construct a App from its components.
+    pub(crate) fn from_parts(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        notification_rx: Arc<RwLock<mpsc::Receiver<Result<Notification, SlimSessionError>>>>,
+        service: Arc<SlimService>,
+    ) -> Self {
+        Self {
+            app,
+            notification_rx,
+            service,
+        }
+    }
+
+    /// Get a reference to the core SlimApp instance
+    ///
+    /// This allows direct access to the core SLIM API methods without going through
+    /// the bindings layer. Useful for advanced use cases that need core functionality.
+    ///
+    /// # Note
+    /// This is a public internal method that exposes the core app. Use with caution as it
+    /// bypasses the bindings layer abstractions.
+    pub fn core_app(&self) -> &Arc<SlimApp<AuthProvider, AuthVerifier>> {
+        &self.app
+    }
+
+    /// Get a clone of the inner core SlimApp instance
+    ///
+    /// This is used internally by other bindings modules (like slimrpc) that need
+    /// to interact with the core SLIM app.
+    pub fn inner(&self) -> Arc<SlimApp<AuthProvider, AuthVerifier>> {
+        self.app.clone()
+    }
+
+    /// Async constructor - Create a new App with complete creation logic
+    ///
+    /// This is the recommended entry point for language bindings to avoid nested block_on issues.
+    /// Uses the global service instance.
+    pub async fn new_async(
+        base_name: SlimName,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+    ) -> Result<Self, SlimError> {
+        // Use the global service
+        let service_arc = get_global_service().inner.clone();
+
+        // Delegate to the core creation logic
+        crate::service::create_app_async_internal(
+            base_name,
+            identity_provider_config,
+            identity_verifier_config,
+            service_arc,
+            Direction::Bidirectional,
+        )
+        .await
+    }
+
+    /// Get a reference to the service instance
+    ///
+    /// This provides access to the underlying SLIM service that manages this app.
+    /// Useful for accessing service-level functionality and state.
+    ///
+    /// # Returns
+    /// A reference to the Arc-wrapped SlimService instance
+    pub fn service(&self) -> &Arc<SlimService> {
+        &self.service
+    }
+
+    /// Create a new App with traffic direction (async version)
+    ///
+    /// This is a convenience function for creating a SLIM application with configurable
+    /// traffic direction (send-only, receive-only, bidirectional, or none).
+    /// This is the async version for use in async contexts.
+    ///
+    /// # Arguments
+    /// * `name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    /// * `direction` - Traffic direction for sessions (Send, Recv, Bidirectional, or None)
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created app
+    /// * `Err(SlimError)` - If app creation fails
+    pub async fn new_with_direction_async(
+        name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+        direction: Direction,
+    ) -> Result<Arc<App>, SlimError> {
+        // Delegate to the global service's async create_app_with_direction method
+        get_global_service()
+            .create_app_with_direction_async(
+                name,
+                identity_provider_config,
+                identity_verifier_config,
+                direction,
+            )
+            .await
+    }
+
+    /// Create a new App with SharedSecret authentication (async version)
+    ///
+    /// This is a convenience function for creating a SLIM application using SharedSecret authentication.
+    /// This is the async version for use in async contexts.
+    ///
+    /// # Arguments
+    /// * `name` - The base name for the app (without ID)
+    /// * `secret` - The shared secret string for authentication
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    pub async fn new_with_secret_async(
+        name: Arc<Name>,
+        secret: String,
+    ) -> Result<Arc<App>, SlimError> {
+        // Delegate to the global service's async create_app_with_secret method
+        get_global_service()
+            .create_app_with_secret_async(name, secret)
+            .await
+    }
+}
+
+#[uniffi::export]
+impl App {
+    /// Create a new App with identity provider and verifier configurations
+    ///
+    /// This is the main entry point for creating a SLIM application from language bindings.
+    ///
+    /// # Arguments
+    /// * `base_name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    ///
+    /// # Supported Identity Types
+    /// - SharedSecret: Symmetric key authentication
+    /// - JWT: Dynamic JWT generation/verification with signing/decoding keys
+    /// - StaticJWT: Static JWT loaded from file with auto-reload
+    #[uniffi::constructor]
+    pub fn new(
+        base_name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+    ) -> Result<Arc<Self>, SlimError> {
+        crate::config::get_runtime().block_on(async {
+            Self::new_async(
+                base_name.as_ref().into(),
+                identity_provider_config,
+                identity_verifier_config,
+            )
+            .await
+            .map(Arc::new)
+        })
+    }
+
+    /// Create a new App with traffic direction (blocking version)
+    ///
+    /// This is a convenience function for creating a SLIM application with configurable
+    /// traffic direction (send-only, receive-only, bidirectional, or none).
+    ///
+    /// # Arguments
+    /// * `name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    /// * `direction` - Traffic direction for sessions (Send, Recv, Bidirectional, or None)
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created app
+    /// * `Err(SlimError)` - If app creation fails
+    #[uniffi::constructor]
+    pub fn new_with_direction(
+        name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+        direction: Direction,
+    ) -> Result<Arc<App>, SlimError> {
+        // Delegate to the global service's blocking method
+        get_global_service().create_app_with_direction(
+            name,
+            identity_provider_config,
+            identity_verifier_config,
+            direction,
+        )
+    }
+
+    /// Create a new App with SharedSecret authentication (blocking version)
+    ///
+    /// This is a convenience function for creating a SLIM application using SharedSecret authentication.
+    ///
+    /// # Arguments
+    /// * `name` - The base name for the app (without ID)
+    /// * `secret` - The shared secret string for authentication
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    #[uniffi::constructor]
+    pub fn new_with_secret(name: Arc<Name>, secret: String) -> Result<Arc<App>, SlimError> {
+        // Delegate to the global service's blocking method
+        get_global_service().create_app_with_secret(name, secret)
+    }
+
+    /// Get the app ID in UUID format
+    pub fn id(&self) -> String {
+        self.app.app_name().string_id()
+    }
+
+    /// Get the app name
+    pub fn name(&self) -> Arc<Name> {
+        Arc::new(self.app.app_name().into())
+    }
+
+    /// Create a new session (blocking version for FFI)
+    ///
+    /// Returns a SessionWithCompletion containing the session context and a completion handle.
+    /// Call `.wait()` on the completion handle to wait for session establishment.
+    pub fn create_session(
+        &self,
+        config: SessionConfig,
+        destination: Arc<Name>,
+    ) -> Result<SessionWithCompletion, SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.create_session_async(config, destination).await })
+    }
+
+    /// Create a new session (async version)
+    ///
+    /// Returns a SessionWithCompletion containing the session context and a completion handle.
+    /// Await the completion handle to wait for session establishment.
+    /// For point-to-point sessions, this ensures the remote peer has acknowledged the session.
+    /// For multicast sessions, this ensures the initial setup is complete.
+    pub async fn create_session_async(
+        &self,
+        config: SessionConfig,
+        destination: Arc<Name>,
+    ) -> Result<SessionWithCompletion, SlimError> {
+        let slim_config: SlimSessionConfig = config.into();
+        let slim_dest: SlimName = destination.as_ref().into();
+        let app = self.app.clone();
+        let runtime = get_runtime();
+
+        // Spawn on the runtime's handle to ensure tokio context is available
+        let handle =
+            runtime.spawn(async move { app.create_session(slim_config, slim_dest, None).await });
+
+        let (session_ctx, completion) = handle.await.map_err(|e| SlimError::SessionError {
+            message: format!("Failed to create session: {e}"),
+        })??;
+
+        // Create Session and CompletionHandle
+        let bindings_ctx = Arc::new(crate::Session::new(session_ctx));
+        let completion_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        Ok(SessionWithCompletion {
+            session: bindings_ctx,
+            completion: completion_handle,
+        })
+    }
+
+    /// Create a new session and wait for completion (blocking version)
+    ///
+    /// This method creates a session and blocks until the session establishment completes.
+    /// Returns only the session context, as the completion has already been awaited.
+    pub fn create_session_and_wait(
+        &self,
+        config: SessionConfig,
+        destination: Arc<Name>,
+    ) -> Result<Arc<crate::Session>, SlimError> {
+        crate::config::get_runtime().block_on(async {
+            self.create_session_and_wait_async(config, destination)
+                .await
+        })
+    }
+
+    /// Create a new session and wait for completion (async version)
+    ///
+    /// This method creates a session and waits until the session establishment completes.
+    /// Returns only the session context, as the completion has already been awaited.
+    pub async fn create_session_and_wait_async(
+        &self,
+        config: SessionConfig,
+        destination: Arc<Name>,
+    ) -> Result<Arc<crate::Session>, SlimError> {
+        let session_with_completion = self.create_session_async(config, destination).await?;
+        session_with_completion.completion.wait_async().await?;
+        Ok(session_with_completion.session)
+    }
+
+    /// Delete a session (blocking version for FFI)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the deletion completes.
+    pub fn delete_session(
+        &self,
+        session: Arc<crate::Session>,
+    ) -> Result<Arc<crate::CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.delete_session_async(session).await })
+    }
+
+    /// Delete a session (async version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the deletion completes.
+    pub async fn delete_session_async(
+        &self,
+        session: Arc<crate::Session>,
+    ) -> Result<Arc<crate::CompletionHandle>, SlimError> {
+        let session_ref = session
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        let completion = self.app.delete_session(&session_ref)?;
+
+        // Return completion handle for caller to wait on
+        Ok(Arc::new(crate::CompletionHandle::from(completion)))
+    }
+
+    /// Delete a session and wait for completion (blocking version)
+    ///
+    /// This method deletes a session and blocks until the deletion completes.
+    pub fn delete_session_and_wait(&self, session: Arc<crate::Session>) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.delete_session_and_wait_async(session).await })
+    }
+
+    /// Delete a session and wait for completion (async version)
+    ///
+    /// This method deletes a session and waits until the deletion completes.
+    pub async fn delete_session_and_wait_async(
+        &self,
+        session: Arc<crate::Session>,
+    ) -> Result<(), SlimError> {
+        let completion_handle = self.delete_session_async(session).await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Subscribe to a session name (blocking version for FFI)
+    pub fn subscribe(&self, name: Arc<Name>, connection_id: Option<u64>) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.subscribe_async(name, connection_id).await })
+    }
+
+    /// Subscribe to a name (async version)
+    pub async fn subscribe_async(
+        &self,
+        name: Arc<Name>,
+        connection_id: Option<u64>,
+    ) -> Result<(), SlimError> {
+        let slim_name: SlimName = name.as_ref().into();
+        self.app.subscribe(&slim_name, connection_id).await?;
+        Ok(())
+    }
+
+    /// Unsubscribe from a name (blocking version for FFI)
+    pub fn unsubscribe(
+        &self,
+        name: Arc<Name>,
+        connection_id: Option<u64>,
+    ) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.unsubscribe_async(name, connection_id).await })
+    }
+
+    /// Unsubscribe from a name (async version)
+    pub async fn unsubscribe_async(
+        &self,
+        name: Arc<Name>,
+        connection_id: Option<u64>,
+    ) -> Result<(), SlimError> {
+        let slim_name: SlimName = name.as_ref().into();
+        self.app.unsubscribe(&slim_name, connection_id).await?;
+        Ok(())
+    }
+
+    /// Set a route to a name for a specific connection (blocking version for FFI)
+    pub fn set_route(&self, name: Arc<Name>, connection_id: u64) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.set_route_async(name, connection_id).await })
+    }
+
+    /// Set a route to a name for a specific connection (async version)
+    pub async fn set_route_async(
+        &self,
+        name: Arc<Name>,
+        connection_id: u64,
+    ) -> Result<(), SlimError> {
+        let slim_name: SlimName = name.as_ref().into();
+        self.app.set_route(&slim_name, connection_id).await?;
+        Ok(())
+    }
+
+    /// Remove a route (blocking version for FFI)
+    pub fn remove_route(&self, name: Arc<Name>, connection_id: u64) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.remove_route_async(name, connection_id).await })
+    }
+
+    /// Remove a route (async version)
+    pub async fn remove_route_async(
+        &self,
+        name: Arc<Name>,
+        connection_id: u64,
+    ) -> Result<(), SlimError> {
+        let slim_name: SlimName = name.as_ref().into();
+        self.app.remove_route(&slim_name, connection_id).await?;
+        Ok(())
+    }
+
+    /// Listen for incoming sessions (blocking version for FFI)
+    pub fn listen_for_session(
+        &self,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<Arc<crate::Session>, SlimError> {
+        crate::get_runtime().block_on(async { self.listen_for_session_async(timeout).await })
+    }
+
+    /// Listen for incoming sessions (async version)
+    pub async fn listen_for_session_async(
+        &self,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<Arc<crate::Session>, SlimError> {
+        let mut rx = self.notification_rx.write().await;
+
+        let recv_fut = rx.recv();
+        let notification_opt = if let Some(dur) = timeout {
+            // Runtime-agnostic timeout using futures-timer
+            futures::pin_mut!(recv_fut);
+            let delay = Delay::new(dur);
+            futures::pin_mut!(delay);
+
+            match futures::future::select(recv_fut, delay).await {
+                futures::future::Either::Left((result, _)) => result,
+                futures::future::Either::Right(_) => {
+                    return Err(SlimError::ReceiveError {
+                        message: "listen_for_session timed out".to_string(),
+                    });
+                }
+            }
+        } else {
+            recv_fut.await
+        };
+
+        if notification_opt.is_none() {
+            return Err(SlimError::ReceiveError {
+                message: "application channel closed".to_string(),
+            });
+        }
+
+        match notification_opt.unwrap() {
+            Ok(Notification::NewSession(ctx)) => Ok(Arc::new(crate::Session::new(ctx))),
+            Ok(Notification::NewMessage(_)) => Err(SlimError::ReceiveError {
+                message: "received unexpected message notification while listening for session"
+                    .to_string(),
+            }),
+            Err(e) => Err(SlimError::ReceiveError {
+                message: format!("failed to receive session notification: {e}"),
+            }),
+        }
+    }
+}
+
+// Non-UniFFI methods for internal use (slimrpc)
+impl App {
+    /// Get reference to internal app for advanced use cases (slimrpc)
+    pub fn inner_app(&self) -> &Arc<SlimApp<AuthProvider, AuthVerifier>> {
+        &self.app
+    }
+
+    /// Get notification receiver for server use (slimrpc)
+    pub fn notification_receiver(
+        &self,
+    ) -> Arc<RwLock<mpsc::Receiver<Result<Notification, SlimSessionError>>>> {
+        self.notification_rx.clone()
+    }
+}
+
+// ============================================================================
+// Internal methods for PyO3 bindings (not exported through UniFFI)
+// ============================================================================
+
+impl App {
+    /// Create a new session returning internal Session (for PyO3 bindings)
+    ///
+    /// This method is for Python bindings to bypass the FFI layer and get
+    /// a proper Session with its CompletionHandle.
+    pub async fn create_session_internal(
+        &self,
+        config: SlimSessionConfig,
+        destination: SlimName,
+    ) -> Result<
+        (
+            slim_session::context::SessionContext,
+            slim_session::CompletionHandle,
+        ),
+        SlimError,
+    > {
+        let (session_ctx, completion) = self.app.create_session(config, destination, None).await?;
+
+        Ok((session_ctx, completion))
+    }
+
+    /// Listen for incoming sessions returning internal Session (for PyO3 bindings)
+    pub async fn listen_for_session_internal(
+        &self,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<slim_session::context::SessionContext, SlimError> {
+        let mut rx = self.notification_rx.write().await;
+
+        let recv_fut = rx.recv();
+        let notification_opt = if let Some(dur) = timeout {
+            // Runtime-agnostic timeout using futures-timer
+            futures::pin_mut!(recv_fut);
+            let delay = Delay::new(dur);
+            futures::pin_mut!(delay);
+
+            match futures::future::select(recv_fut, delay).await {
+                futures::future::Either::Left((result, _)) => result,
+                futures::future::Either::Right(_) => {
+                    return Err(SlimError::ReceiveError {
+                        message: "listen_for_session timed out".to_string(),
+                    });
+                }
+            }
+        } else {
+            recv_fut.await
+        };
+
+        if notification_opt.is_none() {
+            return Err(SlimError::ReceiveError {
+                message: "application channel closed".to_string(),
+            });
+        }
+
+        match notification_opt.unwrap() {
+            Ok(Notification::NewSession(ctx)) => Ok(ctx),
+            Ok(Notification::NewMessage(_)) => Err(SlimError::ReceiveError {
+                message: "received unexpected message notification while listening for session"
+                    .to_string(),
+            }),
+            Err(e) => Err(SlimError::ReceiveError {
+                message: format!("failed to receive session notification: {e}"),
+            }),
+        }
+    }
+
+    /// Delete a session returning CompletionHandle (for PyO3 bindings)
+    ///
+    /// This method is for Python bindings to get the CompletionHandle when deleting a session.
+    pub fn delete_session_internal(
+        &self,
+        session: &SessionController,
+    ) -> Result<slim_session::CompletionHandle, SlimError> {
+        let ret = self.app.delete_session(session)?;
+
+        Ok(ret)
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use crate::SessionType;
+
+    use super::*;
+
+    use slim_config::component::ComponentBuilder;
+    use slim_datapath::api::ProtoName as SlimName;
+
+    const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+    // Helper to create test identity configs
+    fn create_test_configs(secret: &str) -> (IdentityProviderConfig, IdentityVerifierConfig) {
+        (
+            IdentityProviderConfig::SharedSecret {
+                id: "test-service".to_string(),
+                data: secret.to_string(),
+            },
+            IdentityVerifierConfig::SharedSecret {
+                id: "test-service".to_string(),
+                data: secret.to_string(),
+            },
+        )
+    }
+
+    /// Test basic adapter creation
+    #[tokio::test]
+    async fn test_adapter_creation() {
+        let base_name = SlimName::from_strings(["org", "namespace", "test-app"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let result = App::new_async(base_name, provider_config, verifier_config).await;
+        assert!(result.is_ok());
+
+        let adapter = result.unwrap();
+        assert!(!adapter.id().is_empty());
+    }
+
+    /// Test that adapter ID is consistently derived from its internal provider's token ID
+    #[tokio::test]
+    async fn test_deterministic_id_generation() {
+        let base_name = SlimName::from_strings(["org", "namespace", "test-app"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        // Create the adapter
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        // The adapter's ID should be non-zero (derived from token ID hash)
+        let adapter_id = adapter.id();
+        assert!(!adapter_id.is_empty(), "Adapter ID should not be empty");
+
+        // Verify the adapter's name includes the ID
+        let adapter_name = adapter.name();
+        assert_eq!(
+            adapter_name.id(),
+            adapter_id,
+            "Name ID should match adapter ID"
+        );
+    }
+
+    /// Test that session creation auto-waits for establishment
+    #[tokio::test]
+    async fn test_session_creation_auto_wait() {
+        // This test verifies that create_session_async properly awaits the completion handle
+        // In a real scenario, this would ensure the session is fully established
+
+        let base_name = SlimName::from_strings(["org", "namespace", "create-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        let session_config = SessionConfig {
+            session_type: SessionType::PointToPoint,
+            max_retries: Some(3),
+            interval: Some(std::time::Duration::from_millis(100)),
+            metadata: std::collections::HashMap::new(),
+            mls_settings: None,
+        };
+
+        let destination = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            "dest".to_string(),
+        ));
+
+        // This should auto-wait for session establishment
+        // If it returns without error, the session is fully established
+        let result = adapter
+            .create_session_async(session_config, destination)
+            .await;
+
+        // In a real scenario with network, this would verify the session is ready
+        // For this test, we just verify it completes without panicking
+        match result {
+            Ok(_session) => {
+                // Session created and auto-waited successfully
+            }
+            Err(e) => {
+                // Expected to fail in test environment without network
+                // but shouldn't panic
+                println!("Expected error in test environment: {e:?}");
+            }
+        }
+    }
+
+    /// Test publish_with_completion returns a valid completion handle
+    #[tokio::test]
+    async fn test_publish_with_completion_returns_handle() {
+        // Note: This is a structural test - in a real environment with connections,
+        // the completion handle would actually track message delivery
+
+        let base_name = SlimName::from_strings(["org", "namespace", "publish-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        let session_config = SessionConfig {
+            session_type: SessionType::PointToPoint,
+            max_retries: Some(3),
+            interval: Some(std::time::Duration::from_millis(100)),
+            metadata: std::collections::HashMap::new(),
+            mls_settings: None,
+        };
+
+        let destination = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            "dest".to_string(),
+        ));
+
+        // Try to create a session (may fail without network)
+        if let Ok(session) = adapter
+            .create_session_async(session_config, destination)
+            .await
+        {
+            let data = b"test message".to_vec();
+
+            // Attempt to publish (always returns completion handle)
+            // This verifies the API exists and returns the right type
+            let result = session.session.publish_async(data, None, None).await;
+
+            match result {
+                Ok(completion_handle) => {
+                    // Verify we got a completion handle
+                    // In a real scenario, we could wait on it
+                    assert!(Arc::strong_count(&completion_handle) > 0);
+                }
+                Err(e) => {
+                    // Expected to fail without actual connections
+                    println!("Expected error without network: {e:?}");
+                }
+            }
+        }
+    }
+
+    // ========================================================================
+    // TlsConfig Tests
+    // ========================================================================
+
+    /// Test TlsConfig with all fields
+    #[test]
+    fn test_tls_config_full() {
+        use crate::common_config::TlsClientConfig;
+
+        let config = TlsClientConfig {
+            insecure: false,
+            insecure_skip_verify: false,
+            source: crate::common_config::TlsSource::File {
+                cert: "test-cert.pem".to_string(),
+                key: "test-key.pem".to_string(),
+            },
+            ca_source: crate::common_config::CaSource::File {
+                path: "test-ca.pem".to_string(),
+            },
+            include_system_ca_certs_pool: true,
+            tls_version: "tls1.3".to_string(),
+        };
+
+        assert!(!config.insecure);
+        assert!(!config.insecure_skip_verify);
+        assert!(matches!(
+            config.source,
+            crate::common_config::TlsSource::File { .. }
+        ));
+        assert!(matches!(
+            config.ca_source,
+            crate::common_config::CaSource::File { .. }
+        ));
+        assert_eq!(config.tls_version, "tls1.3");
+        assert!(config.include_system_ca_certs_pool);
+    }
+
+    /// Test TlsConfig with insecure mode
+    #[test]
+    fn test_tls_config_insecure() {
+        use crate::common_config::TlsClientConfig;
+
+        let config = TlsClientConfig {
+            insecure: true,
+            insecure_skip_verify: false,
+            source: crate::common_config::TlsSource::None,
+            ca_source: crate::common_config::CaSource::None,
+            include_system_ca_certs_pool: true,
+            tls_version: "tls1.3".to_string(),
+        };
+
+        assert!(config.insecure);
+        assert!(matches!(
+            config.source,
+            crate::common_config::TlsSource::None
+        ));
+    }
+
+    // ========================================================================
+    // Adapter Methods Tests
+    // ========================================================================
+
+    /// Test adapter id() and name() methods
+    #[tokio::test]
+    async fn test_adapter_id_and_name() {
+        let base_name = SlimName::from_strings(["org", "namespace", "id-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name.clone(), provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        // ID should be non-empty
+        let id = adapter.id();
+        assert!(!id.is_empty(), "Adapter ID should not be empty");
+
+        // Name should have the right components
+        let name = adapter.name();
+        assert_eq!(name.components()[0], "org");
+        assert_eq!(name.components()[1], "namespace");
+        assert_eq!(name.components()[2], "id-test");
+        assert!(!name.id().is_empty());
+    }
+
+    /// Test adapter with local service
+    /// Test adapter with global service
+    #[tokio::test]
+    async fn test_adapter_with_global_service() {
+        let base_name = SlimName::from_strings(["org", "namespace", "global-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let result = App::new_async(base_name, provider_config, verifier_config).await;
+        assert!(result.is_ok(), "Should create adapter with global service");
+    }
+
+    /// Test adapter creation with different namespace values
+    #[tokio::test]
+    async fn test_adapter_different_namespaces() {
+        // Test with different valid namespace configurations
+        let namespaces = [
+            ["org1", "namespace1", "app1"],
+            ["company", "team", "service"],
+            ["prod", "api", "gateway"],
+        ];
+
+        for ns in namespaces {
+            let base_name = SlimName::from_strings(ns);
+            let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+            let result = App::new_async(base_name, provider_config, verifier_config).await;
+            assert!(result.is_ok(), "Should create adapter for namespace {ns:?}");
+        }
+    }
+
+    // ========================================================================
+    // initialize_crypto_provider Tests
+    // ========================================================================
+    // App::new Tests
+    // ========================================================================
+
+    /// Test App::new_async entry point
+    #[tokio::test]
+    async fn test_bindings_adapter_new() {
+        let base_name = SlimName::from_strings(["org", "namespace", "ffi-app"]);
+
+        let provider_config = IdentityProviderConfig::SharedSecret {
+            id: "test-sync-service".to_string(),
+            data: TEST_VALID_SECRET.to_string(),
+        };
+        let verifier_config = IdentityVerifierConfig::SharedSecret {
+            id: "test-sync-service".to_string(),
+            data: TEST_VALID_SECRET.to_string(),
+        };
+
+        let result = App::new_async(base_name, provider_config, verifier_config).await;
+        assert!(result.is_ok(), "App::new_async should succeed");
+
+        let adapter = result.unwrap();
+        assert!(!adapter.id().is_empty(), "Adapter ID should not be empty");
+
+        let name = adapter.name();
+        assert_eq!(name.components()[0], "org");
+        assert_eq!(name.components()[1], "namespace");
+        assert_eq!(name.components()[2], "ffi-app");
+    }
+
+    /// Test App::new_async with minimal name (3 components)
+    #[tokio::test]
+    async fn test_bindings_adapter_new_minimal_name() {
+        let base_name = SlimName::from_strings(["org", "ns", "test-app"]);
+
+        let provider_config = IdentityProviderConfig::SharedSecret {
+            id: "test-minimal-service".to_string(),
+            data: TEST_VALID_SECRET.to_string(),
+        };
+        let verifier_config = IdentityVerifierConfig::SharedSecret {
+            id: "test-minimal-service".to_string(),
+            data: TEST_VALID_SECRET.to_string(),
+        };
+
+        let result = App::new_async(base_name, provider_config, verifier_config).await;
+        // Should handle minimal name
+        assert!(result.is_ok(), "Should create adapter with minimal name");
+    }
+
+    // ========================================================================
+    // Listen for Session Timeout Tests
+    // ========================================================================
+
+    /// Test listen_for_session with timeout
+    #[tokio::test]
+    async fn test_listen_for_session_timeout() {
+        let base_name = SlimName::from_strings(["org", "namespace", "listen-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        // Listen with a very short timeout - should timeout
+        let result = adapter
+            .listen_for_session_async(Some(std::time::Duration::from_millis(10)))
+            .await;
+
+        match result {
+            Err(SlimError::ReceiveError { message }) => {
+                assert!(
+                    message.contains("timed out"),
+                    "Should contain timeout message"
+                );
+            }
+            _ => {
+                // May get a different error in some cases, which is fine
+            }
+        }
+    }
+
+    // ========================================================================
+    // Subscribe/Unsubscribe Tests
+    // ========================================================================
+
+    /// Test subscribe and unsubscribe (requires running service)
+    #[tokio::test]
+    async fn test_subscribe_unsubscribe() {
+        let base_name = SlimName::from_strings(["org", "namespace", "sub-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        let target_name = Arc::new(Name::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "target".to_string(),
+        ));
+
+        // Subscribe (may fail without connection, but shouldn't panic)
+        let sub_result = adapter.subscribe_async(target_name.clone(), None).await;
+        // We don't assert success because there's no active connection
+
+        // Unsubscribe
+        let unsub_result = adapter.unsubscribe_async(target_name, None).await;
+        // Same - may fail but shouldn't panic
+
+        let _ = (sub_result, unsub_result);
+    }
+
+    // ========================================================================
+    // Set/Remove Route Tests
+    // ========================================================================
+
+    /// Test set_route and remove_route
+    #[tokio::test]
+    async fn test_set_remove_route() {
+        let base_name = SlimName::from_strings(["org", "namespace", "route-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        let target_name = Arc::new(Name::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "route-target".to_string(),
+        ));
+
+        // Set route (may fail without valid connection_id)
+        let set_result = adapter.set_route_async(target_name.clone(), 12345).await;
+        // Remove route
+        let remove_result = adapter.remove_route_async(target_name, 12345).await;
+
+        // These will likely fail without actual connections, but shouldn't panic
+        let _ = (set_result, remove_result);
+    }
+
+    // ========================================================================
+    // Stop Server Tests
+    // ========================================================================
+
+    /// Test stop_server on non-existent server
+    #[tokio::test]
+    async fn test_stop_server_nonexistent() {
+        let base_name = SlimName::from_strings(["org", "namespace", "stop-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let _adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        // Try to stop a server that doesn't exist using the global service
+        let service = get_global_service();
+        let result = service.stop_server("127.0.0.1:99999".to_string());
+        // Should fail with appropriate error
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Disconnect Tests
+    // ========================================================================
+
+    /// Test disconnect with invalid connection_id
+    #[tokio::test]
+    async fn test_disconnect_invalid_id() {
+        let base_name = SlimName::from_strings(["org", "namespace", "disconnect-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let _adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        // Try to disconnect with an invalid connection ID using the global service
+        let service = get_global_service();
+        let result = service.disconnect(999999);
+        // Should fail but not panic
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Delete Session Tests
+    // ========================================================================
+
+    /// Test delete_session with a session (structural test)
+    #[tokio::test]
+    async fn test_delete_session_flow() {
+        let base_name = SlimName::from_strings(["org", "namespace", "delete-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        let session_config = SessionConfig {
+            session_type: SessionType::PointToPoint,
+            max_retries: Some(1),
+            interval: Some(std::time::Duration::from_millis(50)),
+            metadata: std::collections::HashMap::new(),
+            mls_settings: None,
+        };
+
+        let destination = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            "delete-dest".to_string(),
+        ));
+
+        // Create session (may fail without network)
+        if let Ok(session_with_completion) = adapter
+            .create_session_async(session_config, destination)
+            .await
+        {
+            // Delete session
+            let delete_result = adapter
+                .delete_session_async(session_with_completion.session)
+                .await;
+            // May succeed or fail depending on session state
+            if let Ok(completion) = delete_result {
+                let _ = completion;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Blocking Method Tests
+    // ========================================================================
+
+    /// Test blocking version of listen_for_session
+    #[tokio::test]
+    async fn test_listen_for_session_blocking_timeout() {
+        let base_name = SlimName::from_strings(["org", "namespace", "blocking-listen"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        // Call async version with short timeout (blocking version can't be called from async context)
+        let result = adapter
+            .listen_for_session_async(Some(std::time::Duration::from_millis(10)))
+            .await;
+
+        // Should timeout
+        match result {
+            Err(SlimError::ReceiveError { message }) => {
+                assert!(message.contains("timed out") || message.contains("closed"));
+            }
+            _ => {
+                // Other errors are acceptable too
+            }
+        }
+    }
+
+    /// Test blocking version of subscribe
+    #[tokio::test]
+    async fn test_subscribe_blocking() {
+        let base_name = SlimName::from_strings(["org", "namespace", "blocking-sub"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let adapter = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter");
+
+        let target_name = Arc::new(Name::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "block-target".to_string(),
+        ));
+
+        // Call async version (blocking version can't be called from async context)
+        let _ = adapter.subscribe_async(target_name, None).await;
+    }
+
+    /// Test from_parts internal constructor
+    #[tokio::test]
+    async fn test_from_parts_constructor() {
+        let base_name = SlimName::from_strings(["org", "namespace", "from-parts-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        // First create an adapter normally to get its parts
+        let _adapter1 = App::new_async(
+            base_name.clone(),
+            provider_config.clone(),
+            verifier_config.clone(),
+        )
+        .await
+        .expect("Failed to create adapter");
+
+        // Now create another adapter using the Service's create_adapter_async method
+        // which uses from_parts internally
+        let service = get_global_service();
+        let name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "from-parts-test-2".to_string(),
+        ));
+
+        let adapter2 = service
+            .create_app_async(name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter via service");
+
+        // Verify the adapter created via from_parts works correctly
+        assert!(!adapter2.id().is_empty());
+        assert!(!adapter2.name().to_string().is_empty());
+    }
+
+    /// Test creating app with a custom service using Service::create_app_async
+    #[tokio::test]
+    async fn test_new_async_with_custom_service() {
+        use slim_service::Service as SlimService;
+
+        let base_name = SlimName::from_strings(["org", "namespace", "custom-service-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        // Create a custom service instance
+        let custom_service = SlimService::builder()
+            .build("test-custom-service".to_string())
+            .expect("Failed to create custom service");
+        let service_wrapper = crate::Service {
+            inner: Arc::new(custom_service),
+        };
+
+        // Create adapter with custom service using Service API
+        let base_name_arc = Arc::new(Name::from(base_name));
+        let result = service_wrapper
+            .create_app_async(base_name_arc, provider_config, verifier_config)
+            .await;
+
+        assert!(result.is_ok(), "Should create adapter with custom service");
+        let adapter = result.unwrap();
+        assert!(!adapter.id().is_empty());
+        assert!(!adapter.name().to_string().is_empty());
+    }
+
+    /// Test that new_async uses global service by default
+    #[tokio::test]
+    async fn test_new_async_uses_global_service() {
+        let base_name = SlimName::from_strings(["org", "namespace", "new-async-global"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        // Create two adapters using new_async
+        let adapter1 = App::new_async(
+            base_name.clone(),
+            provider_config.clone(),
+            verifier_config.clone(),
+        )
+        .await
+        .expect("Failed to create first adapter");
+
+        let base_name2 = SlimName::from_strings(["org", "namespace", "new-async-global-2"]);
+        let adapter2 = App::new_async(base_name2, provider_config, verifier_config)
+            .await
+            .expect("Failed to create second adapter");
+
+        // Both should be created successfully (using the same global service)
+        assert!(!adapter1.id().is_empty());
+        assert!(!adapter2.id().is_empty());
+        assert_ne!(
+            adapter1.id(),
+            adapter2.id(),
+            "Different adapters should have different IDs"
+        );
+    }
+
+    /// Test multiple adapters with different custom services
+    /// Test that different service instances create isolated adapters
+    #[tokio::test]
+    async fn test_different_services_create_isolated_adapters() {
+        use slim_service::Service as SlimService;
+
+        let base_name1 = SlimName::from_strings(["org", "namespace", "isolated-1"]);
+        let base_name2 = SlimName::from_strings(["org", "namespace", "isolated-2"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        // Create two different custom services
+        let service1 = SlimService::builder()
+            .build("test-service-1".to_string())
+            .expect("Failed to create service 1");
+        let service1_wrapper = crate::Service {
+            inner: Arc::new(service1),
+        };
+
+        let service2 = SlimService::builder()
+            .build("test-service-2".to_string())
+            .expect("Failed to create service 2");
+        let service2_wrapper = crate::Service {
+            inner: Arc::new(service2),
+        };
+
+        // Create adapters with different services using Service API
+        let base_name1_arc = Arc::new(Name::from(base_name1));
+        let adapter1 = service1_wrapper
+            .create_app_async(
+                base_name1_arc,
+                provider_config.clone(),
+                verifier_config.clone(),
+            )
+            .await
+            .expect("Failed to create adapter 1");
+
+        let base_name2_arc = Arc::new(Name::from(base_name2));
+        let adapter2 = service2_wrapper
+            .create_app_async(base_name2_arc, provider_config, verifier_config)
+            .await
+            .expect("Failed to create adapter 2");
+
+        // Adapters should have different IDs since they're on different services
+        assert_ne!(adapter1.id(), adapter2.id());
+    }
+
+    /// Test new_with_secret_async creates app successfully
+    #[tokio::test]
+    async fn test_new_with_secret_async() {
+        let name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "secret-test".to_string(),
+        ));
+        let secret = TEST_VALID_SECRET.to_string();
+
+        let result = App::new_with_secret_async(name, secret).await;
+
+        assert!(result.is_ok(), "Should create app with secret");
+        let app = result.unwrap();
+        assert!(!app.id().is_empty(), "App should have non-empty ID");
+        assert!(
+            !app.name().to_string().is_empty(),
+            "App should have valid name"
+        );
+    }
+
+    /// Test new_with_secret blocking version
+    #[test]
+    fn test_new_with_secret_blocking() {
+        let name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "secret-blocking-test".to_string(),
+        ));
+        let secret = TEST_VALID_SECRET.to_string();
+
+        // Call blocking version from sync context
+        let result = App::new_with_secret(name, secret);
+
+        assert!(
+            result.is_ok(),
+            "Should create app with secret in blocking mode"
+        );
+        let app = result.unwrap();
+        assert!(!app.id().is_empty(), "App should have empty ID");
+    }
+
+    /// Test new_with_secret creates unique IDs for different apps
+    #[tokio::test]
+    async fn test_new_with_secret_unique_ids() {
+        let secret = TEST_VALID_SECRET.to_string();
+
+        let name1 = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "unique-1".to_string(),
+        ));
+        let name2 = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "unique-2".to_string(),
+        ));
+
+        let app1 = App::new_with_secret_async(name1, secret.clone())
+            .await
+            .expect("Failed to create app1");
+
+        let app2 = App::new_with_secret_async(name2, secret)
+            .await
+            .expect("Failed to create app2");
+
+        assert_ne!(app1.id(), app2.id(), "Apps should have different IDs");
+    }
+
+    /// Test create_session_async runtime spawning
+    #[tokio::test]
+    async fn test_create_session_async_runtime_spawning() {
+        let base_name = SlimName::from_strings(["org", "namespace", "runtime-spawn-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let app = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create app");
+
+        let session_config = SessionConfig {
+            session_type: SessionType::PointToPoint,
+            max_retries: Some(3),
+            interval: Some(std::time::Duration::from_millis(100)),
+            metadata: std::collections::HashMap::new(),
+            mls_settings: None,
+        };
+
+        let destination = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            "spawn-dest".to_string(),
+        ));
+
+        // This should not panic even though it spawns on runtime
+        let result = app.create_session_async(session_config, destination).await;
+
+        // May fail without network, but shouldn't panic from join error
+        let _ = result;
+    }
+
+    /// Test listen_for_session with timeout using futures-timer
+    #[tokio::test]
+    async fn test_listen_for_session_timeout_futures_timer() {
+        let base_name = SlimName::from_strings(["org", "namespace", "listen-timeout-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let app = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create app");
+
+        // Listen with a short timeout - should timeout since no session is incoming
+        let result = app
+            .listen_for_session_async(Some(std::time::Duration::from_millis(50)))
+            .await;
+
+        assert!(result.is_err(), "Should timeout when no session arrives");
+        if let Err(e) = result {
+            let error_msg = format!("{e:?}");
+            assert!(
+                error_msg.contains("timed out") || error_msg.contains("timeout"),
+                "Error should mention timeout"
+            );
+        }
+    }
+
+    /// Test listen_for_session with timeout using futures-timer (second test)
+    #[tokio::test]
+    async fn test_listen_for_session_no_incoming() {
+        let base_name = SlimName::from_strings(["org", "namespace", "no-incoming-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        let app = App::new_async(base_name, provider_config, verifier_config)
+            .await
+            .expect("Failed to create app");
+
+        // Listen with a short timeout when no session is incoming - should timeout
+        let result = app
+            .listen_for_session_async(Some(std::time::Duration::from_millis(30)))
+            .await;
+
+        assert!(result.is_err(), "Should timeout when no session arrives");
+        if let Err(e) = result {
+            let error_msg = format!("{e:?}");
+            assert!(
+                error_msg.contains("timed out") || error_msg.contains("timeout"),
+                "Error should mention timeout"
+            );
+        }
+    }
+
+    /// Test that new_async delegates to service's create_app_async_internal
+    #[tokio::test]
+    async fn test_new_async_uses_internal_creation() {
+        let base_name = SlimName::from_strings(["org", "namespace", "internal-test"]);
+        let (provider_config, verifier_config) = create_test_configs(TEST_VALID_SECRET);
+
+        // This tests that new_async properly delegates to the internal creation function
+        let result = App::new_async(base_name, provider_config, verifier_config).await;
+
+        assert!(result.is_ok(), "Should create app via internal function");
+        let app = result.unwrap();
+        assert!(!app.id().is_empty());
+        assert!(!app.name().to_string().is_empty());
+    }
+}

--- a/crates/slim-bindings/src/build_info.rs
+++ b/crates/slim-bindings/src/build_info.rs
@@ -1,0 +1,87 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+/// Build information for the SLIM bindings
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BuildInfo {
+    /// Semantic version (e.g., "0.7.0")
+    pub version: String,
+    /// Git commit hash (short)
+    pub git_sha: String,
+    /// Build date in ISO 8601 UTC format
+    pub build_date: String,
+    /// Build profile (debug/release)
+    pub profile: String,
+}
+
+/// Get the version of the SLIM bindings (simple string)
+#[uniffi::export]
+pub fn get_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Get detailed build information
+#[uniffi::export]
+pub fn get_build_info() -> BuildInfo {
+    BuildInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git_sha: env!("GIT_SHA").to_string(),
+        build_date: env!("BUILD_DATE").to_string(),
+        profile: env!("PROFILE").to_string(),
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test get_version returns non-empty version string
+    #[test]
+    fn test_get_version() {
+        let version = get_version();
+        assert!(!version.is_empty());
+        // Version should be semver format
+        assert!(
+            version.contains('.'),
+            "Version should contain dot separator"
+        );
+    }
+
+    /// Test get_build_info returns valid build information
+    #[test]
+    fn test_get_build_info() {
+        let info = get_build_info();
+
+        assert!(!info.version.is_empty());
+        assert!(!info.git_sha.is_empty());
+        assert!(!info.build_date.is_empty());
+        assert!(!info.profile.is_empty());
+
+        // Profile should be either debug or release
+        assert!(
+            info.profile == "debug" || info.profile == "release",
+            "Profile should be debug or release, got: {}",
+            info.profile
+        );
+    }
+
+    /// Test BuildInfo clone and debug
+    #[test]
+    fn test_build_info_traits() {
+        let info = get_build_info();
+        let cloned = info.clone();
+
+        assert_eq!(info.version, cloned.version);
+        assert_eq!(info.git_sha, cloned.git_sha);
+        assert_eq!(info.build_date, cloned.build_date);
+        assert_eq!(info.profile, cloned.profile);
+
+        // Debug trait should work
+        let debug_str = format!("{info:?}");
+        assert!(debug_str.contains("BuildInfo"));
+    }
+}

--- a/crates/slim-bindings/src/client_config.rs
+++ b/crates/slim-bindings/src/client_config.rs
@@ -1,0 +1,1120 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use slim_config::grpc::client::ClientConfig as CoreClientConfig;
+use slim_config::grpc::compression::CompressionType as CoreCompressionType;
+use slim_config::grpc::proxy::ProxyConfig as CoreProxyConfig;
+
+use slim_auth::metadata::MetadataMap;
+use slim_config::backoff::exponential::Config as ExponentialBackoffConfig;
+use slim_config::backoff::fixedinterval::Config as FixedIntervalBackoffConfig;
+use slim_config::grpc::client::{
+    BackoffConfig as CoreBackoffConfig, KeepaliveConfig as CoreKeepaliveConfig,
+};
+
+use crate::common_config::{ClientAuthenticationConfig, TlsClientConfig};
+use crate::errors::SlimError;
+
+use slim_config::component::configuration::Configuration;
+
+/// Compression type for gRPC messages
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum CompressionType {
+    Gzip,
+    Zlib,
+    Deflate,
+    Snappy,
+    Zstd,
+    Lz4,
+    None,
+    Empty,
+}
+
+impl From<CompressionType> for CoreCompressionType {
+    fn from(compression: CompressionType) -> Self {
+        match compression {
+            CompressionType::Gzip => CoreCompressionType::Gzip,
+            CompressionType::Zlib => CoreCompressionType::Zlib,
+            CompressionType::Deflate => CoreCompressionType::Deflate,
+            CompressionType::Snappy => CoreCompressionType::Snappy,
+            CompressionType::Zstd => CoreCompressionType::Zstd,
+            CompressionType::Lz4 => CoreCompressionType::Lz4,
+            CompressionType::None => CoreCompressionType::None,
+            CompressionType::Empty => CoreCompressionType::Empty,
+        }
+    }
+}
+
+impl From<CoreCompressionType> for CompressionType {
+    fn from(compression: CoreCompressionType) -> Self {
+        match compression {
+            CoreCompressionType::Gzip => CompressionType::Gzip,
+            CoreCompressionType::Zlib => CompressionType::Zlib,
+            CoreCompressionType::Deflate => CompressionType::Deflate,
+            CoreCompressionType::Snappy => CompressionType::Snappy,
+            CoreCompressionType::Zstd => CompressionType::Zstd,
+            CoreCompressionType::Lz4 => CompressionType::Lz4,
+            CoreCompressionType::None => CompressionType::None,
+            CoreCompressionType::Empty => CompressionType::Empty,
+        }
+    }
+}
+
+/// Keepalive configuration for the client
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct KeepaliveConfig {
+    /// TCP keepalive duration
+    pub tcp_keepalive: Duration,
+    /// HTTP2 keepalive duration
+    pub http2_keepalive: Duration,
+    /// Keepalive timeout
+    pub timeout: Duration,
+    /// Whether to permit keepalive without an active stream
+    pub keep_alive_while_idle: bool,
+}
+
+impl Default for KeepaliveConfig {
+    fn default() -> Self {
+        let core_defaults = CoreKeepaliveConfig::default();
+        KeepaliveConfig {
+            tcp_keepalive: *core_defaults.tcp_keepalive,
+            http2_keepalive: *core_defaults.http2_keepalive,
+            timeout: *core_defaults.timeout,
+            keep_alive_while_idle: core_defaults.keep_alive_while_idle,
+        }
+    }
+}
+
+impl From<KeepaliveConfig> for CoreKeepaliveConfig {
+    fn from(config: KeepaliveConfig) -> Self {
+        CoreKeepaliveConfig {
+            tcp_keepalive: config.tcp_keepalive.into(),
+            http2_keepalive: config.http2_keepalive.into(),
+            timeout: config.timeout.into(),
+            keep_alive_while_idle: config.keep_alive_while_idle,
+        }
+    }
+}
+
+impl From<CoreKeepaliveConfig> for KeepaliveConfig {
+    fn from(config: CoreKeepaliveConfig) -> Self {
+        KeepaliveConfig {
+            tcp_keepalive: *config.tcp_keepalive,
+            http2_keepalive: *config.http2_keepalive,
+            timeout: *config.timeout,
+            keep_alive_while_idle: config.keep_alive_while_idle,
+        }
+    }
+}
+
+/// HTTP Proxy configuration
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct ProxyConfig {
+    /// The HTTP proxy URL (e.g., "http://proxy.example.com:8080")
+    pub url: Option<String>,
+    /// TLS configuration for proxy connection
+    pub tls: TlsClientConfig,
+    /// Optional username for proxy authentication
+    pub username: Option<String>,
+    /// Optional password for proxy authentication
+    pub password: Option<String>,
+    /// Headers to send with proxy requests
+    pub headers: HashMap<String, String>,
+}
+
+impl Default for ProxyConfig {
+    fn default() -> Self {
+        let core_defaults = CoreProxyConfig::default();
+        ProxyConfig {
+            url: core_defaults.url,
+            tls: core_defaults.tls_setting.into(),
+            username: core_defaults.username,
+            password: core_defaults.password,
+            headers: core_defaults.headers,
+        }
+    }
+}
+
+impl From<ProxyConfig> for CoreProxyConfig {
+    fn from(config: ProxyConfig) -> Self {
+        CoreProxyConfig {
+            url: config.url,
+            tls_setting: config.tls.into(),
+            username: config.username,
+            password: config.password,
+            headers: config.headers,
+        }
+    }
+}
+
+impl From<CoreProxyConfig> for ProxyConfig {
+    fn from(config: CoreProxyConfig) -> Self {
+        ProxyConfig {
+            url: config.url,
+            tls: config.tls_setting.into(),
+            username: config.username,
+            password: config.password,
+            headers: config.headers,
+        }
+    }
+}
+
+/// Exponential backoff configuration
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct ExponentialBackoff {
+    /// Base delay
+    pub base: Duration,
+    /// Multiplication factor for each retry
+    pub factor: u64,
+    /// Maximum delay
+    pub max_delay: Duration,
+    /// Maximum number of retry attempts
+    pub max_attempts: u64,
+    /// Whether to add random jitter to delays
+    pub jitter: bool,
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        let core_defaults = ExponentialBackoffConfig::default();
+        ExponentialBackoff {
+            base: Duration::from_millis(core_defaults.base),
+            factor: core_defaults.factor,
+            max_delay: *core_defaults.max_delay,
+            max_attempts: core_defaults.max_attempts as u64,
+            jitter: core_defaults.jitter,
+        }
+    }
+}
+
+/// Fixed interval backoff configuration
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct FixedIntervalBackoff {
+    /// Fixed interval between retries
+    pub interval: Duration,
+    /// Maximum number of retry attempts
+    pub max_attempts: u64,
+}
+
+impl Default for FixedIntervalBackoff {
+    fn default() -> Self {
+        let core_defaults = FixedIntervalBackoffConfig::default();
+        FixedIntervalBackoff {
+            interval: *core_defaults.interval,
+            max_attempts: core_defaults.max_attempts as u64,
+        }
+    }
+}
+
+/// Backoff retry configuration
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum BackoffConfig {
+    Exponential { config: ExponentialBackoff },
+    FixedInterval { config: FixedIntervalBackoff },
+}
+
+impl From<BackoffConfig> for CoreBackoffConfig {
+    fn from(config: BackoffConfig) -> Self {
+        match config {
+            BackoffConfig::Exponential { config } => {
+                CoreBackoffConfig::Exponential(ExponentialBackoffConfig::new(
+                    config.base.as_millis() as u64,
+                    config.factor,
+                    config.max_delay,
+                    config.max_attempts as usize,
+                    config.jitter,
+                ))
+            }
+            BackoffConfig::FixedInterval { config } => CoreBackoffConfig::FixedInterval(
+                FixedIntervalBackoffConfig::new(config.interval, config.max_attempts as usize),
+            ),
+        }
+    }
+}
+
+impl From<CoreBackoffConfig> for BackoffConfig {
+    fn from(config: CoreBackoffConfig) -> Self {
+        match config {
+            CoreBackoffConfig::Exponential(core_config) => BackoffConfig::Exponential {
+                config: ExponentialBackoff {
+                    base: Duration::from_millis(core_config.base),
+                    factor: core_config.factor,
+                    max_delay: *core_config.max_delay,
+                    max_attempts: core_config.max_attempts as u64,
+                    jitter: core_config.jitter,
+                },
+            },
+            CoreBackoffConfig::FixedInterval(core_config) => BackoffConfig::FixedInterval {
+                config: FixedIntervalBackoff {
+                    interval: *core_config.interval,
+                    max_attempts: core_config.max_attempts as u64,
+                },
+            },
+        }
+    }
+}
+
+/// Client configuration for connecting to a SLIM server
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct ClientConfig {
+    /// The target endpoint the client will connect to.
+    ///
+    /// The transport protocol is inferred from the endpoint scheme:
+    /// `ws://`/`wss://` → WebSocket, otherwise gRPC.
+    pub endpoint: String,
+
+    /// TLS client configuration
+    pub tls: TlsClientConfig,
+
+    /// Origin (HTTP Host authority override) for the client
+    pub origin: Option<String>,
+
+    /// Optional TLS SNI server name override
+    pub server_name: Option<String>,
+
+    /// Compression type
+    pub compression: Option<CompressionType>,
+
+    /// Rate limit string (e.g., "100/s" for 100 requests per second)
+    pub rate_limit: Option<String>,
+
+    /// Keepalive parameters
+    pub keepalive: Option<KeepaliveConfig>,
+
+    /// HTTP Proxy configuration
+    pub proxy: Option<ProxyConfig>,
+
+    /// Connection timeout
+    pub connect_timeout: Option<Duration>,
+
+    /// Request timeout
+    pub request_timeout: Option<Duration>,
+
+    /// Read buffer size in bytes
+    pub buffer_size: Option<u64>,
+
+    /// Headers associated with gRPC requests
+    pub headers: Option<HashMap<String, String>>,
+
+    /// Authentication configuration for outgoing RPCs
+    pub auth: Option<ClientAuthenticationConfig>,
+
+    /// Backoff retry configuration
+    pub backoff: Option<BackoffConfig>,
+
+    /// Arbitrary user-provided metadata as JSON string
+    pub metadata: Option<String>,
+
+    /// When true, reject inter-node messages without a valid header MAC (strict mode).
+    pub require_header_mac: Option<bool>,
+}
+
+impl From<ClientConfig> for CoreClientConfig {
+    fn from(config: ClientConfig) -> Self {
+        let core_defaults = CoreClientConfig::default();
+        CoreClientConfig {
+            endpoint: config.endpoint,
+            origin: config.origin,
+            server_name: config.server_name,
+            compression: config.compression.map(Into::into),
+            rate_limit: config.rate_limit,
+            tls_setting: config.tls.into(),
+            keepalive: config.keepalive.map(Into::into),
+            proxy: config.proxy.map(Into::into).unwrap_or(core_defaults.proxy),
+            connect_timeout: config
+                .connect_timeout
+                .map(Into::into)
+                .unwrap_or(core_defaults.connect_timeout),
+            request_timeout: config
+                .request_timeout
+                .map(Into::into)
+                .unwrap_or(core_defaults.request_timeout),
+            buffer_size: config.buffer_size.map(|s| s as usize),
+            headers: config.headers.unwrap_or(core_defaults.headers),
+            auth: config.auth.map(Into::into).unwrap_or(core_defaults.auth),
+            backoff: config
+                .backoff
+                .map(Into::into)
+                .unwrap_or(core_defaults.backoff),
+            metadata: config
+                .metadata
+                .and_then(|json| serde_json::from_str::<MetadataMap>(&json).ok()),
+            link_id: core_defaults.link_id,
+            require_header_mac: config
+                .require_header_mac
+                .unwrap_or(core_defaults.require_header_mac),
+            connection_type: core_defaults.connection_type,
+        }
+    }
+}
+
+impl From<CoreClientConfig> for ClientConfig {
+    fn from(config: CoreClientConfig) -> Self {
+        ClientConfig {
+            endpoint: config.endpoint,
+            origin: config.origin,
+            server_name: config.server_name,
+            compression: config.compression.map(Into::into),
+            rate_limit: config.rate_limit,
+            tls: config.tls_setting.into(),
+            keepalive: config.keepalive.map(Into::into),
+            proxy: Some(config.proxy.into()),
+            connect_timeout: Some(*config.connect_timeout),
+            request_timeout: Some(*config.request_timeout),
+            buffer_size: config.buffer_size.map(|s| s as u64),
+            headers: Some(config.headers),
+            auth: Some(config.auth.into()),
+            backoff: Some(config.backoff.into()),
+            metadata: config.metadata.and_then(|m| serde_json::to_string(&m).ok()),
+            require_header_mac: Some(config.require_header_mac),
+        }
+    }
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        let core_defaults = CoreClientConfig::default();
+        Self {
+            endpoint: core_defaults.endpoint,
+            origin: None,
+            server_name: None,
+            compression: None,
+            rate_limit: None,
+            tls: core_defaults.tls_setting.into(),
+            keepalive: None,
+            proxy: None,
+            connect_timeout: None,
+            request_timeout: None,
+            buffer_size: None,
+            headers: None,
+            auth: None,
+            backoff: None,
+            metadata: None,
+            require_header_mac: None,
+        }
+    }
+}
+
+/// Create a new insecure client config (no TLS)
+#[uniffi::export]
+pub fn new_insecure_client_config(endpoint: String) -> ClientConfig {
+    ClientConfig {
+        endpoint,
+        tls: TlsClientConfig {
+            insecure: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Create a new secure client config (TLS enabled with default settings)
+#[uniffi::export]
+pub fn new_secure_client_config(endpoint: String) -> ClientConfig {
+    ClientConfig {
+        endpoint,
+        tls: TlsClientConfig::default(),
+        ..Default::default()
+    }
+}
+
+/// Parse and validate a SLIM gRPC client configuration from JSON.
+///
+/// The JSON must match [`CoreClientConfig`] (same as
+/// `data-plane/core/config/src/grpc/schema/client-config.schema.json`).
+#[uniffi::export]
+pub fn new_config_from_json(json: String) -> Result<ClientConfig, SlimError> {
+    let core: CoreClientConfig =
+        serde_json::from_str(&json).map_err(|e| SlimError::ConfigError {
+            message: format!("invalid JSON for client config: {e}"),
+        })?;
+    core.validate().map_err(|e| SlimError::ConfigError {
+        message: e.to_string(),
+    })?;
+    Ok(core.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common_config::{CaSource, TlsSource};
+    use crate::errors::SlimError;
+    use slim_config::transport::TransportProtocol as CoreTransportProtocol;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_client_config_creation() {
+        let config = ClientConfig {
+            endpoint: "example.com:443".to_string(),
+            origin: None,
+            server_name: None,
+            compression: None,
+            rate_limit: None,
+            tls: TlsClientConfig {
+                insecure: false,
+                insecure_skip_verify: false,
+                source: TlsSource::None,
+                ca_source: CaSource::File {
+                    path: "/ca.pem".to_string(),
+                },
+                include_system_ca_certs_pool: true,
+                tls_version: "tls1.2".to_string(),
+            },
+            keepalive: None,
+            proxy: None,
+            connect_timeout: Some(Duration::from_secs(10)),
+            request_timeout: Some(Duration::from_secs(30)),
+            buffer_size: None,
+            headers: None,
+            auth: None,
+            backoff: None,
+            metadata: None,
+            require_header_mac: None,
+        };
+
+        assert_eq!(config.endpoint, "example.com:443");
+        assert_eq!(config.tls.tls_version, "tls1.2");
+        assert!(!config.tls.insecure);
+    }
+
+    #[test]
+    fn test_client_config_default() {
+        let config = ClientConfig::default();
+
+        // Verify defaults are all None (core defaults applied during conversion)
+        assert_eq!(config.endpoint, "");
+        assert_eq!(config.origin, None);
+        assert_eq!(config.server_name, None);
+        assert_eq!(config.compression, None);
+        assert_eq!(config.rate_limit, None);
+        assert_eq!(config.tls, TlsClientConfig::default());
+        assert_eq!(config.keepalive, None);
+        assert_eq!(config.proxy, None);
+        assert_eq!(config.connect_timeout, None);
+        assert_eq!(config.request_timeout, None);
+        assert_eq!(config.buffer_size, None);
+        assert_eq!(config.headers, None);
+        assert_eq!(config.auth, None);
+        assert_eq!(config.backoff, None);
+        assert_eq!(config.metadata, None);
+
+        // Verify core defaults are applied when converting to CoreClientConfig
+        let core: CoreClientConfig = config.into();
+        assert_eq!(*core.connect_timeout, Duration::from_secs(0));
+        assert_eq!(*core.request_timeout, Duration::from_secs(0));
+        assert!(core.headers.is_empty());
+        assert_eq!(
+            core.auth,
+            slim_config::grpc::client::AuthenticationConfig::None
+        );
+    }
+
+    #[test]
+    fn test_client_config_new_insecure() {
+        let config = new_insecure_client_config("localhost:50051".to_string());
+
+        assert_eq!(config.endpoint, "localhost:50051");
+        assert!(config.tls.insecure);
+    }
+
+    #[test]
+    fn test_client_config_new_secure() {
+        let config = new_secure_client_config("api.example.com:443".to_string());
+
+        assert_eq!(config.endpoint, "api.example.com:443");
+        assert!(!config.tls.insecure);
+        assert!(!config.tls.insecure_skip_verify);
+        assert_eq!(config.tls, TlsClientConfig::default());
+        // All optional fields should be None
+        assert_eq!(config.origin, None);
+        assert_eq!(config.keepalive, None);
+        assert_eq!(config.proxy, None);
+        assert_eq!(config.connect_timeout, None);
+        assert_eq!(config.request_timeout, None);
+        assert_eq!(config.auth, None);
+        assert_eq!(config.backoff, None);
+    }
+
+    #[test]
+    fn new_config_from_json_minimal_insecure() {
+        let json = r#"{"endpoint":"http://127.0.0.1:46357","tls":{"insecure":true}}"#;
+        let cfg = new_config_from_json(json.to_string()).expect("parse");
+        assert_eq!(cfg.endpoint, "http://127.0.0.1:46357");
+        assert!(cfg.tls.insecure);
+    }
+
+    #[test]
+    fn new_config_from_json_invalid_json() {
+        let err = new_config_from_json("{not json".to_string()).unwrap_err();
+        assert!(matches!(err, SlimError::ConfigError { .. }));
+        let SlimError::ConfigError { message } = err else {
+            unreachable!();
+        };
+        assert!(message.contains("invalid JSON"), "message was: {message}");
+    }
+
+    #[test]
+    fn new_config_from_json_missing_endpoint() {
+        let json = r#"{"endpoint":"","tls":{"insecure":true}}"#;
+        let err = new_config_from_json(json.to_string()).unwrap_err();
+        assert!(matches!(err, SlimError::ConfigError { .. }));
+    }
+
+    #[test]
+    fn test_client_config_to_core_conversion() {
+        let mut headers = HashMap::new();
+        headers.insert("x-api-key".to_string(), "test-key".to_string());
+
+        let ffi_config = ClientConfig {
+            endpoint: "ws://api.example.com:443".to_string(),
+            origin: Some("example.com".to_string()),
+            server_name: Some("sni.example.com".to_string()),
+            compression: Some(CompressionType::Gzip),
+            rate_limit: Some("100/s".to_string()),
+            tls: TlsClientConfig::default(),
+            keepalive: Some(KeepaliveConfig {
+                tcp_keepalive: Duration::from_secs(60),
+                http2_keepalive: Duration::from_secs(30),
+                timeout: Duration::from_secs(20),
+                keep_alive_while_idle: true,
+            }),
+            proxy: Some(ProxyConfig::default()),
+            connect_timeout: Some(Duration::from_secs(15)),
+            request_timeout: Some(Duration::from_secs(60)),
+            buffer_size: Some(8192),
+            headers: Some(headers.clone()),
+            auth: Some(ClientAuthenticationConfig::None),
+            backoff: Some(BackoffConfig::FixedInterval {
+                config: FixedIntervalBackoff {
+                    interval: Duration::from_secs(1),
+                    max_attempts: 5,
+                },
+            }),
+            metadata: Some(r#"{"client":"test"}"#.to_string()),
+            require_header_mac: None,
+        };
+
+        let core_config: CoreClientConfig = ffi_config.into();
+
+        assert_eq!(core_config.endpoint, "ws://api.example.com:443");
+        assert_eq!(
+            core_config.resolved_transport(),
+            CoreTransportProtocol::Websocket
+        );
+        assert_eq!(core_config.origin, Some("example.com".to_string()));
+        assert_eq!(core_config.server_name, Some("sni.example.com".to_string()));
+        assert!(core_config.compression.is_some());
+        assert_eq!(core_config.rate_limit, Some("100/s".to_string()));
+        assert!(core_config.keepalive.is_some());
+        assert_eq!(core_config.buffer_size, Some(8192));
+        assert_eq!(core_config.headers.len(), 1);
+        assert!(core_config.metadata.is_some());
+    }
+
+    #[test]
+    fn test_client_config_from_core_conversion() {
+        // Test the new From<CoreClientConfig> for ClientConfig implementation
+        let core_config = CoreClientConfig::default();
+
+        // Use the From trait to convert
+        let ffi_config: ClientConfig = core_config.clone().into();
+
+        assert_eq!(ffi_config.endpoint, core_config.endpoint);
+        assert_eq!(ffi_config.origin, core_config.origin);
+        assert_eq!(ffi_config.server_name, core_config.server_name);
+        assert_eq!(ffi_config.rate_limit, core_config.rate_limit);
+        assert_eq!(
+            ffi_config.connect_timeout,
+            Some(*core_config.connect_timeout)
+        );
+        assert_eq!(
+            ffi_config.request_timeout,
+            Some(*core_config.request_timeout)
+        );
+    }
+
+    #[test]
+    fn test_client_config_roundtrip_conversion() {
+        let original = ClientConfig {
+            endpoint: "localhost:8080".to_string(),
+            origin: Some("test.local".to_string()),
+            server_name: None,
+            compression: Some(CompressionType::Zstd),
+            rate_limit: Some("50/s".to_string()),
+            tls: TlsClientConfig::default(),
+            keepalive: None,
+            proxy: Some(ProxyConfig::default()),
+            connect_timeout: Some(Duration::from_secs(5)),
+            request_timeout: Some(Duration::from_secs(10)),
+            buffer_size: Some(4096),
+            headers: Some(HashMap::new()),
+            auth: Some(ClientAuthenticationConfig::None),
+            backoff: Some(BackoffConfig::Exponential {
+                config: ExponentialBackoff::default(),
+            }),
+            metadata: None,
+            require_header_mac: None,
+        };
+
+        // FFI -> Core -> FFI using the new From implementation
+        let core: CoreClientConfig = original.clone().into();
+        let roundtrip: ClientConfig = core.into();
+
+        assert_eq!(roundtrip.endpoint, original.endpoint);
+        assert_eq!(roundtrip.origin, original.origin);
+        assert_eq!(roundtrip.rate_limit, original.rate_limit);
+        assert_eq!(roundtrip.buffer_size, original.buffer_size);
+    }
+
+    #[test]
+    fn test_compression_type_conversion() {
+        let compressions = vec![
+            CompressionType::Gzip,
+            CompressionType::Zlib,
+            CompressionType::Deflate,
+            CompressionType::Snappy,
+            CompressionType::Zstd,
+            CompressionType::Lz4,
+            CompressionType::None,
+            CompressionType::Empty,
+        ];
+
+        for compression in compressions {
+            let core: CoreCompressionType = compression.clone().into();
+            let back: CompressionType = core.into();
+            // Verify roundtrip works (can't directly compare enums without PartialEq)
+            match (compression, back) {
+                (CompressionType::Gzip, CompressionType::Gzip) => {}
+                (CompressionType::Zlib, CompressionType::Zlib) => {}
+                (CompressionType::Deflate, CompressionType::Deflate) => {}
+                (CompressionType::Snappy, CompressionType::Snappy) => {}
+                (CompressionType::Zstd, CompressionType::Zstd) => {}
+                (CompressionType::Lz4, CompressionType::Lz4) => {}
+                (CompressionType::None, CompressionType::None) => {}
+                (CompressionType::Empty, CompressionType::Empty) => {}
+                _ => panic!("Compression roundtrip failed"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_keepalive_conversion() {
+        let ffi_keepalive = KeepaliveConfig {
+            tcp_keepalive: Duration::from_secs(120),
+            http2_keepalive: Duration::from_secs(60),
+            timeout: Duration::from_secs(30),
+            keep_alive_while_idle: false,
+        };
+
+        let core_keepalive: CoreKeepaliveConfig = ffi_keepalive.into();
+
+        assert_eq!(*core_keepalive.tcp_keepalive, Duration::from_secs(120));
+        assert_eq!(*core_keepalive.http2_keepalive, Duration::from_secs(60));
+        assert_eq!(*core_keepalive.timeout, Duration::from_secs(30));
+        assert!(!core_keepalive.keep_alive_while_idle);
+    }
+
+    #[test]
+    fn test_backoff_exponential_conversion() {
+        let ffi_backoff = BackoffConfig::Exponential {
+            config: ExponentialBackoff {
+                base: Duration::from_millis(100),
+                factor: 2,
+                max_delay: Duration::from_secs(60),
+                max_attempts: 10,
+                jitter: true,
+            },
+        };
+
+        let core_backoff: CoreBackoffConfig = ffi_backoff.into();
+
+        match core_backoff {
+            CoreBackoffConfig::Exponential(config) => {
+                assert_eq!(config.base, 100);
+                assert_eq!(config.factor, 2);
+                assert_eq!(*config.max_delay, Duration::from_secs(60));
+                assert_eq!(config.max_attempts, 10);
+                assert!(config.jitter);
+            }
+            _ => panic!("Expected Exponential backoff"),
+        }
+    }
+
+    #[test]
+    fn test_backoff_fixed_interval_conversion() {
+        let ffi_backoff = BackoffConfig::FixedInterval {
+            config: FixedIntervalBackoff {
+                interval: Duration::from_secs(2),
+                max_attempts: 3,
+            },
+        };
+
+        let core_backoff: CoreBackoffConfig = ffi_backoff.into();
+
+        match core_backoff {
+            CoreBackoffConfig::FixedInterval(config) => {
+                assert_eq!(*config.interval, Duration::from_secs(2));
+                assert_eq!(config.max_attempts, 3);
+            }
+            _ => panic!("Expected FixedInterval backoff"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_conversion() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Proxy-Authorization".to_string(),
+            "Bearer token".to_string(),
+        );
+
+        let ffi_proxy = ProxyConfig {
+            url: Some("http://proxy.example.com:8080".to_string()),
+            tls: TlsClientConfig::default(),
+            username: Some("user".to_string()),
+            password: Some("pass".to_string()),
+            headers: headers.clone(),
+        };
+
+        let core_proxy: CoreProxyConfig = ffi_proxy.into();
+
+        assert_eq!(
+            core_proxy.url,
+            Some("http://proxy.example.com:8080".to_string())
+        );
+        assert_eq!(core_proxy.username, Some("user".to_string()));
+        assert_eq!(core_proxy.password, Some("pass".to_string()));
+        assert_eq!(core_proxy.headers.len(), 1);
+    }
+
+    #[test]
+    fn test_metadata_serialization() {
+        let config = ClientConfig {
+            endpoint: "test:443".to_string(),
+            tls: TlsClientConfig::default(),
+            metadata: Some(r#"{"env":"production","region":"us-west"}"#.to_string()),
+            ..Default::default()
+        };
+
+        let core: CoreClientConfig = config.into();
+
+        // Metadata should be deserialized successfully
+        assert!(core.metadata.is_some());
+        let metadata = core.metadata.unwrap();
+        assert_eq!(metadata.len(), 2);
+    }
+
+    #[test]
+    fn test_metadata_invalid_json() {
+        let config = ClientConfig {
+            endpoint: "test:443".to_string(),
+            tls: TlsClientConfig::default(),
+            metadata: Some("not valid json".to_string()),
+            ..Default::default()
+        };
+
+        let core: CoreClientConfig = config.into();
+
+        // Invalid JSON should result in None metadata
+        assert!(core.metadata.is_none());
+    }
+
+    #[test]
+    fn test_jwt_auth_roundtrip() {
+        use crate::identity_config::{
+            ClientJwtAuth, JwtAlgorithm, JwtKeyConfig, JwtKeyData, JwtKeyFormat, JwtKeyType,
+        };
+
+        let jwt_config = ClientJwtAuth {
+            key: JwtKeyType::Encoding {
+                key: JwtKeyConfig {
+                    algorithm: JwtAlgorithm::RS256,
+                    format: JwtKeyFormat::Pem,
+                    key: JwtKeyData::File {
+                        path: "/path/to/private_key.pem".to_string(),
+                    },
+                },
+            },
+            audience: Some(vec!["api.example.com".to_string()]),
+            issuer: Some("auth.example.com".to_string()),
+            subject: Some("user123".to_string()),
+            duration: Duration::from_secs(7200),
+        };
+
+        let auth = ClientAuthenticationConfig::Jwt {
+            config: jwt_config.clone(),
+        };
+
+        // Convert to core and back
+        let core_auth: slim_config::grpc::client::AuthenticationConfig = auth.into();
+        let roundtrip_auth: ClientAuthenticationConfig = core_auth.into();
+
+        // Verify roundtrip preserves the configuration
+        if let ClientAuthenticationConfig::Jwt { config } = roundtrip_auth {
+            assert_eq!(config.key, jwt_config.key);
+            assert_eq!(config.audience, jwt_config.audience);
+            assert_eq!(config.issuer, jwt_config.issuer);
+            assert_eq!(config.subject, jwt_config.subject);
+            // Note: duration might not be exactly preserved due to conversion limitations
+        } else {
+            panic!("Expected Jwt authentication config");
+        }
+    }
+
+    #[test]
+    fn test_basic_auth_roundtrip() {
+        use crate::common_config::BasicAuth;
+
+        let basic_config = BasicAuth {
+            username: "admin".to_string(),
+            password: "secret123".to_string(),
+        };
+
+        let auth = ClientAuthenticationConfig::Basic {
+            config: basic_config.clone(),
+        };
+
+        // Convert to core and back
+        let core_auth: slim_config::grpc::client::AuthenticationConfig = auth.into();
+        let roundtrip_auth: ClientAuthenticationConfig = core_auth.into();
+
+        // Verify roundtrip preserves the configuration
+        if let ClientAuthenticationConfig::Basic { config } = roundtrip_auth {
+            assert_eq!(config.username, basic_config.username);
+            assert_eq!(config.password, basic_config.password);
+        } else {
+            panic!("Expected Basic authentication config");
+        }
+    }
+
+    #[test]
+    fn test_static_jwt_auth_roundtrip() {
+        use crate::identity_config::StaticJwtAuth;
+
+        let jwt_config = StaticJwtAuth {
+            token_file: "/path/to/token.jwt".to_string(),
+            duration: Duration::from_secs(1800),
+        };
+
+        let auth = ClientAuthenticationConfig::StaticJwt {
+            config: jwt_config.clone(),
+        };
+
+        // Convert to core and back
+        let core_auth: slim_config::grpc::client::AuthenticationConfig = auth.into();
+        let roundtrip_auth: ClientAuthenticationConfig = core_auth.into();
+
+        // Verify roundtrip preserves the configuration
+        if let ClientAuthenticationConfig::StaticJwt { config } = roundtrip_auth {
+            assert_eq!(config.token_file, jwt_config.token_file);
+            assert_eq!(config.duration, jwt_config.duration);
+        } else {
+            panic!("Expected StaticJwt authentication config");
+        }
+    }
+
+    #[test]
+    fn test_client_config_from_core_with_all_fields() {
+        // Test the new From<CoreClientConfig> for ClientConfig with comprehensive field coverage
+        use slim_config::backoff::exponential::Config as CoreExponentialBackoffConfig;
+        use slim_config::grpc::client::BackoffConfig as CoreBackoffConfig;
+
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom-Header".to_string(), "value".to_string());
+
+        let mut metadata = MetadataMap::new();
+        metadata.insert("service".to_string(), "test-service".to_string());
+        metadata.insert("version".to_string(), "1.0".to_string());
+
+        let core_config = CoreClientConfig {
+            endpoint: "test.example.com:9443".to_string(),
+            origin: Some("origin.example.com".to_string()),
+            server_name: Some("server.example.com".to_string()),
+            rate_limit: Some("100/s".to_string()),
+            buffer_size: Some(8192),
+            headers: headers.clone(),
+            metadata: Some(metadata),
+            backoff: CoreBackoffConfig::Exponential(CoreExponentialBackoffConfig {
+                base: 50,
+                factor: 3,
+                max_delay: Duration::from_secs(120).into(),
+                max_attempts: 5,
+                jitter: true,
+            }),
+            ..Default::default()
+        };
+
+        // Use the new From implementation
+        let ffi_config: ClientConfig = core_config.clone().into();
+
+        // Verify all fields are correctly converted
+        assert_eq!(ffi_config.endpoint, "test.example.com:9443");
+        assert_eq!(ffi_config.origin, Some("origin.example.com".to_string()));
+        assert_eq!(
+            ffi_config.server_name,
+            Some("server.example.com".to_string())
+        );
+        assert_eq!(ffi_config.rate_limit, Some("100/s".to_string()));
+        assert_eq!(ffi_config.buffer_size, Some(8192));
+        let headers_map = ffi_config.headers.unwrap();
+        assert_eq!(headers_map.len(), 1);
+        assert_eq!(
+            headers_map.get("X-Custom-Header"),
+            Some(&"value".to_string())
+        );
+
+        // Verify metadata is serialized correctly
+        assert!(ffi_config.metadata.is_some());
+        let metadata_str = ffi_config.metadata.unwrap();
+        assert!(metadata_str.contains("test-service"));
+        assert!(metadata_str.contains("1.0"));
+    }
+
+    #[test]
+    fn test_client_config_from_core_with_keepalive() {
+        use slim_config::grpc::client::KeepaliveConfig as CoreKeepaliveConfig;
+
+        let core_config = CoreClientConfig {
+            keepalive: Some(CoreKeepaliveConfig {
+                tcp_keepalive: Duration::from_secs(90).into(),
+                http2_keepalive: Duration::from_secs(45).into(),
+                timeout: Duration::from_secs(20).into(),
+                keep_alive_while_idle: true,
+            }),
+            ..Default::default()
+        };
+
+        let ffi_config: ClientConfig = core_config.into();
+
+        let keepalive = ffi_config.keepalive.unwrap();
+        assert_eq!(keepalive.tcp_keepalive, Duration::from_secs(90));
+        assert_eq!(keepalive.http2_keepalive, Duration::from_secs(45));
+        assert_eq!(keepalive.timeout, Duration::from_secs(20));
+        assert!(keepalive.keep_alive_while_idle);
+    }
+
+    #[test]
+    fn test_client_config_from_core_with_compression() {
+        use slim_config::grpc::compression::CompressionType as CoreCompressionType;
+
+        let compressions = vec![
+            CoreCompressionType::Gzip,
+            CoreCompressionType::Zstd,
+            CoreCompressionType::Snappy,
+        ];
+
+        for core_compression in compressions {
+            let core_config = CoreClientConfig {
+                compression: Some(core_compression.clone()),
+                ..Default::default()
+            };
+
+            let ffi_config: ClientConfig = core_config.into();
+
+            assert!(ffi_config.compression.is_some());
+        }
+    }
+
+    #[test]
+    fn test_client_config_from_core_with_proxy() {
+        use slim_config::grpc::proxy::ProxyConfig as CoreProxyConfig;
+
+        let mut proxy_headers = HashMap::new();
+        proxy_headers.insert("Proxy-Auth".to_string(), "token123".to_string());
+
+        let core_config = CoreClientConfig {
+            proxy: CoreProxyConfig {
+                url: Some("http://proxy.internal:3128".to_string()),
+                tls_setting: Default::default(),
+                username: Some("proxy_user".to_string()),
+                password: Some("proxy_pass".to_string()),
+                headers: proxy_headers.clone(),
+            },
+            ..Default::default()
+        };
+
+        let ffi_config: ClientConfig = core_config.into();
+
+        let proxy = ffi_config.proxy.unwrap();
+        assert_eq!(proxy.url, Some("http://proxy.internal:3128".to_string()));
+        assert_eq!(proxy.username, Some("proxy_user".to_string()));
+        assert_eq!(proxy.password, Some("proxy_pass".to_string()));
+        assert_eq!(proxy.headers.len(), 1);
+    }
+
+    #[test]
+    fn test_client_config_from_core_buffer_size_conversion() {
+        // Test that buffer_size is correctly converted from usize to u64
+        let core_config = CoreClientConfig {
+            buffer_size: Some(16384),
+            ..Default::default()
+        };
+
+        let ffi_config: ClientConfig = core_config.into();
+
+        assert_eq!(ffi_config.buffer_size, Some(16384u64));
+    }
+
+    #[test]
+    fn test_client_config_from_core_metadata_serialization_failure() {
+        // Test that invalid metadata (non-serializable) results in None
+        // metadata is already Option, so we just test with None
+        let core_config = CoreClientConfig {
+            metadata: None,
+            ..Default::default()
+        };
+
+        let ffi_config: ClientConfig = core_config.into();
+
+        assert!(ffi_config.metadata.is_none());
+    }
+
+    #[test]
+    fn test_client_config_from_core_fixed_interval_backoff() {
+        use slim_config::backoff::fixedinterval::Config as CoreFixedIntervalBackoffConfig;
+        use slim_config::grpc::client::BackoffConfig as CoreBackoffConfig;
+
+        let core_config = CoreClientConfig {
+            backoff: CoreBackoffConfig::FixedInterval(CoreFixedIntervalBackoffConfig {
+                interval: Duration::from_secs(5).into(),
+                max_attempts: 8,
+            }),
+            ..Default::default()
+        };
+
+        let ffi_config: ClientConfig = core_config.into();
+
+        match ffi_config.backoff.unwrap() {
+            BackoffConfig::FixedInterval { config } => {
+                assert_eq!(config.interval, Duration::from_secs(5));
+                assert_eq!(config.max_attempts, 8);
+            }
+            _ => panic!("Expected FixedInterval backoff"),
+        }
+    }
+
+    #[test]
+    fn test_client_config_from_core_auth_types() {
+        use slim_config::auth::basic::Config as BasicAuthConfig;
+        use slim_config::grpc::client::AuthenticationConfig as CoreAuthConfig;
+
+        // Test with Basic auth
+        let core_config = CoreClientConfig {
+            auth: CoreAuthConfig::Basic(BasicAuthConfig::new("test_user", "test_pass")),
+            ..Default::default()
+        };
+
+        let ffi_config: ClientConfig = core_config.into();
+
+        match ffi_config.auth.unwrap() {
+            ClientAuthenticationConfig::Basic { config } => {
+                assert_eq!(config.username, "test_user");
+                assert_eq!(config.password, "test_pass");
+            }
+            _ => panic!("Expected Basic auth"),
+        }
+    }
+}

--- a/crates/slim-bindings/src/common_config.rs
+++ b/crates/slim-bindings/src/common_config.rs
@@ -1,0 +1,928 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use slim_config::auth::basic::Config as BasicAuthConfig;
+use slim_config::tls::client::TlsClientConfig as CoreTlsClientConfig;
+use slim_config::tls::server::TlsServerConfig as CoreTlsServerConfig;
+
+use crate::identity_config::{ClientJwtAuth, JwtAuth, StaticJwtAuth};
+
+/// SPIRE configuration for SPIFFE Workload API integration
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct SpireConfig {
+    /// Path to the SPIFFE Workload API socket (None => use SPIFFE_ENDPOINT_SOCKET env var)
+    pub socket_path: Option<String>,
+    /// Optional target SPIFFE ID when requesting JWT SVIDs
+    pub target_spiffe_id: Option<String>,
+    /// Audiences to request/verify for JWT SVIDs
+    pub jwt_audiences: Vec<String>,
+    /// Optional trust domains override for X.509 bundle retrieval
+    pub trust_domains: Vec<String>,
+}
+
+impl Default for SpireConfig {
+    fn default() -> Self {
+        SpireConfig {
+            socket_path: None,
+            target_spiffe_id: None,
+            jwt_audiences: vec!["slim".to_string()],
+            trust_domains: vec![],
+        }
+    }
+}
+
+#[cfg(not(target_family = "windows"))]
+impl From<SpireConfig> for slim_config::auth::spire::SpireConfig {
+    fn from(config: SpireConfig) -> Self {
+        slim_config::auth::spire::SpireConfig {
+            socket_path: config.socket_path,
+            target_spiffe_id: config.target_spiffe_id,
+            jwt_audiences: config.jwt_audiences,
+            trust_domains: config.trust_domains,
+        }
+    }
+}
+
+#[cfg(not(target_family = "windows"))]
+impl From<slim_config::auth::spire::SpireConfig> for SpireConfig {
+    fn from(config: slim_config::auth::spire::SpireConfig) -> Self {
+        SpireConfig {
+            socket_path: config.socket_path,
+            target_spiffe_id: config.target_spiffe_id,
+            jwt_audiences: config.jwt_audiences,
+            trust_domains: config.trust_domains,
+        }
+    }
+}
+
+/// TLS certificate and key source configuration
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum TlsSource {
+    /// Load certificate and key from PEM strings
+    Pem { cert: String, key: String },
+    /// Load certificate and key from files (with auto-reload support)
+    File { cert: String, key: String },
+    /// Load certificate and key from SPIRE Workload API
+    Spire { config: SpireConfig },
+    /// No certificate/key configured
+    None,
+}
+
+impl From<TlsSource> for slim_config::tls::common::TlsSource {
+    fn from(source: TlsSource) -> Self {
+        match source {
+            TlsSource::Pem { cert, key } => slim_config::tls::common::TlsSource::Pem { cert, key },
+            TlsSource::File { cert, key } => {
+                slim_config::tls::common::TlsSource::File { cert, key }
+            }
+            #[cfg(not(target_family = "windows"))]
+            TlsSource::Spire { config } => slim_config::tls::common::TlsSource::Spire {
+                config: config.into(),
+            },
+            #[cfg(target_family = "windows")]
+            TlsSource::Spire { .. } => {
+                panic!("SPIRE is not supported on Windows");
+            }
+            TlsSource::None => slim_config::tls::common::TlsSource::None,
+        }
+    }
+}
+
+impl From<slim_config::tls::common::TlsSource> for TlsSource {
+    fn from(source: slim_config::tls::common::TlsSource) -> Self {
+        match source {
+            slim_config::tls::common::TlsSource::Pem { cert, key } => TlsSource::Pem { cert, key },
+            slim_config::tls::common::TlsSource::File { cert, key } => {
+                TlsSource::File { cert, key }
+            }
+            #[cfg(not(target_family = "windows"))]
+            slim_config::tls::common::TlsSource::Spire { config } => TlsSource::Spire {
+                config: config.into(),
+            },
+            slim_config::tls::common::TlsSource::None => TlsSource::None,
+        }
+    }
+}
+
+/// CA certificate source configuration
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum CaSource {
+    /// Load CA from file
+    File { path: String },
+    /// Load CA from PEM string
+    Pem { data: String },
+    /// Load CA from SPIRE Workload API
+    Spire { config: SpireConfig },
+    /// No CA configured
+    None,
+}
+
+impl From<CaSource> for slim_config::tls::common::CaSource {
+    fn from(source: CaSource) -> Self {
+        match source {
+            CaSource::File { path } => slim_config::tls::common::CaSource::File { path },
+            CaSource::Pem { data } => slim_config::tls::common::CaSource::Pem { data },
+            #[cfg(not(target_family = "windows"))]
+            CaSource::Spire { config } => slim_config::tls::common::CaSource::Spire {
+                config: config.into(),
+            },
+            #[cfg(target_family = "windows")]
+            CaSource::Spire { .. } => {
+                panic!("SPIRE is not supported on Windows");
+            }
+            CaSource::None => slim_config::tls::common::CaSource::None,
+        }
+    }
+}
+
+impl From<slim_config::tls::common::CaSource> for CaSource {
+    fn from(source: slim_config::tls::common::CaSource) -> Self {
+        match source {
+            slim_config::tls::common::CaSource::File { path } => CaSource::File { path },
+            slim_config::tls::common::CaSource::Pem { data } => CaSource::Pem { data },
+            #[cfg(not(target_family = "windows"))]
+            slim_config::tls::common::CaSource::Spire { config } => CaSource::Spire {
+                config: config.into(),
+            },
+            slim_config::tls::common::CaSource::None => CaSource::None,
+        }
+    }
+}
+
+/// TLS configuration for client connections
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct TlsClientConfig {
+    /// Disable TLS entirely (plain text connection)
+    pub insecure: bool,
+    /// Skip server certificate verification (enables TLS but doesn't verify certs)
+    /// WARNING: Only use for testing - insecure in production!
+    pub insecure_skip_verify: bool,
+    /// Certificate and key source for client authentication
+    pub source: TlsSource,
+    /// CA certificate source for verifying server certificates
+    pub ca_source: CaSource,
+    /// Include system CA certificates pool (default: true)
+    pub include_system_ca_certs_pool: bool,
+    /// TLS version to use: "tls1.2" or "tls1.3" (default: "tls1.3")
+    pub tls_version: String,
+}
+
+impl Default for TlsClientConfig {
+    fn default() -> Self {
+        let core_defaults = CoreTlsClientConfig::default();
+        TlsClientConfig {
+            insecure: core_defaults.insecure,
+            insecure_skip_verify: core_defaults.insecure_skip_verify,
+            source: core_defaults.config.source.into(),
+            ca_source: core_defaults.config.ca_source.into(),
+            include_system_ca_certs_pool: core_defaults.config.include_system_ca_certs_pool,
+            tls_version: core_defaults.config.tls_version,
+        }
+    }
+}
+
+impl From<TlsClientConfig> for CoreTlsClientConfig {
+    fn from(config: TlsClientConfig) -> Self {
+        CoreTlsClientConfig {
+            config: slim_config::tls::common::Config {
+                source: config.source.into(),
+                ca_source: config.ca_source.into(),
+                include_system_ca_certs_pool: config.include_system_ca_certs_pool,
+                tls_version: config.tls_version,
+                reload_interval: None,
+            },
+            insecure: config.insecure,
+            insecure_skip_verify: config.insecure_skip_verify,
+        }
+    }
+}
+
+impl From<CoreTlsClientConfig> for TlsClientConfig {
+    fn from(config: CoreTlsClientConfig) -> Self {
+        TlsClientConfig {
+            insecure: config.insecure,
+            insecure_skip_verify: config.insecure_skip_verify,
+            source: config.config.source.into(),
+            ca_source: config.config.ca_source.into(),
+            include_system_ca_certs_pool: config.config.include_system_ca_certs_pool,
+            tls_version: config.config.tls_version,
+        }
+    }
+}
+
+/// TLS configuration for server connections
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct TlsServerConfig {
+    /// Disable TLS entirely (plain text connection)
+    pub insecure: bool,
+    /// Certificate and key source for server authentication
+    pub source: TlsSource,
+    /// CA certificate source for verifying client certificates
+    pub client_ca: CaSource,
+    /// Include system CA certificates pool (default: true)
+    pub include_system_ca_certs_pool: Option<bool>,
+    /// TLS version to use: "tls1.2" or "tls1.3" (default: "tls1.3")
+    pub tls_version: Option<String>,
+    /// Reload client CA file when modified
+    pub reload_client_ca_file: Option<bool>,
+}
+
+impl Default for TlsServerConfig {
+    fn default() -> Self {
+        TlsServerConfig {
+            insecure: false,
+            source: TlsSource::None,
+            client_ca: CaSource::None,
+            include_system_ca_certs_pool: None,
+            tls_version: None,
+            reload_client_ca_file: None,
+        }
+    }
+}
+
+impl From<TlsServerConfig> for CoreTlsServerConfig {
+    fn from(config: TlsServerConfig) -> Self {
+        let core_defaults = CoreTlsServerConfig::default();
+        CoreTlsServerConfig {
+            config: slim_config::tls::common::Config {
+                source: config.source.into(),
+                ca_source: slim_config::tls::common::CaSource::None,
+                include_system_ca_certs_pool: config
+                    .include_system_ca_certs_pool
+                    .unwrap_or(core_defaults.config.include_system_ca_certs_pool),
+                tls_version: config
+                    .tls_version
+                    .unwrap_or(core_defaults.config.tls_version),
+                reload_interval: None,
+            },
+            insecure: config.insecure,
+            client_ca: config.client_ca.into(),
+            reload_client_ca_file: config
+                .reload_client_ca_file
+                .unwrap_or(core_defaults.reload_client_ca_file),
+        }
+    }
+}
+
+impl From<CoreTlsServerConfig> for TlsServerConfig {
+    fn from(config: CoreTlsServerConfig) -> Self {
+        TlsServerConfig {
+            insecure: config.insecure,
+            source: config.config.source.into(),
+            client_ca: config.client_ca.into(),
+            include_system_ca_certs_pool: Some(config.config.include_system_ca_certs_pool),
+            tls_version: Some(config.config.tls_version),
+            reload_client_ca_file: Some(config.reload_client_ca_file),
+        }
+    }
+}
+
+/// Basic authentication configuration
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: String,
+}
+
+impl From<BasicAuth> for BasicAuthConfig {
+    fn from(config: BasicAuth) -> Self {
+        BasicAuthConfig::new(&config.username, &config.password)
+    }
+}
+
+impl From<BasicAuthConfig> for BasicAuth {
+    fn from(config: BasicAuthConfig) -> Self {
+        BasicAuth {
+            username: config.username().to_string(),
+            password: config.password().as_str().to_string(),
+        }
+    }
+}
+
+/// Authentication configuration enum for client
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum ClientAuthenticationConfig {
+    Basic {
+        config: BasicAuth,
+    },
+    StaticJwt {
+        config: StaticJwtAuth,
+    },
+    Jwt {
+        config: ClientJwtAuth,
+    },
+    /// SPIRE/SPIFFE authentication (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    Spire {
+        config: SpireConfig,
+    },
+    None,
+}
+
+impl From<ClientAuthenticationConfig> for slim_config::grpc::client::AuthenticationConfig {
+    fn from(config: ClientAuthenticationConfig) -> Self {
+        match config {
+            ClientAuthenticationConfig::Basic { config } => {
+                slim_config::grpc::client::AuthenticationConfig::Basic(config.into())
+            }
+            ClientAuthenticationConfig::StaticJwt { config } => {
+                slim_config::grpc::client::AuthenticationConfig::StaticJwt(config.into())
+            }
+            ClientAuthenticationConfig::Jwt { config } => {
+                slim_config::grpc::client::AuthenticationConfig::Jwt(config.into())
+            }
+            #[cfg(not(target_family = "windows"))]
+            ClientAuthenticationConfig::Spire { config } => {
+                slim_config::grpc::client::AuthenticationConfig::Spire(config.into())
+            }
+            ClientAuthenticationConfig::None => {
+                slim_config::grpc::client::AuthenticationConfig::None
+            }
+        }
+    }
+}
+
+impl From<slim_config::grpc::client::AuthenticationConfig> for ClientAuthenticationConfig {
+    fn from(config: slim_config::grpc::client::AuthenticationConfig) -> Self {
+        match config {
+            slim_config::grpc::client::AuthenticationConfig::None => {
+                ClientAuthenticationConfig::None
+            }
+            slim_config::grpc::client::AuthenticationConfig::Basic(basic) => {
+                ClientAuthenticationConfig::Basic {
+                    config: basic.into(),
+                }
+            }
+            slim_config::grpc::client::AuthenticationConfig::StaticJwt(jwt) => {
+                ClientAuthenticationConfig::StaticJwt { config: jwt.into() }
+            }
+            slim_config::grpc::client::AuthenticationConfig::Jwt(jwt) => {
+                ClientAuthenticationConfig::Jwt { config: jwt.into() }
+            }
+            #[cfg(not(target_family = "windows"))]
+            slim_config::grpc::client::AuthenticationConfig::Spire(spire) => {
+                ClientAuthenticationConfig::Spire {
+                    config: spire.into(),
+                }
+            }
+        }
+    }
+}
+
+/// Authentication configuration enum for server
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum ServerAuthenticationConfig {
+    Basic {
+        config: BasicAuth,
+    },
+    Jwt {
+        config: JwtAuth,
+    },
+    /// SPIRE/SPIFFE authentication (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    Spire {
+        config: SpireConfig,
+    },
+    None,
+}
+
+impl From<ServerAuthenticationConfig> for slim_config::grpc::server::AuthenticationConfig {
+    fn from(config: ServerAuthenticationConfig) -> Self {
+        match config {
+            ServerAuthenticationConfig::Basic { config } => {
+                slim_config::grpc::server::AuthenticationConfig::Basic(config.into())
+            }
+            ServerAuthenticationConfig::Jwt { config } => {
+                slim_config::grpc::server::AuthenticationConfig::Jwt(config.into())
+            }
+            #[cfg(not(target_family = "windows"))]
+            ServerAuthenticationConfig::Spire { config } => {
+                slim_config::grpc::server::AuthenticationConfig::Spire(config.into())
+            }
+            ServerAuthenticationConfig::None => {
+                slim_config::grpc::server::AuthenticationConfig::None
+            }
+        }
+    }
+}
+
+impl From<slim_config::grpc::server::AuthenticationConfig> for ServerAuthenticationConfig {
+    fn from(config: slim_config::grpc::server::AuthenticationConfig) -> Self {
+        match config {
+            slim_config::grpc::server::AuthenticationConfig::None => {
+                ServerAuthenticationConfig::None
+            }
+            slim_config::grpc::server::AuthenticationConfig::Basic(basic) => {
+                ServerAuthenticationConfig::Basic {
+                    config: basic.into(),
+                }
+            }
+            slim_config::grpc::server::AuthenticationConfig::Jwt(jwt) => {
+                ServerAuthenticationConfig::Jwt { config: jwt.into() }
+            }
+            #[cfg(not(target_family = "windows"))]
+            slim_config::grpc::server::AuthenticationConfig::Spire(spire) => {
+                ServerAuthenticationConfig::Spire {
+                    config: spire.into(),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity_config::{
+        JwtAlgorithm, JwtKeyConfig, JwtKeyData, JwtKeyFormat, JwtKeyType,
+    };
+    use std::time::Duration;
+
+    // Test SpireConfig default
+    #[test]
+    fn test_spire_config_default() {
+        let config = SpireConfig::default();
+        assert_eq!(config.socket_path, None);
+        assert_eq!(config.target_spiffe_id, None);
+        assert_eq!(config.jwt_audiences, vec!["slim".to_string()]);
+        assert_eq!(config.trust_domains, Vec::<String>::new());
+    }
+
+    // Test SpireConfig conversions (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    #[test]
+    fn test_spire_config_conversions() {
+        let config = SpireConfig {
+            socket_path: Some("/var/run/spire/socket".to_string()),
+            target_spiffe_id: Some("spiffe://example.com/service".to_string()),
+            jwt_audiences: vec!["audience1".to_string(), "audience2".to_string()],
+            trust_domains: vec!["example.com".to_string()],
+        };
+
+        let core_config: slim_config::auth::spire::SpireConfig = config.clone().into();
+        assert_eq!(core_config.socket_path, config.socket_path);
+        assert_eq!(core_config.target_spiffe_id, config.target_spiffe_id);
+        assert_eq!(core_config.jwt_audiences, config.jwt_audiences);
+        assert_eq!(core_config.trust_domains, config.trust_domains);
+
+        let back: SpireConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test TlsSource conversions - Pem variant
+    #[test]
+    fn test_tls_source_pem_conversion() {
+        let source = TlsSource::Pem {
+            cert: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----".to_string(),
+            key: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----".to_string(),
+        };
+
+        let core_source: slim_config::tls::common::TlsSource = source.clone().into();
+        let back: TlsSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test TlsSource conversions - File variant
+    #[test]
+    fn test_tls_source_file_conversion() {
+        let source = TlsSource::File {
+            cert: "/path/to/cert.pem".to_string(),
+            key: "/path/to/key.pem".to_string(),
+        };
+
+        let core_source: slim_config::tls::common::TlsSource = source.clone().into();
+        let back: TlsSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test TlsSource conversions - None variant
+    #[test]
+    fn test_tls_source_none_conversion() {
+        let source = TlsSource::None;
+        let core_source: slim_config::tls::common::TlsSource = source.clone().into();
+        let back: TlsSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test TlsSource conversions - Spire variant (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    #[test]
+    fn test_tls_source_spire_conversion() {
+        let source = TlsSource::Spire {
+            config: SpireConfig::default(),
+        };
+
+        let core_source: slim_config::tls::common::TlsSource = source.clone().into();
+        let back: TlsSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test CaSource conversions - File variant
+    #[test]
+    fn test_ca_source_file_conversion() {
+        let source = CaSource::File {
+            path: "/path/to/ca.pem".to_string(),
+        };
+
+        let core_source: slim_config::tls::common::CaSource = source.clone().into();
+        let back: CaSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test CaSource conversions - Pem variant
+    #[test]
+    fn test_ca_source_pem_conversion() {
+        let source = CaSource::Pem {
+            data: "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----".to_string(),
+        };
+
+        let core_source: slim_config::tls::common::CaSource = source.clone().into();
+        let back: CaSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test CaSource conversions - None variant
+    #[test]
+    fn test_ca_source_none_conversion() {
+        let source = CaSource::None;
+        let core_source: slim_config::tls::common::CaSource = source.clone().into();
+        let back: CaSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test CaSource conversions - Spire variant (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    #[test]
+    fn test_ca_source_spire_conversion() {
+        let source = CaSource::Spire {
+            config: SpireConfig::default(),
+        };
+
+        let core_source: slim_config::tls::common::CaSource = source.clone().into();
+        let back: CaSource = core_source.into();
+        assert_eq!(back, source);
+    }
+
+    // Test TlsClientConfig default
+    #[test]
+    fn test_tls_client_config_default() {
+        let config = TlsClientConfig::default();
+        assert!(!config.insecure);
+        assert!(!config.insecure_skip_verify);
+        assert_eq!(config.source, TlsSource::None);
+        assert_eq!(config.ca_source, CaSource::None);
+        assert!(config.include_system_ca_certs_pool);
+        assert_eq!(config.tls_version, "tls1.3");
+    }
+
+    // Test TlsClientConfig conversions
+    #[test]
+    fn test_tls_client_config_conversion() {
+        let config = TlsClientConfig {
+            insecure: false,
+            insecure_skip_verify: false,
+            source: TlsSource::File {
+                cert: "/path/to/cert.pem".to_string(),
+                key: "/path/to/key.pem".to_string(),
+            },
+            ca_source: CaSource::File {
+                path: "/path/to/ca.pem".to_string(),
+            },
+            include_system_ca_certs_pool: true,
+            tls_version: "tls1.3".to_string(),
+        };
+
+        let core_config: CoreTlsClientConfig = config.clone().into();
+        assert_eq!(core_config.insecure, config.insecure);
+        assert_eq!(
+            core_config.insecure_skip_verify,
+            config.insecure_skip_verify
+        );
+        assert_eq!(
+            core_config.config.include_system_ca_certs_pool,
+            config.include_system_ca_certs_pool
+        );
+        assert_eq!(core_config.config.tls_version, config.tls_version);
+
+        let back: TlsClientConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test TlsClientConfig with insecure options
+    #[test]
+    fn test_tls_client_config_insecure() {
+        let config = TlsClientConfig {
+            insecure: true,
+            insecure_skip_verify: true,
+            source: TlsSource::None,
+            ca_source: CaSource::None,
+            include_system_ca_certs_pool: false,
+            tls_version: "tls1.2".to_string(),
+        };
+
+        let core_config: CoreTlsClientConfig = config.clone().into();
+        let back: TlsClientConfig = core_config.into();
+        assert!(back.insecure);
+        assert!(back.insecure_skip_verify);
+        assert!(!back.include_system_ca_certs_pool);
+        assert_eq!(back.tls_version, "tls1.2");
+    }
+
+    // Test TlsServerConfig default
+    #[test]
+    fn test_tls_server_config_default() {
+        let config = TlsServerConfig::default();
+        assert!(!config.insecure);
+        assert_eq!(config.source, TlsSource::None);
+        assert_eq!(config.client_ca, CaSource::None);
+        assert_eq!(config.include_system_ca_certs_pool, None);
+        assert_eq!(config.tls_version, None);
+        assert_eq!(config.reload_client_ca_file, None);
+
+        // Verify core defaults are applied when converting
+        let core: CoreTlsServerConfig = config.into();
+        assert!(core.config.include_system_ca_certs_pool);
+        assert_eq!(core.config.tls_version, "tls1.3");
+        assert!(!core.reload_client_ca_file);
+    }
+
+    // Test TlsServerConfig conversions
+    #[test]
+    fn test_tls_server_config_conversion() {
+        let config = TlsServerConfig {
+            insecure: false,
+            source: TlsSource::Pem {
+                cert: "cert-data".to_string(),
+                key: "key-data".to_string(),
+            },
+            client_ca: CaSource::Pem {
+                data: "ca-data".to_string(),
+            },
+            include_system_ca_certs_pool: Some(true),
+            tls_version: Some("tls1.3".to_string()),
+            reload_client_ca_file: Some(true),
+        };
+
+        let core_config: CoreTlsServerConfig = config.clone().into();
+        assert_eq!(core_config.insecure, config.insecure);
+        assert_eq!(
+            core_config.reload_client_ca_file,
+            config.reload_client_ca_file.unwrap()
+        );
+        assert_eq!(
+            core_config.config.include_system_ca_certs_pool,
+            config.include_system_ca_certs_pool.unwrap()
+        );
+        assert_eq!(
+            core_config.config.tls_version,
+            config.tls_version.clone().unwrap()
+        );
+
+        let back: TlsServerConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test BasicAuth conversions
+    #[test]
+    fn test_basic_auth_conversion() {
+        let auth = BasicAuth {
+            username: "testuser".to_string(),
+            password: "testpassword".to_string(),
+        };
+
+        let core_auth: BasicAuthConfig = auth.clone().into();
+        assert_eq!(core_auth.username(), "testuser");
+        assert_eq!(core_auth.password().as_str(), "testpassword");
+
+        let back: BasicAuth = core_auth.into();
+        assert_eq!(back, auth);
+    }
+
+    // Test ClientAuthenticationConfig - Basic variant
+    #[test]
+    fn test_client_auth_config_basic() {
+        let config = ClientAuthenticationConfig::Basic {
+            config: BasicAuth {
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            },
+        };
+
+        let core_config: slim_config::grpc::client::AuthenticationConfig = config.clone().into();
+        let back: ClientAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test ClientAuthenticationConfig - StaticJwt variant
+    #[test]
+    fn test_client_auth_config_static_jwt() {
+        let config = ClientAuthenticationConfig::StaticJwt {
+            config: StaticJwtAuth {
+                token_file: "/path/to/token.jwt".to_string(),
+                duration: Duration::from_secs(3600),
+            },
+        };
+
+        let core_config: slim_config::grpc::client::AuthenticationConfig = config.clone().into();
+        let back: ClientAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test ClientAuthenticationConfig - Jwt variant
+    #[test]
+    fn test_client_auth_config_jwt() {
+        let config = ClientAuthenticationConfig::Jwt {
+            config: ClientJwtAuth {
+                key: JwtKeyType::Autoresolve,
+                audience: Some(vec!["api".to_string()]),
+                issuer: None,
+                subject: None,
+                duration: Duration::from_secs(3600),
+            },
+        };
+
+        let core_config: slim_config::grpc::client::AuthenticationConfig = config.clone().into();
+        let back: ClientAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test ClientAuthenticationConfig - None variant
+    #[test]
+    fn test_client_auth_config_none() {
+        let config = ClientAuthenticationConfig::None;
+        let core_config: slim_config::grpc::client::AuthenticationConfig = config.clone().into();
+        let back: ClientAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test ServerAuthenticationConfig - Basic variant
+    #[test]
+    fn test_server_auth_config_basic() {
+        let config = ServerAuthenticationConfig::Basic {
+            config: BasicAuth {
+                username: "admin".to_string(),
+                password: "secret".to_string(),
+            },
+        };
+
+        let core_config: slim_config::grpc::server::AuthenticationConfig = config.clone().into();
+        let back: ServerAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test ServerAuthenticationConfig - Jwt variant
+    #[test]
+    fn test_server_auth_config_jwt() {
+        let config = ServerAuthenticationConfig::Jwt {
+            config: JwtAuth {
+                key: JwtKeyType::Decoding {
+                    key: JwtKeyConfig {
+                        algorithm: JwtAlgorithm::RS256,
+                        format: JwtKeyFormat::Pem,
+                        key: JwtKeyData::File {
+                            path: "/path/to/key.pem".to_string(),
+                        },
+                    },
+                },
+                audience: Some(vec!["service".to_string()]),
+                issuer: Some("issuer".to_string()),
+                subject: None,
+                duration: Duration::from_secs(7200),
+            },
+        };
+
+        let core_config: slim_config::grpc::server::AuthenticationConfig = config.clone().into();
+        let back: ServerAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test ServerAuthenticationConfig - None variant
+    #[test]
+    fn test_server_auth_config_none() {
+        let config = ServerAuthenticationConfig::None;
+        let core_config: slim_config::grpc::server::AuthenticationConfig = config.clone().into();
+        let back: ServerAuthenticationConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test complex TlsClientConfig with all options
+    #[test]
+    fn test_complex_tls_client_config() {
+        let config = TlsClientConfig {
+            insecure: false,
+            insecure_skip_verify: false,
+            source: TlsSource::Pem {
+                cert: "-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----".to_string(),
+                key: "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----".to_string(),
+            },
+            ca_source: CaSource::Pem {
+                data: "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----".to_string(),
+            },
+            include_system_ca_certs_pool: false,
+            tls_version: "tls1.2".to_string(),
+        };
+
+        let core_config: CoreTlsClientConfig = config.clone().into();
+        let back: TlsClientConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test complex TlsServerConfig with all options
+    #[test]
+    fn test_complex_tls_server_config() {
+        let config = TlsServerConfig {
+            insecure: false,
+            source: TlsSource::File {
+                cert: "/etc/tls/server.crt".to_string(),
+                key: "/etc/tls/server.key".to_string(),
+            },
+            client_ca: CaSource::File {
+                path: "/etc/tls/ca.crt".to_string(),
+            },
+            include_system_ca_certs_pool: Some(false),
+            tls_version: Some("tls1.2".to_string()),
+            reload_client_ca_file: Some(true),
+        };
+
+        let core_config: CoreTlsServerConfig = config.clone().into();
+        let back: TlsServerConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test all TlsSource variants
+    #[test]
+    fn test_all_tls_source_variants() {
+        let variants = vec![
+            TlsSource::Pem {
+                cert: "cert1".to_string(),
+                key: "key1".to_string(),
+            },
+            TlsSource::File {
+                cert: "/path1".to_string(),
+                key: "/path2".to_string(),
+            },
+            TlsSource::None,
+        ];
+
+        for variant in variants {
+            let core: slim_config::tls::common::TlsSource = variant.clone().into();
+            let back: TlsSource = core.into();
+            assert_eq!(back, variant);
+        }
+    }
+
+    // Test all CaSource variants
+    #[test]
+    fn test_all_ca_source_variants() {
+        let variants = vec![
+            CaSource::File {
+                path: "/ca/path".to_string(),
+            },
+            CaSource::Pem {
+                data: "ca-pem-data".to_string(),
+            },
+            CaSource::None,
+        ];
+
+        for variant in variants {
+            let core: slim_config::tls::common::CaSource = variant.clone().into();
+            let back: CaSource = core.into();
+            assert_eq!(back, variant);
+        }
+    }
+
+    // Test SpireConfig with minimal configuration
+    #[test]
+    fn test_spire_config_minimal() {
+        let config = SpireConfig {
+            socket_path: None,
+            target_spiffe_id: None,
+            jwt_audiences: vec![],
+            trust_domains: vec![],
+        };
+
+        assert_eq!(config.socket_path, None);
+        assert_eq!(config.target_spiffe_id, None);
+        assert!(config.jwt_audiences.is_empty());
+        assert!(config.trust_domains.is_empty());
+    }
+
+    // Test SpireConfig with full configuration
+    #[test]
+    fn test_spire_config_full() {
+        let config = SpireConfig {
+            socket_path: Some("/var/run/spire.sock".to_string()),
+            target_spiffe_id: Some("spiffe://example.com/workload".to_string()),
+            jwt_audiences: vec!["aud1".to_string(), "aud2".to_string(), "aud3".to_string()],
+            trust_domains: vec!["domain1.com".to_string(), "domain2.com".to_string()],
+        };
+
+        assert_eq!(config.socket_path, Some("/var/run/spire.sock".to_string()));
+        assert_eq!(
+            config.target_spiffe_id,
+            Some("spiffe://example.com/workload".to_string())
+        );
+        assert_eq!(config.jwt_audiences.len(), 3);
+        assert_eq!(config.trust_domains.len(), 2);
+    }
+}

--- a/crates/slim-bindings/src/completion_handle.rs
+++ b/crates/slim-bindings/src/completion_handle.rs
@@ -1,0 +1,369 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// ============================================================================
+// FFI CompletionHandle Wrapper
+// ============================================================================
+
+use parking_lot::Mutex;
+
+use futures_timer::Delay;
+use slim_session::CompletionHandle as SlimCompletionHandle;
+
+use crate::SlimError;
+
+/// FFI-compatible completion handle for async operations
+///
+/// Represents a pending operation that can be awaited to ensure completion.
+/// Used for operations that need delivery confirmation or handshake acknowledgment.
+///
+/// # Examples
+///
+/// Basic usage:
+/// ```ignore
+/// let completion = session.publish(data, None, None)?;
+/// completion.wait()?; // Wait for delivery confirmation
+/// ```
+#[derive(uniffi::Object)]
+pub struct CompletionHandle {
+    /// Receiver for the completion result (can only be consumed once)
+    handle: Mutex<Option<SlimCompletionHandle>>,
+}
+
+impl std::fmt::Debug for CompletionHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompletionHandle")
+            .field("consumed", &self.handle.lock().is_none())
+            .finish()
+    }
+}
+
+impl From<SlimCompletionHandle> for CompletionHandle {
+    fn from(handle: SlimCompletionHandle) -> Self {
+        Self {
+            handle: Mutex::new(Some(handle)),
+        }
+    }
+}
+
+#[uniffi::export]
+impl CompletionHandle {
+    /// Wait for the operation to complete indefinitely (blocking version)
+    ///
+    /// This blocks the calling thread until the operation completes.
+    /// Use this from Go or other languages when you need to ensure
+    /// an operation has finished before proceeding.
+    ///
+    /// **Note:** This can only be called once per handle. Subsequent calls
+    /// will return an error.
+    ///
+    /// # Returns
+    /// * `Ok(())` - Operation completed successfully
+    /// * `Err(SlimError)` - Operation failed or handle already consumed
+    pub fn wait(self: std::sync::Arc<Self>) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(self.wait_async())
+    }
+
+    /// Wait for the operation to complete with a timeout (blocking version)
+    ///
+    /// This blocks the calling thread until the operation completes or the timeout expires.
+    /// Use this from Go or other languages when you need to ensure
+    /// an operation has finished before proceeding with a time limit.
+    ///
+    /// **Note:** This can only be called once per handle. Subsequent calls
+    /// will return an error.
+    ///
+    /// # Arguments
+    /// * `timeout` - Maximum time to wait for completion
+    ///
+    /// # Returns
+    /// * `Ok(())` - Operation completed successfully
+    /// * `Err(SlimError::Timeout)` - If the operation timed out
+    /// * `Err(SlimError)` - Operation failed or handle already consumed
+    pub fn wait_for(
+        self: std::sync::Arc<Self>,
+        timeout: std::time::Duration,
+    ) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(self.wait_for_async(timeout))
+    }
+
+    /// Wait for the operation to complete indefinitely (async version)
+    ///
+    /// This is the async version that integrates with UniFFI's polling mechanism.
+    /// The operation will yield control while waiting.
+    ///
+    /// **Note:** This can only be called once per handle. Subsequent calls
+    /// will return an error.
+    ///
+    /// # Returns
+    /// * `Ok(())` - Operation completed successfully
+    /// * `Err(SlimError)` - Operation failed or handle already consumed
+    pub async fn wait_async(self: std::sync::Arc<Self>) -> Result<(), SlimError> {
+        self.wait_internal(None).await
+    }
+
+    /// Wait for the operation to complete with a timeout (async version)
+    ///
+    /// This is the async version that integrates with UniFFI's polling mechanism.
+    /// The operation will yield control while waiting until completion or timeout.
+    ///
+    /// **Note:** This can only be called once per handle. Subsequent calls
+    /// will return an error.
+    ///
+    /// # Arguments
+    /// * `timeout` - Maximum time to wait for completion
+    ///
+    /// # Returns
+    /// * `Ok(())` - Operation completed successfully
+    /// * `Err(SlimError::Timeout)` - If the operation timed out
+    /// * `Err(SlimError)` - Operation failed or handle already consumed
+    pub async fn wait_for_async(
+        self: std::sync::Arc<Self>,
+        timeout: std::time::Duration,
+    ) -> Result<(), SlimError> {
+        self.wait_internal(Some(timeout)).await
+    }
+}
+
+impl CompletionHandle {
+    /// Internal implementation for wait operations
+    async fn wait_internal(&self, timeout: Option<std::time::Duration>) -> Result<(), SlimError> {
+        let receiver = self
+            .handle
+            .lock()
+            .take()
+            .ok_or_else(|| SlimError::InternalError {
+                message: "CompletionHandle already consumed (wait can only be called once)"
+                    .to_string(),
+            })?;
+
+        if let Some(duration) = timeout {
+            // Runtime-agnostic timeout using futures-timer
+            futures::pin_mut!(receiver);
+            let delay = Delay::new(duration);
+            futures::pin_mut!(delay);
+
+            match futures::future::select(receiver, delay).await {
+                futures::future::Either::Left((result, _)) => {
+                    result?;
+                    Ok(())
+                }
+                futures::future::Either::Right(_) => Err(SlimError::Timeout),
+            }
+        } else {
+            receiver.await?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::SlimError;
+    use slim_session::SessionError as SlimSessionError;
+
+    /// Test CompletionHandle basic functionality
+    #[tokio::test]
+    async fn test_completion_handle_success() {
+        // Create a successful completion
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        // Send success
+        tx.send(Ok(())).unwrap();
+
+        // Wait should succeed
+        let result = ffi_handle.wait_async().await;
+        assert!(result.is_ok(), "Completion should succeed");
+    }
+
+    /// Test CompletionHandle failure propagation
+    #[tokio::test]
+    async fn test_completion_handle_failure() {
+        // Create a failed completion
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        // Send error
+        tx.send(Err(slim_session::SessionError::SlimMessageSendFailed))
+            .unwrap();
+
+        // Wait should fail with error
+        let result = ffi_handle.wait_async().await;
+        assert!(result.is_err_and(|e| matches!(e, SlimError::SessionError { .. })));
+    }
+
+    /// Test CompletionHandle can only be consumed once
+    #[tokio::test]
+    async fn test_completion_handle_single_consumption() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        tx.send(Ok(())).unwrap();
+
+        // First wait should succeed
+        let result1 = ffi_handle.clone().wait_async().await;
+        assert!(result1.is_ok(), "First wait should succeed");
+
+        // Second wait should fail (already consumed)
+        let result2 = ffi_handle.clone().wait_async().await;
+        assert!(result2.is_err(), "Second wait should fail");
+
+        match result2 {
+            Err(SlimError::InternalError { message }) => {
+                assert!(message.contains("already consumed"));
+            }
+            _ => panic!("Expected InternalError about consumption"),
+        }
+    }
+
+    /// Test CompletionHandle async version
+    #[tokio::test]
+    async fn test_completion_handle_async() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        // Send success in a separate task
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            tx.send(Ok(())).unwrap();
+        });
+
+        // Wait for completion
+        let result = ffi_handle.wait_async().await;
+        assert!(result.is_ok(), "Async wait should succeed");
+    }
+
+    /// Test CompletionHandle with dropped sender
+    #[tokio::test]
+    async fn test_completion_handle_sender_dropped() {
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        // Drop the sender explicitly
+        drop(_tx);
+
+        // Give the spawned task time to process
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Wait should fail with session error
+        let result = ffi_handle.wait_async().await;
+        assert!(
+            result.is_err(),
+            "Should fail when sender is dropped or already consumed"
+        );
+
+        // Either error type is valid depending on timing
+        match result {
+            Err(SlimError::InternalError { message }) => {
+                assert!(
+                    message.contains("sender dropped") || message.contains("already consumed"),
+                    "Error message should mention sender dropped or already consumed, got: {message}"
+                );
+            }
+            Err(SlimError::SessionError { message }) => {
+                // The background task may have consumed the receiver and got a channel closed error
+                assert!(
+                    message.contains("channel closed") || message.contains("receiving ack"),
+                    "Expected channel closed error, got: {message}"
+                );
+            }
+            Err(e) => panic!("Unexpected error type: {e:?}"),
+            Ok(_) => panic!("Expected error, got Ok"),
+        }
+    }
+
+    /// Test concurrent completion handle usage
+    #[tokio::test]
+    async fn test_completion_handle_concurrent() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let success_count = Arc::new(AtomicU32::new(0));
+        let mut handles = vec![];
+
+        // Create multiple completion handles
+        for _ in 0..10 {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+            let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+            let count = Arc::clone(&success_count);
+            let handle = tokio::spawn(async move {
+                // Send success
+                tx.send(Ok(())).unwrap();
+
+                // Wait for completion
+                if ffi_handle.wait_async().await.is_ok() {
+                    count.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+
+            handles.push(handle);
+        }
+
+        // Wait for all tasks
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // All should succeed
+        assert_eq!(success_count.load(Ordering::SeqCst), 10);
+    }
+
+    /// Test CompletionHandle with timeout
+    #[tokio::test]
+    async fn test_completion_handle_with_timeout() {
+        // Create a completion that will never complete (sender not sent)
+        // NOTE: We must hold onto `tx` so the channel stays open.
+        // If we use `_tx`, it gets dropped immediately and the receiver
+        // returns RecvError instead of timing out.
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), SlimSessionError>>();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        // Wait with a short timeout - should timeout
+        let result = ffi_handle
+            .wait_for_async(std::time::Duration::from_millis(50))
+            .await;
+        assert!(
+            result.is_err(),
+            "Should timeout when operation doesn't complete"
+        );
+
+        match result {
+            Err(SlimError::Timeout) => {} // Expected
+            Err(e) => panic!("Expected Timeout error, got: {e:?}"),
+            Ok(_) => panic!("Expected timeout, got Ok"),
+        }
+
+        // Explicitly drop tx after the test to avoid unused variable warning
+        drop(tx);
+    }
+
+    /// Test CompletionHandle with timeout that completes in time
+    #[tokio::test]
+    async fn test_completion_handle_timeout_success() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let completion = slim_session::CompletionHandle::from_oneshot_receiver(rx);
+        let ffi_handle = Arc::new(crate::CompletionHandle::from(completion));
+
+        // Send success immediately
+        tx.send(Ok(())).unwrap();
+
+        // Wait with a generous timeout - should succeed
+        let result = ffi_handle
+            .wait_for_async(std::time::Duration::from_millis(5000))
+            .await;
+        assert!(
+            result.is_ok(),
+            "Should succeed when operation completes before timeout"
+        );
+    }
+}

--- a/crates/slim-bindings/src/config.rs
+++ b/crates/slim-bindings/src/config.rs
@@ -1,0 +1,1179 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration support for SLIM bindings
+//!
+//! This module provides configuration file loading and initialization for the bindings,
+//! using the same configuration system as the main SLIM application.
+
+use std::sync::{Arc, OnceLock};
+
+use display_error_chain::ErrorChainExt;
+use futures_timer::Delay;
+use tracing::{debug, info};
+
+use slim::config::ConfigLoader;
+use slim::runtime::{RuntimeConfiguration as CoreRuntimeConfiguration, SlimRuntime};
+use slim_config::tls::provider;
+use slim_service::ServiceConfiguration as CoreServiceConfiguration;
+use slim_tracing::TracingConfiguration as CoreTracingConfiguration;
+
+use crate::ServiceConfig;
+use crate::errors::SlimError;
+use crate::init_config::{RuntimeConfig, TracingConfig};
+
+/// Global state instance
+static GLOBAL_STATE: OnceLock<GlobalState> = OnceLock::new();
+
+/// Stores the loaded configuration, runtime, service, and tracing guard
+struct GlobalState {
+    /// The tracing guard must be kept alive for the duration of the program
+    #[allow(dead_code)]
+    tracing_guard: Option<Box<dyn std::any::Any + Send + Sync>>,
+
+    /// Runtime configuration
+    runtime_config: CoreRuntimeConfiguration,
+
+    /// Tracing configuration
+    tracing_config: CoreTracingConfiguration,
+
+    /// Service configuration
+    service_config: Vec<CoreServiceConfiguration>,
+
+    /// Global Tokio runtime. Built via `slim::runtime::build`, which picks a
+    /// multi-threaded runtime or a `current_thread` runtime on a dedicated
+    /// driver thread based on the effective core count.
+    runtime: SlimRuntime,
+
+    /// Global service instances (all services)
+    services: Vec<Arc<crate::service::Service>>,
+
+    /// Global service instance (first service, for backward compatibility)
+    service: Arc<crate::service::Service>,
+}
+
+/// Initialize SLIM bindings from a configuration file
+///
+/// This function:
+/// 1. Loads the configuration file
+/// 2. Initializes the crypto provider
+/// 3. Sets up tracing/logging exactly as the main SLIM application does
+/// 4. Initializes the global runtime with configuration from the file
+/// 5. Initializes and starts the global service with servers/clients from config
+///
+/// This must be called before using any SLIM bindings functionality.
+/// It's safe to call multiple times - subsequent calls will be ignored.
+///
+/// # Arguments
+/// * `config_path` - Path to the YAML configuration file
+///
+/// # Returns
+/// * `Ok(())` - Successfully initialized
+/// * `Err(SlimError)` - If initialization fails
+///
+/// # Example
+/// ```ignore
+/// initialize_from_config("/path/to/config.yaml")?;
+/// ```
+#[uniffi::export]
+pub fn initialize_from_config(config_path: String) {
+    // Use get_or_init for atomic initialization
+    GLOBAL_STATE.get_or_init(|| {
+        let (runtime_config, tracing_conf, service_configs) =
+            load_configs(&config_path).unwrap_or_else(|e| panic!("Initialization failed: {e}"));
+
+        // Perform initialization and return config
+        initialize_internal(
+            runtime_config.clone(),
+            tracing_conf.clone(),
+            &service_configs,
+        )
+        .unwrap_or_else(|e| panic!("Initialization failed: {e}"))
+    });
+}
+
+/// Initialize SLIM bindings from a configuration file and return errors
+/// instead of panicking.
+#[uniffi::export]
+pub fn initialize_from_config_with_error(config_path: String) -> Result<(), SlimError> {
+    if GLOBAL_STATE.get().is_some() {
+        return Ok(());
+    }
+
+    let (runtime_config, tracing_conf, service_configs) = load_configs(&config_path)?;
+    let global_state = initialize_internal(runtime_config, tracing_conf, &service_configs)?;
+
+    GLOBAL_STATE
+        .set(global_state)
+        .map_err(|_| SlimError::InternalError {
+            message: "Global state already initialized".to_string(),
+        })?;
+
+    Ok(())
+}
+
+/// Initialize SLIM bindings with custom configuration structs
+///
+/// This function allows you to programmatically configure SLIM bindings by passing
+/// configuration structs directly, without needing a config file.
+///
+/// # Arguments
+/// * `runtime_config` - Runtime configuration (thread count, naming, etc.)
+/// * `tracing_config` - Tracing/logging configuration
+/// * `service_config` - Service configuration (node ID, group name, etc.)
+///
+/// # Returns
+/// * `Ok(())` - Successfully initialized
+/// * `Err(SlimError)` - If initialization fails
+///
+/// # Example
+/// ```ignore
+/// let runtime_config = new_runtime_config();
+/// let tracing_config = new_tracing_config();
+/// let mut service_config = new_service_config();
+/// service_config.node_id = Some("my-node".to_string());
+///
+/// initialize_with_configs(runtime_config, tracing_config, service_config)?;
+/// ```
+#[uniffi::export]
+pub fn initialize_with_configs(
+    runtime_config: RuntimeConfig,
+    tracing_config: TracingConfig,
+    service_config: &[ServiceConfig],
+) -> Result<(), SlimError> {
+    // Convert wrapper types to core types
+    let core_runtime_config: CoreRuntimeConfiguration = runtime_config.into();
+    let core_tracing_config: CoreTracingConfiguration = tracing_config.into();
+    let core_service_config: Vec<CoreServiceConfiguration> =
+        service_config.iter().map(|sc| sc.clone().into()).collect();
+
+    // Use get_or_init for atomic initialization
+    GLOBAL_STATE.get_or_init(|| {
+        initialize_internal(
+            core_runtime_config,
+            core_tracing_config,
+            &core_service_config,
+        )
+        .unwrap_or_else(|e| panic!("Initialization failed: {e}"))
+    });
+    Ok(())
+}
+
+fn load_configs(
+    config_path: &str,
+) -> Result<
+    (
+        CoreRuntimeConfiguration,
+        CoreTracingConfiguration,
+        Vec<CoreServiceConfiguration>,
+    ),
+    SlimError,
+> {
+    let mut config = ConfigLoader::new(config_path).map_err(|e| SlimError::ConfigError {
+        message: e.chain().to_string(),
+    })?;
+
+    let runtime_config = config
+        .runtime()
+        .map_err(|e| SlimError::ConfigError {
+            message: e.chain().to_string(),
+        })?
+        .clone();
+
+    let tracing_conf = config
+        .tracing()
+        .map_err(|e| SlimError::ConfigError {
+            message: e.chain().to_string(),
+        })?
+        .clone();
+
+    let service_configs: Vec<CoreServiceConfiguration> = match config.services_config() {
+        Ok(services) => {
+            if !services.is_empty() {
+                debug!("Using service configuration from config file");
+                services.values().cloned().collect()
+            } else {
+                debug!("No services in config, using default");
+                vec![CoreServiceConfiguration::default()]
+            }
+        }
+        Err(_) => {
+            debug!("No services section in config, using default");
+            vec![CoreServiceConfiguration::default()]
+        }
+    };
+
+    Ok((runtime_config, tracing_conf, service_configs))
+}
+
+/// Initialize SLIM bindings with default configuration
+///
+/// This is a convenience function that initializes the bindings with:
+/// - Default runtime configuration
+/// - Default tracing/logging configuration
+/// - Initialized crypto provider
+/// - Default global service (no servers/clients)
+///
+/// Use `initialize_from_config` for file-based configuration or
+/// `initialize_with_configs` for programmatic configuration.
+#[uniffi::export]
+pub fn initialize_with_defaults() {
+    // Check if already initialized
+    GLOBAL_STATE.get_or_init(|| {
+        // Use default configurations
+        initialize_internal(
+            CoreRuntimeConfiguration::default(),
+            CoreTracingConfiguration::default(),
+            &[CoreServiceConfiguration::default()],
+        )
+        .expect("Failed to initialize with defaults")
+    });
+}
+
+/// Internal initialization function with common logic
+fn initialize_internal(
+    runtime_config: CoreRuntimeConfiguration,
+    tracing_conf: CoreTracingConfiguration,
+    service_configs: &[CoreServiceConfiguration],
+) -> Result<GlobalState, SlimError> {
+    // Initialize crypto provider (must be done before any TLS operations)
+    provider::initialize_crypto_provider();
+
+    // Build runtime from configuration. `build_for_embedding` picks a
+    // dedicated-thread `current_thread` runtime when the effective core count
+    // is 1, so the I/O reactor stays driven even when the host language's
+    // event loop owns the calling thread; otherwise it falls back to the
+    // standard multi-threaded runtime.
+    let runtime = slim::runtime::build_for_embedding(&runtime_config);
+
+    // Setup tracing subscriber (may fail if already set, which is OK)
+    let guard = match tracing_conf.setup_tracing_subscriber() {
+        Ok(g) => {
+            debug!(?tracing_conf, "Tracing configuration loaded");
+            debug!("SLIM bindings initialized");
+            Some(Box::new(g) as Box<dyn std::any::Any + Send + Sync>)
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Tracing subscriber already set or failed to initialize: {}. Using existing subscriber.",
+                e
+            );
+            None
+        }
+    };
+
+    // Initialize the global service with config and start it.
+    // If we're already in an async tokio context (e.g. #[tokio::test]),
+    // delegate the block_on to a fresh OS thread so we don't get "Cannot
+    // start a runtime from within a runtime". `Handle` is Clone, so we just
+    // hand a copy to the worker thread.
+    let services = {
+        let handle = runtime.handle();
+        let configs = service_configs.to_vec();
+        let work = move || handle.block_on(initialize_and_start_global_services(&configs));
+        if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::spawn(work)
+                .join()
+                .expect("Thread panicked while initializing services")?
+        } else {
+            work()?
+        }
+    };
+
+    // Get first service for backward compatibility
+    let service = services
+        .first()
+        .ok_or_else(|| SlimError::ServiceError {
+            message: "No services were initialized".to_string(),
+        })?
+        .clone();
+
+    // Store the global state
+    let global_state = GlobalState {
+        tracing_guard: guard,
+        runtime_config,
+        tracing_config: tracing_conf,
+        service_config: service_configs.to_vec(),
+        runtime,
+        services,
+        service,
+    };
+
+    Ok(global_state)
+}
+
+/// Check if SLIM bindings have been initialized
+#[uniffi::export]
+pub fn is_initialized() -> bool {
+    GLOBAL_STATE.get().is_some()
+}
+
+/// Get a handle to the global Tokio runtime.
+///
+/// The returned `Handle` is cheap to clone and is safe to call `block_on` /
+/// `spawn` on from any thread (including foreign-language threads driven by
+/// UniFFI). When the runtime was built in single-threaded mode the actual
+/// scheduler runs on a dedicated background OS thread; the `Handle` simply
+/// routes work onto it.
+///
+/// If the bindings have not been initialized yet, this initializes them with
+/// defaults first.
+pub fn get_runtime() -> tokio::runtime::Handle {
+    initialize_with_defaults();
+    GLOBAL_STATE
+        .get()
+        .expect("Global runtime not initialized")
+        .runtime
+        .handle()
+}
+
+/// Returns references to all global services.
+/// If not initialized, initializes with defaults first.
+#[uniffi::export]
+pub fn get_services() -> Vec<Arc<crate::service::Service>> {
+    initialize_with_defaults();
+    GLOBAL_STATE
+        .get()
+        .map(|state| state.services.clone())
+        .expect("Global services not initialized")
+}
+
+/// Get the global service instance (creates it if it doesn't exist)
+///
+/// This returns a reference to the shared global service that can be used
+/// across the application. All calls to this function return the same service instance.
+#[uniffi::export]
+pub fn get_global_service() -> Arc<crate::service::Service> {
+    initialize_with_defaults();
+    GLOBAL_STATE
+        .get()
+        .map(|state| state.service.clone())
+        .expect("Main global service not initialized")
+}
+
+/// Get the runtime configuration
+///
+/// Returns a reference to the runtime configuration.
+/// If not initialized, initializes with defaults first.
+pub fn get_runtime_config() -> &'static CoreRuntimeConfiguration {
+    initialize_with_defaults();
+    &GLOBAL_STATE
+        .get()
+        .expect("Global state not initialized")
+        .runtime_config
+}
+
+/// Get the tracing configuration
+///
+/// Returns a reference to the tracing configuration.
+/// If not initialized, initializes with defaults first.
+pub fn get_tracing_config() -> &'static CoreTracingConfiguration {
+    initialize_with_defaults();
+    &GLOBAL_STATE
+        .get()
+        .expect("Global state not initialized")
+        .tracing_config
+}
+
+/// Get the service configuration
+///
+/// Returns a reference to the service configuration.
+/// If not initialized, initializes with defaults first.
+pub fn get_service_config() -> &'static [CoreServiceConfiguration] {
+    initialize_with_defaults();
+    &GLOBAL_STATE
+        .get()
+        .expect("Global state not initialized")
+        .service_config
+}
+
+/// Initialize the global service with configuration and start it
+///
+/// This creates the global service with the provided configuration and calls
+/// start() on it to initialize any configured servers and clients. If no
+/// servers/clients are configured, start() will skip the run phase but is
+/// still called for consistency.
+async fn initialize_and_start_global_services(
+    service_configs: &[CoreServiceConfiguration],
+) -> Result<Vec<Arc<crate::service::Service>>, SlimError> {
+    use slim_config::component::{Component, ComponentBuilder};
+    use slim_service::ServiceBuilder;
+
+    if service_configs.is_empty() {
+        return Err(SlimError::ServiceError {
+            message: "No service configuration provided".to_string(),
+        });
+    }
+
+    let mut services = Vec::with_capacity(service_configs.len());
+
+    // Create and start all services
+    for (idx, service_config) in service_configs.iter().enumerate() {
+        debug!("Creating global service {} with configuration", idx);
+        let mut slim_service =
+            ServiceBuilder::new().build_with_config(service_config.service_id(), service_config)?;
+
+        // Start the service to initialize servers and clients
+        // This calls run() internally if servers/clients are configured
+        debug!("Starting global service {}", idx);
+        match slim_service.start().await {
+            Ok(_) => {
+                info!("Global service {} started successfully", idx);
+            }
+            Err(e) => {
+                // Check if the error is due to no servers/clients configured
+                // This is acceptable for bindings that may not need network layer
+                if e.to_string().contains("no server or client configured") {
+                    debug!(
+                        "No servers or clients configured for service {}, service initialized without network layer",
+                        idx
+                    );
+                } else {
+                    return Err(SlimError::ServiceError {
+                        message: format!("Failed to start service {}: {}", idx, e.chain()),
+                    });
+                }
+            }
+        }
+
+        // Create and add the service
+        let service = Arc::new(crate::service::Service {
+            inner: Arc::new(slim_service),
+        });
+        services.push(service);
+    }
+
+    debug!(
+        "All {} global services initialized and started",
+        services.len()
+    );
+    Ok(services)
+}
+
+/// Perform graceful shutdown operations
+///
+/// This function performs the same shutdown operations as the main SLIM application:
+/// 1. Logs the shutdown signal
+/// 2. Gracefully stops the global service (if initialized)
+///
+/// This should be called when the application receives a shutdown signal (e.g., Ctrl+C)
+/// or when the application is terminating.
+///
+/// # Returns
+/// * `Ok(())` - Successfully shut down
+/// * `Err(SlimError)` - If shutdown fails
+///
+/// # Example
+/// ```ignore
+/// // Handle shutdown signal
+/// shutdown().await?;
+/// ```
+pub async fn shutdown() -> Result<(), SlimError> {
+    use tracing::info;
+
+    info!("Performing graceful shutdown");
+
+    // Get the drain timeout from configuration
+    let drain_timeout = get_runtime_config().drain_timeout();
+
+    // Get the global service if it exists
+    let service_opt = GLOBAL_STATE.get();
+
+    if let Some(state) = service_opt {
+        let inner = &state.service.inner;
+        info!("Stopping global service");
+
+        // Runtime-agnostic timeout using futures-timer
+        let shutdown_fut = inner.shutdown();
+        futures::pin_mut!(shutdown_fut);
+        let delay = Delay::new(drain_timeout);
+        futures::pin_mut!(delay);
+
+        match futures::future::select(shutdown_fut, delay).await {
+            futures::future::Either::Left((result, _)) => {
+                result?;
+            }
+            futures::future::Either::Right(_) => {
+                return Err(SlimError::ServiceError {
+                    message: format!("Service shutdown timed out after {drain_timeout:?}"),
+                });
+            }
+        }
+
+        info!("Global service stopped");
+    } else {
+        debug!("No global service to shutdown");
+    }
+
+    info!("Graceful shutdown complete");
+    Ok(())
+}
+
+/// Perform graceful shutdown operations (blocking version)
+///
+/// This is a blocking wrapper around the async `shutdown()` function for use from
+/// synchronous contexts or language bindings that don't support async.
+///
+/// # Returns
+/// * `Ok(())` - Successfully shut down
+/// * `Err(SlimError)` - If shutdown fails
+#[uniffi::export]
+pub fn shutdown_blocking() -> Result<(), SlimError> {
+    get_runtime().block_on(shutdown())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_error_variant_exists() {
+        // Verify ConfigError variant can be created
+        let err = SlimError::ConfigError {
+            message: "test error".to_string(),
+        };
+        assert!(format!("{err}").contains("Configuration error"));
+    }
+
+    #[test]
+    fn test_runtime_always_accessible() {
+        // The runtime can always be accessed (either from init or get_runtime fallback)
+        let _handle = get_runtime();
+    }
+
+    #[test]
+    fn test_idempotent_behavior() {
+        // Test that multiple initialization calls don't panic
+        // Note: In test environment, tracing may already be set up,
+        // so we just verify the calls don't panic
+        initialize_with_defaults();
+        initialize_with_defaults();
+    }
+
+    #[test]
+    fn test_get_runtime_config() {
+        // Test getting runtime config
+        let runtime_config = get_runtime_config();
+
+        // Should return a valid config (either from init or default)
+        assert!(!runtime_config.thread_name().is_empty());
+        assert!(runtime_config.drain_timeout().as_secs() > 0);
+    }
+
+    #[test]
+    fn test_get_tracing_config() {
+        // Test getting tracing config
+        let tracing_config = get_tracing_config();
+
+        // Should return a valid config (either from init or default)
+        assert!(!tracing_config.log_level().is_empty());
+    }
+
+    #[test]
+    fn test_get_service_config() {
+        // Test getting service config
+        let service_config = get_service_config();
+
+        // Should return a valid config (either from init or default)
+        // Just verify we can access the config fields
+        assert!(!service_config.is_empty());
+        let _ = &service_config[0].node_id;
+        let _ = &service_config[0].group_name;
+    }
+
+    #[test]
+    fn test_config_getters_return_defaults_when_not_initialized() {
+        // Even if not initialized, getters should return defaults
+        let runtime_config = get_runtime_config();
+        let tracing_config = get_tracing_config();
+        let service_config = get_service_config();
+
+        // All should be valid
+        // n_cores is usize, always >= 0, so just check it exists
+        let _ = runtime_config.n_cores();
+        assert!(!tracing_config.log_level().is_empty());
+        // Service config should have default values
+        assert!(!service_config.is_empty());
+        assert!(!service_config[0].node_id.is_empty());
+        assert!(service_config[0].group_name.is_none());
+    }
+
+    #[tokio::test]
+    #[test_fork::fork]
+    async fn test_initialization_from_async_context() {
+        // This test verifies that initialization works correctly when called
+        // from within an async tokio context (e.g., #[tokio::test])
+        // The implementation should detect the existing runtime and use
+        // std::thread::spawn to avoid "Cannot start a runtime from within a runtime" panic
+
+        // Initialize with defaults from async context
+        initialize_with_defaults();
+
+        // Verify we can access the runtime
+        let _handle = get_runtime();
+
+        // Verify we can access configs
+        let _ = get_runtime_config();
+        let _ = get_tracing_config();
+        let _ = get_service_config();
+
+        // Verify initialization is idempotent even from async context
+        initialize_with_defaults();
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_single_thread_runtime_drives_io() {
+        // With n_cores=1 the runtime is built as `current_thread` on a
+        // dedicated OS thread. Verify it actually drives timers and spawned
+        // tasks — this is the property that prevents the UniFFI/asyncio
+        // deadlock from issue #1648.
+        use crate::init_config::{new_runtime_config_with, new_service_config, new_tracing_config};
+        use std::time::Duration;
+
+        let runtime_config =
+            new_runtime_config_with(1, "slim-single".to_string(), Duration::from_secs(1));
+        let result = initialize_with_configs(
+            runtime_config,
+            new_tracing_config(),
+            &[new_service_config()],
+        );
+        assert!(result.is_ok());
+
+        // Schedule work on the global handle from a non-async thread. If the
+        // bg driver thread isn't actually polling, this will hang forever.
+        let handle = get_runtime();
+        let value = handle.block_on(async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            42_u32
+        });
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn test_initialize_with_configs() {
+        // Test initializing with custom config structs using wrapper types
+        use crate::init_config::{new_runtime_config, new_service_config_with, new_tracing_config};
+        use crate::service::DataplaneConfig;
+
+        let runtime_config = new_runtime_config();
+        let tracing_config = new_tracing_config();
+        let service_config = new_service_config_with(
+            Some("test-node".to_string()),
+            Some("test-group".to_string()),
+            DataplaneConfig::default(),
+        );
+
+        // This should succeed (or be idempotent if already initialized)
+        let result = initialize_with_configs(runtime_config, tracing_config, &[service_config]);
+        assert!(result.is_ok());
+
+        // Verify we can access the configs
+        let retrieved_service_config = get_service_config();
+        // Note: The actual values may differ if already initialized by another test
+        assert!(!retrieved_service_config.is_empty());
+        let _ = &retrieved_service_config[0].node_id;
+        let _ = &retrieved_service_config[0].group_name;
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_service_order_preserved_with_function_call() {
+        // Test that service order is preserved when initializing with multiple configs
+        use crate::init_config::{new_runtime_config, new_service_config_with, new_tracing_config};
+        use crate::service::DataplaneConfig;
+
+        let runtime_config = new_runtime_config();
+        let tracing_config = new_tracing_config();
+
+        // Create multiple service configs with distinct identifiers
+        let service_configs = vec![
+            new_service_config_with(
+                Some("service-0".to_string()),
+                Some("group-0".to_string()),
+                DataplaneConfig::default(),
+            ),
+            new_service_config_with(
+                Some("service-1".to_string()),
+                Some("group-1".to_string()),
+                DataplaneConfig::default(),
+            ),
+            new_service_config_with(
+                Some("service-2".to_string()),
+                Some("group-2".to_string()),
+                DataplaneConfig::default(),
+            ),
+        ];
+
+        // Store the expected order for verification
+        let expected_node_ids: Vec<String> = service_configs
+            .iter()
+            .map(|sc| sc.node_id.clone().unwrap())
+            .collect();
+
+        // Initialize with the configs
+        let result = initialize_with_configs(runtime_config, tracing_config, &service_configs);
+        assert!(result.is_ok());
+
+        // Verify the order is preserved
+        let retrieved_configs = get_service_config();
+        assert_eq!(retrieved_configs.len(), 3, "Should have 3 service configs");
+
+        // Verify each config is in the correct order by checking node_id
+        for (idx, config) in retrieved_configs.iter().enumerate() {
+            assert_eq!(
+                &config.node_id, &expected_node_ids[idx],
+                "Config at index {} should have node_id '{}', but got '{}'",
+                idx, expected_node_ids[idx], config.node_id
+            );
+        }
+
+        // Verify services count matches
+        let services = get_services();
+        assert_eq!(services.len(), 3, "Should have 3 services");
+        assert_eq!(
+            services.len(),
+            retrieved_configs.len(),
+            "Number of services must match number of configs"
+        );
+    }
+
+    #[tokio::test]
+    #[test_fork::fork]
+    async fn test_service_order_preserved_async() {
+        // Test that service order is preserved when created via async initialization
+        use crate::init_config::{new_runtime_config, new_service_config_with, new_tracing_config};
+        use crate::service::DataplaneConfig;
+
+        let runtime_config = new_runtime_config();
+        let tracing_config = new_tracing_config();
+
+        // Create multiple service configs with distinct identifiers
+        let service_configs = vec![
+            new_service_config_with(
+                Some("async-service-0".to_string()),
+                Some("async-group-0".to_string()),
+                DataplaneConfig::default(),
+            ),
+            new_service_config_with(
+                Some("async-service-1".to_string()),
+                Some("async-group-1".to_string()),
+                DataplaneConfig::default(),
+            ),
+            new_service_config_with(
+                Some("async-service-2".to_string()),
+                Some("async-group-2".to_string()),
+                DataplaneConfig::default(),
+            ),
+            new_service_config_with(
+                Some("async-service-3".to_string()),
+                Some("async-group-3".to_string()),
+                DataplaneConfig::default(),
+            ),
+        ];
+
+        // Store the expected order for verification
+        let expected_node_ids: Vec<String> = service_configs
+            .iter()
+            .map(|sc| sc.node_id.clone().unwrap())
+            .collect();
+        let expected_group_names: Vec<String> = service_configs
+            .iter()
+            .map(|sc| sc.group_name.clone().unwrap())
+            .collect();
+
+        // Initialize with the configs from async context
+        let result = initialize_with_configs(runtime_config, tracing_config, &service_configs);
+        assert!(result.is_ok());
+
+        // Verify the order is preserved
+        let retrieved_configs = get_service_config();
+        assert_eq!(
+            retrieved_configs.len(),
+            4,
+            "Should have exactly 4 service configs"
+        );
+
+        // Verify each config is in the correct order
+        for (idx, config) in retrieved_configs.iter().enumerate() {
+            assert_eq!(
+                &config.node_id, &expected_node_ids[idx],
+                "Config at index {} should have node_id '{}', but got '{}'",
+                idx, expected_node_ids[idx], config.node_id
+            );
+            assert_eq!(
+                config.group_name.as_ref().unwrap(),
+                &expected_group_names[idx],
+                "Config at index {} should have group_name '{}', but got '{:?}'",
+                idx,
+                expected_group_names[idx],
+                config.group_name
+            );
+        }
+
+        // Verify services are also in order and match config count
+        let services = get_services();
+        assert_eq!(services.len(), 4, "Should have exactly 4 services");
+        assert_eq!(
+            services.len(),
+            retrieved_configs.len(),
+            "Service count must match config count"
+        );
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_service_order_preserved_from_config_file() {
+        // Test that service order is preserved when loading from config file
+        use std::io::Write;
+
+        // Create a temporary config file with multiple services
+        let config_content = r#"# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+tracing:
+  log_level: info
+  display_thread_names: true
+  display_thread_ids: true
+
+runtime:
+  n_cores: 0
+  thread_name: "slim-data-plane"
+  drain_timeout: 10s
+
+services:
+  slim/0:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:56357"
+          tls:
+            insecure: true
+      clients: []
+  slim/1:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:56358"
+          tls:
+            insecure: true
+      clients: []
+  slim/2:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:56359"
+          tls:
+            insecure: true
+      clients: []
+  slim/3:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:56360"
+          tls:
+            insecure: true
+      clients: []
+"#;
+
+        // Write to a temporary file
+        let temp_dir = std::env::temp_dir();
+        let config_path = temp_dir.join("test-multi-service-order.yaml");
+        let mut file =
+            std::fs::File::create(&config_path).expect("Failed to create temp config file");
+        file.write_all(config_content.as_bytes())
+            .expect("Failed to write config");
+        drop(file); // Ensure file is flushed and closed
+
+        // Initialize from config file
+        initialize_from_config(config_path.to_str().unwrap().to_string());
+
+        // Verify all services were created
+        let services = get_services();
+        assert_eq!(
+            services.len(),
+            4,
+            "Should have exactly 4 services from config file"
+        );
+
+        // Verify config order is preserved
+        let configs = get_service_config();
+        assert_eq!(
+            configs.len(),
+            4,
+            "Should have exactly 4 configs from config file"
+        );
+
+        // Verify that the number of services matches the number of configs
+        assert_eq!(
+            services.len(),
+            configs.len(),
+            "Number of services must match number of configs"
+        );
+
+        // The order should be preserved as they appear in the YAML file
+        // IndexMap preserves insertion order from the YAML file
+        // The services in the config file are: slim/0, slim/1, slim/2, slim/3
+        // We verify by checking that each service's name matches the expected key
+        let expected_service_names = ["slim/0", "slim/1", "slim/2", "slim/3"];
+
+        for (idx, service) in services.iter().enumerate() {
+            let service_name = service.get_name();
+            assert_eq!(
+                service_name, expected_service_names[idx],
+                "Service at index {} should be named '{}', but got '{}'",
+                idx, expected_service_names[idx], service_name
+            );
+        }
+
+        // Clean up temp file
+        let _ = std::fs::remove_file(&config_path);
+    }
+
+    #[test]
+    fn test_is_initialized() {
+        // Test the is_initialized function
+        // After any initialization (including defaults), should return true
+        initialize_with_defaults();
+        assert!(is_initialized());
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_is_initialized_before_init() {
+        // In a fresh fork, is_initialized should eventually return true
+        // because other tests or get_runtime will trigger initialization
+        let result = is_initialized();
+        // This may be true or false depending on test execution order
+        // Just verify the function works without panicking
+        let _ = result;
+    }
+
+    #[test]
+    fn test_get_global_service() {
+        // Test that we can get the global service
+        let service = get_global_service();
+
+        // Verify the service has a valid name (defaults to UUID-based node_id)
+        let name = service.get_name();
+        assert!(!name.is_empty());
+    }
+
+    #[test]
+    fn test_get_global_service_singleton() {
+        // Verify get_global_service always returns the same instance
+        let service1 = get_global_service();
+        let service2 = get_global_service();
+
+        // Should be the same Arc instance
+        assert!(Arc::ptr_eq(&service1, &service2));
+    }
+
+    #[tokio::test]
+    #[test_fork::fork]
+    async fn test_shutdown_success() {
+        // Test successful shutdown
+        initialize_with_defaults();
+
+        // Ensure service is initialized
+        let _service = get_global_service();
+
+        // Shutdown should succeed
+        let result = shutdown().await;
+        assert!(result.is_ok(), "Shutdown should succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    #[test_fork::fork]
+    async fn test_shutdown_when_not_initialized() {
+        // Test shutdown when service is not initialized (fresh state)
+        // This should succeed gracefully without errors
+        let result = shutdown().await;
+        // Should succeed even if nothing was initialized
+        assert!(result.is_ok());
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_shutdown_blocking_success() {
+        // Test blocking shutdown wrapper
+        initialize_with_defaults();
+
+        // Ensure service is initialized
+        let _service = get_global_service();
+
+        // Blocking shutdown should succeed
+        let result = shutdown_blocking();
+        assert!(
+            result.is_ok(),
+            "Blocking shutdown should succeed: {result:?}"
+        );
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_shutdown_blocking_when_not_initialized() {
+        // Test blocking shutdown when nothing is initialized
+        let result = shutdown_blocking();
+        // Should succeed gracefully
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[test_fork::fork]
+    async fn test_shutdown_idempotent() {
+        // Test that multiple shutdown calls don't cause issues
+        initialize_with_defaults();
+        let _service = get_global_service();
+
+        // First shutdown
+        let result1 = shutdown().await;
+        assert!(result1.is_ok());
+
+        // Second shutdown should also succeed (or handle gracefully)
+        let result2 = shutdown().await;
+        // May succeed or fail gracefully, but shouldn't panic
+        let _ = result2;
+    }
+
+    #[test]
+    fn test_initialize_from_config_invalid_path() {
+        // Test error handling for invalid config file path
+        let result = std::panic::catch_unwind(|| {
+            initialize_from_config("/nonexistent/path/to/config.yaml".to_string());
+        });
+
+        // The function may panic or handle gracefully depending on implementation
+        // Just verify it doesn't cause undefined behavior
+        let _ = result;
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_initialize_from_config_with_error_invalid_path() {
+        // Test that we get a structured error instead of a panic
+        let result =
+            initialize_from_config_with_error("/nonexistent/path/to/config.yaml".to_string());
+
+        match result {
+            Err(SlimError::ConfigError { message }) => {
+                assert!(!message.is_empty());
+            }
+            other => panic!("Expected ConfigError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_get_services_count() {
+        // Test that get_services returns services
+        let services = get_services();
+
+        // Should have at least one service
+        assert!(!services.is_empty());
+
+        // Each service should be valid
+        for service in services.iter() {
+            let name = service.get_name();
+            assert!(!name.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_services_match_configs() {
+        // Verify that the number of services matches configs
+        let services = get_services();
+        let configs = get_service_config();
+
+        assert_eq!(
+            services.len(),
+            configs.len(),
+            "Number of services should match number of configs"
+        );
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_initialize_from_config_with_valid_yaml() {
+        // Test initializing from a valid config file
+        use std::io::Write;
+
+        let config_content = r#"
+tracing:
+  log_level: debug
+  display_thread_names: true
+
+runtime:
+  n_cores: 2
+  thread_name: "test-runtime"
+  drain_timeout: 5s
+
+services:
+  test-service:
+    node_id: "test-node"
+    group_name: "test-group"
+    dataplane:
+      servers: []
+      clients: []
+"#;
+
+        let temp_dir = std::env::temp_dir();
+        let config_path = temp_dir.join("test-valid-config.yaml");
+        let mut file = std::fs::File::create(&config_path).expect("Failed to create temp file");
+        file.write_all(config_content.as_bytes())
+            .expect("Failed to write config");
+        drop(file);
+
+        // Initialize from config
+        initialize_from_config(config_path.to_str().unwrap().to_string());
+
+        // Verify initialization succeeded by checking configs
+        let tracing_config = get_tracing_config();
+        assert!(!tracing_config.log_level().is_empty());
+
+        let runtime_config = get_runtime_config();
+        assert!(!runtime_config.thread_name().is_empty());
+
+        let service_configs = get_service_config();
+        assert!(!service_configs.is_empty());
+
+        // Clean up
+        let _ = std::fs::remove_file(&config_path);
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_initialize_from_config_with_error_valid_yaml() {
+        // Test the non-panicking initializer with a valid config file
+        use std::io::Write;
+
+        let config_content = r#"
+tracing:
+    log_level: info
+    display_thread_names: true
+
+runtime:
+    n_cores: 1
+    thread_name: "test-runtime-error"
+    drain_timeout: 3s
+
+services:
+    test-service:
+        node_id: "test-node"
+        group_name: "test-group"
+        dataplane:
+            servers: []
+            clients: []
+"#;
+
+        let temp_dir = std::env::temp_dir();
+        let config_path = temp_dir.join("test-valid-config-error.yaml");
+        let mut file = std::fs::File::create(&config_path).expect("Failed to create temp file");
+        file.write_all(config_content.as_bytes())
+            .expect("Failed to write config");
+        drop(file);
+
+        let result = initialize_from_config_with_error(config_path.to_str().unwrap().to_string());
+        assert!(result.is_ok(), "Expected Ok(()), got: {result:?}");
+
+        let service_configs = get_service_config();
+        assert!(!service_configs.is_empty());
+
+        let _ = std::fs::remove_file(&config_path);
+    }
+}

--- a/crates/slim-bindings/src/errors.rs
+++ b/crates/slim-bindings/src/errors.rs
@@ -1,0 +1,98 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use display_error_chain::ErrorChainExt;
+
+use slim_auth::errors::AuthError;
+use slim_service::errors::ServiceError;
+use slim_session::errors::SessionError;
+
+/// Error types for SLIM operations
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum SlimError {
+    #[error("service error: {message}")]
+    ServiceError { message: String },
+    #[error("Session error: {message}")]
+    SessionError { message: String },
+    #[error("Receive error: {message}")]
+    ReceiveError { message: String },
+    #[error("Send error: {message}")]
+    SendError { message: String },
+    #[error("Authentication error: {message}")]
+    AuthError { message: String },
+    #[error("Configuration error: {message}")]
+    ConfigError { message: String },
+    #[error("RPC error: {message}")]
+    RpcError { message: String },
+    #[error("Operation timed out")]
+    Timeout,
+    #[error("Invalid argument: {message}")]
+    InvalidArgument { message: String },
+    #[error("Internal error: {message}")]
+    InternalError { message: String },
+}
+
+macro_rules! impl_from_error_for_slim {
+    ($source:ty, $variant:ident) => {
+        impl From<$source> for SlimError {
+            fn from(err: $source) -> Self {
+                SlimError::$variant {
+                    message: err.chain().to_string(),
+                }
+            }
+        }
+    };
+}
+
+impl_from_error_for_slim!(ServiceError, ServiceError);
+impl_from_error_for_slim!(SessionError, SessionError);
+impl_from_error_for_slim!(AuthError, AuthError);
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test SlimError Display implementations
+    #[test]
+    fn test_slim_error_display() {
+        let errors = vec![
+            SlimError::SessionError {
+                message: "session".to_string(),
+            },
+            SlimError::ReceiveError {
+                message: "receive".to_string(),
+            },
+            SlimError::SendError {
+                message: "send".to_string(),
+            },
+            SlimError::AuthError {
+                message: "auth".to_string(),
+            },
+            SlimError::ConfigError {
+                message: "config".to_string(),
+            },
+            SlimError::RpcError {
+                message: "rpc".to_string(),
+            },
+            SlimError::Timeout,
+            SlimError::InvalidArgument {
+                message: "invalid".to_string(),
+            },
+            SlimError::InternalError {
+                message: "internal".to_string(),
+            },
+        ];
+
+        for error in errors {
+            let display = format!("{error}");
+            assert!(!display.is_empty(), "Error display should not be empty");
+        }
+
+        // Specific checks
+        assert!(format!("{}", SlimError::Timeout).contains("timed out"));
+    }
+}

--- a/crates/slim-bindings/src/identity_config.rs
+++ b/crates/slim-bindings/src/identity_config.rs
@@ -1,0 +1,973 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_config::auth::identity::{
+    IdentityProviderConfig as CoreIdentityProviderConfig,
+    IdentityVerifierConfig as CoreIdentityVerifierConfig,
+};
+use slim_config::auth::jwt::Config as JwtAuthConfig;
+use slim_config::auth::jwt::{Claims as JwtClaims, JwtKey};
+use slim_config::auth::static_jwt::Config as StaticJwtConfig;
+use std::time::Duration;
+
+#[cfg_attr(target_family = "windows", allow(unused_imports))]
+use crate::common_config::SpireConfig;
+use crate::errors::SlimError;
+
+/// Static JWT (Bearer token) authentication configuration
+/// The token is loaded from a file and automatically reloaded when changed
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct StaticJwtAuth {
+    /// Path to file containing the JWT token
+    pub token_file: String,
+    /// Duration for caching the token before re-reading from file (default: 3600 seconds)
+    pub duration: Duration,
+}
+
+impl From<StaticJwtAuth> for StaticJwtConfig {
+    fn from(config: StaticJwtAuth) -> Self {
+        StaticJwtConfig::with_file(&config.token_file).with_duration(config.duration)
+    }
+}
+
+impl From<StaticJwtConfig> for StaticJwtAuth {
+    fn from(config: StaticJwtConfig) -> Self {
+        StaticJwtAuth {
+            token_file: config.source().file.clone(),
+            duration: config.duration(),
+        }
+    }
+}
+
+/// JWT signing/verification algorithm
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum JwtAlgorithm {
+    HS256,
+    HS384,
+    HS512,
+    ES256,
+    ES384,
+    RS256,
+    RS384,
+    RS512,
+    PS256,
+    PS384,
+    PS512,
+    EdDSA,
+}
+
+impl From<JwtAlgorithm> for slim_auth::jwt::Algorithm {
+    fn from(algo: JwtAlgorithm) -> Self {
+        match algo {
+            JwtAlgorithm::HS256 => slim_auth::jwt::Algorithm::HS256,
+            JwtAlgorithm::HS384 => slim_auth::jwt::Algorithm::HS384,
+            JwtAlgorithm::HS512 => slim_auth::jwt::Algorithm::HS512,
+            JwtAlgorithm::ES256 => slim_auth::jwt::Algorithm::ES256,
+            JwtAlgorithm::ES384 => slim_auth::jwt::Algorithm::ES384,
+            JwtAlgorithm::RS256 => slim_auth::jwt::Algorithm::RS256,
+            JwtAlgorithm::RS384 => slim_auth::jwt::Algorithm::RS384,
+            JwtAlgorithm::RS512 => slim_auth::jwt::Algorithm::RS512,
+            JwtAlgorithm::PS256 => slim_auth::jwt::Algorithm::PS256,
+            JwtAlgorithm::PS384 => slim_auth::jwt::Algorithm::PS384,
+            JwtAlgorithm::PS512 => slim_auth::jwt::Algorithm::PS512,
+            JwtAlgorithm::EdDSA => slim_auth::jwt::Algorithm::EdDSA,
+        }
+    }
+}
+
+impl From<slim_auth::jwt::Algorithm> for JwtAlgorithm {
+    fn from(algo: slim_auth::jwt::Algorithm) -> Self {
+        match algo {
+            slim_auth::jwt::Algorithm::HS256 => JwtAlgorithm::HS256,
+            slim_auth::jwt::Algorithm::HS384 => JwtAlgorithm::HS384,
+            slim_auth::jwt::Algorithm::HS512 => JwtAlgorithm::HS512,
+            slim_auth::jwt::Algorithm::ES256 => JwtAlgorithm::ES256,
+            slim_auth::jwt::Algorithm::ES384 => JwtAlgorithm::ES384,
+            slim_auth::jwt::Algorithm::RS256 => JwtAlgorithm::RS256,
+            slim_auth::jwt::Algorithm::RS384 => JwtAlgorithm::RS384,
+            slim_auth::jwt::Algorithm::RS512 => JwtAlgorithm::RS512,
+            slim_auth::jwt::Algorithm::PS256 => JwtAlgorithm::PS256,
+            slim_auth::jwt::Algorithm::PS384 => JwtAlgorithm::PS384,
+            slim_auth::jwt::Algorithm::PS512 => JwtAlgorithm::PS512,
+            slim_auth::jwt::Algorithm::EdDSA => JwtAlgorithm::EdDSA,
+        }
+    }
+}
+
+/// JWT key format
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum JwtKeyFormat {
+    Pem,
+    Jwk,
+    Jwks,
+}
+
+impl From<JwtKeyFormat> for slim_auth::jwt::KeyFormat {
+    fn from(format: JwtKeyFormat) -> Self {
+        match format {
+            JwtKeyFormat::Pem => slim_auth::jwt::KeyFormat::Pem,
+            JwtKeyFormat::Jwk => slim_auth::jwt::KeyFormat::Jwk,
+            JwtKeyFormat::Jwks => slim_auth::jwt::KeyFormat::Jwks,
+        }
+    }
+}
+
+impl From<slim_auth::jwt::KeyFormat> for JwtKeyFormat {
+    fn from(format: slim_auth::jwt::KeyFormat) -> Self {
+        match format {
+            slim_auth::jwt::KeyFormat::Pem => JwtKeyFormat::Pem,
+            slim_auth::jwt::KeyFormat::Jwk => JwtKeyFormat::Jwk,
+            slim_auth::jwt::KeyFormat::Jwks => JwtKeyFormat::Jwks,
+        }
+    }
+}
+
+/// JWT key data source
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum JwtKeyData {
+    /// String with encoded key(s)
+    Data { value: String },
+    /// File path to the key(s)
+    File { path: String },
+}
+
+impl From<JwtKeyData> for slim_auth::jwt::KeyData {
+    fn from(data: JwtKeyData) -> Self {
+        match data {
+            JwtKeyData::Data { value } => slim_auth::jwt::KeyData::Data(value),
+            JwtKeyData::File { path } => slim_auth::jwt::KeyData::File(path),
+        }
+    }
+}
+
+impl From<slim_auth::jwt::KeyData> for JwtKeyData {
+    fn from(data: slim_auth::jwt::KeyData) -> Self {
+        match data {
+            slim_auth::jwt::KeyData::Data(value) => JwtKeyData::Data { value },
+            slim_auth::jwt::KeyData::File(path) => JwtKeyData::File { path },
+        }
+    }
+}
+
+/// JWT key configuration
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct JwtKeyConfig {
+    /// Algorithm used for signing/verifying the JWT
+    pub algorithm: JwtAlgorithm,
+    /// Key format - PEM, JWK or JWKS
+    pub format: JwtKeyFormat,
+    /// Encoded key or file path
+    pub key: JwtKeyData,
+}
+
+impl From<JwtKeyConfig> for slim_auth::jwt::Key {
+    fn from(config: JwtKeyConfig) -> Self {
+        slim_auth::jwt::Key {
+            algorithm: config.algorithm.into(),
+            format: config.format.into(),
+            key: config.key.into(),
+        }
+    }
+}
+
+impl From<slim_auth::jwt::Key> for JwtKeyConfig {
+    fn from(key: slim_auth::jwt::Key) -> Self {
+        JwtKeyConfig {
+            algorithm: key.algorithm.into(),
+            format: key.format.into(),
+            key: key.key.into(),
+        }
+    }
+}
+
+/// JWT key type (encoding, decoding, or autoresolve)
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum JwtKeyType {
+    /// Encoding key for signing JWTs (client-side)
+    Encoding { key: JwtKeyConfig },
+    /// Decoding key for verifying JWTs (server-side)
+    Decoding { key: JwtKeyConfig },
+    /// Automatically resolve keys based on claims
+    Autoresolve,
+}
+
+impl From<JwtKeyType> for JwtKey {
+    fn from(key_type: JwtKeyType) -> Self {
+        match key_type {
+            JwtKeyType::Encoding { key } => JwtKey::Encoding(key.into()),
+            JwtKeyType::Decoding { key } => JwtKey::Decoding(key.into()),
+            JwtKeyType::Autoresolve => JwtKey::Autoresolve,
+        }
+    }
+}
+
+impl From<JwtKey> for JwtKeyType {
+    fn from(key: JwtKey) -> Self {
+        match key {
+            JwtKey::Encoding(k) => JwtKeyType::Encoding { key: k.into() },
+            JwtKey::Decoding(k) => JwtKeyType::Decoding { key: k.into() },
+            JwtKey::Autoresolve => JwtKeyType::Autoresolve,
+        }
+    }
+}
+
+/// JWT authentication configuration for client-side signing
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct ClientJwtAuth {
+    /// JWT key configuration (encoding key for signing)
+    pub key: JwtKeyType,
+    /// JWT audience claims to include
+    pub audience: Option<Vec<String>>,
+    /// JWT issuer to include
+    pub issuer: Option<String>,
+    /// JWT subject to include
+    pub subject: Option<String>,
+    /// Token validity duration (default: 3600 seconds)
+    pub duration: Duration,
+}
+
+impl From<ClientJwtAuth> for JwtAuthConfig {
+    fn from(config: ClientJwtAuth) -> Self {
+        let mut claims = JwtClaims::default();
+
+        if let Some(audience) = config.audience {
+            claims = claims.with_audience(&audience);
+        }
+
+        if let Some(issuer) = config.issuer {
+            claims = claims.with_issuer(issuer);
+        }
+
+        if let Some(subject) = config.subject {
+            claims = claims.with_subject(subject);
+        }
+
+        JwtAuthConfig::new(claims, config.duration, config.key.into())
+    }
+}
+
+impl From<JwtAuthConfig> for ClientJwtAuth {
+    fn from(config: JwtAuthConfig) -> Self {
+        let claims = config.claims();
+        ClientJwtAuth {
+            key: config.key().clone().into(),
+            audience: claims.audience().clone(),
+            issuer: claims.issuer().clone(),
+            subject: claims.subject().clone(),
+            duration: config.duration(),
+        }
+    }
+}
+
+/// JWT authentication configuration for server-side verification
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct JwtAuth {
+    /// JWT key configuration (decoding key for verification)
+    pub key: JwtKeyType,
+    /// JWT audience claims to verify
+    pub audience: Option<Vec<String>>,
+    /// JWT issuer to verify
+    pub issuer: Option<String>,
+    /// JWT subject to verify
+    pub subject: Option<String>,
+    /// Token validity duration (default: 3600 seconds)
+    pub duration: Duration,
+}
+
+impl From<JwtAuth> for JwtAuthConfig {
+    fn from(config: JwtAuth) -> Self {
+        let mut claims = JwtClaims::default();
+
+        if let Some(audience) = config.audience {
+            claims = claims.with_audience(&audience);
+        }
+
+        if let Some(issuer) = config.issuer {
+            claims = claims.with_issuer(issuer);
+        }
+
+        if let Some(subject) = config.subject {
+            claims = claims.with_subject(subject);
+        }
+
+        JwtAuthConfig::new(claims, config.duration, config.key.into())
+    }
+}
+
+impl From<JwtAuthConfig> for JwtAuth {
+    fn from(config: JwtAuthConfig) -> Self {
+        let claims = config.claims();
+        JwtAuth {
+            key: config.key().clone().into(),
+            audience: claims.audience().clone(),
+            issuer: claims.issuer().clone(),
+            subject: claims.subject().clone(),
+            duration: config.duration(),
+        }
+    }
+}
+
+/// Identity provider configuration - used to prove identity to others
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum IdentityProviderConfig {
+    /// Shared secret authentication (symmetric key)
+    SharedSecret { id: String, data: String },
+    /// Static JWT loaded from file with auto-reload
+    StaticJwt { config: StaticJwtAuth },
+    /// Dynamic JWT generation with signing key
+    Jwt { config: ClientJwtAuth },
+    /// SPIRE-based identity provider (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    Spire { config: SpireConfig },
+    /// No identity provider configured
+    None,
+}
+
+impl From<IdentityProviderConfig> for CoreIdentityProviderConfig {
+    fn from(config: IdentityProviderConfig) -> Self {
+        match config {
+            IdentityProviderConfig::SharedSecret { id, data } => {
+                CoreIdentityProviderConfig::SharedSecret { id, data }
+            }
+            IdentityProviderConfig::StaticJwt { config } => {
+                CoreIdentityProviderConfig::StaticJwt(config.into())
+            }
+            IdentityProviderConfig::Jwt { config } => {
+                CoreIdentityProviderConfig::Jwt(config.into())
+            }
+            #[cfg(not(target_family = "windows"))]
+            IdentityProviderConfig::Spire { config } => {
+                CoreIdentityProviderConfig::Spire(config.into())
+            }
+            IdentityProviderConfig::None => CoreIdentityProviderConfig::None,
+        }
+    }
+}
+
+impl From<CoreIdentityProviderConfig> for IdentityProviderConfig {
+    fn from(config: CoreIdentityProviderConfig) -> Self {
+        match config {
+            CoreIdentityProviderConfig::SharedSecret { id, data } => {
+                IdentityProviderConfig::SharedSecret { id, data }
+            }
+            CoreIdentityProviderConfig::StaticJwt(config) => IdentityProviderConfig::StaticJwt {
+                config: config.into(),
+            },
+            CoreIdentityProviderConfig::Jwt(config) => IdentityProviderConfig::Jwt {
+                config: config.into(),
+            },
+            #[cfg(not(target_family = "windows"))]
+            CoreIdentityProviderConfig::Spire(config) => IdentityProviderConfig::Spire {
+                config: config.into(),
+            },
+            CoreIdentityProviderConfig::None => IdentityProviderConfig::None,
+        }
+    }
+}
+
+/// Identity verifier configuration - used to verify identity of others
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum IdentityVerifierConfig {
+    /// Shared secret verification (symmetric key)
+    SharedSecret { id: String, data: String },
+    /// JWT verification with decoding key
+    Jwt { config: JwtAuth },
+    /// SPIRE-based identity verifier (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    Spire { config: SpireConfig },
+    /// No identity verifier configured
+    None,
+}
+
+impl From<IdentityVerifierConfig> for CoreIdentityVerifierConfig {
+    fn from(config: IdentityVerifierConfig) -> Self {
+        match config {
+            IdentityVerifierConfig::SharedSecret { id, data } => {
+                CoreIdentityVerifierConfig::SharedSecret { id, data }
+            }
+            IdentityVerifierConfig::Jwt { config } => {
+                CoreIdentityVerifierConfig::Jwt(config.into())
+            }
+            #[cfg(not(target_family = "windows"))]
+            IdentityVerifierConfig::Spire { config } => {
+                CoreIdentityVerifierConfig::Spire(config.into())
+            }
+            IdentityVerifierConfig::None => CoreIdentityVerifierConfig::None,
+        }
+    }
+}
+
+impl From<CoreIdentityVerifierConfig> for IdentityVerifierConfig {
+    fn from(config: CoreIdentityVerifierConfig) -> Self {
+        match config {
+            CoreIdentityVerifierConfig::SharedSecret { id, data } => {
+                IdentityVerifierConfig::SharedSecret { id, data }
+            }
+            CoreIdentityVerifierConfig::Jwt(config) => IdentityVerifierConfig::Jwt {
+                config: config.into(),
+            },
+            #[cfg(not(target_family = "windows"))]
+            CoreIdentityVerifierConfig::Spire(config) => IdentityVerifierConfig::Spire {
+                config: config.into(),
+            },
+            CoreIdentityVerifierConfig::None => IdentityVerifierConfig::None,
+        }
+    }
+}
+
+impl TryFrom<IdentityProviderConfig> for AuthProvider {
+    type Error = SlimError;
+
+    fn try_from(config: IdentityProviderConfig) -> Result<Self, Self::Error> {
+        match config {
+            IdentityProviderConfig::SharedSecret { id, data } => {
+                Ok(AuthProvider::shared_secret_from_str(&id, &data)?)
+            }
+            IdentityProviderConfig::StaticJwt { config } => {
+                let core_config: StaticJwtConfig = config.into();
+                let provider = core_config.build_static_token_provider()?;
+                Ok(AuthProvider::static_token(provider))
+            }
+            IdentityProviderConfig::Jwt { config } => {
+                let core_config: JwtAuthConfig = config.into();
+                let provider = core_config.get_provider()?;
+                Ok(AuthProvider::jwt_signer(provider))
+            }
+            #[cfg(not(target_family = "windows"))]
+            IdentityProviderConfig::Spire { config } => {
+                let mut builder = slim_auth::spire::SpireIdentityManager::builder();
+
+                if let Some(socket_path) = config.socket_path {
+                    builder = builder.with_socket_path(socket_path);
+                }
+
+                if let Some(target_spiffe_id) = config.target_spiffe_id {
+                    builder = builder.with_target_spiffe_id(target_spiffe_id);
+                }
+
+                if !config.jwt_audiences.is_empty() {
+                    builder = builder.with_jwt_audiences(config.jwt_audiences);
+                }
+
+                let manager = builder.build()?;
+                Ok(AuthProvider::spire(manager))
+            }
+            IdentityProviderConfig::None => Err(SlimError::InvalidArgument {
+                message: "Cannot create AuthProvider from None variant".to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<IdentityVerifierConfig> for AuthVerifier {
+    type Error = SlimError;
+
+    fn try_from(config: IdentityVerifierConfig) -> Result<Self, Self::Error> {
+        match config {
+            IdentityVerifierConfig::SharedSecret { id, data } => {
+                Ok(AuthVerifier::shared_secret_from_str(&id, &data)?)
+            }
+            IdentityVerifierConfig::Jwt { config } => {
+                let core_config: JwtAuthConfig = config.into();
+                let verifier = core_config.get_verifier()?;
+                Ok(AuthVerifier::jwt_verifier(verifier))
+            }
+            #[cfg(not(target_family = "windows"))]
+            IdentityVerifierConfig::Spire { config } => {
+                let mut builder = slim_auth::spire::SpireIdentityManager::builder();
+
+                if let Some(socket_path) = config.socket_path {
+                    builder = builder.with_socket_path(socket_path);
+                }
+
+                if let Some(target_spiffe_id) = config.target_spiffe_id {
+                    builder = builder.with_target_spiffe_id(target_spiffe_id);
+                }
+
+                if !config.jwt_audiences.is_empty() {
+                    builder = builder.with_jwt_audiences(config.jwt_audiences);
+                }
+
+                let manager = builder.build()?;
+                Ok(AuthVerifier::spire(manager))
+            }
+            IdentityVerifierConfig::None => Err(SlimError::InvalidArgument {
+                message: "Cannot create AuthVerifier from None variant".to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // Test StaticJwtAuth conversions
+    #[test]
+    fn test_static_jwt_auth_conversion() {
+        let auth = StaticJwtAuth {
+            token_file: "/path/to/token.jwt".to_string(),
+            duration: Duration::from_secs(7200),
+        };
+
+        let core_config: StaticJwtConfig = auth.clone().into();
+        assert_eq!(core_config.source().file, auth.token_file);
+        assert_eq!(core_config.duration(), auth.duration);
+
+        let back_to_auth: StaticJwtAuth = core_config.into();
+        assert_eq!(back_to_auth, auth);
+    }
+
+    // Test JwtAlgorithm conversions
+    #[test]
+    fn test_jwt_algorithm_conversions() {
+        let algorithms = vec![
+            JwtAlgorithm::HS256,
+            JwtAlgorithm::HS384,
+            JwtAlgorithm::HS512,
+            JwtAlgorithm::ES256,
+            JwtAlgorithm::ES384,
+            JwtAlgorithm::RS256,
+            JwtAlgorithm::RS384,
+            JwtAlgorithm::RS512,
+            JwtAlgorithm::PS256,
+            JwtAlgorithm::PS384,
+            JwtAlgorithm::PS512,
+            JwtAlgorithm::EdDSA,
+        ];
+
+        for algo in algorithms {
+            let core_algo: slim_auth::jwt::Algorithm = algo.clone().into();
+            let back: JwtAlgorithm = core_algo.into();
+            assert_eq!(back, algo);
+        }
+    }
+
+    // Test JwtKeyFormat conversions
+    #[test]
+    fn test_jwt_key_format_conversions() {
+        let formats = vec![JwtKeyFormat::Pem, JwtKeyFormat::Jwk, JwtKeyFormat::Jwks];
+
+        for format in formats {
+            let core_format: slim_auth::jwt::KeyFormat = format.clone().into();
+            let back: JwtKeyFormat = core_format.into();
+            assert_eq!(back, format);
+        }
+    }
+
+    // Test JwtKeyData conversions
+    #[test]
+    fn test_jwt_key_data_conversions() {
+        let data_value = JwtKeyData::Data {
+            value: "test-key-data".to_string(),
+        };
+        let core_data: slim_auth::jwt::KeyData = data_value.clone().into();
+        let back: JwtKeyData = core_data.into();
+        assert_eq!(back, data_value);
+
+        let file_path = JwtKeyData::File {
+            path: "/path/to/key.pem".to_string(),
+        };
+        let core_file: slim_auth::jwt::KeyData = file_path.clone().into();
+        let back_file: JwtKeyData = core_file.into();
+        assert_eq!(back_file, file_path);
+    }
+
+    // Test JwtKeyConfig conversions
+    #[test]
+    fn test_jwt_key_config_conversions() {
+        let key_config = JwtKeyConfig {
+            algorithm: JwtAlgorithm::RS256,
+            format: JwtKeyFormat::Pem,
+            key: JwtKeyData::File {
+                path: "/path/to/key.pem".to_string(),
+            },
+        };
+
+        let core_key: slim_auth::jwt::Key = key_config.clone().into();
+        let back: JwtKeyConfig = core_key.into();
+        assert_eq!(back, key_config);
+    }
+
+    // Test JwtKeyType conversions
+    #[test]
+    fn test_jwt_key_type_conversions() {
+        let encoding_key = JwtKeyType::Encoding {
+            key: JwtKeyConfig {
+                algorithm: JwtAlgorithm::RS256,
+                format: JwtKeyFormat::Pem,
+                key: JwtKeyData::Data {
+                    value: "encoding-key".to_string(),
+                },
+            },
+        };
+
+        let core_encoding: JwtKey = encoding_key.clone().into();
+        let back_encoding: JwtKeyType = core_encoding.into();
+        assert_eq!(back_encoding, encoding_key);
+
+        let decoding_key = JwtKeyType::Decoding {
+            key: JwtKeyConfig {
+                algorithm: JwtAlgorithm::ES256,
+                format: JwtKeyFormat::Jwk,
+                key: JwtKeyData::File {
+                    path: "/path/to/key.jwk".to_string(),
+                },
+            },
+        };
+
+        let core_decoding: JwtKey = decoding_key.clone().into();
+        let back_decoding: JwtKeyType = core_decoding.into();
+        assert_eq!(back_decoding, decoding_key);
+
+        let autoresolve = JwtKeyType::Autoresolve;
+        let core_auto: JwtKey = autoresolve.clone().into();
+        let back_auto: JwtKeyType = core_auto.into();
+        assert_eq!(back_auto, autoresolve);
+    }
+
+    // Test ClientJwtAuth conversions
+    #[test]
+    fn test_client_jwt_auth_conversions() {
+        let client_auth = ClientJwtAuth {
+            key: JwtKeyType::Autoresolve,
+            audience: Some(vec!["api.example.com".to_string()]),
+            issuer: Some("auth.example.com".to_string()),
+            subject: Some("user@example.com".to_string()),
+            duration: Duration::from_secs(1800),
+        };
+
+        let core_config: JwtAuthConfig = client_auth.clone().into();
+        assert_eq!(core_config.duration(), client_auth.duration);
+
+        let back: ClientJwtAuth = core_config.into();
+        assert_eq!(back, client_auth);
+    }
+
+    // Test ClientJwtAuth with None fields
+    #[test]
+    fn test_client_jwt_auth_with_none_fields() {
+        let client_auth = ClientJwtAuth {
+            key: JwtKeyType::Autoresolve,
+            audience: None,
+            issuer: None,
+            subject: None,
+            duration: Duration::from_secs(3600),
+        };
+
+        let core_config: JwtAuthConfig = client_auth.clone().into();
+        let back: ClientJwtAuth = core_config.into();
+        assert_eq!(back.audience, None);
+        assert_eq!(back.issuer, None);
+        assert_eq!(back.subject, None);
+    }
+
+    // Test JwtAuth conversions
+    #[test]
+    fn test_jwt_auth_conversions() {
+        let jwt_auth = JwtAuth {
+            key: JwtKeyType::Decoding {
+                key: JwtKeyConfig {
+                    algorithm: JwtAlgorithm::RS256,
+                    format: JwtKeyFormat::Pem,
+                    key: JwtKeyData::File {
+                        path: "/path/to/key.pem".to_string(),
+                    },
+                },
+            },
+            audience: Some(vec!["service.example.com".to_string()]),
+            issuer: Some("issuer.example.com".to_string()),
+            subject: Some("subject".to_string()),
+            duration: Duration::from_secs(900),
+        };
+
+        let core_config: JwtAuthConfig = jwt_auth.clone().into();
+        let back: JwtAuth = core_config.into();
+        assert_eq!(back, jwt_auth);
+    }
+
+    // Test IdentityProviderConfig conversions
+    #[test]
+    fn test_identity_provider_config_shared_secret() {
+        let config = IdentityProviderConfig::SharedSecret {
+            id: "test-id".to_string(),
+            data: "secret-data".to_string(),
+        };
+
+        let core_config: CoreIdentityProviderConfig = config.clone().into();
+        let back: IdentityProviderConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    #[test]
+    fn test_identity_provider_config_static_jwt() {
+        let config = IdentityProviderConfig::StaticJwt {
+            config: StaticJwtAuth {
+                token_file: "/path/to/token.jwt".to_string(),
+                duration: Duration::from_secs(3600),
+            },
+        };
+
+        let core_config: CoreIdentityProviderConfig = config.clone().into();
+        let back: IdentityProviderConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    #[test]
+    fn test_identity_provider_config_jwt() {
+        let config = IdentityProviderConfig::Jwt {
+            config: ClientJwtAuth {
+                key: JwtKeyType::Autoresolve,
+                audience: Some(vec!["test".to_string()]),
+                issuer: None,
+                subject: None,
+                duration: Duration::from_secs(3600),
+            },
+        };
+
+        let core_config: CoreIdentityProviderConfig = config.clone().into();
+        let back: IdentityProviderConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    #[test]
+    fn test_identity_provider_config_none() {
+        let config = IdentityProviderConfig::None;
+        let core_config: CoreIdentityProviderConfig = config.clone().into();
+        let back: IdentityProviderConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test IdentityVerifierConfig conversions
+    #[test]
+    fn test_identity_verifier_config_shared_secret() {
+        let config = IdentityVerifierConfig::SharedSecret {
+            id: "verifier-id".to_string(),
+            data: "verifier-secret".to_string(),
+        };
+
+        let core_config: CoreIdentityVerifierConfig = config.clone().into();
+        let back: IdentityVerifierConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    #[test]
+    fn test_identity_verifier_config_jwt() {
+        let config = IdentityVerifierConfig::Jwt {
+            config: JwtAuth {
+                key: JwtKeyType::Autoresolve,
+                audience: Some(vec!["verifier".to_string()]),
+                issuer: Some("auth".to_string()),
+                subject: None,
+                duration: Duration::from_secs(7200),
+            },
+        };
+
+        let core_config: CoreIdentityVerifierConfig = config.clone().into();
+        let back: IdentityVerifierConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    #[test]
+    fn test_identity_verifier_config_none() {
+        let config = IdentityVerifierConfig::None;
+        let core_config: CoreIdentityVerifierConfig = config.clone().into();
+        let back: IdentityVerifierConfig = core_config.into();
+        assert_eq!(back, config);
+    }
+
+    // Test TryFrom for IdentityProviderConfig to AuthProvider
+    #[test]
+    fn test_identity_provider_to_auth_provider_shared_secret() {
+        let config = IdentityProviderConfig::SharedSecret {
+            id: "test-id".to_string(),
+            data: "shared-secret-value-0123456789abcdef".to_string(), // Must be 32+ chars
+        };
+
+        let result: Result<AuthProvider, SlimError> = config.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_identity_provider_to_auth_provider_none_fails() {
+        let config = IdentityProviderConfig::None;
+        let result: Result<AuthProvider, SlimError> = config.try_into();
+        assert!(result.is_err());
+        if let Err(SlimError::InvalidArgument { message }) = result {
+            assert!(message.contains("Cannot create AuthProvider from None variant"));
+        }
+    }
+
+    // Test TryFrom for IdentityVerifierConfig to AuthVerifier
+    #[test]
+    fn test_identity_verifier_to_auth_verifier_shared_secret() {
+        let config = IdentityVerifierConfig::SharedSecret {
+            id: "verifier-id".to_string(),
+            data: "verifier-shared-secret-0123456789abcdef".to_string(), // Must be 32+ chars
+        };
+
+        let result: Result<AuthVerifier, SlimError> = config.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_identity_verifier_to_auth_verifier_none_fails() {
+        let config = IdentityVerifierConfig::None;
+        let result: Result<AuthVerifier, SlimError> = config.try_into();
+        assert!(result.is_err());
+        if let Err(SlimError::InvalidArgument { message }) = result {
+            assert!(message.contains("Cannot create AuthVerifier from None variant"));
+        }
+    }
+
+    // Test invalid shared secret (too short)
+    #[test]
+    fn test_identity_provider_invalid_shared_secret() {
+        let config = IdentityProviderConfig::SharedSecret {
+            id: "test-id".to_string(),
+            data: "tooshort".to_string(), // Must be at least 32 characters
+        };
+
+        let result: Result<AuthProvider, SlimError> = config.try_into();
+        assert!(result.is_err());
+        if let Err(SlimError::InvalidArgument { message }) = result {
+            assert!(message.contains("Failed to create SharedSecret provider"));
+        }
+    }
+
+    #[test]
+    fn test_identity_verifier_invalid_shared_secret() {
+        let config = IdentityVerifierConfig::SharedSecret {
+            id: "test-id".to_string(),
+            data: "tooshort".to_string(), // Too short - must be 32+ chars
+        };
+
+        let result: Result<AuthVerifier, SlimError> = config.try_into();
+        assert!(result.is_err());
+        if let Err(SlimError::InvalidArgument { message }) = result {
+            assert!(message.contains("Failed to create SharedSecret verifier"));
+        }
+    }
+
+    // Test SPIRE config conversions (non-Windows only)
+    #[cfg(not(target_family = "windows"))]
+    #[test]
+    fn test_identity_provider_config_spire() {
+        let spire_config = SpireConfig {
+            socket_path: Some("/tmp/spire.sock".to_string()),
+            target_spiffe_id: Some("spiffe://example.com/service".to_string()),
+            jwt_audiences: vec!["audience1".to_string(), "audience2".to_string()],
+            trust_domains: vec![],
+        };
+
+        let config = IdentityProviderConfig::Spire {
+            config: spire_config.clone(),
+        };
+
+        let core_config: CoreIdentityProviderConfig = config.clone().into();
+        let back: IdentityProviderConfig = core_config.into();
+
+        if let IdentityProviderConfig::Spire {
+            config: back_config,
+        } = back
+        {
+            assert_eq!(back_config.socket_path, spire_config.socket_path);
+            assert_eq!(back_config.target_spiffe_id, spire_config.target_spiffe_id);
+            assert_eq!(back_config.jwt_audiences, spire_config.jwt_audiences);
+        } else {
+            panic!("Expected Spire variant");
+        }
+    }
+
+    #[cfg(not(target_family = "windows"))]
+    #[test]
+    fn test_identity_verifier_config_spire() {
+        let spire_config = SpireConfig {
+            socket_path: None,
+            target_spiffe_id: None,
+            jwt_audiences: vec!["slim".to_string()],
+            trust_domains: vec!["example.com".to_string()],
+        };
+
+        let config = IdentityVerifierConfig::Spire {
+            config: spire_config.clone(),
+        };
+
+        let core_config: CoreIdentityVerifierConfig = config.clone().into();
+        let back: IdentityVerifierConfig = core_config.into();
+
+        if let IdentityVerifierConfig::Spire {
+            config: back_config,
+        } = back
+        {
+            assert_eq!(back_config.socket_path, spire_config.socket_path);
+            assert_eq!(back_config.jwt_audiences, spire_config.jwt_audiences);
+        } else {
+            panic!("Expected Spire variant");
+        }
+    }
+
+    // Test complex JWT key configurations
+    #[test]
+    fn test_complex_jwt_key_configurations() {
+        let configurations = vec![
+            JwtKeyConfig {
+                algorithm: JwtAlgorithm::HS256,
+                format: JwtKeyFormat::Pem,
+                key: JwtKeyData::Data {
+                    value: "secret-key".to_string(),
+                },
+            },
+            JwtKeyConfig {
+                algorithm: JwtAlgorithm::ES384,
+                format: JwtKeyFormat::Jwk,
+                key: JwtKeyData::File {
+                    path: "/etc/keys/ec-key.jwk".to_string(),
+                },
+            },
+            JwtKeyConfig {
+                algorithm: JwtAlgorithm::PS512,
+                format: JwtKeyFormat::Jwks,
+                key: JwtKeyData::File {
+                    path: "/etc/keys/jwks.json".to_string(),
+                },
+            },
+        ];
+
+        for config in configurations {
+            let core_key: slim_auth::jwt::Key = config.clone().into();
+            let back: JwtKeyConfig = core_key.into();
+            assert_eq!(back, config);
+        }
+    }
+
+    // Test all JWT algorithms are covered
+    #[test]
+    fn test_all_jwt_algorithms_covered() {
+        let all_algorithms = vec![
+            (JwtAlgorithm::HS256, slim_auth::jwt::Algorithm::HS256),
+            (JwtAlgorithm::HS384, slim_auth::jwt::Algorithm::HS384),
+            (JwtAlgorithm::HS512, slim_auth::jwt::Algorithm::HS512),
+            (JwtAlgorithm::ES256, slim_auth::jwt::Algorithm::ES256),
+            (JwtAlgorithm::ES384, slim_auth::jwt::Algorithm::ES384),
+            (JwtAlgorithm::RS256, slim_auth::jwt::Algorithm::RS256),
+            (JwtAlgorithm::RS384, slim_auth::jwt::Algorithm::RS384),
+            (JwtAlgorithm::RS512, slim_auth::jwt::Algorithm::RS512),
+            (JwtAlgorithm::PS256, slim_auth::jwt::Algorithm::PS256),
+            (JwtAlgorithm::PS384, slim_auth::jwt::Algorithm::PS384),
+            (JwtAlgorithm::PS512, slim_auth::jwt::Algorithm::PS512),
+            (JwtAlgorithm::EdDSA, slim_auth::jwt::Algorithm::EdDSA),
+        ];
+
+        for (adapter_algo, core_algo) in all_algorithms {
+            let converted_core: slim_auth::jwt::Algorithm = adapter_algo.clone().into();
+            let converted_back: JwtAlgorithm = converted_core.into();
+            assert_eq!(converted_back, adapter_algo);
+
+            let direct_back: JwtAlgorithm = core_algo.into();
+            assert_eq!(direct_back, adapter_algo);
+        }
+    }
+}

--- a/crates/slim-bindings/src/init_config.rs
+++ b/crates/slim-bindings/src/init_config.rs
@@ -1,0 +1,293 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! UniFFI-compatible configuration wrappers for initialization
+//!
+//! This module provides wrapper types for RuntimeConfiguration, TracingConfiguration,
+//! and ServiceConfiguration that can be passed through UniFFI bindings.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use slim::runtime::RuntimeConfiguration as CoreRuntimeConfiguration;
+use slim_tracing::TracingConfiguration as CoreTracingConfiguration;
+
+use crate::{ServiceConfig, service::DataplaneConfig};
+
+/// Runtime configuration for the SLIM bindings
+///
+/// Controls the Tokio runtime behavior including thread count, naming, and shutdown timeout.
+#[derive(uniffi::Record, Clone, Debug, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// Number of cores to use for the runtime (0 = use all available cores)
+    pub n_cores: u64,
+
+    /// Thread name prefix for the runtime
+    pub thread_name: String,
+
+    /// Timeout duration for draining services during shutdown
+    pub drain_timeout: Duration,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        let core = CoreRuntimeConfiguration::default();
+        RuntimeConfig {
+            n_cores: core.n_cores() as u64,
+            thread_name: core.thread_name().to_string(),
+            drain_timeout: core.drain_timeout(),
+        }
+    }
+}
+
+impl From<RuntimeConfig> for CoreRuntimeConfiguration {
+    fn from(config: RuntimeConfig) -> Self {
+        CoreRuntimeConfiguration {
+            n_cores: config.n_cores as usize,
+            thread_name: config.thread_name,
+            drain_timeout: config.drain_timeout.into(),
+        }
+    }
+}
+
+impl From<CoreRuntimeConfiguration> for RuntimeConfig {
+    fn from(config: CoreRuntimeConfiguration) -> Self {
+        RuntimeConfig {
+            n_cores: config.n_cores() as u64,
+            thread_name: config.thread_name().to_string(),
+            drain_timeout: config.drain_timeout(),
+        }
+    }
+}
+
+/// Tracing/logging configuration for the SLIM bindings
+///
+/// Controls logging behavior including log level, thread name/ID display, and filters.
+#[derive(uniffi::Record, Clone, Debug, Serialize, Deserialize)]
+pub struct TracingConfig {
+    /// Log level (e.g., "debug", "info", "warn", "error")
+    pub log_level: String,
+
+    /// Whether to display thread names in logs
+    pub display_thread_names: bool,
+
+    /// Whether to display thread IDs in logs
+    pub display_thread_ids: bool,
+
+    /// List of tracing filter directives (e.g., ["slim=debug", "tokio=info"])
+    pub filters: Vec<String>,
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        let core = CoreTracingConfiguration::default();
+        TracingConfig {
+            log_level: core.log_level().to_string(),
+            display_thread_names: core.display_thread_names(),
+            display_thread_ids: core.display_thread_ids(),
+            filters: core.filter().to_vec(),
+        }
+    }
+}
+
+impl From<TracingConfig> for CoreTracingConfiguration {
+    fn from(config: TracingConfig) -> Self {
+        CoreTracingConfiguration::default()
+            .with_log_level(config.log_level)
+            .with_display_thread_names(config.display_thread_names)
+            .with_display_thread_ids(config.display_thread_ids)
+            .with_filter(config.filters)
+    }
+}
+
+impl From<CoreTracingConfiguration> for TracingConfig {
+    fn from(config: CoreTracingConfiguration) -> Self {
+        TracingConfig {
+            log_level: config.log_level().to_string(),
+            display_thread_names: config.display_thread_names(),
+            display_thread_ids: config.display_thread_ids(),
+            filters: config.filter().to_vec(),
+        }
+    }
+}
+
+// Constructor functions for UniFFI
+
+/// Create a new BindingsRuntimeConfig with default values
+#[uniffi::export]
+pub fn new_runtime_config() -> RuntimeConfig {
+    RuntimeConfig::default()
+}
+
+/// Create a new BindingsRuntimeConfig with custom values
+#[uniffi::export]
+pub fn new_runtime_config_with(
+    n_cores: u64,
+    thread_name: String,
+    drain_timeout: Duration,
+) -> RuntimeConfig {
+    RuntimeConfig {
+        n_cores,
+        thread_name,
+        drain_timeout,
+    }
+}
+
+/// Create a new BindingsTracingConfig with default values
+#[uniffi::export]
+pub fn new_tracing_config() -> TracingConfig {
+    TracingConfig::default()
+}
+
+/// Create a new BindingsTracingConfig with custom values
+#[uniffi::export]
+pub fn new_tracing_config_with(
+    log_level: String,
+    display_thread_names: bool,
+    display_thread_ids: bool,
+    filters: Vec<String>,
+) -> TracingConfig {
+    TracingConfig {
+        log_level,
+        display_thread_names,
+        display_thread_ids,
+        filters,
+    }
+}
+
+/// Create a new BindingsServiceConfig with default values
+#[uniffi::export]
+pub fn new_service_config() -> ServiceConfig {
+    ServiceConfig::default()
+}
+
+/// Create a new BindingsServiceConfig with custom values
+#[uniffi::export]
+pub fn new_service_config_with(
+    node_id: Option<String>,
+    group_name: Option<String>,
+    dataplane: DataplaneConfig,
+) -> ServiceConfig {
+    ServiceConfig {
+        node_id,
+        group_name,
+        dataplane,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use slim_service::ServiceConfiguration as CoreServiceConfiguration;
+
+    use super::*;
+
+    #[test]
+    fn test_runtime_configuration_default() {
+        let config = RuntimeConfig::default();
+        assert_eq!(config.n_cores, 0); // 0 means use all cores
+        assert_eq!(config.thread_name, "slim");
+        assert_eq!(config.drain_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_runtime_configuration_roundtrip() {
+        let config = RuntimeConfig {
+            n_cores: 4,
+            thread_name: "test-runtime".to_string(),
+            drain_timeout: Duration::from_secs(30),
+        };
+
+        let core: CoreRuntimeConfiguration = config.clone().into();
+        let back: RuntimeConfig = core.into();
+
+        assert_eq!(back.n_cores, config.n_cores);
+        assert_eq!(back.thread_name, config.thread_name);
+        assert_eq!(back.drain_timeout, config.drain_timeout);
+    }
+
+    #[test]
+    fn test_tracing_configuration_default() {
+        let config = TracingConfig::default();
+        assert_eq!(config.log_level, "info");
+        // Note: display_thread_names, display_thread_ids, and filters defaults come from core
+        // Just verify we can read them
+        let _ = config.display_thread_names;
+        let _ = config.display_thread_ids;
+        let _ = &config.filters;
+    }
+
+    #[test]
+    fn test_tracing_configuration_roundtrip() {
+        let config = TracingConfig {
+            log_level: "debug".to_string(),
+            display_thread_names: true,
+            display_thread_ids: true,
+            filters: vec!["slim=debug".to_string(), "tokio=info".to_string()],
+        };
+
+        let core: CoreTracingConfiguration = config.clone().into();
+        let back: TracingConfig = core.into();
+
+        assert_eq!(back.log_level, config.log_level);
+        assert_eq!(back.display_thread_names, config.display_thread_names);
+        assert_eq!(back.display_thread_ids, config.display_thread_ids);
+        assert_eq!(back.filters, config.filters);
+    }
+
+    #[test]
+    fn test_service_configuration_default() {
+        let config = ServiceConfig::default();
+        assert!(config.node_id.is_none());
+        assert!(config.group_name.is_none());
+    }
+
+    #[test]
+    fn test_service_configuration_roundtrip() {
+        let config = ServiceConfig {
+            node_id: Some("test-node".to_string()),
+            group_name: Some("test-group".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        let core: CoreServiceConfiguration = config.clone().into();
+        let back: ServiceConfig = core.into();
+
+        assert_eq!(back.node_id, config.node_id);
+        assert_eq!(back.group_name, config.group_name);
+    }
+
+    #[test]
+    fn test_constructor_functions() {
+        let runtime = new_runtime_config();
+        assert_eq!(runtime.n_cores, 0);
+
+        let runtime_custom =
+            new_runtime_config_with(4, "custom".to_string(), Duration::from_secs(20));
+        assert_eq!(runtime_custom.n_cores, 4);
+        assert_eq!(runtime_custom.thread_name, "custom");
+        assert_eq!(runtime_custom.drain_timeout, Duration::from_secs(20));
+
+        let tracing = new_tracing_config();
+        assert_eq!(tracing.log_level, "info");
+
+        let tracing_custom = new_tracing_config_with(
+            "debug".to_string(),
+            true,
+            true,
+            vec!["slim=debug".to_string()],
+        );
+        assert_eq!(tracing_custom.log_level, "debug");
+        assert!(tracing_custom.display_thread_names);
+
+        let service = new_service_config();
+        assert!(service.node_id.is_none());
+
+        let service_custom = new_service_config_with(
+            Some("node-1".to_string()),
+            Some("group-1".to_string()),
+            DataplaneConfig::default(),
+        );
+        assert_eq!(service_custom.node_id, Some("node-1".to_string()));
+        assert_eq!(service_custom.group_name, Some("group-1".to_string()));
+    }
+}

--- a/crates/slim-bindings/src/lib.rs
+++ b/crates/slim-bindings/src/lib.rs
@@ -1,0 +1,119 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! # SLIM Bindings - UniFFI Language Bindings
+//!
+//! This crate provides language-agnostic FFI bindings for SLIM using UniFFI.
+//! It enables integration with Go, Python, Kotlin, Swift, and other languages.
+//!
+//! ## Architecture
+//!
+//! The module is organized into distinct components:
+//!
+//! - **`App`**: App-level operations (creation, configuration, session management)
+//! - **`Session`**: Session-specific operations (publish, invite, remove, message reception)
+//! - **`MessageContext`**: Message metadata and routing information
+//! - **`ServiceRef`**: Service reference management (global vs local)
+//!
+//! ## Usage
+//!
+//! ### From Rust
+//!
+//! ```rust,ignore
+//! use slim_bindings::{App, Name, SessionConfig, SessionType, IdentityProviderConfig, IdentityVerifierConfig};
+//!
+//! // Create an app
+//! let app_name = Arc::new(Name { components: vec!["org".into(), "app".into(), "v1".into()], id: None });
+//! let provider_config = IdentityProviderConfig::SharedSecret { data: "my-secret".to_string() };
+//! let verifier_config = IdentityVerifierConfig::SharedSecret { data: "my-secret".to_string() };
+//! let app = App::new(app_name, provider_config, verifier_config, false)?;
+//!
+//! // Create a session
+//! let config = SessionConfig { session_type: SessionType::PointToPoint, ... };
+//! let session = app.create_session(config, destination)?;
+//! ```
+//!
+//! ### From Go (via generated bindings)
+//!
+//! ```go
+//! providerConfig := slim.IdentityProviderConfigSharedSecret{Data: sharedSecret}
+//! verifierConfig := slim.IdentityVerifierConfigSharedSecret{Data: sharedSecret}
+//! app, err := slim.NewApp(appName, providerConfig, verifierConfig, false)
+//! session, err := app.CreateSession(config, destination)
+//! session.Publish(data, payloadType, metadata)
+//! ```
+
+// Module declarations
+mod app;
+mod build_info;
+mod client_config;
+mod common_config;
+mod completion_handle;
+mod config;
+mod errors;
+mod identity_config;
+mod init_config;
+mod message_context;
+mod name;
+mod server_config;
+mod service;
+mod session;
+mod transport_protocol;
+
+// SlimRPC module (unified core + UniFFI bindings)
+pub mod slimrpc;
+
+// Public re-exports
+pub use app::{App, Direction, SessionWithCompletion};
+pub use build_info::{BuildInfo, get_build_info, get_version};
+pub use client_config::{
+    BackoffConfig, ClientConfig, ExponentialBackoff, KeepaliveConfig, ProxyConfig,
+    new_config_from_json, new_insecure_client_config,
+};
+pub use common_config::{
+    BasicAuth, CaSource, ClientAuthenticationConfig, ServerAuthenticationConfig, SpireConfig,
+    TlsClientConfig, TlsServerConfig, TlsSource,
+};
+pub use completion_handle::CompletionHandle;
+pub use config::get_runtime;
+pub use config::{
+    get_global_service, get_runtime_config, get_service_config, get_tracing_config,
+    initialize_from_config, initialize_with_configs, initialize_with_defaults, is_initialized,
+    shutdown, shutdown_blocking,
+};
+pub use errors::SlimError;
+pub use identity_config::{
+    ClientJwtAuth, IdentityProviderConfig, IdentityVerifierConfig, JwtAlgorithm, JwtAuth,
+    JwtKeyConfig, JwtKeyData, JwtKeyFormat, JwtKeyType, StaticJwtAuth,
+};
+pub use init_config::{
+    RuntimeConfig, TracingConfig, new_runtime_config, new_runtime_config_with, new_service_config,
+    new_service_config_with, new_tracing_config, new_tracing_config_with,
+};
+pub use message_context::{MessageContext, ReceivedMessage};
+pub use name::Name;
+pub use server_config::{
+    KeepaliveServerParameters, ServerConfig, new_insecure_server_config, new_server_config,
+};
+pub use service::{
+    DataplaneConfig, Service, ServiceConfig, create_service, create_service_with_config,
+    new_dataplane_config, new_service_configuration,
+};
+pub use session::{MlsSettings, Session, SessionConfig, SessionType};
+pub use transport_protocol::TransportProtocol;
+pub use transport_protocol::TransportProtocol as ClientTransportProtocol;
+pub use transport_protocol::TransportProtocol as ServerTransportProtocol;
+
+// SLIMRpc re-exports
+pub use slimrpc::{
+    BidiStreamHandler, Channel, Codec, Context, DEADLINE_KEY, DecodedStream, Decoder, Encoder,
+    HandlerType, InvalidRpcCode, MAX_TIMEOUT, MulticastBidiStreamHandler, MulticastResponseReader,
+    MulticastStreamMessage, RawStream, RequestStreamWriter, ResponseSink, ResponseStreamReader,
+    RpcCode, RpcError, RpcMessageContext, RpcMulticastItem, STATUS_CODE_KEY, Server,
+    SessionContext as RpcSessionContext, StreamMessage, StreamStreamHandler, StreamUnaryHandler,
+    UnaryStreamHandler, UnaryUnaryHandler, UniffiRequestStream as RequestStream,
+    build_method_subscription_name,
+};
+
+// UniFFI scaffolding setup (must be at crate root)
+uniffi::setup_scaffolding!();

--- a/crates/slim-bindings/src/message_context.rs
+++ b/crates/slim-bindings/src/message_context.rs
@@ -1,0 +1,370 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use slim_datapath::api::ProtoName as SlimName;
+use slim_datapath::api::{ProtoMessage, ProtoPublishType};
+
+use slim_session::SessionError;
+
+// Import the FFI Name type for use in MessageContext fields
+use crate::Name;
+
+/// Generic message context for language bindings (UniFFI-compatible)
+///
+/// Provides routing and descriptive metadata needed for replying,
+/// auditing, and instrumentation across different language bindings.
+/// This type is exported to foreign languages via UniFFI.
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct MessageContext {
+    /// Fully-qualified sender identity
+    pub source_name: Arc<Name>,
+    /// Fully-qualified destination identity (may be empty for broadcast/group scenarios)
+    pub destination_name: Option<Arc<Name>>,
+    /// Logical/semantic type (defaults to "msg" if unspecified)
+    pub payload_type: String,
+    /// Arbitrary key/value pairs supplied by the sender (e.g. tracing IDs)
+    pub metadata: HashMap<String, String>,
+    /// Numeric identifier of the inbound connection carrying the message
+    pub input_connection: u64,
+    /// Identity contained in the message
+    pub identity: String,
+}
+
+impl MessageContext {
+    /// Create a new MessageContext
+    pub fn new(
+        source: Name,
+        destination: Option<Name>,
+        payload_type: String,
+        metadata: HashMap<String, String>,
+        input_connection: u64,
+        identity: String,
+    ) -> Self {
+        Self {
+            source_name: Arc::new(source),
+            destination_name: destination.map(Arc::new),
+            payload_type,
+            metadata,
+            input_connection,
+            identity,
+        }
+    }
+
+    /// Get the source name as a SlimName (for internal use)
+    pub fn source_as_slim_name(&self) -> SlimName {
+        self.source_name.as_ref().into()
+    }
+
+    /// Build a `MessageContext` plus the raw payload bytes from a low-level
+    /// `ProtoMessage`. Returns an error if the message type is unsupported
+    /// (i.e. not a publish payload).
+    ///
+    /// On success:
+    /// * The context captures source/destination identities
+    /// * `payload_type` defaults to "msg" if unset
+    /// * `metadata` is copied from the underlying protocol envelope
+    /// * The returned `Vec<u8>` is the raw application payload
+    #[allow(clippy::result_large_err)]
+    pub fn from_proto_message(msg: ProtoMessage) -> Result<(Self, Vec<u8>), SessionError> {
+        let Some(ProtoPublishType(publish)) = msg.message_type.as_ref() else {
+            return Err(SessionError::MessageTypeUnexpected(Box::new(msg)));
+        };
+
+        // Convert SlimName to FFI Name
+        let source = Name::from(&msg.get_source());
+        let destination = Some(Name::from(&msg.get_dst()));
+        let input_connection = msg.get_incoming_conn();
+        let payload_bytes = publish
+            .msg
+            .as_ref()
+            .and_then(|c| c.as_application_payload().ok())
+            .map(|p| p.blob.clone())
+            .unwrap_or_default();
+        let payload_type = publish
+            .msg
+            .as_ref()
+            .and_then(|c| c.as_application_payload().ok())
+            .map(|p| {
+                if p.payload_type.is_empty() {
+                    "msg".to_string()
+                } else {
+                    p.payload_type.clone()
+                }
+            })
+            .unwrap_or_else(|| "msg".to_string());
+        let metadata = msg.get_metadata_map();
+        let identity = msg.get_identity();
+
+        let ctx = Self::new(
+            source,
+            destination,
+            payload_type,
+            metadata,
+            input_connection,
+            identity,
+        );
+        Ok((ctx, payload_bytes))
+    }
+}
+
+/// Received message containing context and payload
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct ReceivedMessage {
+    pub context: MessageContext,
+    pub payload: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slim_datapath::api::{
+        ApplicationPayload, ProtoMessage, ProtoPublish, ProtoPublishType, SessionHeader, SlimHeader,
+    };
+    use std::collections::HashMap;
+
+    /// Helper to create FFI Name from string parts (matches what SlimName converts to)
+    fn ffi_name(parts: [&str; 3]) -> Arc<Name> {
+        Arc::new(Name::new(
+            parts[0].to_string(),
+            parts[1].to_string(),
+            parts[2].to_string(),
+        ))
+    }
+
+    /// Helper to create SlimName for ProtoMessage construction
+    fn slim_name(parts: [&str; 3]) -> SlimName {
+        SlimName::from_strings(parts)
+    }
+
+    // Helper function to create a test ProtoMessage with Publish type
+    fn create_test_proto_message(
+        source: SlimName,
+        dest: SlimName,
+        connection_id: u64,
+        payload: Vec<u8>,
+        content_type: String,
+        metadata: HashMap<String, String>,
+    ) -> ProtoMessage {
+        let content = ApplicationPayload::new(&content_type, payload).as_content();
+
+        let mut slim_header = SlimHeader::default();
+        slim_header.set_source(source);
+        slim_header.set_destination(dest);
+
+        let publish = ProtoPublish {
+            header: Some(slim_header),
+            session: Some(SessionHeader::default()),
+            msg: Some(content),
+        };
+
+        let mut proto_msg = ProtoMessage {
+            message_type: Some(ProtoPublishType(publish)),
+            metadata,
+        };
+
+        proto_msg.set_incoming_conn(Some(connection_id));
+
+        proto_msg
+    }
+
+    #[tokio::test]
+    async fn test_message_context_creation() {
+        let source = ffi_name(["org", "namespace", "sender"]);
+        let destination = Some(ffi_name(["org", "namespace", "receiver"]));
+        let mut metadata = HashMap::new();
+        metadata.insert("test".to_string(), "value".to_string());
+
+        let ctx = MessageContext::new(
+            source.as_ref().clone(),
+            destination.as_ref().map(|n| n.as_ref().clone()),
+            "application/json".to_string(),
+            metadata.clone(),
+            42,
+            "test-identity".to_string(),
+        );
+
+        assert_eq!(&ctx.source_name, &source);
+        assert_eq!(&ctx.destination_name, &destination);
+        assert_eq!(ctx.payload_type, "application/json");
+        assert_eq!(ctx.metadata, metadata);
+        assert_eq!(ctx.input_connection, 42);
+        assert_eq!(ctx.identity, "test-identity");
+    }
+
+    #[tokio::test]
+    async fn test_from_proto_message_success() {
+        // Create test data
+        let payload_data = b"test payload".to_vec();
+        let content_type = "application/json".to_string();
+        let source_slim = slim_name(["org", "sender", "service"]);
+        let dest_slim = slim_name(["org", "receiver", "service"]);
+        let connection_id = 12345u64;
+        let identity = "test-identity".to_string();
+
+        // Expected FFI names
+        let source_ffi = ffi_name(["org", "sender", "service"]);
+        let dest_ffi = ffi_name(["org", "receiver", "service"]);
+
+        // Create metadata
+        let mut metadata = HashMap::new();
+        metadata.insert("trace_id".to_string(), "abc123".to_string());
+        metadata.insert("user_id".to_string(), "user456".to_string());
+
+        let mut proto_msg = create_test_proto_message(
+            source_slim,
+            dest_slim,
+            connection_id,
+            payload_data.clone(),
+            content_type.clone(),
+            metadata.clone(),
+        );
+
+        // set identity
+        proto_msg
+            .get_slim_header_mut()
+            .set_identity(identity.clone());
+        // Test from_proto_message
+        let result = MessageContext::from_proto_message(proto_msg);
+        assert!(result.is_ok());
+
+        let (ctx, payload) = result.unwrap();
+
+        // Verify context fields (comparing FFI Names)
+        assert_eq!(&ctx.source_name, &source_ffi);
+        assert_eq!(&ctx.destination_name, &Some(dest_ffi));
+        assert_eq!(ctx.payload_type, content_type);
+        assert_eq!(ctx.metadata, metadata);
+        assert_eq!(ctx.input_connection, connection_id);
+        assert_eq!(ctx.identity, identity);
+
+        // Verify payload
+        assert_eq!(payload, payload_data);
+    }
+
+    #[tokio::test]
+    async fn test_from_proto_message_with_default_content_type() {
+        let source_slim = slim_name(["org", "sender", "service"]);
+        let dest_slim = slim_name(["org", "receiver", "service"]);
+        let payload_data = b"test payload".to_vec();
+
+        let proto_msg = create_test_proto_message(
+            source_slim,
+            dest_slim,
+            42,
+            payload_data,
+            String::new(), // Empty content type should default to "msg"
+            HashMap::new(),
+        );
+
+        let result = MessageContext::from_proto_message(proto_msg);
+        assert!(result.is_ok());
+
+        let (ctx, _) = result.unwrap();
+        assert_eq!(ctx.payload_type, "msg"); // Should default to "msg"
+    }
+
+    #[tokio::test]
+    async fn test_from_proto_message_with_no_content() {
+        let source_slim = slim_name(["org", "sender", "service"]);
+        let dest_slim = slim_name(["org", "receiver", "service"]);
+
+        // Create ProtoPublish without msg content
+        let mut slim_header = SlimHeader::default();
+        slim_header.set_source(source_slim);
+        slim_header.set_destination(dest_slim);
+
+        let publish = ProtoPublish {
+            header: Some(slim_header),
+            session: Some(SessionHeader::default()),
+            msg: None, // No content
+        };
+
+        let mut proto_msg = ProtoMessage {
+            message_type: Some(ProtoPublishType(publish)),
+            ..Default::default()
+        };
+        proto_msg.set_incoming_conn(Some(42));
+
+        let result = MessageContext::from_proto_message(proto_msg);
+        assert!(result.is_ok());
+
+        let (ctx, payload) = result.unwrap();
+        assert_eq!(ctx.payload_type, "msg"); // Should default to "msg"
+        assert_eq!(payload, Vec::<u8>::new()); // Should be empty payload
+    }
+
+    #[tokio::test]
+    async fn test_from_proto_message_unsupported_message_type() {
+        // Create ProtoMessage without ProtoPublishType
+        let proto_msg = ProtoMessage {
+            message_type: None, // Unsupported type
+            ..Default::default()
+        };
+
+        let result = MessageContext::from_proto_message(proto_msg);
+        assert!(result.is_err_and(|e| matches!(e, SessionError::MessageTypeUnexpected(_))));
+    }
+
+    #[tokio::test]
+    async fn test_from_proto_message_with_empty_metadata() {
+        let source_slim = slim_name(["test", "source", "v1"]);
+        let dest_slim = slim_name(["test", "dest", "v1"]);
+        let source_ffi = ffi_name(["test", "source", "v1"]);
+        let dest_ffi = ffi_name(["test", "dest", "v1"]);
+        let payload_data = b"test".to_vec();
+
+        let proto_msg = create_test_proto_message(
+            source_slim,
+            dest_slim,
+            99,
+            payload_data.clone(),
+            "text/plain".to_string(),
+            HashMap::new(), // Empty metadata
+        );
+
+        let result = MessageContext::from_proto_message(proto_msg);
+        assert!(result.is_ok());
+
+        let (ctx, payload) = result.unwrap();
+        assert_eq!(&ctx.source_name, &source_ffi);
+        assert_eq!(&ctx.destination_name, &Some(dest_ffi));
+        assert_eq!(ctx.payload_type, "text/plain");
+        assert_eq!(ctx.metadata, HashMap::new()); // Should be empty
+        assert_eq!(ctx.input_connection, 99);
+        assert_eq!(payload, payload_data);
+    }
+
+    /// Test ReceivedMessage creation
+    #[test]
+    fn test_received_message() {
+        let msg = ReceivedMessage {
+            context: MessageContext::new(
+                Name::new_with_id(
+                    "org".to_string(),
+                    "ns".to_string(),
+                    "app".to_string(),
+                    "00000000-0000-0000-0000-00000000007b".to_string(),
+                ),
+                Some(Name::new_with_id(
+                    "org".to_string(),
+                    "ns".to_string(),
+                    "dest".to_string(),
+                    "00000000-0000-0000-0000-000000012345".to_string(),
+                )),
+                "application/json".to_string(),
+                std::collections::HashMap::new(),
+                789,
+                "test-identity".to_string(),
+            ),
+            payload: b"hello world".to_vec(),
+        };
+
+        assert_eq!(msg.payload, b"hello world");
+        assert_eq!(msg.context.input_connection, 789);
+        assert_eq!(msg.context.payload_type, "application/json");
+        assert_eq!(msg.context.identity, "test-identity");
+    }
+}

--- a/crates/slim-bindings/src/name.rs
+++ b/crates/slim-bindings/src/name.rs
@@ -1,0 +1,340 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+
+use slim_datapath::api::{NameId, ProtoName};
+
+use crate::errors::SlimError;
+
+/// Name type for SLIM (Secure Low-Latency Interactive Messaging)
+#[derive(Debug, Clone, PartialEq, uniffi::Object)]
+#[uniffi::export(Display, Debug, Eq)]
+pub struct Name {
+    inner: ProtoName,
+}
+
+impl From<Name> for ProtoName {
+    fn from(name: Name) -> Self {
+        name.inner.clone()
+    }
+}
+
+impl From<&Name> for ProtoName {
+    fn from(name: &Name) -> Self {
+        name.inner.clone()
+    }
+}
+
+impl From<ProtoName> for Name {
+    fn from(name: ProtoName) -> Self {
+        Name { inner: name }
+    }
+}
+
+impl From<&ProtoName> for Name {
+    fn from(name: &ProtoName) -> Self {
+        Name {
+            inner: name.clone(),
+        }
+    }
+}
+
+impl Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (c0, c1, c2) = self.inner.str_components();
+        write!(f, "{c0}/{c1}/{c2}")
+    }
+}
+
+#[uniffi::export]
+impl Name {
+    /// Create a new Name from components without an ID
+    #[uniffi::constructor]
+    pub fn new(component0: String, component1: String, component2: String) -> Self {
+        let inner = ProtoName::from_strings([component0, component1, component2]);
+        Name { inner }
+    }
+
+    /// Parse a Name from a `"org/namespace/agent"` string
+    ///
+    /// The string must contain exactly three `/`-separated components.
+    /// Returns an error if the format is invalid.
+    #[uniffi::constructor]
+    pub fn from_string(s: String) -> Result<Self, SlimError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(SlimError::InvalidArgument {
+                message: format!("expected \"org/namespace/agent\", got {s:?}"),
+            });
+        }
+        let parts: Vec<&str> = trimmed.split('/').map(str::trim).collect();
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+            return Err(SlimError::InvalidArgument {
+                message: format!("expected \"org/namespace/agent\", got {s:?}"),
+            });
+        }
+        Ok(Name {
+            inner: ProtoName::from_strings([parts[0], parts[1], parts[2]]),
+        })
+    }
+
+    /// Create a new Name from components with an ID expressed in UUID format
+    #[uniffi::constructor]
+    pub fn new_with_id(
+        component0: String,
+        component1: String,
+        component2: String,
+        id: String,
+    ) -> Self {
+        let id: u128 = NameId::try_from(id)
+            .unwrap_or_else(|_| panic!("invalid ID format: expected UUID string"))
+            .into();
+        if NameId::is_reserved_id(id) {
+            panic!("id {id:#x} is a reserved value and cannot be used as a name id");
+        }
+        let inner = ProtoName::from_strings([component0, component1, component2]).with_id(id);
+        Name { inner }
+    }
+
+    /// Get the name components as a vector of strings
+    pub fn components(&self) -> Vec<String> {
+        let (c0, c1, c2) = self.inner.str_components();
+        vec![c0.to_string(), c1.to_string(), c2.to_string()]
+    }
+
+    /// Get the name ID formatted as UUID string
+    pub fn id(&self) -> String {
+        self.inner.string_id()
+    }
+}
+
+impl Name {
+    /// Get the inner ProtoName (for internal Rust use only)
+    pub fn as_slim_name(&self) -> ProtoName {
+        self.inner.clone()
+    }
+
+    /// Create from ProtoName (for internal Rust use only)
+    pub fn from_slim_name(proto_name: ProtoName) -> Self {
+        Name { inner: proto_name }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // Name Conversion Tests
+    // ========================================================================
+
+    /// Test Name to ProtoName conversion with full components
+    #[test]
+    fn test_name_to_slim_name_full() {
+        let name = Name::new_with_id(
+            "org".to_string(),
+            "namespace".to_string(),
+            "app".to_string(),
+            "00000000-0000-0000-0000-000000012345".to_string(),
+        );
+
+        let proto_name: ProtoName = name.into();
+        let (c0, c1, c2) = proto_name.str_components();
+
+        assert_eq!(c0, "org");
+        assert_eq!(c1, "namespace");
+        assert_eq!(c2, "app");
+        let val: u128 = NameId::try_from("00000000-0000-0000-0000-000000012345".to_string())
+            .unwrap()
+            .into();
+        assert_eq!(proto_name.id(), val);
+    }
+
+    /// Test Name to ProtoName conversion with partial components
+    #[test]
+    fn test_name_to_slim_name_partial() {
+        let name = Name::new("org".to_string(), "".to_string(), "".to_string());
+
+        let proto_name: ProtoName = name.into();
+        let (c0, c1, c2) = proto_name.str_components();
+
+        assert_eq!(c0, "org");
+        assert_eq!(c1, "");
+        assert_eq!(c2, "");
+    }
+
+    /// Test Name to ProtoName conversion with empty components
+    #[test]
+    fn test_name_to_slim_name_empty() {
+        let name = Name::new("".to_string(), "".to_string(), "".to_string());
+
+        let proto_name: ProtoName = name.into();
+        let (c0, c1, c2) = proto_name.str_components();
+
+        assert_eq!(c0, "");
+        assert_eq!(c1, "");
+        assert_eq!(c2, "");
+    }
+
+    /// Test ProtoName to Name conversion
+    #[test]
+    fn test_slim_name_to_name() {
+        let proto_name = ProtoName::from_strings(["org", "namespace", "app"]).with_id(54321);
+
+        let name = Name::from(&proto_name);
+
+        assert_eq!(name.components(), vec!["org", "namespace", "app"]);
+        let str_id: String = NameId::from(54321).into();
+        assert_eq!(name.id(), str_id);
+    }
+
+    /// Test Name roundtrip conversion
+    #[test]
+    fn test_name_roundtrip() {
+        let original = Name::new_with_id(
+            "org".to_string(),
+            "namespace".to_string(),
+            "app".to_string(),
+            "00000000-0000-0000-0000-0000000186a0".to_string(),
+        );
+
+        let proto_name: ProtoName = original.clone().into();
+        let converted = Name::from(&proto_name);
+
+        assert_eq!(original.components(), converted.components());
+        assert_eq!(original.id(), converted.id());
+    }
+
+    // ========================================================================
+    // Name Traits Tests
+    // ========================================================================
+
+    /// Test Name Debug, Clone, and PartialEq traits
+    #[test]
+    fn test_name_traits() {
+        let name1 = Name::new_with_id(
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "00000000-0000-0000-0000-000000000064".to_string(),
+        );
+        let name2 = name1.clone();
+
+        // PartialEq
+        assert_eq!(name1, name2);
+
+        // Different names should not be equal
+        let name3 = Name::new_with_id(
+            "x".to_string(),
+            "y".to_string(),
+            "z".to_string(),
+            "00000000-0000-0000-0000-0000000000c8".to_string(),
+        );
+        assert_ne!(name1, name3);
+
+        // Debug
+        let debug_str = format!("{name1:?}");
+        assert!(debug_str.contains("Name"));
+        assert!(debug_str.contains("inner"));
+    }
+
+    /// Test Name Display trait
+    #[test]
+    fn test_name_display() {
+        let name = Name::new_with_id(
+            "org".to_string(),
+            "namespace".to_string(),
+            "app".to_string(),
+            "00000000-0000-0000-0000-00000000007b".to_string(),
+        );
+        let display_str = format!("{name}");
+
+        // Should display the ProtoName format
+        assert!(!display_str.is_empty());
+    }
+
+    /// Test Name with different ID values
+    #[test]
+    fn test_name_with_various_ids() {
+        let name_with_id = Name::new_with_id(
+            "org".to_string(),
+            "ns".to_string(),
+            "app".to_string(),
+            "00000000-0000-0000-0000-00000000002a".to_string(),
+        );
+        assert_eq!(
+            name_with_id.id(),
+            "00000000-0000-0000-0000-00000000002a".to_string()
+        );
+
+        let name_without_id = Name::new("org".to_string(), "ns".to_string(), "app".to_string());
+        // ProtoName without with_id sets component_3 to NULL_COMPONENT
+        assert_eq!(name_without_id.id(), "NULL_COMPONENT".to_string());
+    }
+
+    /// Test Name::from_string with a valid input
+    #[test]
+    fn test_from_string_valid() {
+        let name = Name::from_string("org/namespace/agent".to_string()).unwrap();
+        let components = name.components();
+        assert_eq!(components[0], "org");
+        assert_eq!(components[1], "namespace");
+        assert_eq!(components[2], "agent");
+    }
+
+    /// Test Name::from_string roundtrips through Display
+    #[test]
+    fn test_from_string_roundtrip() {
+        let original = Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "agent".to_string(),
+        );
+        let parsed = Name::from_string("org/namespace/agent".to_string()).unwrap();
+        assert_eq!(original.components(), parsed.components());
+    }
+
+    /// Test Name::from_string rejects too few components
+    #[test]
+    fn test_from_string_too_few_components() {
+        assert!(Name::from_string("org/namespace".to_string()).is_err());
+        assert!(Name::from_string("org".to_string()).is_err());
+        assert!(Name::from_string("".to_string()).is_err());
+    }
+
+    /// Test Name::from_string rejects too many components
+    #[test]
+    fn test_from_string_too_many_components() {
+        assert!(Name::from_string("org/namespace/agent/extra".to_string()).is_err());
+    }
+
+    #[test]
+    fn test_from_string_rejects_empty_segment() {
+        assert!(Name::from_string("a//b".to_string()).is_err());
+        assert!(Name::from_string("/a/b".to_string()).is_err());
+        assert!(Name::from_string("a/b/".to_string()).is_err());
+    }
+
+    #[test]
+    fn test_from_string_trims_components() {
+        let name = Name::from_string(" org / app / v1 ".to_string()).unwrap();
+        assert_eq!(name.components(), vec!["org", "app", "v1"]);
+    }
+
+    /// Test Name components getter
+    #[test]
+    fn test_name_components_getter() {
+        let name = Name::new(
+            "comp0".to_string(),
+            "comp1".to_string(),
+            "comp2".to_string(),
+        );
+        let components = name.components();
+
+        assert_eq!(components.len(), 3);
+        assert_eq!(components[0], "comp0");
+        assert_eq!(components[1], "comp1");
+        assert_eq!(components[2], "comp2");
+    }
+}

--- a/crates/slim-bindings/src/server_config.rs
+++ b/crates/slim-bindings/src/server_config.rs
@@ -1,0 +1,793 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use slim_auth::metadata::MetadataMap;
+use slim_config::grpc::server::KeepaliveServerParameters as CoreKeepaliveServerParameters;
+use slim_config::grpc::server::ServerConfig as CoreServerConfig;
+
+use crate::common_config::{ServerAuthenticationConfig, TlsServerConfig, TlsSource};
+
+/// Keepalive configuration for the server
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct KeepaliveServerParameters {
+    /// Max connection idle time (time after which an idle connection is closed)
+    pub max_connection_idle: Duration,
+
+    /// Max connection age (maximum time a connection may exist before being closed)
+    pub max_connection_age: Duration,
+
+    /// Max connection age grace (additional time after max_connection_age before closing)
+    pub max_connection_age_grace: Duration,
+
+    /// Keepalive ping frequency
+    pub time: Duration,
+
+    /// Keepalive ping timeout (time to wait for ack)
+    pub timeout: Duration,
+}
+
+impl Default for KeepaliveServerParameters {
+    fn default() -> Self {
+        let core_defaults = CoreKeepaliveServerParameters::default();
+        KeepaliveServerParameters {
+            max_connection_idle: *core_defaults.max_connection_idle,
+            max_connection_age: *core_defaults.max_connection_age,
+            max_connection_age_grace: *core_defaults.max_connection_age_grace,
+            time: *core_defaults.time,
+            timeout: *core_defaults.timeout,
+        }
+    }
+}
+
+impl From<KeepaliveServerParameters> for CoreKeepaliveServerParameters {
+    fn from(config: KeepaliveServerParameters) -> Self {
+        CoreKeepaliveServerParameters {
+            max_connection_idle: config.max_connection_idle.into(),
+            max_connection_age: config.max_connection_age.into(),
+            max_connection_age_grace: config.max_connection_age_grace.into(),
+            time: config.time.into(),
+            timeout: config.timeout.into(),
+        }
+    }
+}
+
+impl From<CoreKeepaliveServerParameters> for KeepaliveServerParameters {
+    fn from(config: CoreKeepaliveServerParameters) -> Self {
+        KeepaliveServerParameters {
+            max_connection_idle: *config.max_connection_idle,
+            max_connection_age: *config.max_connection_age,
+            max_connection_age_grace: *config.max_connection_age_grace,
+            time: *config.time,
+            timeout: *config.timeout,
+        }
+    }
+}
+
+/// Server configuration for running a SLIM server
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct ServerConfig {
+    /// Endpoint address to listen on (e.g., "0.0.0.0:50051" or "[::]:50051").
+    ///
+    /// The transport protocol is inferred from the endpoint scheme:
+    /// `ws://`/`wss://` → WebSocket, otherwise gRPC.
+    pub endpoint: String,
+
+    /// TLS server configuration
+    pub tls: TlsServerConfig,
+
+    /// Use HTTP/2 only (default: true)
+    pub http2_only: Option<bool>,
+
+    /// Maximum size (in MiB) of messages accepted by the server
+    pub max_frame_size: Option<u32>,
+
+    /// Maximum number of concurrent streams per connection
+    pub max_concurrent_streams: Option<u32>,
+
+    /// Maximum header list size in bytes
+    pub max_header_list_size: Option<u32>,
+
+    /// Read buffer size in bytes
+    pub read_buffer_size: Option<u64>,
+
+    /// Write buffer size in bytes
+    pub write_buffer_size: Option<u64>,
+
+    /// Keepalive parameters
+    pub keepalive: Option<KeepaliveServerParameters>,
+
+    /// Authentication configuration for incoming requests
+    pub auth: Option<ServerAuthenticationConfig>,
+
+    /// Arbitrary user-provided metadata as JSON string
+    pub metadata: Option<String>,
+
+    /// When true, reject inter-node messages without a valid header MAC (strict mode).
+    pub require_header_mac: Option<bool>,
+
+    /// Timeout (in seconds) for link negotiation to complete.
+    pub negotiation_timeout_secs: Option<u64>,
+
+    /// Polling interval (in milliseconds) to wait between HMAC existence checks.
+    pub link_hmac_poll_interval_ms: Option<u64>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        let core_defaults = CoreServerConfig::default();
+        ServerConfig {
+            endpoint: core_defaults.endpoint,
+            tls: core_defaults.tls_setting.into(),
+            http2_only: None,
+            max_frame_size: None,
+            max_concurrent_streams: None,
+            max_header_list_size: None,
+            read_buffer_size: None,
+            write_buffer_size: None,
+            keepalive: None,
+            auth: None,
+            metadata: None,
+            require_header_mac: None,
+            negotiation_timeout_secs: None,
+            link_hmac_poll_interval_ms: None,
+        }
+    }
+}
+
+impl From<ServerConfig> for CoreServerConfig {
+    fn from(config: ServerConfig) -> Self {
+        let core_defaults = CoreServerConfig::default();
+        CoreServerConfig {
+            endpoint: config.endpoint,
+            tls_setting: config.tls.into(),
+            http2_only: config.http2_only.unwrap_or(core_defaults.http2_only),
+            max_frame_size: config.max_frame_size.or(core_defaults.max_frame_size),
+            max_concurrent_streams: config
+                .max_concurrent_streams
+                .or(core_defaults.max_concurrent_streams),
+            max_header_list_size: config
+                .max_header_list_size
+                .or(core_defaults.max_header_list_size),
+            read_buffer_size: config
+                .read_buffer_size
+                .map(|s| s as usize)
+                .or(core_defaults.read_buffer_size),
+            write_buffer_size: config
+                .write_buffer_size
+                .map(|s| s as usize)
+                .or(core_defaults.write_buffer_size),
+            keepalive: config
+                .keepalive
+                .map(Into::into)
+                .unwrap_or(core_defaults.keepalive),
+            auth: config.auth.map(Into::into).unwrap_or(core_defaults.auth),
+            metadata: config
+                .metadata
+                .and_then(|json| serde_json::from_str::<MetadataMap>(&json).ok()),
+            require_header_mac: config
+                .require_header_mac
+                .unwrap_or(core_defaults.require_header_mac),
+            negotiation_timeout_secs: config
+                .negotiation_timeout_secs
+                .unwrap_or(core_defaults.negotiation_timeout_secs),
+            link_hmac_poll_interval_ms: config
+                .link_hmac_poll_interval_ms
+                .unwrap_or(core_defaults.link_hmac_poll_interval_ms),
+        }
+    }
+}
+
+impl From<CoreServerConfig> for ServerConfig {
+    fn from(config: CoreServerConfig) -> Self {
+        ServerConfig {
+            endpoint: config.endpoint,
+            tls: config.tls_setting.into(),
+            http2_only: Some(config.http2_only),
+            max_frame_size: config.max_frame_size,
+            max_concurrent_streams: config.max_concurrent_streams,
+            max_header_list_size: config.max_header_list_size,
+            read_buffer_size: config.read_buffer_size.map(|s| s as u64),
+            write_buffer_size: config.write_buffer_size.map(|s| s as u64),
+            keepalive: Some(config.keepalive.into()),
+            auth: Some(config.auth.into()),
+            metadata: config.metadata.and_then(|m| serde_json::to_string(&m).ok()),
+            require_header_mac: Some(config.require_header_mac),
+            negotiation_timeout_secs: Some(config.negotiation_timeout_secs),
+            link_hmac_poll_interval_ms: Some(config.link_hmac_poll_interval_ms),
+        }
+    }
+}
+
+/// Create a new server config with the given endpoint and default values
+#[uniffi::export]
+pub fn new_server_config(endpoint: String) -> ServerConfig {
+    ServerConfig {
+        endpoint,
+        ..Default::default()
+    }
+}
+
+/// Create a new insecure server config (no TLS)
+#[uniffi::export]
+pub fn new_insecure_server_config(endpoint: String) -> ServerConfig {
+    ServerConfig {
+        endpoint,
+        tls: TlsServerConfig {
+            insecure: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Create a new secure server config (TLS enabled with the given certificate source)
+#[uniffi::export]
+pub fn new_secure_server_config(endpoint: String, tls_source: TlsSource) -> ServerConfig {
+    ServerConfig {
+        endpoint,
+        tls: TlsServerConfig {
+            insecure: false,
+            source: tls_source,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common_config::{CaSource, TlsSource};
+    use slim_config::transport::TransportProtocol as CoreTransportProtocol;
+
+    #[test]
+    fn test_server_config_creation() {
+        let config = ServerConfig {
+            endpoint: "127.0.0.1:8080".to_string(),
+            tls: TlsServerConfig {
+                insecure: false,
+                source: TlsSource::File {
+                    cert: "/cert.pem".to_string(),
+                    key: "/key.pem".to_string(),
+                },
+                client_ca: CaSource::None,
+                include_system_ca_certs_pool: Some(true),
+                tls_version: Some("tls1.3".to_string()),
+                reload_client_ca_file: Some(false),
+            },
+            http2_only: Some(true),
+            ..Default::default()
+        };
+
+        assert_eq!(config.endpoint, "127.0.0.1:8080");
+        assert!(!config.tls.insecure);
+        assert_eq!(config.tls.tls_version, Some("tls1.3".to_string()));
+        assert_eq!(config.http2_only, Some(true));
+    }
+
+    #[test]
+    fn test_server_config_default() {
+        let config = ServerConfig::default();
+
+        // Verify defaults are all None (core defaults applied during conversion)
+        assert_eq!(config.endpoint, "");
+        assert_eq!(config.http2_only, None);
+        assert_eq!(config.max_frame_size, None);
+        assert_eq!(config.max_concurrent_streams, None);
+        assert_eq!(config.max_header_list_size, None);
+        assert_eq!(config.read_buffer_size, None);
+        assert_eq!(config.write_buffer_size, None);
+        assert_eq!(config.keepalive, None);
+        assert_eq!(config.auth, None);
+        assert_eq!(config.metadata, None);
+        assert_eq!(config.negotiation_timeout_secs, None);
+        assert_eq!(config.link_hmac_poll_interval_ms, None);
+
+        // Verify core defaults are applied when converting to CoreServerConfig
+        let core: CoreServerConfig = config.into();
+        assert!(core.http2_only);
+        assert_eq!(core.max_frame_size, Some(4));
+        assert_eq!(core.max_concurrent_streams, Some(100));
+        assert_eq!(core.read_buffer_size, Some(1024 * 1024));
+        assert_eq!(core.write_buffer_size, Some(1024 * 1024));
+        assert_eq!(core.negotiation_timeout_secs, 5);
+        assert_eq!(core.link_hmac_poll_interval_ms, 5);
+        assert_eq!(
+            core.auth,
+            slim_config::grpc::server::AuthenticationConfig::None
+        );
+    }
+
+    #[test]
+    fn test_server_config_new() {
+        let config = new_server_config("0.0.0.0:50051".to_string());
+
+        assert_eq!(config.endpoint, "0.0.0.0:50051");
+        // Other fields should be None defaults
+        assert_eq!(config.http2_only, None);
+        assert_eq!(config.auth, None);
+    }
+
+    #[test]
+    fn test_server_config_new_insecure() {
+        let config = new_insecure_server_config("[::]:50051".to_string());
+
+        assert_eq!(config.endpoint, "[::]:50051");
+        assert!(config.tls.insecure);
+        assert_eq!(config.http2_only, None);
+    }
+
+    #[test]
+    fn test_server_config_new_secure() {
+        let config = new_secure_server_config(
+            "0.0.0.0:443".to_string(),
+            TlsSource::File {
+                cert: "/etc/tls/server.crt".to_string(),
+                key: "/etc/tls/server.key".to_string(),
+            },
+        );
+
+        assert_eq!(config.endpoint, "0.0.0.0:443");
+        assert!(!config.tls.insecure);
+        assert_eq!(
+            config.tls.source,
+            TlsSource::File {
+                cert: "/etc/tls/server.crt".to_string(),
+                key: "/etc/tls/server.key".to_string(),
+            }
+        );
+        // All optional fields should be None
+        assert_eq!(config.http2_only, None);
+        assert_eq!(config.max_frame_size, None);
+        assert_eq!(config.max_concurrent_streams, None);
+        assert_eq!(config.keepalive, None);
+        assert_eq!(config.auth, None);
+        assert_eq!(config.metadata, None);
+    }
+
+    #[test]
+    fn test_server_config_to_core_conversion() {
+        let ffi_config = ServerConfig {
+            endpoint: "ws://127.0.0.1:8080".to_string(),
+            tls: TlsServerConfig::default(),
+            http2_only: Some(false),
+            max_frame_size: Some(8),
+            max_concurrent_streams: Some(200),
+            max_header_list_size: Some(8192),
+            read_buffer_size: Some(2048),
+            write_buffer_size: Some(2048),
+            keepalive: Some(KeepaliveServerParameters::default()),
+            auth: Some(ServerAuthenticationConfig::None),
+            metadata: Some(r#"{"key":"value"}"#.to_string()),
+            require_header_mac: None,
+            negotiation_timeout_secs: None,
+            link_hmac_poll_interval_ms: None,
+        };
+
+        let core_config: CoreServerConfig = ffi_config.into();
+
+        assert_eq!(core_config.endpoint, "ws://127.0.0.1:8080");
+        assert_eq!(
+            core_config.resolved_transport(),
+            CoreTransportProtocol::Websocket
+        );
+        assert!(!core_config.http2_only);
+        assert_eq!(core_config.max_frame_size, Some(8));
+        assert_eq!(core_config.max_concurrent_streams, Some(200));
+        assert_eq!(core_config.max_header_list_size, Some(8192));
+        assert_eq!(core_config.read_buffer_size, Some(2048));
+        assert_eq!(core_config.write_buffer_size, Some(2048));
+        assert!(core_config.metadata.is_some());
+    }
+
+    #[test]
+    fn test_server_config_from_core_conversion() {
+        // Test the new From<CoreServerConfig> for ServerConfig implementation
+        let core_config = CoreServerConfig::default();
+
+        // Use the From trait to convert
+        let ffi_config: ServerConfig = core_config.clone().into();
+
+        assert_eq!(ffi_config.endpoint, core_config.endpoint);
+        assert_eq!(ffi_config.http2_only, Some(core_config.http2_only));
+        assert_eq!(ffi_config.max_frame_size, core_config.max_frame_size);
+        assert_eq!(
+            ffi_config.max_concurrent_streams,
+            core_config.max_concurrent_streams
+        );
+        assert_eq!(
+            ffi_config.max_header_list_size,
+            core_config.max_header_list_size
+        );
+    }
+
+    #[test]
+    fn test_server_config_roundtrip_conversion() {
+        let original = ServerConfig {
+            endpoint: "localhost:9090".to_string(),
+            tls: TlsServerConfig::default(),
+            http2_only: Some(true),
+            max_frame_size: Some(16),
+            max_concurrent_streams: Some(500),
+            max_header_list_size: Some(16384),
+            read_buffer_size: Some(4096),
+            write_buffer_size: Some(4096),
+            keepalive: Some(KeepaliveServerParameters::default()),
+            auth: Some(ServerAuthenticationConfig::None),
+            metadata: None,
+            require_header_mac: None,
+            negotiation_timeout_secs: None,
+            link_hmac_poll_interval_ms: None,
+        };
+
+        // FFI -> Core -> FFI using the new From implementation
+        let core: CoreServerConfig = original.clone().into();
+        let roundtrip: ServerConfig = core.into();
+
+        assert_eq!(roundtrip.endpoint, original.endpoint);
+        assert_eq!(roundtrip.http2_only, original.http2_only);
+        assert_eq!(roundtrip.max_frame_size, original.max_frame_size);
+        assert_eq!(
+            roundtrip.max_concurrent_streams,
+            original.max_concurrent_streams
+        );
+        assert_eq!(
+            roundtrip.max_header_list_size,
+            original.max_header_list_size
+        );
+        assert_eq!(roundtrip.read_buffer_size, original.read_buffer_size);
+        assert_eq!(roundtrip.write_buffer_size, original.write_buffer_size);
+    }
+
+    #[test]
+    fn test_keepalive_defaults() {
+        let keepalive = KeepaliveServerParameters::default();
+
+        // Verify keepalive has reasonable defaults
+        assert!(keepalive.max_connection_idle.as_secs() > 0);
+        assert!(keepalive.max_connection_age.as_secs() > 0);
+        assert!(keepalive.time.as_secs() > 0);
+        assert!(keepalive.timeout.as_secs() > 0);
+    }
+
+    #[test]
+    fn test_keepalive_conversion() {
+        let ffi_keepalive = KeepaliveServerParameters {
+            max_connection_idle: Duration::from_secs(600),
+            max_connection_age: Duration::from_secs(1800),
+            max_connection_age_grace: Duration::from_secs(60),
+            time: Duration::from_secs(300),
+            timeout: Duration::from_secs(20),
+        };
+
+        let core_keepalive: CoreKeepaliveServerParameters = ffi_keepalive.into();
+
+        assert_eq!(
+            *core_keepalive.max_connection_idle,
+            Duration::from_secs(600)
+        );
+        assert_eq!(
+            *core_keepalive.max_connection_age,
+            Duration::from_secs(1800)
+        );
+        assert_eq!(
+            *core_keepalive.max_connection_age_grace,
+            Duration::from_secs(60)
+        );
+        assert_eq!(*core_keepalive.time, Duration::from_secs(300));
+        assert_eq!(*core_keepalive.timeout, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn test_metadata_serialization() {
+        let config = ServerConfig {
+            endpoint: "test:8080".to_string(),
+            tls: TlsServerConfig::default(),
+            metadata: Some(r#"{"env":"test","version":1}"#.to_string()),
+            ..Default::default()
+        };
+
+        let core: CoreServerConfig = config.into();
+
+        // Metadata should be deserialized successfully
+        assert!(core.metadata.is_some());
+        let metadata = core.metadata.unwrap();
+        assert_eq!(metadata.len(), 2);
+    }
+
+    #[test]
+    fn test_metadata_invalid_json() {
+        let config = ServerConfig {
+            endpoint: "test:8080".to_string(),
+            tls: TlsServerConfig::default(),
+            metadata: Some("invalid json".to_string()),
+            ..Default::default()
+        };
+
+        let core: CoreServerConfig = config.into();
+
+        // Invalid JSON should result in None metadata
+        assert!(core.metadata.is_none());
+    }
+
+    #[test]
+    fn test_basic_auth_roundtrip() {
+        use crate::common_config::BasicAuth;
+
+        let basic_config = BasicAuth {
+            username: "admin".to_string(),
+            password: "secret123".to_string(),
+        };
+
+        let auth = ServerAuthenticationConfig::Basic {
+            config: basic_config.clone(),
+        };
+
+        // Convert to core and back
+        let core_auth: slim_config::grpc::server::AuthenticationConfig = auth.into();
+        let roundtrip_auth: ServerAuthenticationConfig = core_auth.into();
+
+        // Verify roundtrip preserves the configuration
+        if let ServerAuthenticationConfig::Basic { config } = roundtrip_auth {
+            assert_eq!(config.username, basic_config.username);
+            assert_eq!(config.password, basic_config.password);
+        } else {
+            panic!("Expected Basic authentication config");
+        }
+    }
+
+    #[test]
+    fn test_jwt_auth_roundtrip() {
+        use crate::identity_config::{
+            JwtAlgorithm, JwtAuth, JwtKeyConfig, JwtKeyData, JwtKeyFormat, JwtKeyType,
+        };
+
+        let jwt_config = JwtAuth {
+            key: JwtKeyType::Decoding {
+                key: JwtKeyConfig {
+                    algorithm: JwtAlgorithm::RS256,
+                    format: JwtKeyFormat::Pem,
+                    key: JwtKeyData::File {
+                        path: "/path/to/public_key.pem".to_string(),
+                    },
+                },
+            },
+            audience: Some(vec!["api.example.com".to_string()]),
+            issuer: Some("auth.example.com".to_string()),
+            subject: Some("service123".to_string()),
+            duration: Duration::from_secs(7200),
+        };
+
+        let auth = ServerAuthenticationConfig::Jwt {
+            config: jwt_config.clone(),
+        };
+
+        // Convert to core and back
+        let core_auth: slim_config::grpc::server::AuthenticationConfig = auth.into();
+        let roundtrip_auth: ServerAuthenticationConfig = core_auth.into();
+
+        // Verify roundtrip preserves the configuration
+        if let ServerAuthenticationConfig::Jwt { config } = roundtrip_auth {
+            assert_eq!(config.key, jwt_config.key);
+            assert_eq!(config.audience, jwt_config.audience);
+            assert_eq!(config.issuer, jwt_config.issuer);
+            assert_eq!(config.subject, jwt_config.subject);
+            // Note: duration might not be exactly preserved due to conversion limitations
+        } else {
+            panic!("Expected Jwt authentication config");
+        }
+    }
+
+    #[test]
+    fn test_server_config_from_core_with_all_fields() {
+        // Test the new From<CoreServerConfig> for ServerConfig with comprehensive field coverage
+        use slim_auth::metadata::MetadataMap;
+
+        let mut metadata = MetadataMap::new();
+        metadata.insert("service".to_string(), "test-server".to_string());
+        metadata.insert("region".to_string(), "us-east-1".to_string());
+
+        let core_config = CoreServerConfig {
+            endpoint: "0.0.0.0:8443".to_string(),
+            http2_only: false,
+            max_frame_size: Some(32),
+            max_concurrent_streams: Some(1000),
+            max_header_list_size: Some(32768),
+            read_buffer_size: Some(16384),
+            write_buffer_size: Some(16384),
+            metadata: Some(metadata),
+            ..Default::default()
+        };
+
+        // Use the new From implementation
+        let ffi_config: ServerConfig = core_config.clone().into();
+
+        // Verify all fields are correctly converted
+        assert_eq!(ffi_config.endpoint, "0.0.0.0:8443");
+        assert_eq!(ffi_config.http2_only, Some(false));
+        assert_eq!(ffi_config.max_frame_size, Some(32));
+        assert_eq!(ffi_config.max_concurrent_streams, Some(1000));
+        assert_eq!(ffi_config.max_header_list_size, Some(32768));
+        assert_eq!(ffi_config.read_buffer_size, Some(16384));
+        assert_eq!(ffi_config.write_buffer_size, Some(16384));
+
+        // Verify metadata is serialized correctly
+        assert!(ffi_config.metadata.is_some());
+        let metadata_str = ffi_config.metadata.unwrap();
+        assert!(metadata_str.contains("test-server"));
+        assert!(metadata_str.contains("us-east-1"));
+    }
+
+    #[test]
+    fn test_server_config_from_core_with_keepalive() {
+        use slim_config::grpc::server::KeepaliveServerParameters as CoreKeepaliveServerParameters;
+
+        let core_config = CoreServerConfig {
+            keepalive: CoreKeepaliveServerParameters {
+                max_connection_idle: Duration::from_secs(300).into(),
+                max_connection_age: Duration::from_secs(900).into(),
+                max_connection_age_grace: Duration::from_secs(30).into(),
+                time: Duration::from_secs(150).into(),
+                timeout: Duration::from_secs(15).into(),
+            },
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        let keepalive = ffi_config.keepalive.unwrap();
+        assert_eq!(keepalive.max_connection_idle, Duration::from_secs(300));
+        assert_eq!(keepalive.max_connection_age, Duration::from_secs(900));
+        assert_eq!(keepalive.max_connection_age_grace, Duration::from_secs(30));
+        assert_eq!(keepalive.time, Duration::from_secs(150));
+        assert_eq!(keepalive.timeout, Duration::from_secs(15));
+    }
+
+    #[test]
+    fn test_server_config_from_core_buffer_size_conversion() {
+        // Test that buffer sizes are correctly converted from usize to u64
+        let core_config = CoreServerConfig {
+            read_buffer_size: Some(8192),
+            write_buffer_size: Some(8192),
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        assert_eq!(ffi_config.read_buffer_size, Some(8192u64));
+        assert_eq!(ffi_config.write_buffer_size, Some(8192u64));
+    }
+
+    #[test]
+    fn test_server_config_from_core_no_buffer_sizes() {
+        // Test with None buffer sizes
+        let core_config = CoreServerConfig {
+            read_buffer_size: None,
+            write_buffer_size: None,
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        assert!(ffi_config.read_buffer_size.is_none());
+        assert!(ffi_config.write_buffer_size.is_none());
+    }
+
+    #[test]
+    fn test_server_config_from_core_http2_only_variations() {
+        // Test http2_only flag both true and false
+        let core_config_true = CoreServerConfig {
+            http2_only: true,
+            ..Default::default()
+        };
+
+        let ffi_config_true: ServerConfig = core_config_true.into();
+        assert_eq!(ffi_config_true.http2_only, Some(true));
+
+        let core_config_false = CoreServerConfig {
+            http2_only: false,
+            ..Default::default()
+        };
+
+        let ffi_config_false: ServerConfig = core_config_false.into();
+        assert_eq!(ffi_config_false.http2_only, Some(false));
+    }
+
+    #[test]
+    fn test_server_config_from_core_with_optional_fields() {
+        // Test with various combinations of optional fields
+        let core_config = CoreServerConfig {
+            max_frame_size: None,
+            max_concurrent_streams: Some(250),
+            max_header_list_size: None,
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        assert!(ffi_config.max_frame_size.is_none());
+        assert_eq!(ffi_config.max_concurrent_streams, Some(250));
+        assert!(ffi_config.max_header_list_size.is_none());
+    }
+
+    #[test]
+    fn test_server_config_from_core_metadata_serialization_failure() {
+        // Test that None metadata results in None
+        let core_config = CoreServerConfig {
+            metadata: None,
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        assert!(ffi_config.metadata.is_none());
+    }
+
+    #[test]
+    fn test_server_config_from_core_auth_types() {
+        use slim_config::auth::basic::Config as BasicAuthConfig;
+        use slim_config::grpc::server::AuthenticationConfig as CoreAuthConfig;
+
+        // Test with Basic auth
+        let core_config = CoreServerConfig {
+            auth: CoreAuthConfig::Basic(BasicAuthConfig::new("server_user", "server_pass")),
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        match ffi_config.auth.unwrap() {
+            ServerAuthenticationConfig::Basic { config } => {
+                assert_eq!(config.username, "server_user");
+                assert_eq!(config.password, "server_pass");
+            }
+            _ => panic!("Expected Basic auth"),
+        }
+    }
+
+    #[test]
+    fn test_server_config_from_core_auth_none() {
+        use slim_config::grpc::server::AuthenticationConfig as CoreAuthConfig;
+
+        // Test with None auth
+        let core_config = CoreServerConfig {
+            auth: CoreAuthConfig::None,
+            ..Default::default()
+        };
+
+        let ffi_config: ServerConfig = core_config.into();
+
+        match ffi_config.auth.unwrap() {
+            ServerAuthenticationConfig::None => {
+                // Success
+            }
+            _ => panic!("Expected None auth"),
+        }
+    }
+
+    #[test]
+    fn test_keepalive_server_parameters_roundtrip() {
+        // Test KeepaliveServerParameters conversion both ways
+        let original = KeepaliveServerParameters {
+            max_connection_idle: Duration::from_secs(500),
+            max_connection_age: Duration::from_secs(1500),
+            max_connection_age_grace: Duration::from_secs(50),
+            time: Duration::from_secs(250),
+            timeout: Duration::from_secs(25),
+        };
+
+        let core: CoreKeepaliveServerParameters = original.clone().into();
+        let roundtrip: KeepaliveServerParameters = core.into();
+
+        assert_eq!(roundtrip.max_connection_idle, original.max_connection_idle);
+        assert_eq!(roundtrip.max_connection_age, original.max_connection_age);
+        assert_eq!(
+            roundtrip.max_connection_age_grace,
+            original.max_connection_age_grace
+        );
+        assert_eq!(roundtrip.time, original.time);
+        assert_eq!(roundtrip.timeout, original.timeout);
+    }
+}

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -1,0 +1,1258 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use crate::client_config::ClientConfig;
+use crate::errors::SlimError;
+use crate::get_runtime;
+use crate::identity_config::{IdentityProviderConfig, IdentityVerifierConfig};
+use crate::server_config::ServerConfig;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::traits::{TokenProvider, Verifier};
+use slim_config::component::Component;
+use slim_config::component::id::{ID, Kind};
+use slim_config::grpc::client::ClientConfig as CoreClientConfig;
+use slim_config::grpc::server::ServerConfig as CoreServerConfig;
+use slim_controller::config::Config as CoreControllerConfig;
+use slim_datapath::api::ProtoName as SlimName;
+use slim_service::{
+    KIND, Service as SlimService, ServiceConfiguration as SlimServiceConfiguration,
+};
+use tokio::task::JoinHandle;
+
+use crate::name::Name;
+
+/// DataPlane configuration wrapper for uniffi bindings
+#[derive(Clone, Default, uniffi::Record)]
+pub struct DataplaneConfig {
+    /// DataPlane GRPC server settings
+    pub servers: Vec<ServerConfig>,
+    /// DataPlane client configs
+    pub clients: Vec<ClientConfig>,
+}
+
+impl From<DataplaneConfig> for CoreControllerConfig {
+    fn from(config: DataplaneConfig) -> Self {
+        let mut core_config = CoreControllerConfig::new();
+        core_config.servers = config
+            .servers
+            .into_iter()
+            .map(|s| {
+                let core: CoreServerConfig = s.into();
+                core
+            })
+            .collect();
+        core_config.clients = config
+            .clients
+            .into_iter()
+            .map(|c| {
+                let core: CoreClientConfig = c.into();
+                core
+            })
+            .collect();
+        core_config
+    }
+}
+
+impl From<CoreControllerConfig> for DataplaneConfig {
+    fn from(config: CoreControllerConfig) -> Self {
+        Self {
+            servers: config.servers.into_iter().map(|s| s.into()).collect(),
+            clients: config.clients.into_iter().map(|c| c.into()).collect(),
+        }
+    }
+}
+
+/// Service configuration wrapper for uniffi bindings
+#[derive(Clone, Default, uniffi::Record)]
+pub struct ServiceConfig {
+    /// Optional node ID for the service
+    pub node_id: Option<String>,
+
+    /// Optional group name for the service
+    pub group_name: Option<String>,
+
+    /// DataPlane configuration (servers and clients)
+    pub dataplane: DataplaneConfig,
+}
+
+impl ServiceConfig {
+    pub fn new() -> Self {
+        Self {
+            node_id: None,
+            group_name: None,
+            dataplane: DataplaneConfig::default(),
+        }
+    }
+}
+
+impl From<ServiceConfig> for SlimServiceConfiguration {
+    fn from(config: ServiceConfig) -> Self {
+        let mut core_config = SlimServiceConfiguration::new();
+        if let Some(node_id) = config.node_id {
+            core_config.node_id = node_id;
+        }
+        core_config.group_name = config.group_name;
+        core_config.dataplane = config.dataplane.into();
+        core_config
+    }
+}
+
+impl From<SlimServiceConfiguration> for ServiceConfig {
+    fn from(config: SlimServiceConfiguration) -> Self {
+        Self {
+            node_id: Some(config.node_id),
+            group_name: config.group_name,
+            dataplane: config.dataplane.into(),
+        }
+    }
+}
+
+impl From<&SlimServiceConfiguration> for ServiceConfig {
+    fn from(config: &SlimServiceConfiguration) -> Self {
+        Self {
+            node_id: Some(config.node_id.clone()),
+            group_name: config.group_name.clone(),
+            dataplane: config.dataplane.clone().into(),
+        }
+    }
+}
+
+/// Service wrapper for uniffi bindings
+#[derive(uniffi::Object)]
+pub struct Service {
+    pub(crate) inner: Arc<SlimService>,
+}
+
+impl Service {
+    /// Get a clone of the inner service Arc for advanced use cases
+    pub fn inner(&self) -> Arc<SlimService> {
+        self.inner.clone()
+    }
+}
+
+/// Conversion traits
+impl From<SlimService> for Service {
+    fn from(service: SlimService) -> Self {
+        Service {
+            inner: Arc::new(service),
+        }
+    }
+}
+
+#[uniffi::export]
+impl Service {
+    /// Create a new Service with the given name
+    #[uniffi::constructor]
+    pub fn new(name: String) -> Self {
+        let kind = Kind::new(KIND).expect("Invalid service kind");
+        let id = ID::new_with_name(kind, &name).expect("Invalid service name");
+        let service = SlimService::new(id);
+        Service {
+            inner: Arc::new(service),
+        }
+    }
+
+    /// Create a new Service with configuration
+    #[uniffi::constructor]
+    pub fn new_with_config(name: String, config: ServiceConfig) -> Self {
+        let kind = Kind::new(KIND).expect("Invalid service kind");
+        let id = ID::new_with_name(kind, &name).expect("Invalid service name");
+        let core_config: SlimServiceConfiguration = config.into();
+        let service = SlimService::new_with_config(id, core_config);
+        Service {
+            inner: Arc::new(service),
+        }
+    }
+
+    /// Get the service configuration
+    pub fn config(&self) -> ServiceConfig {
+        self.inner.config().clone().into()
+    }
+
+    /// Get the service identifier/name
+    pub fn get_name(&self) -> String {
+        self.inner.identifier().to_string()
+    }
+
+    /// Run the service (starts all configured servers and clients)
+    pub async fn run_async(&self) -> Result<(), SlimError> {
+        self.inner.run().await?;
+        Ok(())
+    }
+
+    /// Run the service (starts all configured servers and clients) - blocking version
+    pub fn run(&self) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(self.run_async())
+    }
+
+    /// Shutdown the service gracefully
+    pub async fn shutdown_async(&self) -> Result<(), SlimError> {
+        self.inner.shutdown().await?;
+        Ok(())
+    }
+
+    /// Shutdown the service gracefully - blocking version
+    pub fn shutdown(&self) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(self.shutdown_async())
+    }
+
+    /// Start a server with the given configuration
+    pub async fn run_server_async(&self, config: ServerConfig) -> Result<(), SlimError> {
+        // Use the runtime handle to spawn the task, ensuring proper tokio context
+        let runtime = get_runtime();
+        let core_config: slim_config::grpc::server::ServerConfig = config.into();
+        let inner = self.inner.clone();
+
+        // Spawn on the runtime's handle to ensure tokio context is available
+        let handle: JoinHandle<Result<(), SlimError>> = runtime.spawn(async move {
+            inner.run_server(&core_config).await?;
+            Ok(())
+        });
+
+        handle.await.map_err(|e| SlimError::ServiceError {
+            message: format!("Failed to join server task: {e}"),
+        })?
+    }
+
+    /// Start a server with the given configuration - blocking version
+    pub fn run_server(&self, config: ServerConfig) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(self.run_server_async(config))
+    }
+
+    /// Stop a server by endpoint - blocking version
+    pub fn stop_server(&self, endpoint: String) -> Result<(), SlimError> {
+        self.inner.stop_server(&endpoint)?;
+        Ok(())
+    }
+
+    /// Connect to a remote endpoint as a client
+    pub async fn connect_async(&self, config: ClientConfig) -> Result<u64, SlimError> {
+        let core_config: slim_config::grpc::client::ClientConfig = config.into();
+        let inner = self.inner.clone();
+        let runtime = get_runtime();
+
+        // Spawn in tokio runtime since connect internally uses tokio::spawn
+        let handle = runtime.spawn(async move { inner.connect(&core_config).await });
+
+        let result = handle.await.map_err(|e| SlimError::InternalError {
+            message: format!("Failed to join connect task: {e}"),
+        })?;
+
+        Ok(result?)
+    }
+
+    /// Connect to a remote endpoint as a client - blocking version
+    pub fn connect(&self, config: ClientConfig) -> Result<u64, SlimError> {
+        crate::config::get_runtime().block_on(self.connect_async(config))
+    }
+
+    /// Disconnect a client connection by connection ID - blocking version
+    pub fn disconnect(&self, conn_id: u64) -> Result<(), SlimError> {
+        self.inner.disconnect(conn_id)?;
+        Ok(())
+    }
+
+    /// Get the connection ID for a given endpoint
+    pub fn get_connection_id(&self, endpoint: String) -> Option<u64> {
+        self.inner.get_connection_id(&endpoint)
+    }
+
+    /// Create a new App with authentication configuration (async version)
+    ///
+    /// This method initializes authentication providers/verifiers and creates a App
+    /// on this service instance.
+    ///
+    /// # Arguments
+    /// * `base_name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    pub async fn create_app_async(
+        &self,
+        base_name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+    ) -> Result<Arc<crate::app::App>, SlimError> {
+        let slim_name: SlimName = base_name.as_ref().into();
+        create_app_async_internal(
+            slim_name,
+            identity_provider_config,
+            identity_verifier_config,
+            self.inner.clone(),
+            crate::app::Direction::Bidirectional,
+        )
+        .await
+        .map(Arc::new)
+    }
+
+    /// Create a new App with authentication configuration and traffic direction (async version)
+    ///
+    /// This method initializes authentication providers/verifiers and creates an App
+    /// on this service instance. The direction parameter controls whether the app
+    /// can send messages, receive messages, both, or neither.
+    ///
+    /// # Arguments
+    /// * `base_name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    /// * `direction` - Traffic direction: Send, Recv, Bidirectional, or None
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    pub async fn create_app_with_direction_async(
+        &self,
+        name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+        direction: crate::app::Direction,
+    ) -> Result<Arc<crate::app::App>, SlimError> {
+        let slim_name: SlimName = name.as_ref().into();
+        create_app_async_internal(
+            slim_name,
+            identity_provider_config,
+            identity_verifier_config,
+            self.inner.clone(),
+            direction,
+        )
+        .await
+        .map(Arc::new)
+    }
+
+    /// Create a new App with SharedSecret authentication (async version)
+    ///
+    /// This is a convenience function for creating a SLIM application using SharedSecret authentication
+    /// on this service instance. This is the async version.
+    ///
+    /// # Arguments
+    /// * `name` - The base name for the app (without ID)
+    /// * `secret` - The shared secret string for authentication
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created app
+    /// * `Err(SlimError)` - If app creation fails
+    pub async fn create_app_with_secret_async(
+        &self,
+        name: Arc<Name>,
+        secret: String,
+    ) -> Result<Arc<crate::app::App>, SlimError> {
+        let identity_provider_config = IdentityProviderConfig::SharedSecret {
+            id: name.to_string(),
+            data: secret.clone(),
+        };
+        let identity_verifier_config = IdentityVerifierConfig::SharedSecret {
+            id: name.to_string(),
+            data: secret,
+        };
+
+        self.create_app_async(name, identity_provider_config, identity_verifier_config)
+            .await
+    }
+
+    /// Create a new App with authentication configuration (blocking version)
+    ///
+    /// This method initializes authentication providers/verifiers and creates a App
+    /// on this service instance. This is a blocking wrapper around create_app_async.
+    ///
+    /// # Arguments
+    /// * `base_name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    #[uniffi::method]
+    pub fn create_app(
+        &self,
+        base_name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+    ) -> Result<Arc<crate::app::App>, SlimError> {
+        get_runtime().block_on(self.create_app_async(
+            base_name,
+            identity_provider_config,
+            identity_verifier_config,
+        ))
+    }
+
+    /// Create a new App with authentication configuration and traffic direction (blocking version)
+    ///
+    /// This method initializes authentication providers/verifiers and creates an App
+    /// on this service instance. The direction parameter controls whether the app
+    /// can send messages, receive messages, both, or neither.
+    ///
+    /// # Arguments
+    /// * `base_name` - The base name for the app (without ID)
+    /// * `identity_provider_config` - Configuration for proving identity to others
+    /// * `identity_verifier_config` - Configuration for verifying identity of others
+    /// * `direction` - Traffic direction: Send, Recv, Bidirectional, or None
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created adapter
+    /// * `Err(SlimError)` - If adapter creation fails
+    pub fn create_app_with_direction(
+        &self,
+        base_name: Arc<Name>,
+        identity_provider_config: IdentityProviderConfig,
+        identity_verifier_config: IdentityVerifierConfig,
+        direction: crate::app::Direction,
+    ) -> Result<Arc<crate::app::App>, SlimError> {
+        get_runtime().block_on(self.create_app_with_direction_async(
+            base_name,
+            identity_provider_config,
+            identity_verifier_config,
+            direction,
+        ))
+    }
+
+    /// Create a new App with SharedSecret authentication (helper function)
+    ///
+    /// This is a convenience function for creating a SLIM application using SharedSecret authentication
+    /// on this service instance.
+    ///
+    /// # Arguments
+    /// * `name` - The base name for the app (without ID)
+    /// * `secret` - The shared secret string for authentication
+    ///
+    /// # Returns
+    /// * `Ok(Arc<App>)` - Successfully created app
+    /// * `Err(SlimError)` - If app creation fails
+    #[uniffi::method]
+    pub fn create_app_with_secret(
+        &self,
+        name: Arc<Name>,
+        secret: String,
+    ) -> Result<Arc<crate::app::App>, SlimError> {
+        get_runtime().block_on(self.create_app_with_secret_async(name, secret))
+    }
+}
+
+/// Internal async app creation logic (used by both service and app constructors)
+///
+/// This is the core implementation shared by Service::create_app_async and App::new_async_with_service.
+///
+/// # Arguments
+/// * `base_name` - The base name for the app (without ID)
+/// * `identity_provider_config` - Configuration for proving identity to others
+/// * `identity_verifier_config` - Configuration for verifying identity of others
+/// * `service` - The service instance to use for creating the app
+///
+/// # Returns
+/// * `Ok(App)` - Successfully created app
+/// * `Err(SlimError)` - If app creation fails
+pub(crate) async fn create_app_async_internal(
+    base_name: SlimName,
+    identity_provider_config: IdentityProviderConfig,
+    identity_verifier_config: IdentityVerifierConfig,
+    service: Arc<SlimService>,
+    direction: crate::app::Direction,
+) -> Result<crate::app::App, SlimError> {
+    // Convert configurations to actual providers/verifiers
+    let mut identity_provider: AuthProvider = identity_provider_config.try_into()?;
+    let mut identity_verifier: AuthVerifier = identity_verifier_config.try_into()?;
+
+    // Initialize the identity provider
+    identity_provider.initialize().await?;
+
+    // Initialize the identity verifier
+    identity_verifier.initialize().await?;
+
+    // Validate token
+    let _identity_token = identity_provider.get_token()?;
+
+    // Create the app using the provided service
+    let (app, rx) = service.create_app_with_direction(
+        &base_name,
+        identity_provider,
+        identity_verifier,
+        direction.into(),
+    )?;
+
+    Ok(crate::app::App::from_parts(
+        Arc::new(app),
+        Arc::new(tokio::sync::RwLock::new(rx)),
+        service,
+    ))
+}
+
+/// Create a new ServiceConfiguration
+#[uniffi::export]
+pub fn new_service_configuration() -> ServiceConfig {
+    ServiceConfig::new()
+}
+
+/// Create a new DataplaneConfig
+#[uniffi::export]
+pub fn new_dataplane_config() -> DataplaneConfig {
+    DataplaneConfig::default()
+}
+
+/// Create a new Service with builder pattern
+#[uniffi::export]
+pub fn create_service(name: String) -> Result<Arc<Service>, SlimError> {
+    Ok(Arc::new(Service::new(name)))
+}
+
+/// Create a new Service with configuration
+#[uniffi::export]
+pub fn create_service_with_config(
+    name: String,
+    config: ServiceConfig,
+) -> Result<Arc<Service>, SlimError> {
+    Ok(Arc::new(Service::new_with_config(name, config)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slim_datapath::api::ProtoName as SlimName;
+
+    const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+    use crate::app::App;
+    use crate::config::get_global_service;
+    use crate::identity_config::{IdentityProviderConfig, IdentityVerifierConfig};
+    use crate::name::Name;
+
+    /// Create test authentication configurations
+    fn create_test_auth() -> (IdentityProviderConfig, IdentityVerifierConfig) {
+        let provider = IdentityProviderConfig::SharedSecret {
+            id: "test-service".to_string(),
+            data: TEST_VALID_SECRET.to_string(),
+        };
+        let verifier = IdentityVerifierConfig::SharedSecret {
+            id: "test-service".to_string(),
+            data: TEST_VALID_SECRET.to_string(),
+        };
+        (provider, verifier)
+    }
+
+    /// Create test app name
+    fn create_test_name() -> SlimName {
+        SlimName::from_strings(["org", "namespace", "test-app"])
+    }
+
+    // ========================================================================
+    // Configuration Tests
+    // ========================================================================
+
+    #[test]
+    fn test_dataplane_config_default() {
+        let config = DataplaneConfig::default();
+        assert!(config.servers.is_empty());
+        assert!(config.clients.is_empty());
+    }
+
+    #[test]
+    fn test_dataplane_config_to_core_conversion() {
+        let server_config = ServerConfig::default();
+        let client_config = ClientConfig::default();
+
+        let config = DataplaneConfig {
+            servers: vec![server_config],
+            clients: vec![client_config],
+        };
+
+        let core_config: CoreControllerConfig = config.clone().into();
+        assert_eq!(core_config.servers.len(), 1);
+        assert_eq!(core_config.clients.len(), 1);
+    }
+
+    #[test]
+    fn test_dataplane_config_from_core_conversion() {
+        let mut core_config = CoreControllerConfig::new();
+        core_config.servers = vec![CoreServerConfig::default()];
+        core_config.clients = vec![CoreClientConfig::default()];
+
+        let config: DataplaneConfig = core_config.into();
+        assert_eq!(config.servers.len(), 1);
+        assert_eq!(config.clients.len(), 1);
+    }
+
+    #[test]
+    fn test_dataplane_config_roundtrip() {
+        let original = DataplaneConfig {
+            servers: vec![ServerConfig::default()],
+            clients: vec![ClientConfig::default()],
+        };
+
+        let core: CoreControllerConfig = original.clone().into();
+        let roundtrip: DataplaneConfig = core.into();
+
+        assert_eq!(original.servers.len(), roundtrip.servers.len());
+        assert_eq!(original.clients.len(), roundtrip.clients.len());
+    }
+
+    #[test]
+    fn test_service_configuration_new() {
+        let config = ServiceConfig::new();
+        assert!(config.node_id.is_none());
+        assert!(config.group_name.is_none());
+        assert!(config.dataplane.servers.is_empty());
+        assert!(config.dataplane.clients.is_empty());
+    }
+
+    #[test]
+    fn test_service_configuration_default() {
+        let config = ServiceConfig::default();
+        assert!(config.node_id.is_none());
+        assert!(config.group_name.is_none());
+    }
+
+    #[test]
+    fn test_service_configuration_with_values() {
+        let config = ServiceConfig {
+            node_id: Some("node-123".to_string()),
+            group_name: Some("test-group".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        assert_eq!(config.node_id.as_deref(), Some("node-123"));
+        assert_eq!(config.group_name.as_deref(), Some("test-group"));
+    }
+
+    #[test]
+    fn test_service_configuration_to_core_conversion() {
+        let config = ServiceConfig {
+            node_id: Some("node-456".to_string()),
+            group_name: Some("group-abc".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        let core_config: SlimServiceConfiguration = config.clone().into();
+        assert_eq!(core_config.node_id, "node-456");
+        assert_eq!(core_config.group_name.as_deref(), Some("group-abc"));
+    }
+
+    #[test]
+    fn test_service_configuration_from_core_conversion() {
+        let mut core_config = SlimServiceConfiguration::new();
+        core_config.node_id = "core-node".to_string();
+        core_config.group_name = Some("core-group".to_string());
+
+        let config: ServiceConfig = core_config.into();
+        assert_eq!(config.node_id.as_deref(), Some("core-node"));
+        assert_eq!(config.group_name.as_deref(), Some("core-group"));
+    }
+
+    #[test]
+    fn test_service_configuration_roundtrip() {
+        let original = ServiceConfig {
+            node_id: Some("roundtrip-node".to_string()),
+            group_name: Some("roundtrip-group".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        let core: SlimServiceConfiguration = original.clone().into();
+        let roundtrip: ServiceConfig = core.into();
+
+        assert_eq!(original.node_id, roundtrip.node_id);
+        assert_eq!(original.group_name, roundtrip.group_name);
+    }
+
+    // ========================================================================
+    // Service Creation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_service_new() {
+        let service = Service::new("test-service".to_string());
+        let name = service.get_name();
+        assert!(name.contains("test-service"));
+    }
+
+    #[test]
+    fn test_service_new_with_config() {
+        let config = ServiceConfig {
+            node_id: Some("test-node".to_string()),
+            group_name: Some("test-group".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        let service = Service::new_with_config("configured-service".to_string(), config.clone());
+        let retrieved_config = service.config();
+
+        assert_eq!(retrieved_config.node_id, config.node_id);
+        assert_eq!(retrieved_config.group_name, config.group_name);
+    }
+
+    #[test]
+    fn test_service_inner_clone() {
+        let service = Service::new("inner-test".to_string());
+        let inner1 = service.inner();
+        let inner2 = service.inner();
+
+        // Both should point to the same Arc
+        assert!(Arc::ptr_eq(&inner1, &inner2));
+    }
+
+    #[test]
+    fn test_service_from_slim_service() {
+        let kind = Kind::new(KIND).expect("Invalid service kind");
+        let id = ID::new_with_name(kind, "from-test").expect("Invalid service name");
+        let slim_service = SlimService::new(id);
+
+        let service: Service = slim_service.into();
+        // Just verify it doesn't panic
+        assert!(Arc::strong_count(&service.inner) >= 1);
+    }
+
+    // ========================================================================
+    // Global Service Tests
+    // ========================================================================
+
+    #[test]
+    fn test_global_service_singleton() {
+        let service1 = get_global_service();
+        let service2 = get_global_service();
+
+        // They should be the same instance (same memory address)
+        assert!(Arc::ptr_eq(&service1, &service2));
+
+        // Also check that the inner Arc is the same
+        assert!(Arc::ptr_eq(&service1.inner, &service2.inner));
+    }
+
+    #[test]
+    fn test_get_global_service_function() {
+        let service1 = get_global_service();
+        let service2 = get_global_service();
+
+        assert!(Arc::ptr_eq(&service1, &service2));
+    }
+
+    #[tokio::test]
+    async fn test_service_arc_sharing() {
+        let base_name = create_test_name();
+        let (provider, verifier) = create_test_auth();
+
+        // Get global service instance
+        let global_service = get_global_service();
+        let ptr1 = Arc::as_ptr(&global_service.inner) as usize;
+
+        // Test global service - just ensure it creates without error
+        let _global_adapter1 =
+            App::new_async(base_name.clone(), provider.clone(), verifier.clone())
+                .await
+                .unwrap();
+
+        // Test global service again - ensure it uses the same Arc
+        let _global_adapter2 = App::new_async(base_name, provider, verifier).await.unwrap();
+
+        let global_service2 = get_global_service();
+        let ptr2 = Arc::as_ptr(&global_service2.inner) as usize;
+
+        // They should point to the same inner Arc
+        assert_eq!(ptr1, ptr2);
+    }
+
+    #[test]
+    fn test_global_service_name() {
+        let name = get_global_service().get_name();
+        assert!(!name.is_empty());
+    }
+
+    // ========================================================================
+    // Service Lifecycle Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_service_shutdown_without_run() {
+        let service = Service::new("shutdown-test".to_string());
+        // Should not error even if service wasn't run
+        let result = service.shutdown_async().await;
+        // Shutdown might succeed or fail gracefully
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    // ========================================================================
+    // Client/Server Configuration Tests
+    // ========================================================================
+
+    #[test]
+    fn test_stop_nonexistent_server() {
+        let service = Service::new("stop-test".to_string());
+        let result = service.stop_server("127.0.0.1:99999".to_string());
+        // Should fail because server doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_disconnect_invalid_connection() {
+        let service = Service::new("disconnect-test".to_string());
+        let result = service.disconnect(999999);
+        // Should fail because connection doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_connection_id_nonexistent() {
+        let service = Service::new("conn-id-test".to_string());
+        let conn_id = service.get_connection_id("nonexistent-endpoint".to_string());
+        assert!(conn_id.is_none());
+    }
+
+    // ========================================================================
+    // Adapter Creation Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_create_adapter_async() {
+        let service = Service::new("adapter-test".to_string());
+        let base_name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "adapter-app".to_string(),
+        ));
+        let (provider, verifier) = create_test_auth();
+
+        let result = service
+            .create_app_async(base_name, provider, verifier)
+            .await;
+
+        assert!(result.is_ok(), "Should create adapter successfully");
+        let adapter = result.unwrap();
+        assert!(!adapter.id().is_empty(), "Adapter should have non-empty ID");
+    }
+
+    #[tokio::test]
+    async fn test_create_adapter_with_different_names() {
+        let service = Service::new("multi-adapter-test".to_string());
+        let (provider, verifier) = create_test_auth();
+
+        let names = vec![
+            ("org1", "ns1", "app1"),
+            ("org2", "ns2", "app2"),
+            ("org3", "ns3", "app3"),
+        ];
+
+        for (org, ns, app) in names {
+            let base_name = Arc::new(Name::new(org.to_string(), ns.to_string(), app.to_string()));
+
+            let result = service
+                .create_app_async(base_name, provider.clone(), verifier.clone())
+                .await;
+
+            assert!(result.is_ok(), "Should create adapter for {org}/{ns}/{app}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_adapter_unique_ids() {
+        // Each adapter gets a unique ID due to token generation
+        let service = Service::new("unique-ids-test".to_string());
+        let base_name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "unique-app".to_string(),
+        ));
+        let (provider, verifier) = create_test_auth();
+
+        let adapter1 = service
+            .create_app_async(base_name.clone(), provider.clone(), verifier.clone())
+            .await
+            .expect("Failed to create first adapter");
+
+        let adapter2 = service
+            .create_app_async(base_name, provider, verifier)
+            .await
+            .expect("Failed to create second adapter");
+
+        // IDs should be different since each adapter gets a fresh token
+        // (tokens include timestamps, so they're unique per creation)
+        assert_ne!(adapter1.id(), adapter2.id());
+
+        // Both IDs should be non-empty
+        assert!(!adapter1.id().is_empty());
+        assert!(!adapter2.id().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_create_app_with_secret_async() {
+        let service = Service::new("secret-app-test".to_string());
+        let base_name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "secret-app".to_string(),
+        ));
+        let secret = TEST_VALID_SECRET.to_string();
+
+        let result = service
+            .create_app_with_secret_async(base_name, secret)
+            .await;
+
+        assert!(result.is_ok(), "Should create app with secret successfully");
+        let app = result.unwrap();
+        assert!(!app.id().is_empty(), "App should have non-empty ID");
+    }
+
+    #[tokio::test]
+    async fn test_create_app_with_secret_multiple() {
+        let service = Service::new("multi-secret-app-test".to_string());
+        let secret = TEST_VALID_SECRET.to_string();
+
+        let names = vec![
+            ("org1", "ns1", "secret-app1"),
+            ("org2", "ns2", "secret-app2"),
+            ("org3", "ns3", "secret-app3"),
+        ];
+
+        for (org, ns, app) in names {
+            let base_name = Arc::new(Name::new(org.to_string(), ns.to_string(), app.to_string()));
+
+            let result = service
+                .create_app_with_secret_async(base_name, secret.clone())
+                .await;
+
+            assert!(
+                result.is_ok(),
+                "Should create secret app for {org}/{ns}/{app}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_create_app_blocking() {
+        let service = Service::new("blocking-app-test".to_string());
+        let base_name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "blocking-app".to_string(),
+        ));
+        let (provider, verifier) = create_test_auth();
+
+        let result = service.create_app(base_name, provider, verifier);
+
+        assert!(result.is_ok(), "Should create app in blocking mode");
+        let app = result.unwrap();
+        assert!(!app.id().is_empty(), "App should have non-empty ID");
+    }
+
+    #[test]
+    fn test_create_app_with_secret_blocking() {
+        let service = Service::new("blocking-secret-app-test".to_string());
+        let base_name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "blocking-secret-app".to_string(),
+        ));
+        let secret = TEST_VALID_SECRET.to_string();
+
+        let result = service.create_app_with_secret(base_name, secret);
+
+        assert!(result.is_ok(), "Should create secret app in blocking mode");
+        let app = result.unwrap();
+        assert!(!app.id().is_empty(), "App should have non-empty ID");
+    }
+
+    #[tokio::test]
+    async fn test_create_app_async_internal_directly() {
+        let service = Service::new("internal-test".to_string());
+        let base_name = create_test_name();
+        let (provider, verifier) = create_test_auth();
+
+        let result = create_app_async_internal(
+            base_name,
+            provider,
+            verifier,
+            service.inner.clone(),
+            crate::app::Direction::Bidirectional,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Should create app via internal function");
+        let app = result.unwrap();
+        assert!(!app.id().is_empty(), "App should have non-empty ID");
+    }
+
+    #[tokio::test]
+    async fn test_create_app_with_same_secret_different_ids() {
+        // Even with the same secret, different apps should get unique IDs
+        let service = Service::new("same-secret-test".to_string());
+        let secret = TEST_VALID_SECRET.to_string();
+        let base_name = Arc::new(Name::new(
+            "org".to_string(),
+            "namespace".to_string(),
+            "same-secret-app".to_string(),
+        ));
+
+        let app1 = service
+            .create_app_with_secret_async(base_name.clone(), secret.clone())
+            .await
+            .expect("Failed to create first app");
+
+        let app2 = service
+            .create_app_with_secret_async(base_name, secret)
+            .await
+            .expect("Failed to create second app");
+
+        // IDs should be different due to timestamp in token generation
+        assert_ne!(app1.id(), app2.id());
+        assert!(!app1.id().is_empty());
+        assert!(!app2.id().is_empty());
+    }
+
+    // ========================================================================
+    // Factory Function Tests
+    // ========================================================================
+
+    #[test]
+    fn test_new_service_configuration() {
+        let config = new_service_configuration();
+        assert!(config.node_id.is_none());
+        assert!(config.group_name.is_none());
+    }
+
+    #[test]
+    fn test_new_dataplane_config() {
+        let config = new_dataplane_config();
+        assert!(config.servers.is_empty());
+        assert!(config.clients.is_empty());
+    }
+
+    #[test]
+    fn test_create_service() {
+        let result = create_service("factory-test".to_string());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_create_service_with_config() {
+        let config = ServiceConfig {
+            node_id: Some("factory-node".to_string()),
+            group_name: Some("factory-group".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        let result = create_service_with_config("factory-configured-test".to_string(), config);
+        assert!(result.is_ok());
+    }
+
+    // ========================================================================
+    // Global Service Convenience Functions Tests
+    // ========================================================================
+
+    #[test]
+    fn test_global_stop_server_convenience() {
+        let result = get_global_service().stop_server("127.0.0.1:88888".to_string());
+        // Should error since server doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_global_disconnect_convenience() {
+        let result = get_global_service().disconnect(888888);
+        // Should error since connection doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_global_get_connection_id_convenience() {
+        let conn_id = get_global_service().get_connection_id("nonexistent-global".to_string());
+        assert!(conn_id.is_none());
+    }
+
+    // ========================================================================
+    // Error Handling Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_service_operations_on_uninitialized_service() {
+        // These operations should handle gracefully even on a fresh service
+        let service = Service::new("uninitialized-test".to_string());
+
+        // Stop server that doesn't exist
+        let result = service.stop_server("127.0.0.1:11111".to_string());
+        assert!(result.is_err());
+
+        // Disconnect non-existent connection
+        let result = service.disconnect(11111);
+        assert!(result.is_err());
+
+        // Get non-existent connection ID
+        let conn_id = service.get_connection_id("fake-endpoint".to_string());
+        assert!(conn_id.is_none());
+    }
+
+    // ========================================================================
+    // Integration Tests
+    // ========================================================================
+
+    #[test]
+    fn test_service_with_multiple_configs() {
+        let server_config = ServerConfig::default();
+        let client_config = ClientConfig::default();
+
+        let dataplane = DataplaneConfig {
+            servers: vec![server_config.clone(), server_config],
+            clients: vec![client_config.clone(), client_config],
+        };
+
+        let service_config = ServiceConfig {
+            node_id: Some("multi-config-node".to_string()),
+            group_name: Some("multi-config-group".to_string()),
+            dataplane,
+        };
+
+        let service = Service::new_with_config("multi-config-service".to_string(), service_config);
+        let retrieved = service.config();
+
+        assert_eq!(retrieved.dataplane.servers.len(), 2);
+        assert_eq!(retrieved.dataplane.clients.len(), 2);
+    }
+
+    #[test]
+    fn test_service_config_mutation_isolation() {
+        let config = ServiceConfig {
+            node_id: Some("original-node".to_string()),
+            group_name: Some("original-group".to_string()),
+            dataplane: DataplaneConfig::default(),
+        };
+
+        let service = Service::new_with_config("isolation-test".to_string(), config.clone());
+
+        // Get config and verify it matches
+        let retrieved = service.config();
+        assert_eq!(retrieved.node_id, config.node_id);
+
+        // Original config should be independent
+        let mut modified_config = config;
+        modified_config.node_id = Some("modified-node".to_string());
+
+        // Service config should not have changed
+        let retrieved2 = service.config();
+        assert_eq!(retrieved2.node_id.as_deref(), Some("original-node"));
+    }
+
+    // ========================================================================
+    // Runtime Spawning Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_run_server_async_runtime_context() {
+        let service = Service::new("run-server-runtime-test".to_string());
+        let config = ServerConfig::default();
+
+        // This should not panic even though it's spawning on runtime
+        let result = service.run_server_async(config).await;
+        // May fail due to address already in use or other reasons, but shouldn't panic
+        let _ = result; // We just want to ensure it doesn't panic
+    }
+
+    #[tokio::test]
+    async fn test_connect_async_runtime_context() {
+        let service = Service::new("connect-runtime-test".to_string());
+        let config = ClientConfig::default();
+
+        // This should not panic even though it's spawning on runtime
+        let result = service.connect_async(config).await;
+        // May fail to connect, but shouldn't panic from join error
+        let _ = result; // We just want to ensure proper error handling
+    }
+
+    #[test]
+    fn test_run_server_blocking() {
+        let service = Service::new("run-server-blocking-test".to_string());
+        let config = ServerConfig::default();
+
+        // Test blocking version
+        let result = service.run_server(config);
+        // May fail but should not panic
+        let _ = result;
+    }
+
+    #[test]
+    fn test_connect_blocking() {
+        let service = Service::new("connect-blocking-test".to_string());
+        let config = ClientConfig::default();
+
+        // Test blocking version
+        let result = service.connect(config);
+        // May fail but should not panic
+        let _ = result;
+    }
+
+    // ========================================================================
+    // Additional Edge Case Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_multiple_apps_on_same_service() {
+        let service = Service::new("multi-app-service".to_string());
+        let secret = TEST_VALID_SECRET.to_string();
+
+        let name1 = Arc::new(Name::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "app1".to_string(),
+        ));
+        let name2 = Arc::new(Name::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "app2".to_string(),
+        ));
+        let name3 = Arc::new(Name::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "app3".to_string(),
+        ));
+
+        let app1 = service
+            .create_app_with_secret_async(name1, secret.clone())
+            .await
+            .expect("Failed to create app1");
+
+        let app2 = service
+            .create_app_with_secret_async(name2, secret.clone())
+            .await
+            .expect("Failed to create app2");
+
+        let app3 = service
+            .create_app_with_secret_async(name3, secret)
+            .await
+            .expect("Failed to create app3");
+
+        // All apps should have unique IDs
+        assert_ne!(app1.id(), app2.id());
+        assert_ne!(app1.id(), app3.id());
+        assert_ne!(app2.id(), app3.id());
+
+        // All IDs should be non-empty
+        assert!(!app1.id().is_empty());
+        assert!(!app2.id().is_empty());
+        assert!(!app3.id().is_empty());
+    }
+
+    #[test]
+    fn test_service_run_blocking() {
+        let service = Service::new("run-blocking-test".to_string());
+        // Test that run() doesn't panic
+        let result = service.run();
+        // May succeed or fail, we just ensure no panic
+        let _ = result;
+    }
+
+    #[test]
+    fn test_service_shutdown_blocking() {
+        let service = Service::new("shutdown-blocking-test".to_string());
+        // Test that shutdown() doesn't panic
+        let result = service.shutdown();
+        // May succeed or fail, we just ensure no panic
+        let _ = result;
+    }
+
+    #[tokio::test]
+    async fn test_run_async() {
+        let service = Service::new("run-async-test".to_string());
+        // run_async starts all configured servers/clients
+        let result = service.run_async().await;
+        // May fail if nothing configured, but shouldn't panic
+        let _ = result;
+    }
+}

--- a/crates/slim-bindings/src/session.rs
+++ b/crates/slim-bindings/src/session.rs
@@ -1,0 +1,1687 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use slim_session::CompletionHandle as SlimCompletionHandle;
+use slim_session::session_controller::SessionController;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use futures_timer::Delay;
+use slim_datapath::api::ProtoName as SlimName;
+use slim_datapath::api::ProtoSessionType;
+use slim_datapath::messages::utils::{PUBLISH_TO, SlimHeaderFlags, TRUE_VAL};
+use slim_session::SessionConfig as SlimSessionConfig;
+use slim_session::SessionError;
+use slim_session::context::SessionContext as SlimSession;
+
+use crate::message_context::MessageContext;
+use crate::{CompletionHandle, Name, ReceivedMessage, SlimError};
+
+/// Session type enum
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum SessionType {
+    PointToPoint,
+    Group,
+}
+
+impl From<SessionType> for ProtoSessionType {
+    fn from(session_type: SessionType) -> Self {
+        match session_type {
+            SessionType::PointToPoint => ProtoSessionType::PointToPoint,
+            SessionType::Group => ProtoSessionType::Multicast,
+        }
+    }
+}
+
+impl From<ProtoSessionType> for SessionType {
+    fn from(session_type: ProtoSessionType) -> Self {
+        match session_type {
+            ProtoSessionType::PointToPoint => SessionType::PointToPoint,
+            ProtoSessionType::Multicast => SessionType::Group,
+            ProtoSessionType::Unspecified => SessionType::PointToPoint, // Default to PointToPoint
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct MlsSettings {
+    /// 0 = disable header-integrity checks; 1–100 = percent of messages to verify after decrypt.
+    pub header_integrity_validation_percent: u32,
+}
+
+impl Default for MlsSettings {
+    fn default() -> Self {
+        Self {
+            header_integrity_validation_percent: 100,
+        }
+    }
+}
+
+impl From<MlsSettings> for slim_session::session_config::MlsSettings {
+    fn from(s: MlsSettings) -> Self {
+        Self {
+            header_integrity_validation_percent: s.header_integrity_validation_percent.min(100),
+            max_seen_control_message_ids_size: None,
+        }
+    }
+}
+
+impl From<slim_session::session_config::MlsSettings> for MlsSettings {
+    fn from(s: slim_session::session_config::MlsSettings) -> Self {
+        Self {
+            header_integrity_validation_percent: s.header_integrity_validation_percent,
+        }
+    }
+}
+
+/// Session configuration
+#[derive(uniffi::Record)]
+pub struct SessionConfig {
+    /// Session type (PointToPoint or Group)
+    pub session_type: SessionType,
+
+    /// Maximum number of retries for message transmission (None = use default)
+    pub max_retries: Option<u32>,
+
+    /// Interval between retries in milliseconds (None = use default)
+    pub interval: Option<std::time::Duration>,
+
+    /// Custom metadata key-value pairs for the session
+    pub metadata: std::collections::HashMap<String, String>,
+
+    /// MLS options (None disables MLS).
+    pub mls_settings: Option<MlsSettings>,
+}
+
+impl From<SessionConfig> for SlimSessionConfig {
+    fn from(config: SessionConfig) -> Self {
+        SlimSessionConfig {
+            session_type: config.session_type.into(),
+            max_retries: config.max_retries,
+            interval: config.interval,
+            initiator: true,
+            metadata: config.metadata,
+            mls_settings: config.mls_settings.map(Into::into),
+        }
+    }
+}
+
+impl From<SlimSessionConfig> for SessionConfig {
+    fn from(config: SlimSessionConfig) -> Self {
+        SessionConfig {
+            session_type: config.session_type.into(),
+            max_retries: config.max_retries,
+            interval: config.interval,
+            metadata: config.metadata,
+            mls_settings: config.mls_settings.map(Into::into),
+        }
+    }
+}
+
+/// Session context for language bindings (UniFFI-compatible)
+///
+/// Wraps the session context with proper async access patterns for message reception.
+/// Provides both synchronous (blocking) and asynchronous methods for FFI compatibility.
+#[derive(uniffi::Object)]
+pub struct Session {
+    /// Weak reference to the underlying session
+    pub session: std::sync::Weak<SessionController>,
+    /// Message receiver wrapped in RwLock for concurrent access
+    pub rx: RwLock<slim_session::AppChannelReceiver>,
+}
+
+impl Session {
+    /// Create a new Session from a Session and runtime
+    pub fn new(ctx: SlimSession) -> Self {
+        let (session, rx) = ctx.into_parts();
+        Self {
+            session,
+            rx: RwLock::new(rx),
+        }
+    }
+
+    /// Get the runtime (for internal use)
+    pub fn runtime(&self) -> tokio::runtime::Handle {
+        crate::config::get_runtime()
+    }
+}
+
+// ============================================================================
+// Internal async methods (used by both FFI and Python bindings)
+// ============================================================================
+
+impl Session {
+    /// Publish a message through this session (internal API for language bindings)
+    ///
+    /// This is the low-level publish method that takes SlimName directly.
+    /// Use `publish()` or `publish_with_params()` for FFI-compatible APIs.
+    pub async fn publish_internal(
+        &self,
+        name: &SlimName,
+        fanout: u32,
+        blob: Vec<u8>,
+        conn_out: Option<u64>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<SlimCompletionHandle, SessionError> {
+        let session = self.session.upgrade().ok_or(SessionError::SessionClosed)?;
+
+        let flags = SlimHeaderFlags::new(fanout, None, conn_out, None, None);
+
+        let ret = session
+            .publish_with_flags(name, flags, blob, payload_type, metadata)
+            .await?;
+
+        Ok(ret)
+    }
+
+    /// Publish a message as a reply (internal API for language bindings)
+    ///
+    /// This is the low-level publish_to method that takes MessageContext reference.
+    /// Use `publish_to()` for FFI-compatible API.
+    pub async fn publish_to_internal(
+        &self,
+        message_ctx: &MessageContext,
+        blob: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<SlimCompletionHandle, SessionError> {
+        let session = self.session.upgrade().ok_or(SessionError::SessionClosed)?;
+
+        let flags = SlimHeaderFlags::new(
+            1, // fanout = 1 for reply semantics
+            None,
+            Some(message_ctx.input_connection), // reply to the same connection
+            None,
+            None,
+        );
+
+        let mut final_metadata = metadata.unwrap_or_default();
+        final_metadata.insert(PUBLISH_TO.to_string(), TRUE_VAL.to_string());
+
+        // Convert FFI Name to SlimName for the datapath layer
+        let source_name = message_ctx.source_as_slim_name();
+
+        let ret = session
+            .publish_with_flags(
+                &source_name, // reply to the original source
+                flags,
+                blob,
+                payload_type,
+                Some(final_metadata),
+            )
+            .await?;
+
+        Ok(ret)
+    }
+
+    /// Invite a peer to join this session (internal API for language bindings)
+    ///
+    /// This is the low-level invite method that takes SlimName reference.
+    /// Use `invite()` for FFI-compatible API with auto-wait.
+    pub async fn invite_internal(
+        &self,
+        destination: &SlimName,
+    ) -> Result<SlimCompletionHandle, SessionError> {
+        let session = self.session.upgrade().ok_or(SessionError::SessionClosed)?;
+
+        session.invite_participant(destination).await
+    }
+
+    /// Remove a peer from this session (internal API for language bindings)
+    ///
+    /// This is the low-level remove method that takes SlimName reference.
+    /// Use `remove()` for FFI-compatible API with auto-wait.
+    pub async fn remove_internal(
+        &self,
+        destination: &SlimName,
+    ) -> Result<SlimCompletionHandle, SessionError> {
+        let session = self.session.upgrade().ok_or(SessionError::SessionClosed)?;
+
+        session.remove_participant(destination).await
+    }
+
+    /// Receive a message from this session with optional timeout
+    pub async fn get_session_message(
+        &self,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<(MessageContext, Vec<u8>), SessionError> {
+        let mut rx = self.rx.write().await;
+
+        let recv_future = async {
+            let msg = rx.recv().await.ok_or(SessionError::SessionClosed)??;
+
+            MessageContext::from_proto_message(msg)
+        };
+
+        if let Some(timeout_duration) = timeout {
+            // Runtime-agnostic timeout using futures-timer
+            futures::pin_mut!(recv_future);
+            let delay = Delay::new(timeout_duration);
+            futures::pin_mut!(delay);
+
+            match futures::future::select(recv_future, delay).await {
+                futures::future::Either::Left((result, _)) => result,
+                futures::future::Either::Right(_) => Err(SessionError::ReceiveTimeout),
+            }
+        } else {
+            recv_future.await
+        }
+    }
+}
+
+// ============================================================================
+// FFI-exported methods (UniFFI)
+// ============================================================================
+
+#[uniffi::export]
+impl Session {
+    /// Publish a message to the session's destination (blocking version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the message was delivered.
+    ///
+    /// # Arguments
+    /// * `data` - The message payload bytes
+    /// * `payload_type` - Optional content type identifier
+    /// * `metadata` - Optional key-value metadata pairs
+    ///
+    /// # Returns
+    /// * `Ok(CompletionHandle)` - Handle to await delivery confirmation
+    /// * `Err(SlimError)` - If publishing fails
+    ///
+    /// # Example
+    /// ```ignore
+    /// let completion = session.publish(data, None, None)?;
+    /// completion.wait()?; // Blocks until message is delivered
+    /// ```
+    pub fn publish(
+        &self,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.publish_async(data, payload_type, metadata).await })
+    }
+
+    /// Publish a message to the session's destination (async version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the message was delivered.
+    pub async fn publish_async(
+        &self,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        let destination = session.dst();
+
+        let completion = self
+            .publish_internal(
+                destination,
+                1, // fanout = 1 for normal publish
+                data,
+                None, // connection_out
+                payload_type,
+                metadata,
+            )
+            .await?;
+
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Publish a message and wait for completion (blocking version)
+    ///
+    /// This method publishes a message and blocks until the delivery completes.
+    pub fn publish_and_wait(
+        &self,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(async {
+            self.publish_and_wait_async(data, payload_type, metadata)
+                .await
+        })
+    }
+
+    /// Publish a message and wait for completion (async version)
+    ///
+    /// This method publishes a message and waits until the delivery completes.
+    pub async fn publish_and_wait_async(
+        &self,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<(), SlimError> {
+        let completion_handle = self.publish_async(data, payload_type, metadata).await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Publish a reply message to the originator of a received message (blocking version for FFI)
+    ///
+    /// This method uses the routing information from a previously received message
+    /// to send a reply back to the sender. This is the preferred way to implement
+    /// request/reply patterns.
+    ///
+    /// Returns a completion handle that can be awaited to ensure the message was delivered.
+    ///
+    /// # Arguments
+    /// * `message_context` - Context from a message received via `get_message()`
+    /// * `data` - The reply payload bytes
+    /// * `payload_type` - Optional content type identifier
+    /// * `metadata` - Optional key-value metadata pairs
+    ///
+    /// # Returns
+    /// * `Ok(CompletionHandle)` - Handle to await delivery confirmation
+    /// * `Err(SlimError)` - If publishing fails
+    pub fn publish_to(
+        &self,
+        message_context: MessageContext,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async {
+            self.publish_to_async(message_context, data, payload_type, metadata)
+                .await
+        })
+    }
+
+    /// Publish a reply message (async version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the message was delivered.
+    pub async fn publish_to_async(
+        &self,
+        message_context: MessageContext,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        let completion = self
+            .publish_to_internal(&message_context, data, payload_type, metadata)
+            .await?;
+
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Publish a reply message and wait for completion (blocking version)
+    ///
+    /// This method publishes a reply to a received message and blocks until the delivery completes.
+    pub fn publish_to_and_wait(
+        &self,
+        message_context: MessageContext,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(async {
+            self.publish_to_and_wait_async(message_context, data, payload_type, metadata)
+                .await
+        })
+    }
+
+    /// Publish a reply message and wait for completion (async version)
+    ///
+    /// This method publishes a reply to a received message and waits until the delivery completes.
+    pub async fn publish_to_and_wait_async(
+        &self,
+        message_context: MessageContext,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<(), SlimError> {
+        let completion_handle = self
+            .publish_to_async(message_context, data, payload_type, metadata)
+            .await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Low-level publish with full control over all parameters (blocking version for FFI)
+    ///
+    /// This is an advanced method that provides complete control over routing and delivery.
+    /// Most users should use `publish()` or `publish_to()` instead.
+    ///
+    /// # Arguments
+    /// * `destination` - Target name to send to
+    /// * `fanout` - Number of copies to send (for multicast)
+    /// * `data` - The message payload bytes
+    /// * `connection_out` - Optional specific connection ID to use
+    /// * `payload_type` - Optional content type identifier
+    /// * `metadata` - Optional key-value metadata pairs
+    pub fn publish_with_params(
+        &self,
+        destination: Arc<Name>,
+        fanout: u32,
+        data: Vec<u8>,
+        connection_out: Option<u64>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(async {
+            self.publish_with_params_async(
+                destination,
+                fanout,
+                data,
+                connection_out,
+                payload_type,
+                metadata,
+            )
+            .await
+        })
+    }
+
+    /// Low-level publish with full control (async version)
+    pub async fn publish_with_params_async(
+        &self,
+        destination: Arc<Name>,
+        fanout: u32,
+        data: Vec<u8>,
+        connection_out: Option<u64>,
+        payload_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<(), SlimError> {
+        let slim_dest: SlimName = destination.as_ref().into();
+
+        self.publish_internal(
+            &slim_dest,
+            fanout,
+            data,
+            connection_out,
+            payload_type,
+            metadata,
+        )
+        .await
+        .map(|_| ())?;
+
+        Ok(())
+    }
+
+    /// Receive a message from the session (blocking version for FFI)
+    ///
+    /// # Arguments
+    /// * `timeout` - Optional timeout duration
+    ///
+    /// # Returns
+    /// * `Ok(ReceivedMessage)` - Message with context and payload bytes
+    /// * `Err(SlimError)` - If the receive fails or times out
+    pub fn get_message(
+        &self,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<ReceivedMessage, SlimError> {
+        crate::config::get_runtime().block_on(async { self.get_message_async(timeout).await })
+    }
+
+    /// Receive a message from the session (async version)
+    pub async fn get_message_async(
+        &self,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<ReceivedMessage, SlimError> {
+        let (ctx, payload) = self.get_session_message(timeout).await?;
+
+        Ok(ReceivedMessage {
+            context: ctx,
+            payload,
+        })
+    }
+
+    /// Invite a participant to the session (blocking version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the invitation completes.
+    pub fn invite(&self, participant: Arc<Name>) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.invite_async(participant).await })
+    }
+
+    /// Invite a participant to the session (async version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the invitation completes.
+    pub async fn invite_async(
+        &self,
+        participant: Arc<Name>,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        let slim_name: SlimName = participant.as_ref().into();
+
+        let completion = self.invite_internal(&slim_name).await?;
+
+        // Return completion handle for caller to wait on
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Invite a participant and wait for completion (blocking version)
+    ///
+    /// This method invites a participant and blocks until the invitation completes.
+    pub fn invite_and_wait(&self, participant: Arc<Name>) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.invite_and_wait_async(participant).await })
+    }
+
+    /// Invite a participant and wait for completion (async version)
+    ///
+    /// This method invites a participant and waits until the invitation completes.
+    pub async fn invite_and_wait_async(&self, participant: Arc<Name>) -> Result<(), SlimError> {
+        let completion_handle = self.invite_async(participant).await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Remove a participant from the session (blocking version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the removal completes.
+    pub fn remove(&self, participant: Arc<Name>) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.remove_async(participant).await })
+    }
+
+    /// Remove a participant from the session (async version)
+    ///
+    /// Returns a completion handle that can be awaited to ensure the removal completes.
+    pub async fn remove_async(
+        &self,
+        participant: Arc<Name>,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        let slim_name: SlimName = participant.as_ref().into();
+
+        let completion = self.remove_internal(&slim_name).await?;
+
+        // Return completion handle for caller to wait on
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Remove a participant and wait for completion (blocking version)
+    ///
+    /// This method removes a participant and blocks until the removal completes.
+    pub fn remove_and_wait(&self, participant: Arc<Name>) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.remove_and_wait_async(participant).await })
+    }
+
+    /// Remove a participant and wait for completion (async version)
+    ///
+    /// This method removes a participant and waits until the removal completes.
+    pub async fn remove_and_wait_async(&self, participant: Arc<Name>) -> Result<(), SlimError> {
+        let completion_handle = self.remove_async(participant).await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Get the destination name for this session
+    pub fn destination(&self) -> Result<Name, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        Ok(Name::from(session.dst()))
+    }
+
+    /// Get the source name for this session
+    pub fn source(&self) -> Result<Name, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        Ok(Name::from(session.source()))
+    }
+
+    /// Get the session ID
+    pub fn session_id(&self) -> Result<u32, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        Ok(session.id())
+    }
+
+    /// Get the session type (PointToPoint or Group)
+    pub fn session_type(&self) -> Result<SessionType, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        match session.session_type() {
+            ProtoSessionType::PointToPoint => Ok(SessionType::PointToPoint),
+            ProtoSessionType::Multicast => Ok(SessionType::Group),
+            ProtoSessionType::Unspecified => Err(SlimError::InvalidArgument {
+                message: "Session has unspecified type".to_string(),
+            }),
+        }
+    }
+
+    /// Check if this session is the initiator
+    pub fn is_initiator(&self) -> Result<bool, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        Ok(session.is_initiator())
+    }
+
+    /// Get the session metadata
+    pub fn metadata(&self) -> Result<HashMap<String, String>, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+        Ok(session.metadata())
+    }
+
+    /// Get the session configuration
+    pub fn config(&self) -> Result<SessionConfig, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        Ok(session.session_config().into())
+    }
+
+    /// Get list of participants in the session
+    pub async fn participants_list_async(&self) -> Result<Vec<Arc<Name>>, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        let list = session.participants_list().await?;
+        Ok(list.into_iter().map(|n| Arc::new(Name::from(n))).collect())
+    }
+
+    /// Get list of participants in the session (blocking version for FFI)
+    pub fn participants_list(&self) -> Result<Vec<Arc<Name>>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.participants_list_async().await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Name as FfiName;
+    use crate::errors::SlimError;
+    use slim_datapath::api::{
+        ApplicationPayload, ProtoMessage, ProtoPublish, ProtoPublishType, SessionHeader, SlimHeader,
+    };
+    use slim_session::SessionError;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    /// Helper to create SlimName for proto message construction
+    fn make_slim_name(parts: [&str; 3]) -> SlimName {
+        SlimName::from_strings(parts).with_id(0)
+    }
+
+    /// Helper to create FFI Name for MessageContext construction
+    fn make_ffi_name(parts: [&str; 3]) -> FfiName {
+        FfiName::new(
+            parts[0].to_string(),
+            parts[1].to_string(),
+            parts[2].to_string(),
+        )
+    }
+
+    fn make_context() -> (
+        Session,
+        mpsc::UnboundedSender<Result<ProtoMessage, SessionError>>,
+    ) {
+        let (tx, rx) = mpsc::unbounded_channel::<Result<ProtoMessage, SessionError>>();
+        let ctx = Session {
+            session: std::sync::Weak::new(),
+            rx: RwLock::new(rx),
+        };
+        (ctx, tx)
+    }
+
+    /// Helper to create a valid ProtoMessage for testing message reception
+    fn create_test_proto_message(
+        source: SlimName,
+        dest: SlimName,
+        connection_id: u64,
+        payload: Vec<u8>,
+        content_type: &str,
+        metadata: HashMap<String, String>,
+    ) -> ProtoMessage {
+        let content = ApplicationPayload::new(content_type, payload).as_content();
+
+        let mut slim_header = SlimHeader::default();
+        slim_header.set_source(source);
+        slim_header.set_destination(dest);
+
+        let publish = ProtoPublish {
+            header: Some(slim_header),
+            session: Some(SessionHeader::default()),
+            msg: Some(content),
+        };
+
+        let mut proto_msg = ProtoMessage {
+            message_type: Some(ProtoPublishType(publish)),
+            metadata,
+        };
+
+        proto_msg.set_incoming_conn(Some(connection_id));
+        proto_msg
+    }
+
+    // ==================== Message Reception Tests ====================
+
+    #[tokio::test]
+    async fn test_get_session_message_success() {
+        let (ctx, tx) = make_context();
+
+        let source = make_slim_name(["org", "sender", "app"]);
+        let dest = make_slim_name(["org", "receiver", "app"]);
+        let payload = b"hello world".to_vec();
+        let mut metadata = HashMap::new();
+        metadata.insert("key".to_string(), "value".to_string());
+
+        let msg = create_test_proto_message(
+            source.clone(),
+            dest,
+            42,
+            payload.clone(),
+            "text/plain",
+            metadata.clone(),
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        let result = ctx
+            .get_session_message(Some(Duration::from_millis(100)))
+            .await;
+        assert!(result.is_ok(), "should receive message successfully");
+
+        let (msg_ctx, received_payload) = result.unwrap();
+        assert_eq!(received_payload, payload);
+        assert_eq!(msg_ctx.payload_type, "text/plain");
+        assert_eq!(msg_ctx.input_connection, 42);
+        assert_eq!(msg_ctx.metadata.get("key"), Some(&"value".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_timeout() {
+        let (ctx, _tx) = make_context();
+        let result = ctx
+            .get_session_message(Some(Duration::from_millis(50)))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("timeout"));
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_channel_closed() {
+        let (ctx, tx) = make_context();
+        drop(tx); // close sender so receiver sees channel closed
+        let result = ctx
+            .get_session_message(Some(Duration::from_millis(50)))
+            .await;
+        assert!(result.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_decode_error() {
+        let (ctx, tx) = make_context();
+
+        // Send an error through the channel (simulates decode failure)
+        tx.send(Err(SessionError::SlimMessageSendFailed)).unwrap();
+
+        let result = ctx
+            .get_session_message(Some(Duration::from_millis(100)))
+            .await;
+        assert!(result.is_err_and(|e| matches!(e, SessionError::SlimMessageSendFailed)));
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_no_timeout() {
+        let (ctx, tx) = make_context();
+
+        // Spawn a task that sends a message after a short delay
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let msg = create_test_proto_message(
+                make_slim_name(["org", "sender", "app"]),
+                make_slim_name(["org", "receiver", "app"]),
+                1,
+                b"delayed".to_vec(),
+                "text/plain",
+                HashMap::new(),
+            );
+            let _ = tx.send(Ok(msg));
+        });
+
+        // Call without timeout - should block until message arrives
+        let result = ctx.get_session_message(None).await;
+        assert!(result.is_ok());
+        let (_, payload) = result.unwrap();
+        assert_eq!(payload, b"delayed".to_vec());
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_various_timeouts() {
+        let (ctx, _tx) = make_context();
+
+        // Very short timeout
+        let start = std::time::Instant::now();
+        let result = ctx
+            .get_session_message(Some(Duration::from_millis(10)))
+            .await;
+        assert!(result.is_err());
+        assert!(start.elapsed() >= Duration::from_millis(10));
+
+        // Zero timeout should return immediately
+        let start = std::time::Instant::now();
+        let result = ctx.get_session_message(Some(Duration::ZERO)).await;
+        assert!(result.is_err());
+        assert!(start.elapsed() < Duration::from_millis(50));
+
+        // Longer timeout
+        let start = std::time::Instant::now();
+        let result = ctx
+            .get_session_message(Some(Duration::from_millis(100)))
+            .await;
+        assert!(result.is_err());
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(90)); // Allow variance
+        assert!(elapsed < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_multiple_messages() {
+        let (ctx, tx) = make_context();
+
+        // Send multiple messages
+        for i in 0..3 {
+            let msg = create_test_proto_message(
+                make_slim_name(["org", "sender", "app"]),
+                make_slim_name(["org", "receiver", "app"]),
+                i as u64,
+                format!("message {i}").into_bytes(),
+                "text/plain",
+                HashMap::new(),
+            );
+            tx.send(Ok(msg)).expect("send should succeed");
+        }
+
+        // Receive them in order
+        for i in 0..3 {
+            let result = ctx
+                .get_session_message(Some(Duration::from_millis(100)))
+                .await;
+            assert!(result.is_ok());
+            let (msg_ctx, payload) = result.unwrap();
+            assert_eq!(payload, format!("message {i}").into_bytes());
+            assert_eq!(msg_ctx.input_connection, i as u64);
+        }
+    }
+
+    // ==================== Publish Tests (Session Missing) ====================
+
+    #[tokio::test]
+    async fn test_publish_internal_errors_when_session_missing() {
+        let (ctx, _tx) = make_context();
+        let res = ctx
+            .publish_internal(
+                &make_slim_name(["dest", "app", "v1"]),
+                1,
+                b"payload".to_vec(),
+                None,
+                Some("text/plain".to_string()),
+                None,
+            )
+            .await;
+        assert!(res.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    #[tokio::test]
+    async fn test_publish_internal_with_all_params_errors_when_session_missing() {
+        let (ctx, _tx) = make_context();
+        let mut metadata = HashMap::new();
+        metadata.insert("key".to_string(), "value".to_string());
+
+        let res = ctx
+            .publish_internal(
+                &make_slim_name(["dest", "app", "v1"]),
+                3,                                    // fanout
+                b"payload".to_vec(),                  // blob
+                Some(123),                            // conn_out
+                Some("application/json".to_string()), // payload_type
+                Some(metadata),                       // metadata
+            )
+            .await;
+        assert!(res.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    #[tokio::test]
+    async fn test_publish_to_internal_errors_when_session_missing() {
+        let (ctx, _tx) = make_context();
+        let message_ctx = MessageContext::new(
+            make_ffi_name(["sender", "org", "service"]),
+            Some(make_ffi_name(["receiver", "org", "service"])),
+            "application/json".to_string(),
+            HashMap::new(),
+            42,
+            "unique".to_string(),
+        );
+
+        let res = ctx
+            .publish_to_internal(
+                &message_ctx,
+                b"reply".to_vec(),
+                Some("json".to_string()),
+                None,
+            )
+            .await;
+        assert!(res.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    // ==================== Invite/Remove Tests (Session Missing) ====================
+
+    #[tokio::test]
+    async fn test_invite_internal_errors_when_session_missing() {
+        let (ctx, _tx) = make_context();
+        let res = ctx
+            .invite_internal(&make_slim_name(["org", "peer", "app"]))
+            .await;
+        assert!(res.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    #[tokio::test]
+    async fn test_remove_internal_errors_when_session_missing() {
+        let (ctx, _tx) = make_context();
+        let err = ctx
+            .remove_internal(&make_slim_name(["org", "peer", "app"]))
+            .await;
+        assert!(err.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    // ==================== Context Creation Tests ====================
+
+    #[tokio::test]
+    async fn test_bindings_session_context_weak_ref() {
+        let (ctx, _tx) = make_context();
+        // With no actual SessionController, the weak ref should be None
+        assert!(ctx.session.upgrade().is_none());
+    }
+
+    // ==================== FFI Method Tests (Session Missing) ====================
+
+    #[tokio::test]
+    async fn test_publish_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.publish_async(b"test".to_vec(), None, None).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_publish_to_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let message_ctx = MessageContext::new(
+            make_ffi_name(["sender", "org", "service"]),
+            Some(make_ffi_name(["receiver", "org", "service"])),
+            "application/json".to_string(),
+            HashMap::new(),
+            42,
+            "identity".to_string(),
+        );
+
+        let result = ctx
+            .publish_to_async(message_ctx, b"reply".to_vec(), None, None)
+            .await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("closed")
+            } else {
+                false
+            }
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_publish_with_params_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let dest = Arc::new(FfiName::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "dest".to_string(),
+        ));
+
+        let result = ctx
+            .publish_with_params_async(dest, 1, b"test".to_vec(), None, None, None)
+            .await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("closed")
+            } else {
+                false
+            }
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_publish_with_params_async_with_all_options() {
+        let (ctx, _tx) = make_context();
+        let dest = Arc::new(FfiName::new_with_id(
+            "org".to_string(),
+            "ns".to_string(),
+            "dest".to_string(),
+            "00000000-0000-0000-0000-000000012345".to_string(),
+        ));
+
+        let mut metadata = HashMap::new();
+        metadata.insert("key".to_string(), "value".to_string());
+
+        let result = ctx
+            .publish_with_params_async(
+                dest,
+                3, // fanout
+                b"test payload".to_vec(),
+                Some(456),                            // connection_out
+                Some("application/json".to_string()), // payload_type
+                Some(metadata),                       // metadata
+            )
+            .await;
+
+        // Should fail because session is missing, but this tests the parameter passing
+        assert!(result.is_err());
+    }
+
+    // ==================== Get Message FFI Tests ====================
+
+    #[tokio::test]
+    async fn test_get_message_async_success() {
+        let (ctx, tx) = make_context();
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "app"]),
+            make_slim_name(["org", "receiver", "app"]),
+            42,
+            b"hello".to_vec(),
+            "text/plain",
+            HashMap::new(),
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+        assert!(result.is_ok());
+
+        let received = result.unwrap();
+        assert_eq!(received.payload, b"hello");
+        assert_eq!(received.context.payload_type, "text/plain");
+        assert_eq!(received.context.input_connection, 42);
+    }
+
+    #[tokio::test]
+    async fn test_get_message_async_timeout() {
+        let (ctx, _tx) = make_context();
+
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(50)))
+            .await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("receive timeout")
+            } else {
+                false
+            }
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_get_message_async_channel_closed() {
+        let (ctx, tx) = make_context();
+        drop(tx);
+
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+        assert!(result.is_err_and(|e| matches!(e, SlimError::SessionError { .. })));
+    }
+
+    // ==================== Invite/Remove FFI Tests ====================
+
+    #[tokio::test]
+    async fn test_invite_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let participant = Arc::new(FfiName::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "peer".to_string(),
+        ));
+
+        let result = ctx.invite_async(participant).await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("closed")
+            } else {
+                false
+            }
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_remove_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let participant = Arc::new(FfiName::new(
+            "org".to_string(),
+            "ns".to_string(),
+            "peer".to_string(),
+        ));
+
+        let result = ctx.remove_async(participant).await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("closed")
+            } else {
+                false
+            }
+        }));
+    }
+
+    // ==================== Session Info Accessor Tests ====================
+
+    #[tokio::test]
+    async fn test_destination_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.destination();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_source_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.source();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_session_id_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.session_id();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_session_type_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.session_type();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_is_initiator_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.is_initiator();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_participants_list_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.participants_list_async().await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SlimError::SessionError { message } => {
+                assert!(message.contains("closed") || message.contains("dropped"));
+            }
+            _ => panic!("Expected SessionError"),
+        }
+    }
+
+    // ==================== Publish Internal with Metadata Tests ====================
+
+    #[tokio::test]
+    async fn test_publish_to_internal_adds_publish_to_metadata() {
+        // This test verifies the metadata manipulation in publish_to_internal
+        // Even though session is missing, we can verify the code path is exercised
+        let (ctx, _tx) = make_context();
+        let message_ctx = MessageContext::new(
+            make_ffi_name(["sender", "org", "service"]),
+            Some(make_ffi_name(["receiver", "org", "service"])),
+            "application/json".to_string(),
+            HashMap::new(),
+            42,
+            "identity".to_string(),
+        );
+
+        let mut metadata = HashMap::new();
+        metadata.insert("custom_key".to_string(), "custom_value".to_string());
+
+        // This should fail but exercises the metadata handling code
+        let result = ctx
+            .publish_to_internal(
+                &message_ctx,
+                b"reply".to_vec(),
+                Some("text/plain".to_string()),
+                Some(metadata),
+            )
+            .await;
+
+        assert!(result.is_err_and(|e| matches!(e, SessionError::SessionClosed)));
+    }
+
+    // ==================== ReceivedMessage Construction Test ====================
+
+    #[tokio::test]
+    async fn test_received_message_construction() {
+        let (ctx, tx) = make_context();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("trace_id".to_string(), "abc123".to_string());
+        metadata.insert("user".to_string(), "test_user".to_string());
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "service"]),
+            make_slim_name(["org", "receiver", "service"]),
+            999,
+            b"complex payload with special chars: \x00\xFF".to_vec(),
+            "application/octet-stream",
+            metadata,
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+        assert!(result.is_ok());
+
+        let received = result.unwrap();
+        assert_eq!(
+            received.payload,
+            b"complex payload with special chars: \x00\xFF"
+        );
+        assert_eq!(received.context.payload_type, "application/octet-stream");
+        assert_eq!(received.context.input_connection, 999);
+        assert_eq!(
+            received.context.metadata.get("trace_id"),
+            Some(&"abc123".to_string())
+        );
+        assert_eq!(
+            received.context.metadata.get("user"),
+            Some(&"test_user".to_string())
+        );
+    }
+
+    // ==================== Message Context Conversion Test ====================
+
+    #[tokio::test]
+    async fn test_message_context_source_as_slim_name() {
+        let ffi_name = make_ffi_name(["org", "namespace", "app"]);
+        let message_ctx = MessageContext::new(
+            ffi_name,
+            None,
+            "text/plain".to_string(),
+            HashMap::new(),
+            1,
+            "id".to_string(),
+        );
+
+        let slim_name = message_ctx.source_as_slim_name();
+        let (c0, c1, c2) = slim_name.str_components();
+        assert_eq!(c0, "org");
+        assert_eq!(c1, "namespace");
+        assert_eq!(c2, "app");
+    }
+
+    // ==================== Empty/Edge Case Tests ====================
+
+    #[tokio::test]
+    async fn test_get_message_with_empty_payload() {
+        let (ctx, tx) = make_context();
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "app"]),
+            make_slim_name(["org", "receiver", "app"]),
+            1,
+            vec![], // empty payload
+            "text/plain",
+            HashMap::new(),
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+        assert!(result.is_ok());
+        let received = result.unwrap();
+        assert!(received.payload.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_message_with_large_payload() {
+        let (ctx, tx) = make_context();
+
+        // 1MB payload
+        let large_payload = vec![0xAB; 1024 * 1024];
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "app"]),
+            make_slim_name(["org", "receiver", "app"]),
+            1,
+            large_payload.clone(),
+            "application/octet-stream",
+            HashMap::new(),
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+        assert!(result.is_ok());
+        let received = result.unwrap();
+        assert_eq!(received.payload.len(), 1024 * 1024);
+        assert_eq!(received.payload, large_payload);
+    }
+
+    #[tokio::test]
+    async fn test_publish_async_with_metadata() {
+        let (ctx, _tx) = make_context();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("key1".to_string(), "value1".to_string());
+        metadata.insert("key2".to_string(), "value2".to_string());
+
+        let result = ctx
+            .publish_async(
+                b"test".to_vec(),
+                Some("application/json".to_string()),
+                Some(metadata),
+            )
+            .await;
+
+        // Should fail because session is missing
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_publish_async_with_options() {
+        let (ctx, _tx) = make_context();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("trace".to_string(), "123".to_string());
+
+        let result = ctx
+            .publish_async(
+                b"important message".to_vec(),
+                Some("text/plain".to_string()),
+                Some(metadata),
+            )
+            .await;
+
+        // Should fail because session is missing, but returns CompletionHandle
+        assert!(result.is_err());
+    }
+
+    // ==================== get_message Duration Tests ====================
+
+    /// Test get_message blocking version with Duration timeout
+    #[test]
+    fn test_get_message_blocking_with_duration() {
+        let (ctx, tx) = make_context();
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "app"]),
+            make_slim_name(["org", "receiver", "app"]),
+            1,
+            b"test message".to_vec(),
+            "text/plain",
+            HashMap::new(),
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        // Test blocking version with Duration parameter
+        let result = ctx.get_message(Some(std::time::Duration::from_millis(100)));
+        assert!(result.is_ok());
+        let received = result.unwrap();
+        assert_eq!(received.payload, b"test message");
+    }
+
+    /// Test get_message_async with Duration parameter instead of milliseconds
+    #[tokio::test]
+    async fn test_get_message_async_with_duration_parameter() {
+        let (ctx, tx) = make_context();
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "app"]),
+            make_slim_name(["org", "receiver", "app"]),
+            1,
+            b"duration test".to_vec(),
+            "text/plain",
+            HashMap::new(),
+        );
+
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        // New signature takes Duration directly
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(200)))
+            .await;
+        assert!(result.is_ok());
+        let received = result.unwrap();
+        assert_eq!(received.payload, b"duration test");
+    }
+
+    /// Test get_message with no timeout (None)
+    #[tokio::test]
+    async fn test_get_message_with_no_timeout() {
+        let (ctx, tx) = make_context();
+
+        let msg = create_test_proto_message(
+            make_slim_name(["org", "sender", "app"]),
+            make_slim_name(["org", "receiver", "app"]),
+            1,
+            b"no timeout".to_vec(),
+            "text/plain",
+            HashMap::new(),
+        );
+
+        // Send immediately so it doesn't block forever
+        tx.send(Ok(msg)).expect("send should succeed");
+
+        let result = ctx.get_message_async(None).await;
+        assert!(result.is_ok());
+        let received = result.unwrap();
+        assert_eq!(received.payload, b"no timeout");
+    }
+
+    /// Test futures-timer timeout behavior in get_session_message
+    #[tokio::test]
+    async fn test_get_session_message_futures_timer_timeout() {
+        let (ctx, _tx) = make_context();
+
+        // Test with short timeout using futures-timer
+        let result = ctx
+            .get_session_message(Some(std::time::Duration::from_millis(50)))
+            .await;
+
+        // Should timeout because no message is sent
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(
+                matches!(e, SessionError::ReceiveTimeout),
+                "Should be ReceiveTimeout error"
+            );
+        }
+    }
+
+    /// Test futures-timer select between message and timeout
+    #[tokio::test]
+    async fn test_get_message_futures_timer_race_condition() {
+        let (ctx, tx) = make_context();
+
+        // Spawn a task to send message after a delay
+        let tx_clone = tx.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let msg = create_test_proto_message(
+                make_slim_name(["org", "sender", "app"]),
+                make_slim_name(["org", "receiver", "app"]),
+                1,
+                b"delayed message".to_vec(),
+                "text/plain",
+                HashMap::new(),
+            );
+            let _ = tx_clone.send(Ok(msg));
+        });
+
+        // Wait with sufficient timeout - message should arrive first
+        let result = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+
+        assert!(result.is_ok(), "Message should arrive before timeout");
+        let received = result.unwrap();
+        assert_eq!(received.payload, b"delayed message");
+    }
+
+    /// Test blocking get_message with timeout
+    #[test]
+    fn test_get_message_blocking_timeout() {
+        let (ctx, _tx) = make_context();
+
+        // Blocking version with timeout should fail when no message arrives
+        let result = ctx.get_message(Some(std::time::Duration::from_millis(50)));
+
+        assert!(result.is_err(), "Should timeout when no message arrives");
+    }
+
+    /// Test get_message_async consistency with different timeout values
+    #[tokio::test]
+    async fn test_get_message_various_timeout_durations() {
+        // Test that different Duration values work correctly
+        let (ctx, _tx) = make_context();
+
+        // Very short timeout
+        let result1 = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(1)))
+            .await;
+        assert!(result1.is_err());
+
+        // Medium timeout
+        let result2 = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(50)))
+            .await;
+        assert!(result2.is_err());
+
+        // Longer timeout (but still short for test speed)
+        let result3 = ctx
+            .get_message_async(Some(std::time::Duration::from_millis(100)))
+            .await;
+        assert!(result3.is_err());
+    }
+
+    // ========================================================================
+    // SessionConfig Conversion Tests
+    // ========================================================================
+
+    /// Test SessionConfig to SlimSessionConfig conversion for PointToPoint
+    #[test]
+    fn test_session_config_point_to_point() {
+        let config = SessionConfig {
+            session_type: SessionType::PointToPoint,
+            max_retries: Some(5),
+            interval: Some(std::time::Duration::from_millis(200)),
+            metadata: std::collections::HashMap::from([
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string()),
+            ]),
+            mls_settings: Some(MlsSettings::default()),
+        };
+
+        let slim_config: SlimSessionConfig = config.into();
+
+        assert_eq!(slim_config.session_type, ProtoSessionType::PointToPoint);
+        assert!(slim_config.mls_settings.is_some());
+        assert_eq!(slim_config.max_retries, Some(5));
+        assert_eq!(
+            slim_config.interval,
+            Some(std::time::Duration::from_millis(200))
+        );
+        assert_eq!(
+            slim_config.metadata.get("key1"),
+            Some(&"value1".to_string())
+        );
+    }
+
+    /// Test SessionConfig to SlimSessionConfig conversion for Group
+    #[test]
+    fn test_session_config_group() {
+        let config = SessionConfig {
+            session_type: SessionType::Group,
+            max_retries: None,
+            interval: None,
+            metadata: std::collections::HashMap::new(),
+            mls_settings: None,
+        };
+
+        let slim_config: SlimSessionConfig = config.into();
+
+        assert_eq!(slim_config.session_type, ProtoSessionType::Multicast);
+        assert!(slim_config.mls_settings.is_none());
+        assert!(slim_config.max_retries.is_none());
+        assert!(slim_config.interval.is_none());
+    }
+}

--- a/crates/slim-bindings/src/slimrpc.rs
+++ b/crates/slim-bindings/src/slimrpc.rs
@@ -1,0 +1,265 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! # SlimRPC - gRPC-like RPC framework over SLIM
+//!
+//! SlimRPC provides a gRPC-compatible RPC framework built on top of the SLIM messaging protocol.
+//! It supports all standard gRPC interaction patterns:
+//! - Unary-Unary: Single request, single response
+//! - Unary-Stream: Single request, streaming responses
+//! - Stream-Unary: Streaming requests, single response
+//! - Stream-Stream: Streaming requests, streaming responses
+//!
+//! ## Architecture
+//!
+//! SlimRPC uses SLIM sessions as the underlying transport mechanism. A persistent session
+//! is maintained per remote peer and shared across concurrent RPC calls. Each call is
+//! identified by a unique `rpc-id` in message metadata, which allows the server to
+//! demultiplex concurrent calls over the shared session.
+//!
+//! ## Core Types
+//!
+//! This crate works directly with core SLIM types:
+//! - `slim_service::app::App` - The SLIM application instance
+//! - `slim_session::context::SessionContext` - Session context for RPC calls
+//! - `slim_datapath::api::ProtoName` - SLIM names for service addressing
+//!
+//! ## Client Example
+//!
+//! ```no_run
+//! # use slim_bindings::{Channel, Context, RpcError, Encoder, Decoder};
+//! # use slim_bindings::Name;
+//! # use slim_service::app::App;
+//! # use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+//! # use std::sync::Arc;
+//! # async fn example(app: Arc<App<AuthProvider, AuthVerifier>>) -> Result<(), RpcError> {
+//! # #[derive(Default)]
+//! # struct Request {}
+//! # impl Encoder for Request {
+//! #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+//! # }
+//! # #[derive(Default)]
+//! # struct Response {}
+//! # impl Decoder for Response {
+//! #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Response::default()) }
+//! # }
+//! # let request = Request::default();
+//! // Create a channel
+//! let remote = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+//! let channel = Channel::new_with_members_internal(app.clone(), vec![remote.as_slim_name().clone()], false, None).unwrap();
+//!
+//! // Make an RPC call (typically through generated code)
+//! let response: Response = channel.unary("MyService", "MyMethod", request, None, None).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Server Example
+//!
+//! ```no_run
+//! # use slim_bindings::{Server, Context, RpcError, Encoder, Decoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+//! # use std::sync::Arc;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+//! # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+//! # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+//! # let app = App::new(app_name, provider, verifier)?;
+//! # let core_app = app.inner();
+//! # let notification_rx = app.notification_receiver();
+//! # #[derive(Default)]
+//! # struct Request {}
+//! # impl Decoder for Request {
+//! #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+//! # }
+//! # #[derive(Default)]
+//! # struct Response {}
+//! # impl Encoder for Response {
+//! #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+//! # }
+//! // Register and run server
+//! let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+//! let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+//!
+//! // Register a handler
+//! server.register_unary_unary_internal(
+//!     "MyService",
+//!     "MyMethod",
+//!     |request: Request, _ctx: Context| async move {
+//!         Ok(Response::default())
+//!     }
+//! );
+//! # Ok(())
+//! # }
+//! ```
+
+use slim_datapath::api::ProtoName as Name;
+
+/// Build a method-specific subscription name (base-service-method)
+///
+/// This creates a subscription name in the format: `org/namespace/app-service-method`
+/// matching the Python implementation's `handler_name_to_pyname`.
+///
+/// # Arguments
+/// * `base_name` - The base name (e.g., "org/namespace/app")
+/// * `service_name` - The service name (e.g., "MyService")
+/// * `method_name` - The method name (e.g., "MyMethod")
+///
+/// # Panics
+/// Panics if base_name doesn't have at least 3 components
+pub fn build_method_subscription_name(
+    base_name: &Name,
+    service_name: &str,
+    method_name: &str,
+) -> Name {
+    let (c0, c1, c2) = base_name.str_components();
+
+    // Create subscription name: org/namespace/app-service-method
+    let app_with_method = format!("{c2}-{service_name}-{method_name}");
+
+    Name::from_strings([c0, c1, &app_with_method])
+}
+
+mod channel;
+mod codec;
+mod context;
+mod error;
+mod rpc_session;
+mod server;
+mod session_wrapper;
+
+// UniFFI-specific modules
+mod handler_traits;
+mod stream_types;
+
+pub use channel::{Channel, MessageContext, MulticastItem};
+pub use codec::{Codec, Decoder, Encoder};
+pub use context::{Context, Metadata, SessionContext};
+pub use error::{InvalidRpcCode, RpcCode, RpcError};
+pub use rpc_session::{
+    HandlerInfo, RpcSession, send_eos, send_error, send_error_for_rpc, send_response_stream,
+};
+pub use server::{HandlerType, RpcHandler, Server, StreamRpcHandler};
+pub use session_wrapper::{ReceivedMessage, SessionRx, SessionTx, new_session};
+
+// UniFFI handler traits and stream types
+pub use handler_traits::{
+    StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler,
+};
+pub use stream_types::{
+    BidiStreamHandler, DecodedStream, MulticastBidiStreamHandler, MulticastResponseReader,
+    MulticastStreamMessage, RawStream, RequestStream as UniffiRequestStream, RequestStreamWriter,
+    ResponseSink, ResponseStreamReader, RpcMessageContext, RpcMulticastItem, StreamMessage,
+    StreamSource,
+};
+
+/// Key used in metadata for RPC deadline/timeout
+pub const DEADLINE_KEY: &str = "slimrpc-timeout";
+
+/// Key used in metadata for RPC status code
+pub const STATUS_CODE_KEY: &str = "slimrpc-code";
+
+/// Key used in metadata for RPC call ID (used for session multiplexing)
+pub const RPC_ID_KEY: &str = "rpc-id";
+
+/// Key used in metadata for the RPC service name
+pub const SERVICE_KEY: &str = "service";
+
+/// Key used in metadata for the RPC method name
+pub const METHOD_KEY: &str = "method";
+
+/// Key used in metadata to mark a message as a client request.
+/// Present on all client-originated messages (data frames and EOS).
+/// Absent on server responses so the server can tell them apart.
+pub const RPC_DIR_KEY: &str = "slimrpc-dir";
+
+/// Value for [`RPC_DIR_KEY`] that marks a message as a client request.
+pub const RPC_DIR_REQ: &str = "req";
+
+/// Maximum timeout in seconds (10 hours)
+pub const MAX_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(36000);
+
+/// Calculate timeout duration from optional timeout
+///
+/// Returns the provided timeout or MAX_TIMEOUT if None.
+/// This is the single point of truth for timeout duration calculation in SlimRPC.
+pub fn calculate_timeout_duration(timeout: Option<std::time::Duration>) -> std::time::Duration {
+    timeout.unwrap_or(MAX_TIMEOUT)
+}
+
+/// Calculate deadline from optional timeout duration
+///
+/// Returns now + timeout_duration (or now + MAX_TIMEOUT if None).
+/// If overflow occurs, falls back to now + MAX_TIMEOUT.
+/// This is the single point of truth for deadline calculation in SlimRPC.
+pub fn calculate_deadline(timeout: Option<std::time::Duration>) -> std::time::SystemTime {
+    let timeout_duration = timeout.unwrap_or(MAX_TIMEOUT);
+    std::time::SystemTime::now()
+        .checked_add(timeout_duration)
+        .unwrap_or_else(|| std::time::SystemTime::now() + MAX_TIMEOUT)
+}
+
+/// Result type for SlimRPC operations
+pub type Result<T> = std::result::Result<T, RpcError>;
+
+/// Type alias for request streams in stream-based RPC handlers
+///
+/// This represents a pinned, boxed stream of requests that can be used
+/// in stream-unary and stream-stream RPC handlers.
+///
+/// # Example
+///
+/// ```no_run
+/// # use slim_bindings::{RpcError, Decoder, Encoder};
+/// # use futures::StreamExt;
+/// # use futures::stream::BoxStream;
+/// # #[derive(Default)]
+/// # struct MyRequest {}
+/// # impl Decoder for MyRequest {
+/// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(MyRequest::default()) }
+/// # }
+/// # #[derive(Default)]
+/// # struct MyResponse {}
+/// # impl Encoder for MyResponse {
+/// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+/// # }
+/// async fn handler(mut stream: BoxStream<'static, Result<MyRequest, RpcError>>) -> Result<MyResponse, RpcError> {
+///     while let Some(request) = stream.next().await {
+///         let req = request?;
+///         // Process request
+///     }
+///     Ok(MyResponse::default())
+/// }
+/// ```
+pub type RequestStream<T> = futures::stream::BoxStream<'static, Result<T>>;
+
+/// Type alias for response streams in stream-based RPC handlers
+///
+/// This represents a stream of responses that can be returned from
+/// unary-stream and stream-stream RPC handlers.
+///
+/// Note: While this type can represent the return value, handlers typically
+/// return concrete stream types (like those from `futures::stream::iter`) which
+/// are then automatically converted.
+///
+/// # Example
+///
+/// ```no_run
+/// # use slim_bindings::{RpcError, Decoder, Encoder};
+/// # type Result<T> = std::result::Result<T, RpcError>;
+/// # use futures::stream::{self, Stream};
+/// # #[derive(Default, Clone)]
+/// # struct MyRequest {}
+/// # impl Decoder for MyRequest {
+/// #     fn decode(_buf: impl Into<Vec<u8>>) -> std::result::Result<Self, RpcError> { Ok(MyRequest::default()) }
+/// # }
+/// # #[derive(Default, Clone)]
+/// # struct MyResponse {}
+/// # impl Encoder for MyResponse {
+/// #     fn encode(self) -> std::result::Result<Vec<u8>, RpcError> { Ok(vec![]) }
+/// # }
+/// async fn handler(request: MyRequest) -> std::result::Result<impl Stream<Item = Result<MyResponse>>, RpcError> {
+///     let responses = vec![MyResponse::default(), MyResponse::default(), MyResponse::default()];
+///     Ok(stream::iter(responses.into_iter().map(Ok)))
+/// }
+/// ```
+pub type ResponseStream<T> = futures::stream::BoxStream<'static, Result<T>>;

--- a/crates/slim-bindings/src/slimrpc/channel.rs
+++ b/crates/slim-bindings/src/slimrpc/channel.rs
@@ -1,0 +1,1335 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client-side RPC channel implementation
+//!
+//! Provides a Channel type for making RPC calls to remote services.
+//! Supports all gRPC streaming patterns over SLIM sessions.
+//!
+//! All eight public RPC methods are built on top of `responses_from_stream_input`.
+//! Single-request callers wrap their request in `futures::stream::once`.
+//!
+//! Both core methods dispatch based on `self.is_group`:
+//! - P2P (`is_group = false`): uses a PointToPoint session; stream ends on server EOS
+//! - GROUP (`is_group = true`): uses a Multicast session; stream ends when all members
+//!   have sent their final response (EOS); member errors are yielded as stream items
+//!
+//! The "unary" variants are simply the streaming variants followed by `.next()`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_stream::stream;
+use display_error_chain::ErrorChainExt;
+use futures::StreamExt;
+use futures::future::join_all;
+use futures::stream::Stream;
+use futures_timer::Delay;
+use parking_lot::RwLock as ParkingRwLock;
+use slim_session::session_config::MlsSettings;
+use tokio::sync::mpsc::{self, unbounded_channel};
+use tokio::task::JoinHandle;
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::ProtoName as Name;
+use slim_datapath::api::ProtoSessionType;
+use slim_service::app::App as SlimApp;
+use slim_session::errors::SessionError;
+
+// ── Multicast response types ──────────────────────────────────────────────────
+
+/// Per-message context attached to every item in a multicast response stream.
+///
+/// Identifies which group member produced the response, allowing callers to
+/// correlate responses with their origin when multiple members are involved.
+#[derive(Debug, Clone)]
+pub struct MessageContext {
+    /// SLIM name of the member app that sent this message.
+    pub source: Name,
+}
+
+/// A single item in a multicast response stream: the decoded response together
+/// with the context identifying its origin.
+#[derive(Debug, Clone)]
+pub struct MulticastItem<T> {
+    /// Context identifying the member that produced this response.
+    pub context: MessageContext,
+    /// The decoded response message.
+    pub message: T,
+}
+
+use super::{
+    BidiStreamHandler, Context, METHOD_KEY, Metadata, MulticastBidiStreamHandler,
+    MulticastResponseReader, RPC_DIR_KEY, RPC_DIR_REQ, RPC_ID_KEY, ReceivedMessage,
+    RequestStreamWriter, ResponseStreamReader, RpcCode, RpcError, SERVICE_KEY, STATUS_CODE_KEY,
+    calculate_timeout_duration,
+    codec::{Decoder, Encoder},
+    send_eos,
+    session_wrapper::{SessionRx, SessionTx, new_session},
+};
+
+// ── ResponseDispatcher ────────────────────────────────────────────────────────
+
+/// Routes incoming response messages to the correct per-RPC mpsc channel.
+///
+/// The background `response_dispatcher_task` calls `dispatch()` for each
+/// message it receives from the shared `SessionRx`. RPC callers register
+/// before sending their request and unregister after receiving all responses.
+struct ResponseDispatcher {
+    pending: ParkingRwLock<HashMap<String, mpsc::UnboundedSender<ReceivedMessage>>>,
+}
+
+impl ResponseDispatcher {
+    fn new() -> Self {
+        Self {
+            pending: ParkingRwLock::new(HashMap::new()),
+        }
+    }
+
+    fn register(&self, rpc_id: &str) -> mpsc::UnboundedReceiver<ReceivedMessage> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.pending.write().insert(rpc_id.to_string(), tx);
+        rx
+    }
+
+    fn unregister(&self, rpc_id: &str) {
+        self.pending.write().remove(rpc_id);
+    }
+
+    /// Forward a message to the channel registered for `rpc_id`.
+    ///
+    /// Returns `true` on delivery to an active RPC caller, `false` if
+    /// no caller is registered for this rpc-id (message is dropped).
+    fn dispatch(&self, msg: ReceivedMessage, rpc_id: &str) -> bool {
+        let lock = self.pending.read();
+        if let Some(tx) = lock.get(rpc_id) {
+            tx.send(msg).is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Drop all pending registrations.
+    ///
+    /// Called when the underlying session closes. Dropping every sender causes
+    /// each waiting `rx.recv().await` to return `None`, cleanly ending the
+    /// response loop in all in-flight multicast callers.
+    fn close_all(&self) {
+        self.pending.write().clear();
+    }
+}
+
+// ── DispatcherGuard ───────────────────────────────────────────────────────────
+
+/// RAII guard that calls `dispatcher.unregister(rpc_id)` on drop.
+///
+/// Ensures the per-RPC channel is always removed from the dispatcher even
+/// when a stream is abandoned early (e.g. after a single `.next()` call).
+struct DispatcherGuard {
+    dispatcher: Arc<ResponseDispatcher>,
+    rpc_id: String,
+}
+
+impl Drop for DispatcherGuard {
+    fn drop(&mut self) {
+        self.dispatcher.unregister(&self.rpc_id);
+    }
+}
+
+// ── Dispatcher task ───────────────────────────────────────────────────────────
+
+/// Reads every message from `session_rx` and routes it by `rpc-id`.
+///
+/// On session close `close_all()` is called so any in-flight receive loop
+/// unblocks with `None`.
+async fn response_dispatcher_task(mut session_rx: SessionRx, dispatcher: Arc<ResponseDispatcher>) {
+    loop {
+        match session_rx.get_message(None).await {
+            Ok(msg) => {
+                let rpc_id = msg.metadata.get(RPC_ID_KEY).cloned().unwrap_or_default();
+                if !dispatcher.dispatch(msg, &rpc_id) {
+                    tracing::trace!(%rpc_id, "Received message for unknown rpc-id, dropping");
+                }
+            }
+            Err(SessionError::ParticipantDisconnected(name)) => {
+                tracing::debug!(%name, "Response dispatcher: group member disconnected, continuing");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "Response dispatcher: session closed");
+                dispatcher.close_all();
+                break;
+            }
+        }
+    }
+}
+
+// ── ChannelSession ────────────────────────────────────────────────────────────
+
+/// A live SLIM session together with its dispatcher, background task, and member set.
+struct ChannelSession {
+    tx: SessionTx,
+    dispatcher: Arc<ResponseDispatcher>,
+    /// Background task reading from the session. When finished the session
+    /// is considered dead and will be recreated on the next RPC call.
+    task: JoinHandle<()>,
+}
+
+impl ChannelSession {
+    fn is_alive(&self) -> bool {
+        !self.task.is_finished()
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn generate_rpc_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+async fn send_invite(session_tx: &SessionTx, member: &Name) -> Result<(), RpcError> {
+    tracing::debug!("Inviting member to rpc channel.. {}", member);
+    session_tx
+        .controller()
+        .invite_participant(member)
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to invite {member}: {e}")))?
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to invite {member}: {e}")))
+}
+
+/// Generate a random group session name derived from the client name.
+///
+/// Uses the first two components of `client_name` and a UUID as the third,
+/// so the group address lives in the same namespace as the client app.
+fn generate_group_name(client_name: &Name) -> Name {
+    let (c0, c1, _) = client_name.str_components();
+    Name::from_strings([c0, c1, &uuid::Uuid::new_v4().to_string()])
+}
+
+/// Metadata for the first message of an RPC call.
+fn first_msg_metadata(ctx: &Context, service: &str, method: &str, rpc_id: &str) -> Metadata {
+    let mut meta = ctx.metadata();
+    meta.insert(SERVICE_KEY.to_string(), service.to_string());
+    meta.insert(METHOD_KEY.to_string(), method.to_string());
+    meta.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
+    meta.insert(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string());
+    meta
+}
+
+/// Metadata for a stream continuation message (not the first).
+fn continuation_metadata(rpc_id: &str) -> Metadata {
+    let mut meta = HashMap::new();
+    meta.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
+    meta.insert(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string());
+    meta
+}
+
+// ── Channel ───────────────────────────────────────────────────────────────────
+
+/// Client-side channel for making RPC calls.
+///
+/// Manages a single persistent SLIM session: either a `PointToPoint` session
+/// to a single remote server, or a `Multicast` (GROUP) session shared across
+/// multiple remote servers. The session is lazily initialised and recreated
+/// when dead.
+///
+/// ## Constructor
+///
+/// - `new_with_members_internal(app, members)` — Smart constructor:
+///   - **1 member**: creates a P2P channel.
+///   - **Many members**: creates a GROUP channel with a generated session name
+///     and auto-invites all members on the first multicast call.
+#[derive(Clone, uniffi::Object)]
+pub struct Channel {
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+    /// Session destination: the remote server name for P2P channels, or a
+    /// generated group name (same org/namespace as the client, random UUID)
+    /// for GROUP channels.
+    remote: Name,
+    /// `true` for GROUP channels (`new_group` / `new_group_with_connection`),
+    /// `false` for P2P channels (`new` / `new_with_connection`).
+    is_group: bool,
+    /// Initial group members set at construction time. Used to seed a new
+    /// session on the first call. Dynamically invited members are stored
+    /// in `ChannelSession::members` and inherited across session recreations.
+    initial_members: HashSet<Name>,
+    connection_id: Option<u64>,
+    runtime: tokio::runtime::Handle,
+    /// Persistent session (lazily initialised, recreated when dead).
+    /// PointToPoint for P2P channels, Multicast for GROUP channels.
+    session: Arc<tokio::sync::Mutex<Option<ChannelSession>>>,
+}
+
+impl Channel {
+    /// Create a channel. This is the single construction point.
+    ///
+    /// - `is_group = false`: P2P channel; `members` must contain exactly one entry.
+    /// - `is_group = true`: GROUP channel; a random UUID session name is generated
+    ///   and all `members` are auto-invited on the first multicast call.
+    ///
+    /// Returns an error if `members` is empty.
+    pub fn new_with_members_internal(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Name>,
+        is_group: bool,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        if members.is_empty() {
+            return Err(RpcError::invalid_argument("members must not be empty"));
+        }
+        if !is_group && members.len() != 1 {
+            return Err(RpcError::invalid_argument(
+                "P2P channel requires exactly one member",
+            ));
+        }
+
+        let runtime = crate::get_runtime();
+
+        let members_set: HashSet<Name> = members.into_iter().collect();
+
+        let remote = if is_group {
+            generate_group_name(app.app_name())
+        } else {
+            members_set.iter().next().unwrap().clone()
+        };
+
+        Ok(Self {
+            app,
+            remote,
+            is_group,
+            initial_members: members_set,
+            connection_id,
+            runtime,
+            session: Arc::new(tokio::sync::Mutex::new(None)),
+        })
+    }
+
+    // ── Session management ────────────────────────────────────────────────────
+
+    /// Return the active session, creating it if needed.
+    ///
+    /// - Single-member channel (`is_group == false`): uses the P2P slot.
+    /// - Multi-member channel (`is_group == true`): uses the GROUP slot and
+    ///   auto-invites all members on every (re)creation under the session lock.
+    async fn get_or_create_session(
+        &self,
+    ) -> Result<(SessionTx, Arc<ResponseDispatcher>, HashMap<Name, bool>), RpcError> {
+        let mut guard = self.session.lock().await;
+        self.ensure_session(&mut guard).await?;
+        let cs = guard
+            .as_ref()
+            .ok_or_else(|| RpcError::internal("session missing after creation"))?;
+        let members = self
+            .initial_members
+            .iter()
+            .map(|m| {
+                let mut name = m.clone();
+                name.reset_id();
+                (name, false)
+            })
+            .collect();
+        Ok((cs.tx.clone(), cs.dispatcher.clone(), members))
+    }
+
+    /// Create (or recreate) the SLIM session inside an already-held lock guard.
+    ///
+    /// If the session is already alive this is a no-op. Members are always
+    /// taken from `self.initial_members` since the member set is fixed at
+    /// channel construction time.
+    async fn ensure_session(
+        &self,
+        guard: &mut tokio::sync::MutexGuard<'_, Option<ChannelSession>>,
+    ) -> Result<(), RpcError> {
+        if let Some(ref cs) = **guard
+            && cs.is_alive()
+        {
+            return Ok(());
+        }
+
+        let session_type = if self.is_group {
+            ProtoSessionType::Multicast
+        } else {
+            ProtoSessionType::PointToPoint
+        };
+
+        tracing::debug!(?session_type, "no persistent session — recreating");
+        let (session_tx, session_rx) = self.create_raw_session(session_type).await?;
+        let dispatcher = Arc::new(ResponseDispatcher::new());
+        let task = self
+            .runtime
+            .spawn(response_dispatcher_task(session_rx, dispatcher.clone()));
+
+        **guard = Some(ChannelSession {
+            tx: session_tx.clone(),
+            dispatcher: dispatcher.clone(),
+            task,
+        });
+
+        // Invite all members whenever the GROUP session is (re)created.
+        if self.is_group {
+            for member in &self.initial_members {
+                if let Some(conn_id) = self.connection_id {
+                    self.app.set_route(member, conn_id).await.map_err(|e| {
+                        RpcError::internal(format!(
+                            "Failed to set route for group member {member}: {e}"
+                        ))
+                    })?;
+                }
+                send_invite(&session_tx, member).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create a raw SLIM session to the remote peer.
+    async fn create_raw_session(
+        &self,
+        session_type: ProtoSessionType,
+    ) -> Result<(SessionTx, SessionRx), RpcError> {
+        let app = self.app.clone();
+        let remote = self.remote.clone();
+        let connection_id = self.connection_id;
+        let runtime = &self.runtime;
+
+        // Runs in a tokio task because create_session needs tokio runtime
+        let handle = runtime.spawn(async move {
+            if let Some(conn_id) = connection_id {
+                tracing::debug!(
+                    remote = %remote,
+                    connection_id = conn_id,
+                    "Setting route before creating session"
+                );
+                if let Err(e) = app.set_route(&remote, conn_id).await {
+                    tracing::warn!(
+                        remote = %remote,
+                        connection_id = conn_id,
+                        error = %e,
+                        "Failed to set route"
+                    );
+                }
+            }
+
+            tracing::debug!(remote = %remote, ?session_type, "Creating persistent session");
+
+            let slim_config = slim_session::session_config::SessionConfig {
+                session_type,
+                max_retries: Some(10),
+                interval: Some(Duration::from_secs(1)),
+                initiator: true,
+                metadata: HashMap::new(),
+                mls_settings: Some(MlsSettings::default()),
+            };
+
+            let (session_ctx, completion) = app
+                .create_session(slim_config, remote.clone(), None)
+                .await
+                .map_err(|e| RpcError::unavailable(format!("Failed to create session: {e}")))?;
+
+            completion
+                .await
+                .map_err(|e| RpcError::unavailable(format!("Session handshake failed: {e}")))?;
+
+            Ok(new_session(session_ctx))
+        });
+
+        handle
+            .await
+            .map_err(|e| RpcError::internal(format!("Session creation task failed: {e}")))?
+    }
+
+    // ── Send helpers ──────────────────────────────────────────────────────────
+
+    /// Send a stream of request messages.
+    async fn send_request_stream<Req>(
+        &self,
+        session: &SessionTx,
+        ctx: &Context,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        service_name: &str,
+        method_name: &str,
+        rpc_id: &str,
+    ) -> Result<(), RpcError>
+    where
+        Req: Encoder,
+    {
+        let mut request_stream = std::pin::pin!(request_stream);
+        let mut handles = vec![];
+        let mut first = true;
+        while let Some(request) = request_stream.next().await {
+            let request_bytes = request.encode()?;
+            let msg_meta = if first {
+                first = false;
+                first_msg_metadata(ctx, service_name, method_name, rpc_id)
+            } else {
+                continuation_metadata(rpc_id)
+            };
+            let handle = session
+                .publish(
+                    session.destination(),
+                    request_bytes,
+                    Some("msg".to_string()),
+                    Some(msg_meta),
+                )
+                .await?;
+            handles.push(handle);
+        }
+        // The client EOS always carries RPC_DIR_KEY so the server can distinguish
+        // it from an echoed server EOS.  When the request stream was empty we also
+        // include service + method so the server can dispatch without a data frame.
+        let mut eos_meta = HashMap::from([(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string())]);
+        if first {
+            eos_meta.insert(SERVICE_KEY.to_string(), service_name.to_string());
+            eos_meta.insert(METHOD_KEY.to_string(), method_name.to_string());
+        }
+        handles.push(send_eos(session, session.destination(), rpc_id, Some(eos_meta)).await?);
+
+        // Wait for all (data + EOS) acks in a single batch.
+        for result in join_all(handles).await {
+            result.map_err(|e| {
+                RpcError::internal(format!(
+                    "Failed to complete sending {}-{}: {}",
+                    service_name,
+                    method_name,
+                    ErrorChainExt::chain(&e)
+                ))
+            })?;
+        }
+
+        // When the stream was empty `first` is still true: the EOS must carry
+        // service + method so the server can dispatch without a preceding data frame.
+        let extra = if first {
+            Some(HashMap::from([
+                (SERVICE_KEY.to_string(), service_name.to_string()),
+                (METHOD_KEY.to_string(), method_name.to_string()),
+            ]))
+        } else {
+            None
+        };
+        send_eos(session, session.destination(), rpc_id, extra).await?;
+        Ok(())
+    }
+
+    // ── Core streaming methods ────────────────────────────────────────────────
+
+    /// Core streaming method for all interaction patterns (P2P and GROUP).
+    ///
+    /// Broadcasts `request_stream` concurrently while collecting responses.
+    /// For P2P (`num_members = 1`) the stream ends on the single server EOS.
+    /// For GROUP the stream ends when all members have sent their EOS.
+    /// Member errors are yielded as `Err` items and count as that member's EOS.
+    fn responses_from_stream_input<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        let service_name = service_name.to_string();
+        let method_name = method_name.to_string();
+        let channel = self.clone();
+
+        stream! {
+            let ctx = Context::for_rpc(timeout, metadata.clone());
+            let timeout_duration = calculate_timeout_duration(timeout);
+            let mut delay = Delay::new(timeout_duration);
+
+            let (session_tx, dispatcher, members) = match tokio::select! {
+                result = channel.get_or_create_session() => result,
+                _ = &mut delay => Err(RpcError::deadline_exceeded("Client deadline exceeded during session setup")),
+            } {
+                Ok(v) => v,
+                Err(e) => { yield Err(e); return; }
+            };
+
+            let rpc_id = generate_rpc_id();
+            let mut rx = dispatcher.register(&rpc_id);
+            let _guard = DispatcherGuard { dispatcher: dispatcher.clone(), rpc_id: rpc_id.clone() };
+
+            let session_tx_for_send = session_tx.clone();
+            let ctx_for_send = ctx.clone();
+            let service_for_send = service_name.clone();
+            let method_for_send = method_name.clone();
+            let rpc_id_for_send = rpc_id.clone();
+            let channel_for_send = channel.clone();
+            let mut send_handle = channel.runtime.spawn(async move {
+                channel_for_send
+                    .send_request_stream(
+                        &session_tx_for_send, &ctx_for_send, request_stream,
+                        &service_for_send, &method_for_send, &rpc_id_for_send,
+                    )
+                    .await
+            });
+            let mut members = members;
+            let num_members = members.len();
+            let mut num_completed = 0usize;
+            let mut send_completed = false;
+
+            loop {
+                let received_opt = tokio::select! {
+                    msg = rx.recv() => Ok(msg),
+                    send_result = &mut send_handle, if !send_completed => {
+                        send_completed = true;
+                        match send_result {
+                            Ok(Ok(_)) => continue,
+                            Ok(Err(e)) => Err(e),
+                            Err(e) => Err(RpcError::internal(format!("Send task panicked: {e}"))),
+                        }
+                    },
+                    _ = &mut delay => Err(RpcError::deadline_exceeded(
+                        "Client deadline exceeded while receiving response"
+                    )),
+                };
+
+                let received = match received_opt {
+                    Err(e) => { yield Err(e); break; }
+                    Ok(None) => {
+                        if num_completed < num_members {
+                            if channel.is_group {
+                                yield Err(RpcError::multicast_session_closed(
+                                    members.iter().map(|(m, done)| (m, *done))
+                                ));
+                            } else {
+                                yield Err(RpcError::internal(format!(
+                                    "Session closed after {num_completed}/{num_members} EOS markers"
+                                )));
+                            }
+                        }
+                        break;
+                    }
+                    Ok(Some(m)) => m,
+                };
+
+                let mut source = received.source.clone();
+                source.reset_id();
+
+                if received.is_eos() {
+                    if !*members.get(&source).unwrap_or(&true) {
+                        members.insert(source, true);
+                        num_completed += 1;
+                    }
+                    if num_completed >= num_members { break; }
+                    continue;
+                }
+                let code = RpcCode::from_metadata_str(
+                    received.metadata.get(STATUS_CODE_KEY).map(String::as_str)
+                );
+                if code != RpcCode::Ok {
+                    let msg_text = String::from_utf8_lossy(&received.payload).to_string();
+                    if !*members.get(&source).unwrap_or(&true) {
+                        members.insert(source.clone(), true);
+                        num_completed += 1;
+                    }
+                    let err = RpcError::new(code, msg_text);
+                    yield Err(if channel.is_group { err.with_origin(source.to_string()) } else { err });
+                    if num_completed >= num_members { break; }
+                    continue;
+                }
+
+                let response = match Res::decode(received.payload) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        if !*members.get(&source).unwrap_or(&true) {
+                            members.insert(source.clone(), true);
+                            num_completed += 1;
+                        }
+                        yield Err(if channel.is_group { e.with_origin(source.to_string()) } else { e });
+                        if num_completed >= num_members { break; }
+                        continue;
+                    }
+                };
+                yield Ok(MulticastItem { context: MessageContext { source }, message: response });
+            }
+        }
+    }
+
+    // ── RPC methods ───────────────────────────────────────────────────────────
+
+    /// Unary RPC: single request → single response.
+    ///
+    /// Equivalent to `unary_stream(...).next()`.
+    pub async fn unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Res, RpcError>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        let stream = self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        );
+        futures::pin_mut!(stream);
+        stream
+            .next()
+            .await
+            .unwrap_or_else(|| Err(RpcError::internal("No response received")))
+            .map(|item| item.message)
+    }
+
+    /// Unary-stream RPC: single request → stream of responses.
+    pub fn unary_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<Res, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        )
+        .map(|r| r.map(|item| item.message))
+    }
+
+    /// Stream-unary RPC: stream of requests → single response.
+    ///
+    /// Equivalent to `stream_stream(...).next()`.
+    pub async fn stream_unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Res, RpcError>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        let stream = self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        );
+        futures::pin_mut!(stream);
+        stream
+            .next()
+            .await
+            .unwrap_or_else(|| Err(RpcError::internal("No response received")))
+            .map(|item| item.message)
+    }
+
+    /// Stream-stream RPC: stream of requests → stream of responses.
+    pub fn stream_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<Res, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        )
+        .map(|r| r.map(|item| item.message))
+    }
+
+    /// Multicast unary: broadcast one request, receive one `MulticastItem` per member.
+    ///
+    /// Each item carries a `MessageContext` identifying the source member plus the
+    /// decoded response. The stream ends when all members have sent their response.
+    pub fn multicast_unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        )
+    }
+
+    /// Multicast unary-stream: broadcast one request, receive a stream of `MulticastItem`s.
+    ///
+    /// Each group member may return multiple responses. All responses from all
+    /// members are interleaved in arrival order, each tagged with its source.
+    /// The stream ends when all members have sent their final EOS.
+    ///
+    /// Transport is identical to `multicast_unary`; the semantic difference
+    /// (one vs many responses per member) lives in the server handler.
+    pub fn multicast_unary_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: Req,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            futures::stream::once(std::future::ready(request)),
+            timeout,
+            metadata,
+        )
+    }
+
+    /// Multicast stream-unary: broadcast a request stream, receive one `MulticastItem` per member.
+    ///
+    /// The request stream is broadcast to all members. Each member replies with
+    /// a single response tagged with its source. The stream ends when all members
+    /// have sent their response.
+    pub fn multicast_stream_unary<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        )
+    }
+
+    /// Multicast stream-stream: broadcast a request stream, receive a stream of `MulticastItem`s.
+    ///
+    /// The request stream is broadcast to all members. Each member replies with
+    /// its own response stream. All responses from all members are interleaved in
+    /// arrival order, each tagged with its source. The stream ends when all members
+    /// have sent their final EOS.
+    ///
+    /// Transport is identical to `multicast_stream_unary`; the semantic
+    /// difference lives in the server handler.
+    pub fn multicast_stream_stream<Req, Res>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request_stream: impl Stream<Item = Req> + Send + 'static,
+        timeout: Option<Duration>,
+        metadata: Option<Metadata>,
+    ) -> impl Stream<Item = Result<MulticastItem<Res>, RpcError>>
+    where
+        Req: Encoder + Send + 'static,
+        Res: Decoder + Send + 'static,
+    {
+        self.responses_from_stream_input(
+            service_name,
+            method_name,
+            request_stream,
+            timeout,
+            metadata,
+        )
+    }
+
+    pub fn app(&self) -> &Arc<SlimApp<AuthProvider, AuthVerifier>> {
+        &self.app
+    }
+
+    pub fn remote(&self) -> &Name {
+        &self.remote
+    }
+
+    pub fn connection_id(&self) -> Option<u64> {
+        self.connection_id
+    }
+}
+
+// ── UniFFI exports ────────────────────────────────────────────────────────────
+
+#[uniffi::export]
+impl Channel {
+    #[uniffi::constructor]
+    pub fn new(app: Arc<crate::App>, remote: Arc<crate::Name>) -> Self {
+        Self::new_with_connection(app, remote, None)
+    }
+
+    #[uniffi::constructor]
+    pub fn new_with_connection(
+        app: Arc<crate::App>,
+        remote: Arc<crate::Name>,
+        connection_id: Option<u64>,
+    ) -> Self {
+        let slim_app = app.inner_app().clone();
+        let slim_name = remote.as_slim_name().clone();
+        Self::new_with_members_internal(slim_app, vec![slim_name], false, connection_id)
+            .expect("single non-empty member list is always valid")
+    }
+
+    #[uniffi::constructor]
+    pub fn new_group(
+        app: Arc<crate::App>,
+        members: Vec<Arc<crate::Name>>,
+    ) -> Result<Self, RpcError> {
+        Self::new_group_with_connection(app, members, None)
+    }
+
+    #[uniffi::constructor]
+    pub fn new_group_with_connection(
+        app: Arc<crate::App>,
+        members: Vec<Arc<crate::Name>>,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        let slim_app = app.inner_app().clone();
+        let slim_names = members.iter().map(|n| n.as_slim_name().clone()).collect();
+        Self::new_with_members_internal(slim_app, slim_names, true, connection_id)
+    }
+
+    pub fn call_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Vec<u8>, RpcError> {
+        crate::get_runtime().block_on(self.call_unary_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    pub async fn call_unary_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Vec<u8>, RpcError> {
+        self.unary(&service_name, &method_name, request, timeout, metadata)
+            .await
+    }
+
+    pub fn call_unary_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<ResponseStreamReader>, RpcError> {
+        crate::get_runtime().block_on(self.call_unary_stream_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    pub async fn call_unary_stream_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<ResponseStreamReader>, RpcError> {
+        let channel = self.clone();
+        let (tx, rx) = unbounded_channel();
+        crate::get_runtime().spawn(async move {
+            let stream = channel.unary_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request,
+                timeout,
+                metadata,
+            );
+            futures::pin_mut!(stream);
+            while let Some(item) = futures::StreamExt::next(&mut stream).await {
+                if tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Arc::new(ResponseStreamReader::new(rx)))
+    }
+
+    pub fn call_stream_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Arc<RequestStreamWriter> {
+        Arc::new(RequestStreamWriter::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    pub fn call_stream_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Arc<BidiStreamHandler> {
+        Arc::new(BidiStreamHandler::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    // ── Multicast UniFFI methods ───────────────────────────────────────────────
+
+    /// Broadcast one request to all GROUP members and collect their responses.
+    ///
+    /// Returns a reader from which each member's response (wrapped in
+    /// `MulticastStreamMessage`) can be pulled one at a time (blocking).
+    pub fn call_multicast_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        crate::get_runtime().block_on(self.call_multicast_unary_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Broadcast one request to all GROUP members and collect their responses
+    /// (async).
+    pub async fn call_multicast_unary_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        let channel = self.clone();
+        let (tx, rx) = unbounded_channel();
+        crate::get_runtime().spawn(async move {
+            let stream = channel.multicast_unary::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request,
+                timeout,
+                metadata,
+            );
+            futures::pin_mut!(stream);
+            while let Some(item) = futures::StreamExt::next(&mut stream).await {
+                if tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Arc::new(MulticastResponseReader::new(rx)))
+    }
+
+    /// Broadcast one request to all GROUP members and stream their responses
+    /// (blocking).
+    ///
+    /// Semantically identical to `call_multicast_unary` at the transport level;
+    /// the difference is that each member may send multiple responses before its
+    /// EOS, which the server handler determines.
+    pub fn call_multicast_unary_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        crate::get_runtime().block_on(self.call_multicast_unary_stream_async(
+            service_name,
+            method_name,
+            request,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Broadcast one request to all GROUP members and stream their responses
+    /// (async).
+    pub async fn call_multicast_unary_stream_async(
+        &self,
+        service_name: String,
+        method_name: String,
+        request: Vec<u8>,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Result<Arc<MulticastResponseReader>, RpcError> {
+        let channel = self.clone();
+        let (tx, rx) = unbounded_channel();
+        crate::get_runtime().spawn(async move {
+            let stream = channel.multicast_unary_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request,
+                timeout,
+                metadata,
+            );
+            futures::pin_mut!(stream);
+            while let Some(item) = futures::StreamExt::next(&mut stream).await {
+                if tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Arc::new(MulticastResponseReader::new(rx)))
+    }
+
+    /// Broadcast a request stream to all GROUP members and collect their
+    /// responses.
+    ///
+    /// Returns a handler that lets you send requests and receive responses
+    /// concurrently. Use `send` / `send_async` to push request messages,
+    /// `close_send` / `close_send_async` to signal end-of-requests, and
+    /// `recv` / `recv_async` to pull response items.
+    pub fn call_multicast_stream_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Arc<MulticastBidiStreamHandler> {
+        Arc::new(MulticastBidiStreamHandler::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Broadcast a request stream to all GROUP members and stream their
+    /// responses.
+    ///
+    /// Semantically equivalent to `call_multicast_stream_unary` at the
+    /// transport level; the difference (one vs many responses per member) is
+    /// determined by the server handler.
+    pub fn call_multicast_stream_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<Metadata>,
+    ) -> Arc<MulticastBidiStreamHandler> {
+        Arc::new(MulticastBidiStreamHandler::new(
+            self.clone(),
+            service_name,
+            method_name,
+            timeout,
+            metadata,
+        ))
+    }
+
+    /// Close the persistent SLIM session held by this channel, if any.
+    ///
+    /// `timeout` optionally bounds how long to wait for the session layer to
+    /// confirm the close before giving up and proceeding with cleanup anyway.
+    /// Pass `None` to wait indefinitely.
+    ///
+    /// After this call the channel can still be used; a new session will be
+    /// created automatically on the next RPC call.
+    pub fn close(&self, timeout: Option<Duration>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_async(timeout))
+    }
+
+    /// Async version of [`close`](Self::close).
+    pub async fn close_async(&self, timeout: Option<Duration>) -> Result<(), RpcError> {
+        let mut guard = self.session.lock().await;
+        let Some(cs) = guard.take() else {
+            return Ok(());
+        };
+
+        let close_future = cs.tx.close(self.app.as_ref());
+        futures::pin_mut!(close_future);
+
+        if let Some(duration) = timeout {
+            // Bound the wait with a futures-timer delay so this works across
+            // all async runtimes exposed by the bindings.
+            let delay = Delay::new(duration);
+            futures::pin_mut!(delay);
+            match futures::future::select(close_future, delay).await {
+                futures::future::Either::Left((Err(e), _)) => {
+                    tracing::warn!(error = %e, "Error closing session");
+                }
+                futures::future::Either::Right(_) => {
+                    tracing::warn!("Timeout waiting for session close");
+                }
+                _ => {}
+            }
+        } else if let Err(e) = close_future.await {
+            tracing::warn!(error = %e, "Error closing session");
+        }
+
+        // Closing the session tx drops the underlying receive channel; the
+        // dispatcher task detects the closed channel and exits naturally.
+        let _ = cs.task.await;
+
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_status_code() {
+        assert_eq!(RpcCode::try_from(0), Ok(RpcCode::Ok));
+        assert_eq!(RpcCode::try_from(13), Ok(RpcCode::Internal));
+        assert!(RpcCode::try_from(999).is_err());
+    }
+
+    #[test]
+    fn test_generate_rpc_id() {
+        let id1 = generate_rpc_id();
+        let id2 = generate_rpc_id();
+        assert_eq!(id1.len(), 36);
+        assert_eq!(id2.len(), 36);
+        assert_ne!(id1, id2);
+    }
+
+    // ── ResponseDispatcher ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_response_dispatcher_close_all() {
+        let dispatcher = ResponseDispatcher::new();
+        let mut rx1 = dispatcher.register("rpc-a");
+        let mut rx2 = dispatcher.register("rpc-b");
+
+        dispatcher.close_all();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert!(
+                rx1.recv().await.is_none(),
+                "rx1 should see None after close_all"
+            );
+            assert!(
+                rx2.recv().await.is_none(),
+                "rx2 should see None after close_all"
+            );
+        });
+    }
+
+    #[test]
+    fn test_response_dispatcher_dispatch_and_unregister() {
+        let dispatcher = ResponseDispatcher::new();
+        let mut rx = dispatcher.register("rpc-x");
+
+        let dummy_name = Name::from_strings(["", "", ""]);
+        let msg = ReceivedMessage {
+            metadata: HashMap::new(),
+            payload: vec![1, 2, 3],
+            source: dummy_name.clone(),
+        };
+        assert!(dispatcher.dispatch(msg, "rpc-x"));
+        assert!(!dispatcher.dispatch(
+            ReceivedMessage {
+                metadata: HashMap::new(),
+                payload: vec![],
+                source: dummy_name.clone(),
+            },
+            "rpc-unknown"
+        ));
+
+        dispatcher.unregister("rpc-x");
+        assert!(!dispatcher.dispatch(
+            ReceivedMessage {
+                metadata: HashMap::new(),
+                payload: vec![],
+                source: dummy_name.clone(),
+            },
+            "rpc-x"
+        ));
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let received = rx.recv().await;
+            assert!(received.is_some());
+            assert_eq!(received.unwrap().payload, vec![1, 2, 3]);
+        });
+    }
+
+    // ── DispatcherGuard ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_dispatcher_guard_unregisters_on_drop() {
+        let dispatcher = Arc::new(ResponseDispatcher::new());
+        let _rx = dispatcher.register("rpc-guard");
+        {
+            let _guard = DispatcherGuard {
+                dispatcher: dispatcher.clone(),
+                rpc_id: "rpc-guard".to_string(),
+            };
+            // _guard dropped here → unregister called
+        }
+        // After guard drops, dispatch must fail.
+        assert!(!dispatcher.dispatch(
+            ReceivedMessage {
+                metadata: HashMap::new(),
+                payload: vec![],
+                source: Name::from_strings(["", "", ""]),
+            },
+            "rpc-guard"
+        ));
+    }
+}

--- a/crates/slim-bindings/src/slimrpc/codec.rs
+++ b/crates/slim-bindings/src/slimrpc/codec.rs
@@ -1,0 +1,79 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Codec traits for message serialization and deserialization
+//!
+//! Provides trait abstractions for encoding and decoding messages in SlimRPC.
+//! These traits are typically implemented by protobuf-generated code.
+
+use super::RpcError;
+
+/// Trait for encoding messages to bytes
+pub trait Encoder {
+    /// Encode a message to bytes
+    fn encode(self) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Trait for decoding messages from bytes
+pub trait Decoder: Default {
+    /// Decode a message from bytes
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError>;
+}
+
+/// Combined codec trait for types that can be both encoded and decoded
+pub trait Codec: Encoder + Decoder {}
+
+// Blanket implementation
+impl<T: Encoder + Decoder> Codec for T {}
+
+// Standard implementations for Vec<u8> (pass-through)
+impl Encoder for Vec<u8> {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        Ok(self)
+    }
+}
+
+impl Decoder for Vec<u8> {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        Ok(buf.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Simple test message type for codec tests
+    #[derive(Debug, Clone, Default, PartialEq)]
+    struct TestMessage {
+        data: Vec<u8>,
+    }
+
+    impl Encoder for TestMessage {
+        fn encode(self) -> Result<Vec<u8>, RpcError> {
+            Ok(self.data)
+        }
+    }
+
+    impl Decoder for TestMessage {
+        fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+            Ok(TestMessage { data: buf.into() })
+        }
+    }
+
+    #[test]
+    fn test_encode() {
+        let msg = TestMessage {
+            data: vec![1, 2, 3, 4],
+        };
+        let encoded = msg.encode().unwrap();
+        assert_eq!(encoded, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_decode() {
+        let buf = vec![1, 2, 3, 4];
+        let msg: TestMessage = TestMessage::decode(buf).unwrap();
+        assert_eq!(msg.data, vec![1, 2, 3, 4]);
+    }
+}

--- a/crates/slim-bindings/src/slimrpc/context.rs
+++ b/crates/slim-bindings/src/slimrpc/context.rs
@@ -1,0 +1,324 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Context types for SlimRPC request handling
+//!
+//! Provides context information for RPC handlers including metadata, deadlines,
+//! session information, and message routing details.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
+
+use slim_datapath::api::ProtoName as Name;
+use slim_session::context::SessionContext as SlimSessionContext;
+
+use super::{DEADLINE_KEY, SessionTx, calculate_deadline};
+
+pub type Metadata = HashMap<String, String>;
+
+/// Context passed to RPC handlers
+///
+/// Contains all contextual information about an RPC call including:
+/// - Session information (source, destination, session ID)
+/// - Metadata (key-value pairs)
+/// - Deadline/timeout information
+/// - Message routing details
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct Context {
+    /// Session context information
+    session: SessionContext,
+    /// Deadline for the RPC call (always set, defaults to now + MAX_TIMEOUT)
+    deadline: SystemTime,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[uniffi::export]
+impl Context {
+    /// Get the session ID
+    pub fn session_id(&self) -> String {
+        self.session.session_id().to_string()
+    }
+
+    /// Get the rpc session metadata
+    pub fn metadata(&self) -> HashMap<String, String> {
+        self.session.metadata.clone()
+    }
+
+    /// Get the deadline for this RPC call
+    pub fn deadline(&self) -> SystemTime {
+        self.deadline
+    }
+
+    /// Get the remaining time until deadline
+    ///
+    /// Returns Duration::ZERO if the deadline has already passed
+    pub fn remaining_time(&self) -> Duration {
+        self.deadline
+            .duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO)
+    }
+
+    /// Check if the deadline has been exceeded
+    pub fn is_deadline_exceeded(&self) -> bool {
+        SystemTime::now() > self.deadline
+    }
+}
+
+impl Context {
+    /// Create a context for an outbound RPC call.
+    ///
+    /// Sets the deadline from `timeout` (or the default max timeout if `None`)
+    /// and merges any caller-supplied `metadata`.
+    pub fn for_rpc(timeout: Option<Duration>, metadata: Option<Metadata>) -> Self {
+        let mut ctx = Self::new();
+        ctx.set_deadline(calculate_deadline(timeout));
+        if let Some(meta) = metadata {
+            ctx.metadata_mut().extend(meta);
+        }
+        ctx
+    }
+
+    /// Create a new empty context with default deadline (now + MAX_TIMEOUT)
+    pub fn new() -> Self {
+        Self::with_session(SessionContext {
+            session_id: String::new(),
+            source: Name::from_strings(["", "", ""]),
+            destination: Name::from_strings(["", "", ""]),
+            metadata: Metadata::new(),
+        })
+    }
+
+    /// Create a new context with a session context and default deadline
+    pub fn with_session(session: SessionContext) -> Self {
+        Self {
+            deadline: calculate_deadline(None),
+            session,
+        }
+    }
+
+    /// Create a new context from a session
+    pub fn from_session(session: &SlimSessionContext) -> Self {
+        let session_ctx = SessionContext::from_session(session);
+        let deadline =
+            Self::parse_deadline(&session_ctx.metadata).unwrap_or(calculate_deadline(None));
+
+        Self {
+            session: session_ctx,
+            deadline,
+        }
+    }
+
+    /// Create a new context from a SessionRx wrapper
+    pub fn from_session_tx(session: &SessionTx) -> Self {
+        let session_id = session.session_id().to_string();
+        let source = session.source().clone();
+        let destination = session.destination().clone();
+        let metadata = session.metadata();
+        let deadline = Self::parse_deadline(&metadata).unwrap_or(calculate_deadline(None));
+
+        Self {
+            session: SessionContext {
+                session_id,
+                source,
+                destination,
+                metadata,
+            },
+            deadline,
+        }
+    }
+
+    /// Create a new context with message metadata
+    pub fn with_message_metadata(
+        mut self,
+        msg_metadata: std::collections::HashMap<String, String>,
+    ) -> Self {
+        // Merge message metadata into context metadata
+        self.session.metadata.extend(msg_metadata);
+        // Re-parse deadline from merged metadata (message metadata takes precedence)
+        self.deadline =
+            Self::parse_deadline(&self.session.metadata).unwrap_or(calculate_deadline(None));
+        self
+    }
+
+    /// Get the session context
+    pub fn session(&self) -> &SessionContext {
+        &self.session
+    }
+
+    /// Get the request metadata
+    pub fn metadata_ref(&self) -> &Metadata {
+        &self.session.metadata
+    }
+
+    /// Get a mutable reference to metadata
+    pub fn metadata_mut(&mut self) -> &mut Metadata {
+        &mut self.session.metadata
+    }
+
+    /// Parse deadline from metadata
+    fn parse_deadline(metadata: &Metadata) -> Option<SystemTime> {
+        metadata.get(DEADLINE_KEY).and_then(|deadline_str| {
+            deadline_str.parse::<f64>().ok().and_then(|seconds| {
+                SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs_f64(seconds))
+            })
+        })
+    }
+
+    /// Set the deadline
+    pub fn set_deadline(&mut self, deadline: SystemTime) {
+        self.deadline = deadline;
+        let seconds = deadline
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64();
+        self.session
+            .metadata
+            .insert(DEADLINE_KEY.into(), seconds.to_string());
+    }
+
+    /// Set the deadline from a duration
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        let deadline = SystemTime::now()
+            .checked_add(timeout)
+            .unwrap_or(SystemTime::now());
+        self.set_deadline(deadline);
+    }
+}
+
+/// Session-level context information
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    /// Session ID
+    session_id: String,
+    /// Source name (sender)
+    source: Name,
+    /// Destination name (receiver)
+    destination: Name,
+    /// Session metadata
+    pub(crate) metadata: Metadata,
+}
+
+impl SessionContext {
+    /// Create from a SLIM session context
+    pub fn from_session(session: &SlimSessionContext) -> Self {
+        let session_arc = session.session_arc();
+        if let Some(controller) = session_arc {
+            Self {
+                session_id: controller.id().to_string(),
+                source: controller.source().clone(),
+                destination: controller.dst().clone(),
+                metadata: controller.metadata(),
+            }
+        } else {
+            // Fallback if session is already closed
+            Self {
+                session_id: session.session_id().to_string(),
+                source: Name::from_strings(["", "", ""]),
+                destination: Name::from_strings(["", "", ""]),
+                metadata: Metadata::new(),
+            }
+        }
+    }
+
+    /// Get the session ID
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Get the source name
+    pub fn source(&self) -> &Name {
+        &self.source
+    }
+
+    /// Get the destination name
+    pub fn destination(&self) -> &Name {
+        &self.destination
+    }
+
+    /// Get the session metadata
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_context_deadline_parsing() {
+        let mut metadata = Metadata::new();
+        let deadline_time = SystemTime::now()
+            .checked_add(Duration::from_secs(60))
+            .unwrap();
+        let seconds = deadline_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        metadata.insert(DEADLINE_KEY.into(), seconds.to_string());
+
+        let parsed = Context::parse_deadline(&metadata);
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn test_context_deadline_exceeded() {
+        let mut metadata = Metadata::new();
+        let past_deadline = SystemTime::now()
+            .checked_sub(Duration::from_secs(60))
+            .unwrap();
+        let seconds = past_deadline
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        metadata.insert(DEADLINE_KEY.into(), seconds.to_string());
+
+        let deadline = Context::parse_deadline(&metadata);
+        assert!(deadline.is_some());
+        if let Some(d) = deadline {
+            assert!(SystemTime::now() > d);
+        }
+    }
+
+    #[test]
+    fn test_context_set_timeout() {
+        let session_metadata = HashMap::new();
+        let ctx_session = SessionContext {
+            session_id: "test-session".to_string(),
+            source: Name::from_strings(["org", "ns", "app"]),
+            destination: Name::from_strings(["org", "ns", "dest"]),
+            metadata: session_metadata,
+        };
+
+        let mut ctx = Context::with_session(ctx_session);
+
+        ctx.set_timeout(Duration::from_secs(30));
+        assert!(!ctx.is_deadline_exceeded());
+    }
+
+    #[test]
+    fn test_remaining_time() {
+        let session_metadata = HashMap::new();
+        let ctx_session = SessionContext {
+            session_id: "test-session".to_string(),
+            source: Name::from_strings(["org", "ns", "app"]),
+            destination: Name::from_strings(["org", "ns", "dest"]),
+            metadata: session_metadata,
+        };
+
+        let mut ctx = Context::with_session(ctx_session);
+
+        ctx.set_timeout(Duration::from_secs(60));
+        let remaining = ctx.remaining_time();
+        // Should be close to 60 seconds, allow some margin
+        assert!(remaining.as_secs() >= 59 && remaining.as_secs() <= 60);
+    }
+}

--- a/crates/slim-bindings/src/slimrpc/error.rs
+++ b/crates/slim-bindings/src/slimrpc/error.rs
@@ -1,0 +1,659 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Status codes and error handling for SlimRPC
+//!
+//! This module provides gRPC-compatible status codes and error types.
+
+use std::fmt;
+
+/// gRPC status codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, uniffi::Enum)]
+#[repr(u16)]
+pub enum RpcCode {
+    /// Success
+    #[default]
+    Ok = 0,
+    /// The operation was cancelled
+    Cancelled = 1,
+    /// Unknown error
+    Unknown = 2,
+    /// Client specified an invalid argument
+    InvalidArgument = 3,
+    /// Deadline exceeded before operation could complete
+    DeadlineExceeded = 4,
+    /// Some requested entity was not found
+    NotFound = 5,
+    /// Some entity that we attempted to create already exists
+    AlreadyExists = 6,
+    /// The caller does not have permission to execute the specified operation
+    PermissionDenied = 7,
+    /// Some resource has been exhausted
+    ResourceExhausted = 8,
+    /// The system is not in a state required for the operation's execution
+    FailedPrecondition = 9,
+    /// The operation was aborted
+    Aborted = 10,
+    /// Operation was attempted past the valid range
+    OutOfRange = 11,
+    /// Operation is not implemented or not supported
+    Unimplemented = 12,
+    /// Internal errors
+    Internal = 13,
+    /// The service is currently unavailable
+    Unavailable = 14,
+    /// Unrecoverable data loss or corruption
+    DataLoss = 15,
+    /// The request does not have valid authentication credentials
+    Unauthenticated = 16,
+}
+
+impl RpcCode {
+    /// Returns true if this is a success code
+    pub fn is_ok(&self) -> bool {
+        matches!(self, RpcCode::Ok)
+    }
+
+    /// Returns true if this is an error code
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Parse an optional metadata value into an `RpcCode`.
+    ///
+    /// Returns `RpcCode::Ok` when the string is absent or cannot be parsed,
+    /// mirroring the wire convention where a missing status key means success.
+    pub fn from_metadata_str(s: Option<&str>) -> Self {
+        s.and_then(|s| s.parse::<i32>().ok())
+            .and_then(|code| RpcCode::try_from(code).ok())
+            .unwrap_or(RpcCode::Ok)
+    }
+}
+
+impl fmt::Display for RpcCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            RpcCode::Ok => "OK",
+            RpcCode::Cancelled => "CANCELLED",
+            RpcCode::Unknown => "UNKNOWN",
+            RpcCode::InvalidArgument => "INVALID_ARGUMENT",
+            RpcCode::DeadlineExceeded => "DEADLINE_EXCEEDED",
+            RpcCode::NotFound => "NOT_FOUND",
+            RpcCode::AlreadyExists => "ALREADY_EXISTS",
+            RpcCode::PermissionDenied => "PERMISSION_DENIED",
+            RpcCode::ResourceExhausted => "RESOURCE_EXHAUSTED",
+            RpcCode::FailedPrecondition => "FAILED_PRECONDITION",
+            RpcCode::Aborted => "ABORTED",
+            RpcCode::OutOfRange => "OUT_OF_RANGE",
+            RpcCode::Unimplemented => "UNIMPLEMENTED",
+            RpcCode::Internal => "INTERNAL",
+            RpcCode::Unavailable => "UNAVAILABLE",
+            RpcCode::DataLoss => "DATA_LOSS",
+            RpcCode::Unauthenticated => "UNAUTHENTICATED",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl From<RpcCode> for i32 {
+    fn from(code: RpcCode) -> i32 {
+        code as i32
+    }
+}
+
+impl TryFrom<i32> for RpcCode {
+    type Error = InvalidRpcCode;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(RpcCode::Ok),
+            1 => Ok(RpcCode::Cancelled),
+            2 => Ok(RpcCode::Unknown),
+            3 => Ok(RpcCode::InvalidArgument),
+            4 => Ok(RpcCode::DeadlineExceeded),
+            5 => Ok(RpcCode::NotFound),
+            6 => Ok(RpcCode::AlreadyExists),
+            7 => Ok(RpcCode::PermissionDenied),
+            8 => Ok(RpcCode::ResourceExhausted),
+            9 => Ok(RpcCode::FailedPrecondition),
+            10 => Ok(RpcCode::Aborted),
+            11 => Ok(RpcCode::OutOfRange),
+            12 => Ok(RpcCode::Unimplemented),
+            13 => Ok(RpcCode::Internal),
+            14 => Ok(RpcCode::Unavailable),
+            15 => Ok(RpcCode::DataLoss),
+            16 => Ok(RpcCode::Unauthenticated),
+            _ => Err(InvalidRpcCode(value)),
+        }
+    }
+}
+
+/// Error returned when trying to convert an invalid i32 to RpcCode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidRpcCode(pub i32);
+
+impl fmt::Display for InvalidRpcCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid RPC code: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidRpcCode {}
+
+/// UniFFI-compatible RPC error
+///
+/// This represents RPC errors with gRPC-compatible status codes.
+#[derive(Debug, Clone, uniffi::Error, thiserror::Error)]
+pub enum RpcError {
+    #[error("{message}")]
+    Rpc {
+        code: RpcCode,
+        message: String,
+        details: Option<Vec<u8>>,
+    },
+
+    #[error("[origin: {origin}] {message}")]
+    MulticastRpc {
+        origin: String,
+        code: RpcCode,
+        message: String,
+        details: Option<Vec<u8>>,
+    },
+
+    #[error("Session closed after {completed}/{total} members; received: [{}], missing: [{}]", received.join(", "), missing.join(", "))]
+    MulticastSessionClosed {
+        completed: u64,
+        total: u64,
+        received: Vec<String>,
+        missing: Vec<String>,
+    },
+}
+
+impl RpcError {
+    /// Create a new RPC error
+    pub fn new(code: RpcCode, message: impl Into<String>) -> Self {
+        Self::Rpc {
+            code,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Create a new multicast RPC error
+    pub fn new_multicast(
+        origin: impl Into<String>,
+        code: RpcCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::MulticastRpc {
+            origin: origin.into(),
+            code,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Create a multicast session-closed error from a member completion map.
+    ///
+    /// Partitions the members into received (done) and missing (not done) lists.
+    pub fn multicast_session_closed(
+        members: impl IntoIterator<Item = (impl ToString, bool)>,
+    ) -> Self {
+        let mut received = Vec::new();
+        let mut missing = Vec::new();
+        for (m, done) in members {
+            if done {
+                received.push(m.to_string());
+            } else {
+                missing.push(m.to_string());
+            }
+        }
+        let completed = received.len() as u64;
+        let total = (received.len() + missing.len()) as u64;
+        Self::MulticastSessionClosed {
+            completed,
+            total,
+            received,
+            missing,
+        }
+    }
+
+    /// Create a new multicast RPC error with details
+    pub fn multicast_with_details(
+        origin: impl Into<String>,
+        code: RpcCode,
+        message: impl Into<String>,
+        details: Vec<u8>,
+    ) -> Self {
+        Self::MulticastRpc {
+            origin: origin.into(),
+            code,
+            message: message.into(),
+            details: Some(details),
+        }
+    }
+
+    /// Create a new RPC error with details
+    pub fn with_details(code: RpcCode, message: impl Into<String>, details: Vec<u8>) -> Self {
+        Self::Rpc {
+            code,
+            message: message.into(),
+            details: Some(details),
+        }
+    }
+
+    /// Create a RPC error with just a code
+    pub fn with_code(code: RpcCode) -> Self {
+        Self::Rpc {
+            code,
+            message: String::new(),
+            details: None,
+        }
+    }
+
+    /// Create an OK status (for completeness, though typically not used as an error)
+    pub fn ok() -> Self {
+        Self::with_code(RpcCode::Ok)
+    }
+
+    /// Create a cancelled error
+    pub fn cancelled(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Cancelled, message)
+    }
+
+    /// Create an unknown error
+    pub fn unknown(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unknown, message)
+    }
+
+    /// Create an invalid argument error
+    pub fn invalid_argument(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::InvalidArgument, message)
+    }
+
+    /// Create a deadline exceeded error
+    pub fn deadline_exceeded(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::DeadlineExceeded, message)
+    }
+
+    /// Create a not found error
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::NotFound, message)
+    }
+
+    /// Create an already exists error
+    pub fn already_exists(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::AlreadyExists, message)
+    }
+
+    /// Create a permission denied error
+    pub fn permission_denied(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::PermissionDenied, message)
+    }
+
+    /// Create a resource exhausted error
+    pub fn resource_exhausted(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::ResourceExhausted, message)
+    }
+
+    /// Create a failed precondition error
+    pub fn failed_precondition(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::FailedPrecondition, message)
+    }
+
+    /// Create an aborted error
+    pub fn aborted(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Aborted, message)
+    }
+
+    /// Create an out of range error
+    pub fn out_of_range(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::OutOfRange, message)
+    }
+
+    /// Create an unimplemented error
+    pub fn unimplemented(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unimplemented, message)
+    }
+
+    /// Create an internal error
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Internal, message)
+    }
+
+    /// Create an unavailable error
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unavailable, message)
+    }
+
+    /// Create a data loss error
+    pub fn data_loss(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::DataLoss, message)
+    }
+
+    /// Create an unauthenticated error
+    pub fn unauthenticated(message: impl Into<String>) -> Self {
+        Self::new(RpcCode::Unauthenticated, message)
+    }
+
+    /// Get the error code
+    pub fn code(&self) -> RpcCode {
+        match self {
+            Self::Rpc { code, .. } | Self::MulticastRpc { code, .. } => *code,
+            Self::MulticastSessionClosed { .. } => RpcCode::Internal,
+        }
+    }
+
+    /// Get the error message
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Rpc { message, .. } | Self::MulticastRpc { message, .. } => message,
+            Self::MulticastSessionClosed { .. } => "multicast session closed prematurely",
+        }
+    }
+
+    /// Get the error details
+    pub fn details(&self) -> Option<&[u8]> {
+        match self {
+            Self::Rpc { details, .. } | Self::MulticastRpc { details, .. } => details.as_deref(),
+            Self::MulticastSessionClosed { .. } => None,
+        }
+    }
+
+    /// Get the origin of the error (only available for multicast errors)
+    pub fn origin(&self) -> Option<&str> {
+        match self {
+            Self::MulticastRpc { origin, .. } => Some(origin),
+            _ => None,
+        }
+    }
+
+    /// Convert this error into a `MulticastRpc` variant, attaching the given origin.
+    ///
+    /// If the error is already a `MulticastRpc`, the origin is replaced.
+    /// `MulticastSessionClosed` is returned as-is since it has no single origin.
+    pub fn with_origin(self, origin: impl Into<String>) -> Self {
+        let origin = origin.into();
+        match self {
+            Self::Rpc {
+                code,
+                message,
+                details,
+            }
+            | Self::MulticastRpc {
+                code,
+                message,
+                details,
+                ..
+            } => Self::MulticastRpc {
+                origin,
+                code,
+                message,
+                details,
+            },
+            other @ Self::MulticastSessionClosed { .. } => other,
+        }
+    }
+
+    /// Returns true if this is a success status
+    pub fn is_ok(&self) -> bool {
+        self.code().is_ok()
+    }
+
+    /// Returns true if this is an error status
+    pub fn is_err(&self) -> bool {
+        self.code().is_err()
+    }
+
+    /// Add details to an existing error
+    pub fn with_details_added(mut self, details: Vec<u8>) -> Self {
+        match &mut self {
+            Self::Rpc { details: d, .. } | Self::MulticastRpc { details: d, .. } => {
+                *d = Some(details)
+            }
+            Self::MulticastSessionClosed { .. } => {}
+        }
+        self
+    }
+}
+
+impl Default for RpcError {
+    fn default() -> Self {
+        Self::ok()
+    }
+}
+
+impl From<RpcCode> for RpcError {
+    fn from(code: RpcCode) -> Self {
+        Self::with_code(code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_code_conversions() {
+        let ok_code: i32 = RpcCode::Ok.into();
+        let internal_code: i32 = RpcCode::Internal.into();
+        assert_eq!(ok_code, 0);
+        assert_eq!(internal_code, 13);
+        assert_eq!(RpcCode::try_from(0), Ok(RpcCode::Ok));
+        assert_eq!(RpcCode::try_from(13), Ok(RpcCode::Internal));
+        assert!(RpcCode::try_from(999).is_err());
+    }
+
+    #[test]
+    fn test_code_display() {
+        assert_eq!(RpcCode::Ok.to_string(), "OK");
+        assert_eq!(RpcCode::NotFound.to_string(), "NOT_FOUND");
+        assert_eq!(RpcCode::Internal.to_string(), "INTERNAL");
+    }
+
+    #[test]
+    fn test_code_is_ok() {
+        assert!(RpcCode::Ok.is_ok());
+        assert!(!RpcCode::Internal.is_ok());
+        assert!(!RpcCode::Ok.is_err());
+        assert!(RpcCode::Internal.is_err());
+    }
+
+    #[test]
+    fn test_error_creation() {
+        let error = RpcError::ok();
+        assert_eq!(error.code(), RpcCode::Ok);
+        assert!(error.is_ok());
+
+        let error = RpcError::internal("test error");
+        assert_eq!(error.code(), RpcCode::Internal);
+        assert!(error.is_err());
+        assert_eq!(error.message(), "test error");
+    }
+
+    #[test]
+    fn test_error_with_details() {
+        let details = vec![1, 2, 3, 4];
+        let error = RpcError::with_details(RpcCode::Internal, "error", details.clone());
+        assert_eq!(error.details(), Some(details.as_slice()));
+    }
+
+    #[test]
+    fn test_error_display() {
+        let error = RpcError::ok();
+        assert_eq!(error.to_string(), "");
+
+        let error = RpcError::internal("test");
+        assert_eq!(error.to_string(), "test");
+    }
+
+    #[test]
+    fn test_error_from_code() {
+        let error: RpcError = RpcCode::NotFound.into();
+        assert_eq!(error.code(), RpcCode::NotFound);
+        assert_eq!(error.message(), "");
+    }
+
+    #[test]
+    fn test_all_error_constructors() {
+        assert_eq!(RpcError::cancelled("msg").code(), RpcCode::Cancelled);
+        assert_eq!(RpcError::unknown("msg").code(), RpcCode::Unknown);
+        assert_eq!(
+            RpcError::invalid_argument("msg").code(),
+            RpcCode::InvalidArgument
+        );
+        assert_eq!(
+            RpcError::deadline_exceeded("msg").code(),
+            RpcCode::DeadlineExceeded
+        );
+        assert_eq!(RpcError::not_found("msg").code(), RpcCode::NotFound);
+        assert_eq!(
+            RpcError::already_exists("msg").code(),
+            RpcCode::AlreadyExists
+        );
+        assert_eq!(
+            RpcError::permission_denied("msg").code(),
+            RpcCode::PermissionDenied
+        );
+        assert_eq!(
+            RpcError::resource_exhausted("msg").code(),
+            RpcCode::ResourceExhausted
+        );
+        assert_eq!(
+            RpcError::failed_precondition("msg").code(),
+            RpcCode::FailedPrecondition
+        );
+        assert_eq!(RpcError::aborted("msg").code(), RpcCode::Aborted);
+        assert_eq!(RpcError::out_of_range("msg").code(), RpcCode::OutOfRange);
+        assert_eq!(
+            RpcError::unimplemented("msg").code(),
+            RpcCode::Unimplemented
+        );
+        assert_eq!(RpcError::internal("msg").code(), RpcCode::Internal);
+        assert_eq!(RpcError::unavailable("msg").code(), RpcCode::Unavailable);
+        assert_eq!(RpcError::data_loss("msg").code(), RpcCode::DataLoss);
+        assert_eq!(
+            RpcError::unauthenticated("msg").code(),
+            RpcCode::Unauthenticated
+        );
+    }
+
+    #[test]
+    fn test_with_origin_converts_rpc_to_multicast() {
+        let details = vec![1, 2, 3];
+        let err = RpcError::with_details(RpcCode::NotFound, "gone", details.clone());
+        let err = err.with_origin("org/ns/member-0");
+        match err {
+            RpcError::MulticastRpc {
+                origin,
+                code,
+                message,
+                details: d,
+            } => {
+                assert_eq!(origin, "org/ns/member-0");
+                assert_eq!(code, RpcCode::NotFound);
+                assert_eq!(message, "gone");
+                assert_eq!(d, Some(details));
+            }
+            other => panic!("expected MulticastRpc, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_with_origin_replaces_existing_origin() {
+        let err = RpcError::new_multicast("old-origin", RpcCode::Internal, "msg");
+        let err = err.with_origin("new-origin");
+        match err {
+            RpcError::MulticastRpc { origin, .. } => {
+                assert_eq!(origin, "new-origin");
+            }
+            other => panic!("expected MulticastRpc, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_constructor() {
+        let members = vec![
+            ("member-0".to_string(), true),
+            ("member-1".to_string(), false),
+            ("member-2".to_string(), true),
+            ("member-3".to_string(), false),
+        ];
+        let err = RpcError::multicast_session_closed(members);
+        match err {
+            RpcError::MulticastSessionClosed {
+                completed,
+                total,
+                received,
+                missing,
+            } => {
+                assert_eq!(completed, 2);
+                assert_eq!(total, 4);
+                let mut received = received;
+                received.sort();
+                assert_eq!(received, vec!["member-0", "member-2"]);
+                let mut missing = missing;
+                missing.sort();
+                assert_eq!(missing, vec!["member-1", "member-3"]);
+            }
+            other => panic!("expected MulticastSessionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_all_done() {
+        let members = vec![("a".to_string(), true), ("b".to_string(), true)];
+        let err = RpcError::multicast_session_closed(members);
+        match err {
+            RpcError::MulticastSessionClosed {
+                completed,
+                total,
+                missing,
+                ..
+            } => {
+                assert_eq!(completed, 2);
+                assert_eq!(total, 2);
+                assert!(missing.is_empty());
+            }
+            other => panic!("expected MulticastSessionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_none_done() {
+        let members = vec![("a".to_string(), false), ("b".to_string(), false)];
+        let err = RpcError::multicast_session_closed(members);
+        match err {
+            RpcError::MulticastSessionClosed {
+                completed,
+                total,
+                received,
+                ..
+            } => {
+                assert_eq!(completed, 0);
+                assert_eq!(total, 2);
+                assert!(received.is_empty());
+            }
+            other => panic!("expected MulticastSessionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multicast_session_closed_display() {
+        let members = vec![("alice".to_string(), true), ("bob".to_string(), false)];
+        let err = RpcError::multicast_session_closed(members);
+        let display = err.to_string();
+        assert!(
+            display.contains("1/2"),
+            "display should contain completed/total"
+        );
+        assert!(
+            display.contains("alice"),
+            "display should contain received member"
+        );
+        assert!(
+            display.contains("bob"),
+            "display should contain missing member"
+        );
+    }
+}

--- a/crates/slim-bindings/src/slimrpc/handler_traits.rs
+++ b/crates/slim-bindings/src/slimrpc/handler_traits.rs
@@ -1,0 +1,108 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Handler trait interface for SlimRPC UniFFI bindings
+//!
+//! Defines the callback traits that foreign language applications implement to handle RPC calls.
+//! UniFFI will generate foreign language interfaces for these traits.
+
+use std::sync::Arc;
+
+use super::{
+    Context, RpcError,
+    stream_types::{RequestStream, ResponseSink},
+};
+
+/// Unary-to-Unary RPC handler trait
+///
+/// Implement this trait to handle unary-to-unary RPC calls.
+/// The handler receives a single request and returns a single response.
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait UnaryUnaryHandler: Send + Sync {
+    /// Handle a unary-to-unary RPC call
+    ///
+    /// # Arguments
+    /// * `request` - The request message bytes
+    /// * `context` - RPC context with metadata and session information
+    ///
+    /// # Returns
+    /// The response message bytes or an error
+    async fn handle(&self, request: Vec<u8>, context: Arc<Context>) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Unary-to-Stream RPC handler trait
+///
+/// Implement this trait to handle unary-to-stream RPC calls.
+/// The handler receives a single request and sends multiple responses via the sink.
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait UnaryStreamHandler: Send + Sync {
+    /// Handle a unary-to-stream RPC call
+    ///
+    /// # Arguments
+    /// * `request` - The request message bytes
+    /// * `context` - RPC context with metadata and session information
+    /// * `sink` - Response sink to send streaming responses
+    ///
+    /// # Returns
+    /// Ok(()) if handling succeeded, or an error
+    ///
+    /// # Note
+    /// You must call `sink.close()` or `sink.send_error()` when done.
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError>;
+}
+
+/// Stream-to-Unary RPC handler trait
+///
+/// Implement this trait to handle stream-to-unary RPC calls.
+/// The handler receives multiple requests via the stream and returns a single response.
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait StreamUnaryHandler: Send + Sync {
+    /// Handle a stream-to-unary RPC call
+    ///
+    /// # Arguments
+    /// * `stream` - Request stream to pull messages from
+    /// * `context` - RPC context with metadata and session information
+    ///
+    /// # Returns
+    /// The response message bytes or an error
+    async fn handle(
+        &self,
+        stream: Arc<RequestStream>,
+        context: Arc<Context>,
+    ) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Stream-to-Stream RPC handler trait
+///
+/// Implement this trait to handle stream-to-stream RPC calls.
+/// The handler receives multiple requests via the stream and sends multiple responses via the sink.
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait StreamStreamHandler: Send + Sync {
+    /// Handle a stream-to-stream RPC call
+    ///
+    /// # Arguments
+    /// * `stream` - Request stream to pull messages from
+    /// * `context` - RPC context with metadata and session information
+    /// * `sink` - Response sink to send streaming responses
+    ///
+    /// # Returns
+    /// Ok(()) if handling succeeded, or an error
+    ///
+    /// # Note
+    /// You must call `sink.close()` or `sink.send_error()` when done.
+    async fn handle(
+        &self,
+        stream: Arc<RequestStream>,
+        context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError>;
+}

--- a/crates/slim-bindings/src/slimrpc/rpc_session.rs
+++ b/crates/slim-bindings/src/slimrpc/rpc_session.rs
@@ -1,0 +1,242 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! RPC session handling implementation
+//!
+//! This module contains the logic for handling individual RPC sessions,
+//! including message sending/receiving, timeout handling, and stream processing.
+
+use std::{collections::HashMap, sync::Arc};
+
+use futures::StreamExt;
+use slim_session::CompletionHandle;
+use tokio::sync::mpsc;
+
+use slim_datapath::api::ProtoName as Name;
+
+use super::{
+    Context, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError, RpcHandler, STATUS_CODE_KEY,
+    SessionTx, StreamRpcHandler, StreamSource,
+};
+
+/// Handler information retrieved from registry
+pub enum HandlerInfo {
+    Stream(StreamRpcHandler),
+    Unary(RpcHandler),
+}
+
+/// RPC session handler for all four interaction patterns.
+///
+/// For stream-input methods (stream-unary, stream-stream), construct with
+/// [`RpcSession::new_stream`]. For unary-input methods (unary-unary,
+/// unary-stream), construct with [`RpcSession::new_unary`].
+pub struct RpcSession<'a> {
+    session_tx: &'a SessionTx,
+    /// Present for stream-input handlers; absent for unary-input handlers.
+    session_rx: Option<mpsc::UnboundedReceiver<ReceivedMessage>>,
+    method_path: &'a str,
+    /// First message read from the wire, carrying the request payload and metadata.
+    first_message: ReceivedMessage,
+}
+
+impl<'a> RpcSession<'a> {
+    /// Create a session for a unary-input RPC (unary-unary, unary-stream).
+    pub fn new_unary(
+        session_tx: &'a SessionTx,
+        method_path: &'a str,
+        first_message: ReceivedMessage,
+    ) -> Self {
+        Self {
+            session_tx,
+            session_rx: None,
+            method_path,
+            first_message,
+        }
+    }
+
+    /// Create a session for a stream-input RPC (stream-unary, stream-stream).
+    pub fn new_stream(
+        session_tx: &'a SessionTx,
+        channel_rx: mpsc::UnboundedReceiver<ReceivedMessage>,
+        method_path: &'a str,
+        first_message: ReceivedMessage,
+    ) -> Self {
+        Self {
+            session_tx,
+            session_rx: Some(channel_rx),
+            method_path,
+            first_message,
+        }
+    }
+
+    /// Handle the session, dispatching to the appropriate interaction pattern.
+    pub async fn handle(self, handler_info: HandlerInfo, rpc_id: Arc<str>) -> Result<(), RpcError> {
+        let Self {
+            session_tx,
+            session_rx,
+            method_path,
+            first_message,
+        } = self;
+
+        tracing::debug!(%method_path, "Processing RPC");
+
+        // Pre-compute first-message status before moving fields into ctx / stream.
+        let first_is_eos = first_message.is_eos();
+        let first_code = RpcCode::from_metadata_str(
+            first_message
+                .metadata
+                .get(STATUS_CODE_KEY)
+                .map(String::as_str),
+        );
+        let ReceivedMessage {
+            metadata,
+            payload,
+            source,
+        } = first_message;
+        let ctx = Context::from_session_tx(session_tx).with_message_metadata(metadata);
+
+        if ctx.is_deadline_exceeded() {
+            return Err(RpcError::deadline_exceeded("Deadline exceeded"));
+        }
+
+        let deadline = tokio::time::Instant::now() + ctx.remaining_time();
+
+        let result = tokio::select! {
+            result = async move {
+                match &handler_info {
+                    HandlerInfo::Unary(handler) => {
+                        handler(payload, ctx, session_tx.clone(), source, rpc_id).await
+                    }
+                    HandlerInfo::Stream(handler) => {
+                        let stream_source = StreamSource { session_rx, payload, first_is_eos, first_code };
+                        handler(stream_source, ctx, session_tx.clone(), source, rpc_id).await
+                    }
+                }
+            } => result,
+            _ = tokio::time::sleep_until(deadline) => {
+                tracing::debug!("RPC handler execution exceeded deadline");
+                Err(RpcError::deadline_exceeded("Deadline exceeded during RPC execution"))
+            }
+        };
+
+        if let Err(e) = &result {
+            tracing::error!(%method_path, error = %e, "Error handling RPC");
+        } else {
+            tracing::debug!(%method_path, "RPC completed successfully");
+        }
+
+        result
+    }
+}
+
+/// Send a session-level error response (no rpc_id — used before dispatch)
+pub async fn send_error(session: &SessionTx, error: RpcError) -> Result<(), RpcError> {
+    send_error_for_rpc(session, error, "").await
+}
+
+/// Send an RPC-level error response including the rpc_id so the client can
+/// route it back to the correct waiting caller over the shared session.
+pub async fn send_error_for_rpc(
+    session: &SessionTx,
+    error: RpcError,
+    rpc_id: &str,
+) -> Result<(), RpcError> {
+    let message = error.message().to_string();
+    let metadata = create_status_metadata(error.code(), rpc_id);
+    let handle = session
+        .publish(
+            session.destination(),
+            message.into_bytes(),
+            Some("msg".to_string()),
+            Some(metadata),
+        )
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to send error: {e}")))?;
+    handle.await.map_err(|e| {
+        tracing::warn!(error = %e, "Failed to send error response");
+        RpcError::internal(format!("Failed to complete error send: {e}"))
+    })
+}
+
+/// Send an end-of-stream marker to `target`.
+///
+/// An EOS is an empty-payload message with `slimrpc-code = Ok`. Every server
+/// handler must send one after its final response so GROUP/multicast callers
+/// can count per-member stream ends. P2P callers discard it harmlessly.
+///
+/// `extra` is merged into the EOS metadata after the status code. Pass
+/// `None` for the common case where no additional metadata is needed.
+/// When the EOS is also the first message (empty request stream), pass
+/// service + method so the server can dispatch without a preceding data frame.
+pub async fn send_eos(
+    session_tx: &SessionTx,
+    target: &Name,
+    rpc_id: &str,
+    extra: Option<HashMap<String, String>>,
+) -> Result<CompletionHandle, RpcError> {
+    let mut metadata = create_status_metadata(RpcCode::Ok, rpc_id);
+    if let Some(extra) = extra {
+        metadata.extend(extra);
+    }
+    session_tx
+        .publish(target, Vec::new(), Some("msg".to_string()), Some(metadata))
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to send EOS: {e}")))
+}
+
+fn create_status_metadata(code: RpcCode, rpc_id: &str) -> HashMap<String, String> {
+    let mut metadata = HashMap::new();
+    let code_i32: i32 = code.into();
+    metadata.insert(STATUS_CODE_KEY.to_string(), code_i32.to_string());
+    if !rpc_id.is_empty() {
+        metadata.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
+    }
+    metadata
+}
+
+pub async fn send_response_stream<S>(
+    session_tx: &SessionTx,
+    stream: S,
+    rpc_id: &str,
+    target: &Name,
+) -> Result<(), RpcError>
+where
+    S: futures::Stream<Item = Result<Vec<u8>, RpcError>>,
+{
+    futures::pin_mut!(stream);
+
+    // Publish every response message without awaiting its CompletionHandle,
+    // collecting all handles so we can wait for them in a single batch once
+    // the stream is exhausted.  This avoids a per-message round-trip delay
+    // caused by the session layer's reliable-delivery acknowledgement protocol.
+    let mut handles: Vec<CompletionHandle> = Vec::new();
+
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(response_bytes) => {
+                handles.push(
+                    session_tx
+                        .publish(
+                            target,
+                            response_bytes,
+                            Some("msg".to_string()),
+                            Some(create_status_metadata(RpcCode::Ok, rpc_id)),
+                        )
+                        .await
+                        .map_err(|e| RpcError::internal(format!("Failed to send response: {e}")))?,
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Queue the EOS marker and collect its handle too.
+    handles.push(send_eos(session_tx, target, rpc_id, None).await?);
+
+    // Wait for all in-flight sends to be acknowledged by the session layer.
+    futures::future::try_join_all(handles)
+        .await
+        .map_err(|e| RpcError::internal(format!("Failed to complete sending: {e}")))?;
+
+    Ok(())
+}

--- a/crates/slim-bindings/src/slimrpc/server.rs
+++ b/crates/slim-bindings/src/slimrpc/server.rs
@@ -1,0 +1,1471 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-side RPC handling implementation
+//!
+//! Provides a Server type for handling incoming RPC requests and dispatching
+//! them to registered service implementations.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::join_all;
+use futures::stream::Stream;
+use futures::{FutureExt, StreamExt, future::BoxFuture, stream};
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::app::App as SlimApp;
+use slim_session::errors::SessionError;
+use slim_session::notification::Notification;
+
+use super::{RPC_DIR_KEY, RPC_DIR_REQ};
+use crate::STATUS_CODE_KEY;
+
+use super::{
+    Context, HandlerInfo, METHOD_KEY, RPC_ID_KEY, ReceivedMessage, ResponseSink, RpcCode, RpcError,
+    RpcSession, SERVICE_KEY, StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler,
+    UnaryUnaryHandler, UniffiRequestStream,
+    codec::{Decoder, Encoder},
+    send_error_for_rpc, send_response_stream,
+    session_wrapper::{SessionRx, SessionTx, new_session},
+    stream_types::{DecodedStream, StreamSource},
+};
+
+pub type Item = Vec<u8>;
+pub type ResponseStream = BoxFuture<'static, Result<(), RpcError>>;
+
+/// Handler function type for RPC methods (unary input)
+pub type RpcHandler =
+    Arc<dyn Fn(Item, Context, SessionTx, Name, Arc<str>) -> ResponseStream + Send + Sync>;
+
+/// Handler function type for stream-input RPC methods
+pub type StreamRpcHandler =
+    Arc<dyn Fn(StreamSource, Context, SessionTx, Name, Arc<str>) -> ResponseStream + Send + Sync>;
+
+/// Type of RPC handler
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandlerType {
+    /// Unary request, unary response
+    UnaryUnary,
+    /// Unary request, streaming response
+    UnaryStream,
+    /// Streaming request, unary response
+    StreamUnary,
+    /// Streaming request, streaming response
+    StreamStream,
+}
+
+/// Registry for RPC service methods (internal implementation detail)
+#[derive(Clone)]
+struct ServiceRegistry {
+    /// Map of method paths to handlers (for unary-input methods)
+    handlers: HashMap<String, RpcHandler>,
+    /// Map of method paths to stream handlers (for stream-input methods)
+    stream_handlers: HashMap<String, StreamRpcHandler>,
+}
+
+impl ServiceRegistry {
+    /// Create a new service registry
+    fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+            stream_handlers: HashMap::new(),
+        }
+    }
+
+    /// Register a unary-unary handler
+    fn register_unary_unary<F, Req, Res, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |bytes: Vec<u8>,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  source: Name,
+                  rpc_id: Arc<str>| {
+                let fut = Req::decode(bytes).map(|req| handler(req, ctx));
+                async move {
+                    let encoded = fut?.await?.encode()?;
+                    send_response_stream(
+                        &session_tx,
+                        stream::once(std::future::ready(Ok(encoded))),
+                        &rpc_id,
+                        &source,
+                    )
+                    .await
+                }
+                .boxed()
+            },
+        );
+
+        self.handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a unary-stream handler
+    pub fn register_unary_stream<F, Req, Res, S, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |bytes: Vec<u8>,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  source: Name,
+                  rpc_id: Arc<str>| {
+                let fut = Req::decode(bytes).map(|req| handler(req, ctx));
+                async move {
+                    let response_stream = fut?.await?;
+                    let byte_mapped = response_stream.map(|res| res.and_then(|r| r.encode()));
+                    send_response_stream(&session_tx, byte_mapped, &rpc_id, &source).await
+                }
+                .boxed()
+            },
+        );
+
+        self.handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a stream-unary handler
+    pub fn register_stream_unary<F, Req, Res, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |source: StreamSource,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  target: Name,
+                  rpc_id: Arc<str>| {
+                let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
+                    |res| res.and_then(|bytes| Req::decode(bytes));
+                let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
+                let fut = handler(decoded, ctx);
+                async move {
+                    let encoded = fut.await?.encode()?;
+                    send_response_stream(
+                        &session_tx,
+                        stream::once(std::future::ready(Ok(encoded))),
+                        &rpc_id,
+                        &target,
+                    )
+                    .await
+                }
+                .boxed()
+            },
+        );
+
+        self.stream_handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a stream-stream handler
+    pub fn register_stream_stream<F, Req, Res, S, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |source: StreamSource,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  target: Name,
+                  rpc_id: Arc<str>| {
+                let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
+                    |res| res.and_then(|bytes| Req::decode(bytes));
+                let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
+                let fut = handler(decoded, ctx);
+                async move {
+                    let response_stream = fut.await?;
+                    let byte_mapped = response_stream.map(|res| res.and_then(|r| r.encode()));
+                    send_response_stream(&session_tx, byte_mapped, &rpc_id, &target).await
+                }
+                .boxed()
+            },
+        );
+
+        self.stream_handlers.insert(method_path, wrapper);
+    }
+
+    /// Get handler info (either stream or unary) in one lookup
+    fn get_handler_info(&self, method_path: &str) -> Option<HandlerInfo> {
+        self.stream_handlers
+            .get(method_path)
+            .cloned()
+            .map(HandlerInfo::Stream)
+            .or_else(|| {
+                self.handlers
+                    .get(method_path)
+                    .cloned()
+                    .map(HandlerInfo::Unary)
+            })
+    }
+
+    /// Get all registered method paths
+    fn methods(&self) -> Vec<String> {
+        let mut methods: Vec<String> = self.handlers.keys().cloned().collect();
+        methods.extend(self.stream_handlers.keys().cloned());
+        methods
+    }
+}
+
+impl Default for ServiceRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Enum to hold either an owned or shared notification receiver
+enum NotificationReceiver {
+    Owned(mpsc::Receiver<Result<Notification, SessionError>>),
+    Shared(Arc<tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>>),
+}
+
+/// Result handed back from the spawned `serve_handle` task: the notification
+/// receiver (so the caller can keep consuming after shutdown) plus the run
+/// outcome.
+type ServeHandleResult = (NotificationReceiver, Result<(), RpcError>);
+
+/// RPC Server
+///
+/// Handles incoming RPC requests by creating sessions and dispatching
+/// to registered service handlers.
+///
+/// # Example
+///
+/// ```no_run
+/// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name};
+/// # use std::sync::Arc;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # use slim_bindings::{IdentityProviderConfig, IdentityVerifierConfig};
+/// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+/// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+/// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+/// # let app = App::new(app_name, provider, verifier)?;
+/// # let core_app = app.inner();
+/// # let notification_rx = app.notification_receiver();
+/// # #[derive(Default)]
+/// # struct Request {}
+/// # impl Decoder for Request {
+/// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+/// # }
+/// # #[derive(Default)]
+/// # struct Response {}
+/// # impl Encoder for Response {
+/// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+/// # }
+/// let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+/// let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+///
+/// // Register handlers
+/// server.register_unary_unary_internal(
+///     "MyService",
+///     "MyMethod",
+///     |request: Request, _ctx: Context| async move {
+///         Ok(Response::default())
+///     }
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(uniffi::Object)]
+pub struct Server {
+    /// The SLIM app instance
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+    /// Service registry containing all registered handlers
+    registry: RwLock<ServiceRegistry>,
+    /// Base service name
+    base_name: Name,
+    /// Optional connection ID for subscription propagation
+    connection_id: Option<u64>,
+    /// Notification receiver for incoming sessions (either owned or shared)
+    notification_rx: parking_lot::Mutex<Option<NotificationReceiver>>,
+    /// Drain signal for graceful shutdown
+    drain_signal: RwLock<Option<drain::Signal>>,
+    /// Drain watch for session handlers
+    drain_watch: RwLock<Option<drain::Watch>>,
+    /// Runtime handle for spawning tasks (resolved at construction)
+    runtime: tokio::runtime::Handle,
+}
+
+/// Spawn a handler task for a new RPC call and, for stream-input handlers, register the mpsc
+/// sender in `pending_streams` so that subsequent messages can be routed to the same task.
+fn spawn_handler_task(
+    handler_info: HandlerInfo,
+    msg: ReceivedMessage,
+    rpc_id: Arc<str>,
+    method_path: String,
+    session_tx: SessionTx,
+    pending_streams: &mut HashMap<Arc<str>, mpsc::UnboundedSender<ReceivedMessage>>,
+    session_drain_watch: drain::Watch,
+) {
+    // For stream-input handlers, create the mpsc channel and register the sender
+    // so that subsequent messages can be routed to the same handler task.
+    // Only register if the first message is not already terminal; otherwise drop
+    // stream_tx immediately so the handler's channel closes after the first message.
+    let stream_rx = match &handler_info {
+        HandlerInfo::Stream(_) => {
+            let (stream_tx, stream_rx) = mpsc::unbounded_channel();
+            if !msg.is_eos() {
+                pending_streams.insert(rpc_id.clone(), stream_tx);
+            }
+            Some(stream_rx)
+        }
+        HandlerInfo::Unary(_) => None,
+    };
+
+    tokio::spawn(async move {
+        let session = match stream_rx {
+            Some(rx) => RpcSession::new_stream(&session_tx, rx, &method_path, msg),
+            None => RpcSession::new_unary(&session_tx, &method_path, msg),
+        };
+        let handler_fut = async {
+            match session.handle(handler_info, rpc_id.clone()).await {
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::error!(%method_path, error = %e, "Error in RPC handler");
+                    Some(e)
+                }
+            }
+        };
+        let error = tokio::select! {
+            err = handler_fut => err,
+            _ = session_drain_watch.signaled() => {
+                tracing::debug!(%method_path, %rpc_id, "Session closed, aborting handler");
+                Some(RpcError::cancelled("Server shutting down"))
+            }
+        };
+        if let Some(e) = error {
+            let _ = send_error_for_rpc(&session_tx, e, &rpc_id).await;
+        }
+    });
+}
+
+/// Per-session demultiplexer: routes incoming messages by `rpc-id` and dispatches each new
+/// RPC call to a dedicated handler task.  Runs until the drain signal fires or the session
+/// closes, then aborts any still-running handler tasks and cleans up the session.
+async fn run_session_demux(
+    session_tx: SessionTx,
+    mut session_rx: SessionRx,
+    registry: ServiceRegistry,
+    app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+    drain_watch: drain::Watch,
+) {
+    // Map rpc_id → mpsc sender for live stream-input handlers.
+    let mut pending_streams: HashMap<Arc<str>, mpsc::UnboundedSender<ReceivedMessage>> =
+        HashMap::new();
+
+    // Per-session drain: signals all active handler tasks when the session closes.
+    // drain().await serves as a barrier — it resolves once every task has dropped its Watch.
+    let (session_drain_signal, session_drain_watch) = drain::channel();
+
+    let mut drain_fut = std::pin::pin!(drain_watch.signaled());
+
+    loop {
+        let msg = tokio::select! {
+            _ = &mut drain_fut => {
+                tracing::info!("Session demux task: server shutdown");
+                break;
+            }
+            result = session_rx.get_message(None) => match result {
+                Ok(m) => m,
+                Err(SessionError::ParticipantDisconnected(name)) => {
+                    tracing::warn!(%name, "Participant disconnected, closing session");
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "Session closed by peer");
+                    break;
+                }
+            }
+        };
+
+        let Some(rpc_id_str) = msg.metadata.get(RPC_ID_KEY).filter(|s| !s.is_empty()) else {
+            tracing::trace!("Skipping message with missing or empty rpc-id");
+            continue;
+        };
+
+        if let Some(tx) = pending_streams.get(rpc_id_str.as_str()).cloned() {
+            // Route client request messages (data or EOS) to the existing stream-input handler.
+            //
+            // All client-originated messages carry RPC_DIR_KEY="req".  Server responses
+            // (data frames, EOSes, and error replies — including echoes of this server's own
+            // responses in a GROUP session and responses from peer servers) do not carry
+            // this key.  Drop anything that isn't tagged as a client request.
+            if msg.metadata.get(RPC_DIR_KEY).map(String::as_str) != Some(RPC_DIR_REQ) {
+                tracing::trace!(%rpc_id_str, "Skipping server response for active stream");
+                continue;
+            }
+            // Remove before send so rpc_id_str (borrows msg.metadata) is last used
+            // before msg is moved — NLL lets the borrow end here.
+            let is_terminal = msg.is_eos();
+            if is_terminal {
+                pending_streams.remove(rpc_id_str.as_str());
+            }
+            let _ = tx.send(msg);
+            continue;
+        }
+
+        // No active stream for this rpc_id.
+        // Drop server responses: they have STATUS_CODE_KEY but are NOT tagged as client
+        // requests.  An empty-stream client EOS also has STATUS_CODE_KEY but carries
+        // RPC_DIR_KEY="req", so it passes through and is dispatched as a new RPC call.
+        if msg.metadata.contains_key(STATUS_CODE_KEY)
+            && msg.metadata.get(RPC_DIR_KEY).map(String::as_str) != Some(RPC_DIR_REQ)
+        {
+            tracing::trace!("Skipping server response (no pending stream)");
+            continue;
+        }
+
+        // New RPC call — create Arc now that we know we need it.
+        let rpc_id: Arc<str> = Arc::from(rpc_id_str.as_str());
+
+        let (Some(service), Some(method)) = (
+            msg.metadata
+                .get(SERVICE_KEY)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.as_str()),
+            msg.metadata
+                .get(METHOD_KEY)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.as_str()),
+        ) else {
+            tracing::trace!(%rpc_id, "Skipping message missing service or method key");
+            continue;
+        };
+
+        let method_path = format!("{service}/{method}");
+
+        tracing::debug!(%method_path, %rpc_id, "Dispatching new RPC call");
+
+        let Some(handler_info) = registry.get_handler_info(&method_path) else {
+            tracing::error!(%method_path, "No handler registered");
+            let _ = send_error_for_rpc(
+                &session_tx,
+                RpcError::unimplemented(format!("Method not found: {method_path}")),
+                &rpc_id,
+            )
+            .await;
+            continue;
+        };
+
+        spawn_handler_task(
+            handler_info,
+            msg,
+            rpc_id,
+            method_path,
+            session_tx.clone(),
+            &mut pending_streams,
+            session_drain_watch.clone(),
+        );
+    }
+
+    // Drop mpsc senders so stream-input handlers see channel close at their next recv.
+    drop(pending_streams);
+    // Drop watch otherwise next call to drain would also wait for this
+    drop(session_drain_watch);
+    // Fire the session drain and wait: resolves once every handler task drops its Watch,
+    // so when each task completes
+    session_drain_signal.drain().await;
+
+    // Close session_tx. This might fail if session was already dropped by the channel endpoint
+    let _ = tokio::time::timeout(Duration::from_secs(10), session_tx.close(app.as_ref())).await;
+}
+
+impl Server {
+    /// Create a new RPC server
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `notification_rx` - Receiver for session notifications
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_internal(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        notification_rx: mpsc::Receiver<Result<Notification, SessionError>>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            None,
+            NotificationReceiver::Owned(notification_rx),
+            None,
+        )
+    }
+
+    /// Create a new RPC server with optional connection ID
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `connection_id` - Optional connection ID for subscription propagation to next SLIM node
+    /// * `notification_rx` - Receiver for session notifications
+    /// * `runtime` - Optional tokio runtime handle for spawning tasks
+    pub fn new_with_connection_and_runtime(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: mpsc::Receiver<Result<Notification, SessionError>>,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            connection_id,
+            NotificationReceiver::Owned(notification_rx),
+            runtime,
+        )
+    }
+
+    /// Create a new RPC server with shared notification receiver
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `notification_rx` - Shared Arc to the notification receiver
+    pub fn new_with_shared_rx(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        notification_rx: Arc<
+            tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>,
+        >,
+    ) -> Self {
+        Self::new_with_shared_rx_and_connection(app, base_name, None, notification_rx, None)
+    }
+
+    /// Create a new RPC server with shared notification receiver and connection ID
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server (e.g., "org/namespace/app")
+    /// * `connection_id` - Optional connection ID for subscription propagation to next SLIM node
+    /// * `notification_rx` - Shared Arc to the notification receiver
+    /// * `runtime` - Optional tokio runtime handle for spawning tasks
+    pub fn new_with_shared_rx_and_connection(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: Arc<
+            tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>,
+        >,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            connection_id,
+            NotificationReceiver::Shared(notification_rx),
+            runtime,
+        )
+    }
+
+    /// Internal constructor - single point of truth for Server construction
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app to use for communication
+    /// * `base_name` - The base name for this server
+    /// * `connection_id` - Optional connection ID for subscription propagation
+    /// * `notification_rx` - Notification receiver (owned or shared)
+    /// * `runtime` - Optional tokio runtime handle for spawning tasks
+    fn construct_internal(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: NotificationReceiver,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        let (drain_signal, drain_watch) = drain::channel();
+
+        // Resolve runtime handle: use provided or try to get current
+        let runtime = runtime.unwrap_or_else(|| {
+            tokio::runtime::Handle::try_current()
+                .expect("No tokio runtime found. Either provide a runtime handle or call from within a tokio runtime context")
+        });
+
+        Self {
+            app,
+            registry: RwLock::new(ServiceRegistry::new()),
+            base_name,
+            connection_id,
+            notification_rx: parking_lot::Mutex::new(Some(notification_rx)),
+            drain_signal: RwLock::new(Some(drain_signal)),
+            drain_watch: RwLock::new(Some(drain_watch)),
+            runtime,
+        }
+    }
+
+    /// Register a unary-unary RPC handler
+    ///
+    /// Handles a single request and returns a single response.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request and context, returns a response
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { name: String }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { greeting: String }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// server.register_unary_unary_internal(
+    ///     "GreeterService",
+    ///     "SayHello",
+    ///     |request: Request, _ctx: Context| async move {
+    ///         Ok(Response {
+    ///             greeting: format!("Hello, {}", request.name)
+    ///         })
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_unary_unary_internal<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_unary_unary(service_name, method_name, handler);
+    }
+
+    /// Register a unary-stream RPC handler
+    ///
+    /// Handles a single request and returns a stream of responses.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request and returns a stream of responses
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # use futures::stream;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { count: i32 }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { value: i32 }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// server.register_unary_stream_internal(
+    ///     "NumberService",
+    ///     "GenerateNumbers",
+    ///     |request: Request, _ctx: Context| async move {
+    ///         let numbers: Vec<Result<Response, RpcError>> = (0..request.count)
+    ///             .map(|i| Ok(Response { value: i }))
+    ///             .collect();
+    ///         Ok(stream::iter(numbers))
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_unary_stream_internal<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_unary_stream(service_name, method_name, handler);
+    }
+
+    /// Register a stream-unary RPC handler
+    ///
+    /// Handles a stream of requests and returns a single response.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request stream and returns a response
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # use futures::StreamExt;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { value: i32 }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { sum: i32 }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// # use slim_bindings::DecodedStream;
+    /// server.register_stream_unary_internal(
+    ///     "AggregateService",
+    ///     "SumNumbers",
+    ///     |mut request_stream: DecodedStream<Request>, _ctx: Context| async move {
+    ///         let mut sum = 0;
+    ///         while let Some(result) = request_stream.next().await {
+    ///             let request = result?;
+    ///             sum += request.value;
+    ///         }
+    ///         Ok(Response { sum })
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_stream_unary_internal<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_stream_unary(service_name, method_name, handler);
+    }
+
+    /// Register a stream-stream RPC handler
+    ///
+    /// Handles a stream of requests and returns a stream of responses.
+    ///
+    /// # Arguments
+    /// * `service_name` - The name of the service
+    /// * `method_name` - The name of the method
+    /// * `handler` - An async function that takes a request stream and returns a response stream
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, Context, RpcError, Decoder, Encoder, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # use futures::StreamExt;
+    /// # use async_stream::stream;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// # #[derive(Default)]
+    /// # struct Request { message: String }
+    /// # impl Decoder for Request {
+    /// #     fn decode(_buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> { Ok(Request::default()) }
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Response { reply: String }
+    /// # impl Encoder for Response {
+    /// #     fn encode(self) -> Result<Vec<u8>, RpcError> { Ok(vec![]) }
+    /// # }
+    /// # use slim_bindings::DecodedStream;
+    /// server.register_stream_stream_internal(
+    ///     "EchoService",
+    ///     "Echo",
+    ///     |mut request_stream: DecodedStream<Request>, _ctx: Context| async move {
+    ///         let responses = stream! {
+    ///             while let Some(result) = request_stream.next().await {
+    ///                 match result {
+    ///                     Ok(request) => {
+    ///                         yield Ok(Response {
+    ///                             reply: format!("Echo: {}", request.message)
+    ///                         });
+    ///                     }
+    ///                     Err(e) => {
+    ///                         yield Err(e);
+    ///                         break;
+    ///                     }
+    ///                 }
+    ///             }
+    ///         };
+    ///         Ok(responses)
+    ///     }
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_stream_stream_internal<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_stream_stream(service_name, method_name, handler);
+    }
+
+    /// Get all registered method paths
+    ///
+    /// Returns a list of all registered service/method paths in the format "Service/Method".
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// let methods = server.methods();
+    /// for method in methods {
+    ///     println!("Registered: {}", method);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn methods(&self) -> Vec<String> {
+        self.registry.read().methods()
+    }
+
+    /// Start the server and listen for incoming RPC requests in a separate task
+    ///
+    /// This method spawns a background task that listens for incoming sessions and
+    /// dispatches them to registered handlers. The service/method routing is determined
+    /// by metadata in the session.
+    ///
+    /// The spawned task runs indefinitely until [`shutdown`](Self::shutdown) is called
+    /// or an error occurs.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `JoinHandle` for the spawned server task. The task result is `Result<(), RpcError>`.
+    ///
+    /// # Example
+    ///
+    /// This is a private internal method. Use the public `serve()` or `serve_async()` methods instead:
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// // Register handlers first...
+    ///
+    /// // For async contexts, use serve_async():
+    /// // server.serve_async().await?;
+    ///
+    /// // For blocking contexts, use serve():
+    /// // server.serve()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn serve_handle(&self) -> Result<JoinHandle<ServeHandleResult>, RpcError> {
+        let notification = self
+            .notification_rx
+            .lock()
+            .take()
+            .ok_or(RpcError::internal("server already running"))?;
+
+        let registry = self.registry.read().clone();
+        let base_name = self.base_name.clone();
+        let app = self.app.clone();
+        let connection_id = self.connection_id;
+        let drain_watch = self
+            .drain_watch
+            .read()
+            .clone()
+            .ok_or_else(|| RpcError::internal("drain_watch not available"))?;
+
+        let ret = self.runtime.spawn(Server::serve_internal(
+            notification,
+            registry,
+            connection_id,
+            base_name,
+            app,
+            drain_watch,
+        ));
+
+        Ok(ret)
+    }
+
+    /// Internal server loop implementation
+    ///
+    /// This method contains the actual server loop logic and is called by [`serve`](Self::serve)
+    /// in a spawned task.
+    async fn serve_internal(
+        mut rx: NotificationReceiver,
+        registry: ServiceRegistry,
+        connection_id: Option<u64>,
+        base_name: Name,
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        drain_watch: drain::Watch,
+    ) -> (NotificationReceiver, Result<(), RpcError>) {
+        tracing::info!(
+            %base_name,
+            "SlimRPC server starting"
+        );
+
+        // Subscribe to the base name so that the SLIM network routes incoming
+        // sessions to this server.
+        tracing::info!(%base_name, "Subscribing");
+        if let Err(e) = app.subscribe(&base_name, connection_id).await {
+            let status = RpcError::internal(format!("Failed to subscribe to {base_name}: {e}"));
+            return (rx, Err(status));
+        }
+
+        // Save spawned tasks
+        let mut tasks = vec![];
+
+        // Pin the drain watch for use in select (clone to avoid moving)
+        let mut drain_signaled = std::pin::pin!(drain_watch.clone().signaled());
+
+        // Main server loop - listen for sessions
+        loop {
+            tokio::select! {
+                // Handle shutdown signal via drain
+                _ = &mut drain_signaled => {
+                    tracing::info!("Server received drain signal, waiting for {} tasks to complete", tasks.len());
+                    break;
+                }
+                // Handle incoming sessions
+                session_result = Server::listen_for_session(&mut rx) => {
+                    tracing::debug!("Received session notification");
+
+                    let session_ctx = match session_result {
+                        Ok(ctx) => ctx,
+                        Err(e) => {
+                            tracing::error!("Error receiving session: {}", e);
+                            return (rx, Err(e));
+                        }
+                    };
+
+                    tracing::debug!("Received new session — starting per-session demux task");
+
+                    let (session_tx, session_rx) = new_session(session_ctx);
+                    tasks.push(tokio::spawn(run_session_demux(
+                        session_tx,
+                        session_rx,
+                        registry.clone(),
+                        app.clone(),
+                        drain_watch.clone(),
+                    )));
+                }
+            }
+        }
+
+        // Wait for all tasks to finish
+        tracing::debug!("Waiting for {} session tasks to complete", tasks.len());
+        let results = join_all(tasks).await;
+
+        // Log any panicked tasks
+        let mut panicked_count = 0;
+        for (idx, result) in results.iter().enumerate() {
+            if let Err(e) = result {
+                tracing::error!(task_index = idx, error = %e, "Session task panicked");
+                panicked_count += 1;
+            }
+        }
+
+        if panicked_count > 0 {
+            tracing::warn!("{} session tasks panicked during shutdown", panicked_count);
+        } else {
+            tracing::info!("All session tasks completed successfully");
+        }
+
+        (rx, Ok(()))
+    }
+
+    /// Shutdown the server gracefully
+    ///
+    /// This signals all active session handlers to terminate and waits for them to drain.
+    /// After shutdown completes, the server can be restarted by calling [`serve`](Self::serve) again.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use slim_bindings::{Server, App, Name, IdentityProviderConfig, IdentityVerifierConfig};
+    /// # use std::sync::Arc;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let app_name = Arc::new(Name::new("test".to_string(), "app".to_string(), "v1".to_string()));
+    /// # let provider = IdentityProviderConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let verifier = IdentityVerifierConfig::SharedSecret { id: "test".to_string(), data: "secret".to_string() };
+    /// # let app = App::new(app_name, provider, verifier)?;
+    /// # let core_app = app.inner();
+    /// # let notification_rx = app.notification_receiver();
+    /// # let base_name = Name::new("org".to_string(), "namespace".to_string(), "service".to_string());
+    /// # let server = Server::new_with_shared_rx_and_connection(core_app, base_name.as_slim_name(), None, notification_rx, None);
+    /// // In another task or signal handler:
+    /// # slim_bindings::get_runtime().block_on(async {
+    /// server.shutdown_internal().await;
+    /// # });
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn shutdown_internal(&self) {
+        tracing::info!("Shutting down SlimRPC server");
+
+        // Take the drain signal and watch
+        let drain_signal = self.drain_signal.write().take();
+        let drain_watch = self.drain_watch.write().take();
+
+        // Drop the watch to complete the drain
+        drop(drain_watch);
+
+        // Signal all session handlers to terminate
+        if let Some(signal) = drain_signal {
+            signal.drain().await;
+        }
+
+        // Recreate drain signal and watch so the server can be restarted
+        let (new_signal, new_watch) = drain::channel();
+        *self.drain_signal.write() = Some(new_signal);
+        *self.drain_watch.write() = Some(new_watch);
+
+        tracing::debug!("Server shutdown complete, ready to restart");
+    }
+
+    /// Listen for an incoming session from the notification receiver
+    async fn listen_for_session(
+        notification_rx: &mut NotificationReceiver,
+    ) -> Result<slim_session::context::SessionContext, RpcError> {
+        tracing::debug!("Waiting for incoming session notification");
+        let notification_opt = match notification_rx {
+            NotificationReceiver::Owned(rx) => rx.recv().await,
+            NotificationReceiver::Shared(rx_arc) => {
+                // For shared receiver, put it back immediately and work with the Arc
+                tracing::debug!("Acquiring shared notification receiver");
+
+                // Now lock and receive from the shared receiver
+                let mut rx = rx_arc.write().await;
+                tracing::debug!("Receiving from shared notification receiver");
+                rx.recv().await
+            }
+        };
+
+        if notification_opt.is_none() {
+            return Err(RpcError::internal("notification channel closed"));
+        }
+
+        let notification = notification_opt
+            .unwrap()
+            .map_err(|e| RpcError::internal(format!("Session error: {e}")))?;
+
+        match notification {
+            Notification::NewSession(session_ctx) => Ok(session_ctx),
+            _ => Err(RpcError::internal("Unexpected notification type")),
+        }
+    }
+}
+
+// UniFFI-compatible methods for foreign language bindings
+#[uniffi::export]
+impl Server {
+    /// Create a new RPC server
+    ///
+    /// This is the primary constructor for creating an RPC server instance
+    /// that can handle incoming RPC requests over SLIM.
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM application instance that provides the underlying
+    ///   network transport and session management
+    /// * `base_name` - The base name for this service (e.g., org.namespace.service).
+    ///   This name is used to construct subscription names for RPC methods.
+    ///
+    /// # Returns
+    /// A new RPC server instance wrapped in an Arc for shared ownership
+    #[uniffi::constructor]
+    pub fn new(app: &Arc<crate::App>, base_name: Arc<crate::Name>) -> Self {
+        Self::new_with_connection(app, base_name, None)
+    }
+
+    /// Create a new RPC server with optional connection ID
+    ///
+    /// The connection ID is used to set up routing before serving RPC requests,
+    /// enabling multi-hop RPC calls through specific connections.
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM application instance that provides the underlying
+    ///   network transport and session management
+    /// * `base_name` - The base name for this service (e.g., org.namespace.service).
+    ///   This name is used to construct subscription names for RPC methods.
+    /// * `connection_id` - Optional connection ID for routing setup
+    ///
+    /// # Returns
+    /// A new RPC server instance wrapped in an Arc for shared ownership
+    #[uniffi::constructor]
+    pub fn new_with_connection(
+        app: &Arc<crate::App>,
+        base_name: Arc<crate::Name>,
+        connection_id: Option<u64>,
+    ) -> Self {
+        let app_inner = app.inner();
+        let rx = app.notification_receiver();
+
+        Self::new_with_shared_rx_and_connection(
+            app_inner,
+            base_name.as_ref().into(),
+            connection_id,
+            rx,
+            Some(crate::get_runtime()),
+        )
+    }
+
+    /// Register a unary-to-unary RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name (e.g., "MyService")
+    /// * `method_name` - The method name (e.g., "GetUser")
+    /// * `handler` - Implementation of the UnaryUnaryHandler trait
+    pub fn register_unary_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn UnaryUnaryHandler>,
+    ) {
+        let service_clone = service_name.clone();
+        let method_clone = method_name.clone();
+
+        tracing::debug!(service = %service_clone, method = %method_clone, "Registering unary-unary handler");
+
+        self.register_unary_unary_internal(
+            &service_name,
+            &method_name,
+            move |request: Vec<u8>, context: Context| {
+                let handler = handler.clone();
+                tracing::debug!(service = %service_clone, method = %method_clone, "Handling unary-unary request");
+
+                async move { handler.handle(request, Arc::new(context)).await }
+            },
+        );
+    }
+
+    /// Register a unary-to-stream RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name
+    /// * `method_name` - The method name
+    /// * `handler` - Implementation of the UnaryStreamHandler trait
+    pub fn register_unary_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn UnaryStreamHandler>,
+    ) {
+        self.register_unary_stream_internal(
+            &service_name,
+            &method_name,
+            move |request: Vec<u8>, context: Context| {
+                let handler = handler.clone();
+
+                async move {
+                    let (sink, rx) = ResponseSink::receiver();
+                    let sink_arc = Arc::new(sink);
+
+                    // Spawn a task to run the handler
+                    let handler_task = {
+                        let sink = sink_arc.clone();
+                        crate::get_runtime().spawn(async move {
+                            if let Err(e) = handler
+                                .handle(request, Arc::new(context), sink.clone())
+                                .await
+                            {
+                                let _ = sink.send_error_async(e).await;
+                            }
+                        })
+                    };
+
+                    // Detach the task - it will run independently
+                    drop(handler_task);
+
+                    // Convert the receiver to a stream
+                    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+                    Ok(stream)
+                }
+            },
+        );
+    }
+
+    /// Register a stream-to-unary RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name
+    /// * `method_name` - The method name
+    /// * `handler` - Implementation of the StreamUnaryHandler trait
+    pub fn register_stream_unary(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn StreamUnaryHandler>,
+    ) {
+        self.register_stream_unary_internal(
+            &service_name,
+            &method_name,
+            move |stream: DecodedStream<Vec<u8>>, context: Context| {
+                let handler = handler.clone();
+                let request_stream = Arc::new(UniffiRequestStream::new(stream));
+
+                async move { handler.handle(request_stream, Arc::new(context)).await }
+            },
+        );
+    }
+
+    /// Register a stream-to-stream RPC handler
+    ///
+    /// # Arguments
+    /// * `service_name` - The service name
+    /// * `method_name` - The method name
+    /// * `handler` - Implementation of the StreamStreamHandler trait
+    pub fn register_stream_stream(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn StreamStreamHandler>,
+    ) {
+        self.register_stream_stream_internal(
+            &service_name,
+            &method_name,
+            move |stream: DecodedStream<Vec<u8>>, context: Context| {
+                let handler = handler.clone();
+                let request_stream = Arc::new(UniffiRequestStream::new(stream));
+
+                async move {
+                    let (sink, rx) = ResponseSink::receiver();
+                    let sink_arc = Arc::new(sink);
+
+                    // Spawn a task to run the handler
+                    let handler_task = {
+                        let sink = sink_arc.clone();
+                        crate::get_runtime().spawn(async move {
+                            if let Err(e) = handler
+                                .handle(request_stream, Arc::new(context), sink.clone())
+                                .await
+                            {
+                                let _ = sink.send_error_async(e).await;
+                            }
+                        })
+                    };
+
+                    // Detach the task - it will run independently
+                    drop(handler_task);
+
+                    // Convert the receiver to a stream
+                    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+                    Ok(stream)
+                }
+            },
+        );
+    }
+
+    /// Start serving RPC requests (blocking version)
+    ///
+    /// This is a blocking method that runs until the server is shut down.
+    /// It listens for incoming RPC calls and dispatches them to registered handlers.
+    pub fn serve(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.serve_async())
+    }
+
+    /// Start serving RPC requests (async version)
+    ///
+    /// This is an async method that runs until the server is shut down.
+    /// It listens for incoming RPC calls and dispatches them to registered handlers.
+    pub async fn serve_async(&self) -> Result<(), RpcError> {
+        let handle = self.serve_handle()?;
+
+        // Wait for the server task to complete and restore the NotificationReceiver
+        let (notification_rx, result) = handle
+            .await
+            .map_err(|e| RpcError::new(RpcCode::Internal, format!("Server task panicked: {e}")))?;
+
+        // Restore the NotificationReceiver back to the server
+        *self.notification_rx.lock() = Some(notification_rx);
+
+        // Return the result from the server task
+        result.map_err(|e| RpcError::new(RpcCode::Internal, e.to_string()))
+    }
+
+    /// Shutdown the server gracefully (blocking version)
+    ///
+    /// This signals the server to stop accepting new requests and wait for
+    /// in-flight requests to complete.
+    pub fn shutdown(&self) {
+        crate::get_runtime().block_on(self.shutdown_async())
+    }
+
+    /// Shutdown the server gracefully (async version)
+    ///
+    /// This signals the server to stop accepting new requests and wait for
+    /// in-flight requests to complete.
+    pub async fn shutdown_async(&self) {
+        self.shutdown_internal().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_registry_new() {
+        let registry = ServiceRegistry::new();
+        assert_eq!(registry.methods().len(), 0);
+    }
+
+    #[test]
+    fn test_build_method_name() {
+        // Test name building logic without requiring full App setup
+        let base_name = Name::from_strings(["org", "namespace", "app"]);
+        let (_, _, c2) = base_name.str_components();
+        let expected = format!("{}-{}-{}", c2, "MyService", "MyMethod");
+
+        assert_eq!(expected, "app-MyService-MyMethod");
+    }
+
+    #[test]
+    fn test_parse_method_from_destination() {
+        // Test parsing logic
+        let full_method = "app-MyService-MyMethod";
+        let base_app = "app";
+
+        if let Some(suffix) = full_method.strip_prefix(&format!("{base_app}-")) {
+            let parts: Vec<&str> = suffix.splitn(2, '-').collect();
+            assert_eq!(parts.len(), 2);
+            assert_eq!(parts[0], "MyService");
+            assert_eq!(parts[1], "MyMethod");
+        } else {
+            panic!("Failed to parse method name");
+        }
+    }
+
+    #[test]
+    fn test_handler_type_equality() {
+        assert_eq!(HandlerType::UnaryUnary, HandlerType::UnaryUnary);
+        assert_ne!(HandlerType::UnaryUnary, HandlerType::UnaryStream);
+    }
+}

--- a/crates/slim-bindings/src/slimrpc/session_wrapper.rs
+++ b/crates/slim-bindings/src/slimrpc/session_wrapper.rs
@@ -1,0 +1,194 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session wrapper for SlimRPC operations
+//!
+//! Provides a lightweight wrapper around SessionContext that exposes the
+//! publish and receive operations needed for RPC communication.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use display_error_chain::ErrorChainExt;
+
+use futures_timer::Delay;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::app::App as SlimApp;
+use slim_session::context::SessionContext;
+use slim_session::errors::SessionError;
+use slim_session::{AppChannelReceiver, CompletionHandle};
+
+use super::{RpcCode, RpcError, STATUS_CODE_KEY};
+
+/// Received message from a session
+#[derive(Debug, Clone)]
+pub struct ReceivedMessage {
+    /// Message metadata
+    pub metadata: std::collections::HashMap<String, String>,
+    /// Message payload
+    pub payload: Vec<u8>,
+    /// Name of the app that sent this message (extracted from the SLIM header)
+    pub source: Name,
+}
+
+impl ReceivedMessage {
+    /// Returns `true` when this message is an end-of-stream marker:
+    /// status code is `Ok` **and** the payload is empty.
+    pub fn is_eos(&self) -> bool {
+        RpcCode::from_metadata_str(self.metadata.get(STATUS_CODE_KEY).map(String::as_str))
+            == RpcCode::Ok
+            && self.payload.is_empty()
+    }
+}
+
+/// Session transmitter - used only for sending messages
+#[derive(Clone)]
+pub struct SessionTx {
+    /// The underlying session controller
+    controller: Arc<slim_session::session_controller::SessionController>,
+}
+
+/// Session receiver - used only for receiving messages
+pub struct SessionRx {
+    /// Receiver for incoming messages
+    rx: AppChannelReceiver,
+}
+
+impl SessionTx {
+    /// Get the session ID
+    pub fn session_id(&self) -> u32 {
+        self.controller.id()
+    }
+
+    /// Get the source name
+    pub fn source(&self) -> &Name {
+        self.controller.source()
+    }
+
+    /// Get the destination name
+    pub fn destination(&self) -> &Name {
+        self.controller.dst()
+    }
+
+    /// Get session metadata
+    pub fn metadata(&self) -> std::collections::HashMap<String, String> {
+        self.controller.metadata()
+    }
+
+    /// Publish a message to `target` through this session.
+    ///
+    /// Pass `self.destination()` for broadcast behaviour, or pass the
+    /// requester's source name to unicast a reply directly to the caller.
+    pub async fn publish(
+        &self,
+        target: &Name,
+        data: Vec<u8>,
+        payload_type: Option<String>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Result<CompletionHandle, RpcError> {
+        self.controller
+            .publish(target, data, payload_type, metadata)
+            .await
+            .map_err(|e| RpcError::internal(e.chain().to_string()))
+    }
+
+    /// Get a clone of the underlying session controller
+    pub fn controller(&self) -> Arc<slim_session::session_controller::SessionController> {
+        self.controller.clone()
+    }
+
+    /// Close the session and delete it from the app
+    ///
+    /// This properly cleans up the session resources by calling app.delete_session().
+    /// After calling this, the session should not be used anymore.
+    ///
+    /// # Arguments
+    /// * `app` - The SLIM app instance to delete the session from
+    pub async fn close(&self, app: &SlimApp<AuthProvider, AuthVerifier>) -> Result<(), RpcError> {
+        tracing::debug!(session_id = %self.controller.id(), "Closing session");
+
+        match app.delete_session(self.controller.as_ref()) {
+            Ok(handle) => {
+                handle.await.map_err(|e| {
+                    RpcError::internal(format!("Failed to delete session: {}", e.chain()))
+                })?;
+                tracing::debug!(session_id = %self.controller.id(), "Successfully deleted session");
+            }
+            Err(e) => {
+                tracing::warn!(session_id = %self.controller.id(), error = %e, "Failed to delete session");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SessionRx {
+    /// Receive a message from the session with optional timeout.
+    ///
+    /// Returns `Err(SessionError::SessionClosed)` when the channel is gone,
+    /// `Err(SessionError::ReceiveTimeout)` on timeout, and the raw
+    /// `SessionError` for all other session-level errors (e.g.
+    /// `ParticipantDisconnected`).  Callers can therefore distinguish
+    /// transient membership events from fatal failures.
+    pub async fn get_message(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<ReceivedMessage, SessionError> {
+        let recv_future = async {
+            let msg = self.rx.recv().await.ok_or(SessionError::SessionClosed)??;
+
+            // Extract payload from the proto message
+            let payload = if let Some(content) = msg.get_payload() {
+                if let Ok(app_payload) = content.as_application_payload() {
+                    app_payload.blob.clone()
+                } else {
+                    Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
+
+            let source = msg.get_source();
+            Ok(ReceivedMessage {
+                metadata: msg.metadata,
+                payload,
+                source,
+            })
+        };
+
+        if let Some(timeout_duration) = timeout {
+            futures::pin_mut!(recv_future);
+            let delay = Delay::new(timeout_duration);
+            futures::pin_mut!(delay);
+
+            match futures::future::select(recv_future, delay).await {
+                futures::future::Either::Left((result, _)) => result,
+                futures::future::Either::Right(_) => Err(SessionError::ReceiveTimeout),
+            }
+        } else {
+            recv_future.await
+        }
+    }
+}
+
+/// Create session transmitter and receiver from a SessionContext
+///
+/// Returns a tuple of (SessionTx, SessionRx) where:
+/// - SessionTx is used only for sending messages
+/// - SessionRx is used only for receiving messages
+pub fn new_session(ctx: SessionContext) -> (SessionTx, SessionRx) {
+    let (session_weak, rx) = ctx.into_parts();
+    let controller = session_weak
+        .upgrade()
+        .expect("Session controller should be available");
+
+    let tx = SessionTx {
+        controller: controller.clone(),
+    };
+
+    let rx_wrapper = SessionRx { rx };
+
+    (tx, rx_wrapper)
+}

--- a/crates/slim-bindings/src/slimrpc/stream_types.rs
+++ b/crates/slim-bindings/src/slimrpc/stream_types.rs
@@ -1,0 +1,848 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stream wrapper types for SlimRPC UniFFI bindings
+//!
+//! Provides UniFFI-compatible wrappers for streaming operations.
+//! Since UniFFI doesn't support Rust async streams, we provide synchronous
+//! pull/push interfaces backed by async channels.
+
+use std::pin::Pin;
+use std::task::Poll;
+
+use futures::StreamExt;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tokio::sync::{
+    Mutex as TokioMutex,
+    mpsc::{self, UnboundedReceiver, UnboundedSender, unbounded_channel},
+};
+
+use super::{Channel, MulticastItem, ReceivedMessage, RpcCode, RpcError, STATUS_CODE_KEY};
+
+/// Result type for raw byte payloads flowing through the RPC streams.
+type RpcBytesResult = Result<Vec<u8>, RpcError>;
+/// Sender end of a channel carrying RPC byte results.
+type RpcBytesSender = UnboundedSender<RpcBytesResult>;
+/// Tokio JoinHandle producing a final RPC byte result.
+type RpcBytesJoinHandle = tokio::task::JoinHandle<RpcBytesResult>;
+
+/// Raw byte stream for a stream-input RPC call.
+///
+/// Implements [`Stream`] directly using `poll_recv` — no heap allocation.
+/// All fields are [`Unpin`], so this type is `Unpin` too.
+///
+/// Yielded values:
+/// - `Ok(payload)` — normal message bytes
+/// - `Err(e)` — protocol error (bad status code, channel closed)
+///
+/// The stream ends (returns `None`) on EOS or after yielding an error.
+pub struct RawStream {
+    session_rx: Option<mpsc::UnboundedReceiver<ReceivedMessage>>,
+    payload: Vec<u8>,
+    first_is_eos: bool,
+    first_code: RpcCode,
+    /// `true` once the first message has been yielded or skipped.
+    first_done: bool,
+    /// `true` once the stream has permanently ended (EOS, error, or channel close).
+    done: bool,
+}
+
+impl futures::Stream for RawStream {
+    type Item = Result<Vec<u8>, RpcError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        // ── First message ────────────────────────────────────────────────────
+        if !self.first_done {
+            self.first_done = true;
+
+            if self.first_is_eos {
+                self.done = true;
+                return Poll::Ready(None);
+            }
+
+            let first_code = self.first_code;
+            if first_code != RpcCode::Ok {
+                let payload = std::mem::take(&mut self.payload);
+                self.done = true;
+                return Poll::Ready(Some(Err(RpcError::new(
+                    first_code,
+                    String::from_utf8_lossy(&payload).into_owned(),
+                ))));
+            }
+
+            let payload = std::mem::take(&mut self.payload);
+            return Poll::Ready(Some(Ok(payload)));
+        }
+
+        // ── Continuation messages ────────────────────────────────────────────
+        let Some(ref mut rx) = self.session_rx else {
+            self.done = true;
+            return Poll::Ready(None);
+        };
+
+        match rx.poll_recv(cx) {
+            Poll::Ready(Some(msg)) => {
+                tracing::debug!("Received message in stream-based method");
+
+                if msg.is_eos() {
+                    self.done = true;
+                    return Poll::Ready(None);
+                }
+
+                let code = RpcCode::from_metadata_str(
+                    msg.metadata.get(STATUS_CODE_KEY).map(String::as_str),
+                );
+                if code != RpcCode::Ok {
+                    let message = String::from_utf8_lossy(&msg.payload).into_owned();
+                    self.done = true;
+                    return Poll::Ready(Some(Err(RpcError::new(code, message))));
+                }
+
+                Poll::Ready(Some(Ok(msg.payload)))
+            }
+            Poll::Ready(None) => {
+                self.done = true;
+                Poll::Ready(Some(Err(RpcError::internal("Stream channel closed"))))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// A decoded request stream: `RawStream` items mapped through `Req::decode`.
+///
+/// Using a concrete named type (instead of `BoxStream`) lets the compiler
+/// stack-allocate the stream combinator and eliminates the `BoxStream`
+/// allocation that `RequestStream<Req>` required.
+///
+/// Handlers registered via `register_stream_unary_internal` /
+/// `register_stream_stream_internal` receive `DecodedStream<Req>` directly.
+pub type DecodedStream<Req> =
+    futures::stream::Map<RawStream, fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError>>;
+
+/// Raw stream components passed to stream-input handlers.
+///
+/// Holding the raw components avoids boxing at the dispatch level. Each typed
+/// wrapper calls [`StreamSource::into_raw_stream`] to get a [`RawStream`], then
+/// maps it to the decoded type — with zero heap allocations.
+pub struct StreamSource {
+    pub session_rx: Option<mpsc::UnboundedReceiver<ReceivedMessage>>,
+    pub payload: Vec<u8>,
+    pub first_is_eos: bool,
+    pub first_code: RpcCode,
+}
+
+impl StreamSource {
+    /// Consume `self` and produce an allocation-free [`RawStream`].
+    pub fn into_raw_stream(self) -> RawStream {
+        RawStream {
+            session_rx: self.session_rx,
+            payload: self.payload,
+            first_is_eos: self.first_is_eos,
+            first_code: self.first_code,
+            first_done: false,
+            done: false,
+        }
+    }
+}
+
+/// Request stream reader
+///
+/// Allows pulling messages from a client request stream.
+/// This wraps the underlying async stream and provides a blocking interface
+/// suitable for UniFFI callback traits.
+#[derive(uniffi::Object)]
+pub struct RequestStream {
+    /// Inner stream wrapped in a mutex for interior mutability
+    inner: TokioMutex<DecodedStream<Vec<u8>>>,
+}
+
+impl RequestStream {
+    /// Create a new request stream wrapper
+    pub fn new(stream: DecodedStream<Vec<u8>>) -> Self {
+        Self {
+            inner: TokioMutex::new(stream),
+        }
+    }
+}
+
+#[uniffi::export]
+impl RequestStream {
+    /// Pull the next message from the stream (blocking version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub fn next(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next message from the stream (async version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub async fn next_async(&self) -> StreamMessage {
+        let mut stream = self.inner.lock().await;
+        match stream.next().await {
+            Some(Ok(data)) => StreamMessage::Data(data),
+            Some(Err(e)) => StreamMessage::Error(e),
+            None => StreamMessage::End,
+        }
+    }
+}
+
+/// Message from a stream
+#[derive(uniffi::Enum)]
+pub enum StreamMessage {
+    /// Successfully received data
+    Data(Vec<u8>),
+    /// Stream error occurred
+    Error(RpcError),
+    /// Stream has ended
+    End,
+}
+
+/// Response stream writer
+///
+/// Allows pushing messages to a client response stream.
+/// This wraps an async channel sender and provides a blocking interface
+/// suitable for UniFFI callback traits.
+#[derive(uniffi::Object)]
+pub struct ResponseSink {
+    /// Channel sender for streaming responses (None when closed)
+    sender: Mutex<Option<RpcBytesSender>>,
+}
+
+impl ResponseSink {
+    /// Create a new response sink wrapper
+    pub fn new(sender: UnboundedSender<Result<Vec<u8>, RpcError>>) -> Self {
+        Self {
+            sender: Mutex::new(Some(sender)),
+        }
+    }
+
+    /// Get the receiver side of the channel
+    pub fn receiver() -> (Self, UnboundedReceiver<Result<Vec<u8>, RpcError>>) {
+        let (tx, rx) = unbounded_channel();
+        let sink = Self::new(tx);
+        (sink, rx)
+    }
+}
+
+#[uniffi::export]
+impl ResponseSink {
+    /// Send a message to the response stream (blocking version)
+    ///
+    /// Returns an error if the stream has been closed or if sending fails.
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a message to the response stream (async version)
+    ///
+    /// Returns an error if the stream has been closed or if sending fails.
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock();
+        match sender.as_ref() {
+            Some(s) => s.send(Ok(data)).map_err(|_| {
+                RpcError::new(RpcCode::Unavailable, "Failed to send response".to_string())
+            }),
+            None => Err(RpcError::new(
+                RpcCode::FailedPrecondition,
+                "Response sink is closed".to_string(),
+            )),
+        }
+    }
+
+    /// Send an error to the response stream and close it (blocking version)
+    ///
+    /// This terminates the stream with an error status.
+    pub fn send_error(&self, error: RpcError) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_error_async(error))
+    }
+
+    /// Send an error to the response stream and close it (async version)
+    ///
+    /// This terminates the stream with an error status.
+    pub async fn send_error_async(&self, error: RpcError) -> Result<(), RpcError> {
+        let mut sender_guard = self.sender.lock();
+        match sender_guard.take() {
+            Some(sender) => sender.send(Err(error)).map_err(|_| {
+                RpcError::new(RpcCode::Unavailable, "Failed to send error".to_string())
+            }),
+            None => Err(RpcError::new(
+                RpcCode::FailedPrecondition,
+                "Response sink is already closed".to_string(),
+            )),
+        }
+    }
+
+    /// Close the response stream (blocking version)
+    ///
+    /// Signals that no more messages will be sent.
+    /// The stream will end gracefully.
+    pub fn close(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_async())
+    }
+
+    /// Close the response stream (async version)
+    ///
+    /// Signals that no more messages will be sent.
+    /// The stream will end gracefully.
+    pub async fn close_async(&self) -> Result<(), RpcError> {
+        let mut sender = self.sender.lock();
+        sender.take(); // Drop the sender to signal stream end
+        Ok(())
+    }
+
+    /// Check if the sink has been closed (blocking version)
+    pub fn is_closed(&self) -> bool {
+        crate::get_runtime().block_on(self.is_closed_async())
+    }
+
+    /// Check if the sink has been closed (async version)
+    pub async fn is_closed_async(&self) -> bool {
+        self.sender.lock().is_none()
+    }
+}
+
+/// Response stream reader for unary-to-stream RPC calls
+///
+/// Allows pulling messages from a server response stream one at a time.
+#[derive(uniffi::Object)]
+pub struct ResponseStreamReader {
+    /// Inner receiver channel for stream messages
+    inner: TokioMutex<UnboundedReceiver<Result<Vec<u8>, RpcError>>>,
+}
+
+impl ResponseStreamReader {
+    /// Create a new response stream reader
+    pub fn new(rx: UnboundedReceiver<Result<Vec<u8>, RpcError>>) -> Self {
+        Self {
+            inner: TokioMutex::new(rx),
+        }
+    }
+}
+
+#[uniffi::export]
+impl ResponseStreamReader {
+    /// Pull the next message from the response stream (blocking version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub fn next(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next message from the response stream (async version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub async fn next_async(&self) -> StreamMessage {
+        let mut rx = self.inner.lock().await;
+        match rx.recv().await {
+            Some(Ok(data)) => StreamMessage::Data(data),
+            Some(Err(e)) => StreamMessage::Error(e),
+            None => StreamMessage::End,
+        }
+    }
+}
+
+/// Request stream writer for stream-to-unary RPC calls
+///
+/// Allows sending multiple request messages and getting a final response.
+#[derive(uniffi::Object)]
+pub struct RequestStreamWriter {
+    sender: TokioMutex<Option<UnboundedSender<Vec<u8>>>>,
+    response: TokioMutex<Option<RpcBytesJoinHandle>>,
+}
+
+impl RequestStreamWriter {
+    pub fn new(
+        channel: Channel,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        let (tx, mut rx) = unbounded_channel();
+
+        let channel_clone = channel;
+        let service_name_clone = service_name;
+        let method_name_clone = method_name;
+
+        // Spawn task to handle the stream_unary call
+        let response_handle = crate::get_runtime().spawn(async move {
+            use async_stream::stream;
+
+            let stream = stream! {
+                while let Some(data) = rx.recv().await {
+                    yield data;
+                }
+            };
+
+            channel_clone
+                .stream_unary::<Vec<u8>, Vec<u8>>(
+                    &service_name_clone,
+                    &method_name_clone,
+                    stream,
+                    timeout,
+                    metadata,
+                )
+                .await
+        });
+
+        Self {
+            sender: TokioMutex::new(Some(tx)),
+            response: TokioMutex::new(Some(response_handle)),
+        }
+    }
+}
+
+#[uniffi::export]
+impl RequestStreamWriter {
+    /// Send a request message to the stream (blocking version)
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a request message to the stream (async version)
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock().await;
+        if let Some(tx) = sender.as_ref() {
+            tx.send(data)
+                .map_err(|_| RpcError::new(RpcCode::Internal, "Stream closed".to_string()))
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already finalized".to_string(),
+            ))
+        }
+    }
+
+    /// Finalize the stream and get the response (blocking version)
+    pub fn finalize_stream(&self) -> Result<Vec<u8>, RpcError> {
+        crate::get_runtime().block_on(self.finalize_stream_async())
+    }
+
+    /// Finalize the stream and get the response (async version)
+    pub async fn finalize_stream_async(&self) -> Result<Vec<u8>, RpcError> {
+        // Drop the sender to signal end of stream
+        {
+            let mut sender = self.sender.lock().await;
+            *sender = None;
+        }
+
+        // Wait for response
+        let mut response_guard = self.response.lock().await;
+        if let Some(handle) = response_guard.take() {
+            handle
+                .await
+                .map_err(|e| RpcError::new(RpcCode::Internal, format!("Task failed: {e}")))?
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already finalized".to_string(),
+            ))
+        }
+    }
+}
+
+#[uniffi::export]
+impl RequestStreamWriter {
+    /// Finalize the stream and get the response (async version)
+    ///
+    /// **Deprecated**: Use [`finalize_stream_async`](Self::finalize_stream_async) instead.
+    pub async fn finalize_async(&self) -> Result<Vec<u8>, RpcError> {
+        self.finalize_stream_async().await
+    }
+}
+
+/// Bidirectional stream handler for stream-to-stream RPC calls
+///
+/// Allows sending and receiving messages concurrently.
+#[derive(uniffi::Object)]
+pub struct BidiStreamHandler {
+    sender: TokioMutex<Option<UnboundedSender<Vec<u8>>>>,
+    receiver: TokioMutex<UnboundedReceiver<Result<Vec<u8>, RpcError>>>,
+}
+
+impl BidiStreamHandler {
+    pub fn new(
+        channel: Channel,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        let (req_tx, mut req_rx) = unbounded_channel();
+        let (resp_tx, resp_rx) = unbounded_channel();
+
+        // Spawn task to handle the stream_stream call
+        crate::get_runtime().spawn(async move {
+            use async_stream::stream;
+
+            let request_stream = stream! {
+                while let Some(data) = req_rx.recv().await {
+                    yield data;
+                }
+            };
+
+            let response_stream = channel.stream_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request_stream,
+                timeout,
+                metadata,
+            );
+
+            futures::pin_mut!(response_stream);
+            while let Some(item) = futures::StreamExt::next(&mut response_stream).await {
+                if resp_tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            sender: TokioMutex::new(Some(req_tx)),
+            receiver: TokioMutex::new(resp_rx),
+        }
+    }
+}
+
+#[uniffi::export]
+impl BidiStreamHandler {
+    /// Send a request message to the stream (blocking version)
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a request message to the stream (async version)
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock().await;
+        if let Some(tx) = sender.as_ref() {
+            tx.send(data)
+                .map_err(|_| RpcError::new(RpcCode::Internal, "Stream closed".to_string()))
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already closed".to_string(),
+            ))
+        }
+    }
+
+    /// Close the request stream (no more messages will be sent)
+    pub fn close_send(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_send_async())
+    }
+
+    /// Close the request stream (async version)
+    pub async fn close_send_async(&self) -> Result<(), RpcError> {
+        let mut sender = self.sender.lock().await;
+        *sender = None;
+        Ok(())
+    }
+
+    /// Receive the next response message (blocking version)
+    pub fn recv(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.recv_async())
+    }
+
+    /// Receive the next response message (async version)
+    pub async fn recv_async(&self) -> StreamMessage {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(Ok(data)) => StreamMessage::Data(data),
+            Some(Err(e)) => StreamMessage::Error(e),
+            None => StreamMessage::End,
+        }
+    }
+}
+
+// ── Multicast stream types ────────────────────────────────────────────────────
+
+/// Per-message context for a multicast RPC response — identifies which group
+/// member sent the response.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct RpcMessageContext {
+    /// The SLIM name of the group member that sent this response.
+    pub source: Arc<crate::Name>,
+}
+
+/// A single item in a multicast response stream, pairing the response payload
+/// with the identity of the member that produced it.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct RpcMulticastItem {
+    /// Context identifying the source member.
+    pub context: RpcMessageContext,
+    /// The encoded response payload (raw bytes).
+    pub message: Vec<u8>,
+}
+
+/// Message from a multicast response stream.
+#[derive(uniffi::Enum)]
+pub enum MulticastStreamMessage {
+    /// Successfully received response item with source context.
+    Data { item: RpcMulticastItem },
+    /// Error from one member — other members may still be active.
+    Error { error: RpcError },
+    /// All members have finished — the stream has ended.
+    End,
+}
+
+/// Response stream reader for multicast RPC calls.
+///
+/// Allows pulling `RpcMulticastItem`s from a GROUP response stream one at a
+/// time. Each item carries the source member's identity alongside the payload.
+#[derive(uniffi::Object)]
+pub struct MulticastResponseReader {
+    inner: TokioMutex<UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>>,
+}
+
+impl MulticastResponseReader {
+    /// Create a new reader backed by the given mpsc receiver.
+    pub fn new(rx: UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>) -> Self {
+        Self {
+            inner: TokioMutex::new(rx),
+        }
+    }
+
+    /// Convert one channel item into a `MulticastStreamMessage`.
+    pub(crate) fn convert_item(
+        item: Result<MulticastItem<Vec<u8>>, RpcError>,
+    ) -> MulticastStreamMessage {
+        match item {
+            Ok(mi) => MulticastStreamMessage::Data {
+                item: RpcMulticastItem {
+                    context: RpcMessageContext {
+                        source: Arc::new(crate::Name::from_slim_name(mi.context.source)),
+                    },
+                    message: mi.message,
+                },
+            },
+            Err(e) => MulticastStreamMessage::Error { error: e },
+        }
+    }
+}
+
+#[uniffi::export]
+impl MulticastResponseReader {
+    /// Pull the next item from the multicast response stream (blocking).
+    pub fn next(&self) -> MulticastStreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next item from the multicast response stream (async).
+    pub async fn next_async(&self) -> MulticastStreamMessage {
+        let mut rx = self.inner.lock().await;
+        match rx.recv().await {
+            Some(item) => Self::convert_item(item),
+            None => MulticastStreamMessage::End,
+        }
+    }
+}
+
+/// Bidirectional stream handler for multicast stream-to-unary and
+/// stream-to-stream RPC calls.
+///
+/// Send request messages via [`send`](Self::send) / [`send_async`](Self::send_async),
+/// close the request stream via [`close_send`](Self::close_send), and receive
+/// responses via [`recv`](Self::recv) / [`recv_async`](Self::recv_async). Each
+/// response item carries the source member's identity.
+#[derive(uniffi::Object)]
+pub struct MulticastBidiStreamHandler {
+    sender: TokioMutex<Option<UnboundedSender<Vec<u8>>>>,
+    receiver: TokioMutex<UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>>,
+}
+
+impl MulticastBidiStreamHandler {
+    /// Create a new handler that pipes a request stream through a multicast
+    /// `stream_stream` call on `channel`.
+    pub fn new(
+        channel: Channel,
+        service_name: String,
+        method_name: String,
+        timeout: Option<std::time::Duration>,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        let (req_tx, mut req_rx) = unbounded_channel();
+        let (resp_tx, resp_rx) = unbounded_channel();
+
+        crate::get_runtime().spawn(async move {
+            use async_stream::stream;
+
+            let request_stream = stream! {
+                while let Some(data) = req_rx.recv().await {
+                    yield data;
+                }
+            };
+
+            let response_stream = channel.multicast_stream_stream::<Vec<u8>, Vec<u8>>(
+                &service_name,
+                &method_name,
+                request_stream,
+                timeout,
+                metadata,
+            );
+
+            futures::pin_mut!(response_stream);
+            while let Some(item) = futures::StreamExt::next(&mut response_stream).await {
+                if resp_tx.send(item).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            sender: TokioMutex::new(Some(req_tx)),
+            receiver: TokioMutex::new(resp_rx),
+        }
+    }
+}
+
+#[uniffi::export]
+impl MulticastBidiStreamHandler {
+    /// Send a request message to the stream (blocking).
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send a request message to the stream (async).
+    pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        let sender = self.sender.lock().await;
+        if let Some(tx) = sender.as_ref() {
+            tx.send(data)
+                .map_err(|_| RpcError::new(RpcCode::Internal, "Stream closed".to_string()))
+        } else {
+            Err(RpcError::new(
+                RpcCode::Internal,
+                "Stream already closed".to_string(),
+            ))
+        }
+    }
+
+    /// Close the request stream — signals that no more messages will be sent
+    /// (blocking).
+    pub fn close_send(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_send_async())
+    }
+
+    /// Close the request stream (async).
+    pub async fn close_send_async(&self) -> Result<(), RpcError> {
+        let mut sender = self.sender.lock().await;
+        *sender = None;
+        Ok(())
+    }
+
+    /// Receive the next response item (blocking).
+    pub fn recv(&self) -> MulticastStreamMessage {
+        crate::get_runtime().block_on(self.recv_async())
+    }
+
+    /// Receive the next response item (async).
+    pub async fn recv_async(&self) -> MulticastStreamMessage {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(item) => MulticastResponseReader::convert_item(item),
+            None => MulticastStreamMessage::End,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_request_stream() {
+        use crate::slimrpc::{ReceivedMessage, StreamSource};
+        use futures::StreamExt;
+        use slim_datapath::api::ProtoName as Name;
+
+        let dummy_name = Name::from_strings(["", "", ""]);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ReceivedMessage>();
+
+        // Second message
+        tx.send(ReceivedMessage {
+            metadata: std::collections::HashMap::new(),
+            payload: vec![4, 5, 6],
+            source: dummy_name.clone(),
+        })
+        .unwrap();
+        // EOS: empty payload with default (Ok) status code
+        tx.send(ReceivedMessage {
+            metadata: std::collections::HashMap::new(),
+            payload: vec![],
+            source: dummy_name,
+        })
+        .unwrap();
+
+        let source = StreamSource {
+            session_rx: Some(rx),
+            payload: vec![1, 2, 3],
+            first_is_eos: false,
+            first_code: RpcCode::Ok,
+        };
+        let decode_fn: fn(RpcBytesResult) -> RpcBytesResult = |res| res;
+        let stream: DecodedStream<Vec<u8>> = source.into_raw_stream().map(decode_fn);
+        let request_stream = RequestStream::new(stream);
+
+        let msg1 = request_stream.next_async().await;
+        match msg1 {
+            StreamMessage::Data(d) => assert_eq!(d, vec![1, 2, 3]),
+            _ => panic!("Expected data"),
+        }
+
+        let msg2 = request_stream.next_async().await;
+        match msg2 {
+            StreamMessage::Data(d) => assert_eq!(d, vec![4, 5, 6]),
+            _ => panic!("Expected data"),
+        }
+
+        let msg3 = request_stream.next_async().await;
+        match msg3 {
+            StreamMessage::End => {}
+            _ => panic!("Expected end"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_response_sink() {
+        let (sink, mut rx) = ResponseSink::receiver();
+
+        sink.send_async(vec![1, 2, 3]).await.unwrap();
+        sink.send_async(vec![4, 5, 6]).await.unwrap();
+        sink.close_async().await.unwrap();
+
+        let msg1 = rx.recv().await.unwrap();
+        assert_eq!(msg1.unwrap(), vec![1, 2, 3]);
+
+        let msg2 = rx.recv().await.unwrap();
+        assert_eq!(msg2.unwrap(), vec![4, 5, 6]);
+
+        // After close, no more messages
+        assert!(sink.is_closed_async().await);
+    }
+
+    #[tokio::test]
+    async fn test_response_sink_error() {
+        let (sink, mut rx) = ResponseSink::receiver();
+
+        sink.send_async(vec![1, 2, 3]).await.unwrap();
+
+        let error = RpcError::new(RpcCode::Internal, "Test error".to_string());
+        sink.send_error_async(error).await.unwrap();
+
+        let msg1 = rx.recv().await.unwrap();
+        assert_eq!(msg1.unwrap(), vec![1, 2, 3]);
+
+        let msg2 = rx.recv().await.unwrap();
+        assert!(msg2.is_err());
+
+        assert!(sink.is_closed_async().await);
+    }
+}

--- a/crates/slim-bindings/src/transport_protocol.rs
+++ b/crates/slim-bindings/src/transport_protocol.rs
@@ -1,0 +1,29 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use slim_config::transport::TransportProtocol as CoreTransportProtocol;
+
+/// Transport protocol for dataplane communication.
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum TransportProtocol {
+    Grpc,
+    Websocket,
+}
+
+impl From<TransportProtocol> for CoreTransportProtocol {
+    fn from(transport: TransportProtocol) -> Self {
+        match transport {
+            TransportProtocol::Grpc => CoreTransportProtocol::Grpc,
+            TransportProtocol::Websocket => CoreTransportProtocol::Websocket,
+        }
+    }
+}
+
+impl From<CoreTransportProtocol> for TransportProtocol {
+    fn from(transport: CoreTransportProtocol) -> Self {
+        match transport {
+            CoreTransportProtocol::Grpc => TransportProtocol::Grpc,
+            CoreTransportProtocol::Websocket => TransportProtocol::Websocket,
+        }
+    }
+}

--- a/crates/slim-bindings/tests/slimrpc_core.rs
+++ b/crates/slim-bindings/tests/slimrpc_core.rs
@@ -1,0 +1,2740 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for SlimRPC
+//!
+//! These tests verify the four RPC interaction patterns:
+//! - Unary-Unary: Single request, single response
+//! - Stream-Unary: Streaming requests, single response
+//! - Unary-Stream: Single request, streaming responses
+//! - Stream-Stream: Streaming requests, streaming responses
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use futures::pin_mut;
+use futures::stream::{self, StreamExt};
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::shared_secret::SharedSecret;
+use slim_config::component::id::{ID, Kind};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::service::Service;
+use tokio::sync::Mutex;
+
+const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+use slim_bindings::slimrpc::{
+    Channel, Context, DecodedStream, Decoder, Encoder, RpcCode, RpcError, Server,
+};
+
+// ============================================================================
+// Test Message Types
+// ============================================================================
+
+/// Simple request message for testing
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestRequest {
+    pub message: String,
+    pub value: i32,
+}
+
+impl Encoder for TestRequest {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        let encoded = bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))?;
+        Ok(encoded)
+    }
+}
+
+impl Decoder for TestRequest {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (decoded, _len): (TestRequest, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(decoded)
+    }
+}
+
+/// Simple response message for testing
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestResponse {
+    pub result: String,
+    pub count: i32,
+}
+
+impl Encoder for TestResponse {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        let encoded = bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))?;
+        Ok(encoded)
+    }
+}
+
+impl Decoder for TestResponse {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (decoded, _len): (TestResponse, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(decoded)
+    }
+}
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/// Test environment containing service, server, and client components
+struct TestEnv {
+    service: Arc<Service>,
+    server: Arc<Server>,
+    channel: Channel,
+}
+
+impl TestEnv {
+    /// Create a new test environment with server and client (server not started yet)
+    async fn new(test_name: &str) -> Self {
+        let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+        let service = Arc::new(Service::new(id));
+
+        let server_name = Name::from_strings(["org", "ns", "server"]);
+        let secret = SharedSecret::new("server", TEST_VALID_SECRET).unwrap();
+
+        let (server_app, server_notifications) = service
+            .create_app(
+                &server_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret.clone()),
+            )
+            .unwrap();
+        let server_app = Arc::new(server_app);
+
+        let server = Arc::new(Server::new_internal(
+            server_app.clone(),
+            server_app.app_name().clone(),
+            server_notifications,
+        ));
+
+        // Create client
+        let client_name = Name::from_strings(["org", "ns", "client"]);
+        let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+        let (client_app, _) = service
+            .create_app(
+                &client_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        let client_app = Arc::new(client_app);
+
+        let channel = Channel::new_with_members_internal(
+            client_app.clone(),
+            vec![server_app.app_name().clone()],
+            false,
+            None,
+        )
+        .expect("single non-empty member list is always valid");
+
+        Self {
+            service,
+            server,
+            channel,
+        }
+    }
+
+    /// Start the server in the background
+    async fn start_server(&self) {
+        let server = self.server.clone();
+
+        // Spawn task to run the server
+        tokio::spawn(async move {
+            if let Err(e) = server.serve_async().await {
+                tracing::error!("Server error: {:?}", e);
+            }
+        });
+
+        // Give server time to start and subscribe
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    /// Clean shutdown of the test environment
+    async fn shutdown(&mut self) {
+        tracing::info!("Shutting down server...");
+        self.server.shutdown_internal().await;
+
+        tracing::info!("Shutting down service...");
+        self.service.shutdown().await.unwrap();
+    }
+}
+
+// ============================================================================
+// Test Helper Functions
+// ============================================================================
+
+/// Collect all responses from a stream into a vector
+async fn collect_stream_responses<T>(
+    mut stream: impl futures::Stream<Item = Result<T, RpcError>> + Unpin,
+) -> Vec<T> {
+    let mut responses = Vec::new();
+    while let Some(result) = stream.next().await {
+        responses.push(result.expect("Stream item failed"));
+    }
+    responses
+}
+
+/// Collect responses from a stream until an error occurs
+async fn collect_stream_until_error<T>(
+    mut stream: impl futures::Stream<Item = Result<T, RpcError>> + Unpin,
+) -> (Vec<T>, Option<RpcError>) {
+    let mut responses = Vec::new();
+    let mut error = None;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(response) => responses.push(response),
+            Err(e) => {
+                error = Some(e);
+                break;
+            }
+        }
+    }
+    (responses, error)
+}
+
+/// Register a unary-unary handler that counts calls and tracks session IDs
+fn register_counting_handler(
+    server: &Arc<Server>,
+    service: &str,
+    method: &str,
+    call_count: Arc<Mutex<i32>>,
+    session_ids: Option<Arc<Mutex<Vec<String>>>>,
+) {
+    server.register_unary_unary_internal(
+        service,
+        method,
+        move |request: TestRequest, ctx: Context| {
+            let count = call_count.clone();
+            let ids = session_ids.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                let current = *c;
+                drop(c);
+
+                if let Some(ids) = ids {
+                    let session_id = ctx.session().session_id().to_string();
+                    tracing::info!(
+                        "RPC '{}' (call #{}) handled by session ID: {}",
+                        request.message,
+                        current,
+                        session_id
+                    );
+                    let mut id_list = ids.lock().await;
+                    id_list.push(session_id);
+                    drop(id_list);
+                }
+
+                Ok(TestResponse {
+                    result: format!("Echo: {}", request.message),
+                    count: current,
+                })
+            }
+        },
+    );
+}
+
+/// Assert that a result is an error with the expected code and optional message substring
+fn assert_error_with_code(
+    result: Result<impl std::fmt::Debug, RpcError>,
+    code: RpcCode,
+    msg_contains: Option<&str>,
+) {
+    assert!(result.is_err(), "Expected an error");
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), code, "Error code mismatch");
+    if let Some(expected_msg) = msg_contains {
+        let actual_msg = err.message();
+        assert!(
+            actual_msg.contains(expected_msg),
+            "Error message '{actual_msg}' does not contain '{expected_msg}'"
+        );
+    }
+}
+
+// ============================================================================
+// Test 1: Unary-Unary RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_rpc() {
+    let mut env = TestEnv::new("test-service-unary").await;
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        |request: TestRequest, _ctx: Context| async move {
+            Ok(TestResponse {
+                result: format!("Echo: {}", request.message),
+                count: request.value * 2,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "Hello".to_string(),
+        value: 42,
+    };
+
+    let response: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request, None, None)
+        .await
+        .expect("Unary call failed");
+
+    // Verify response
+    assert_eq!(response.result, "Echo: Hello");
+    assert_eq!(response.count, 84);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_error_handling() {
+    let mut env = TestEnv::new("test-service-error").await;
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "ErrorMethod",
+        |_request: TestRequest, _ctx: Context| async move {
+            Err::<TestResponse, _>(RpcError::invalid_argument("Invalid input"))
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 1,
+    };
+
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary("TestService", "ErrorMethod", request, None, None)
+        .await;
+
+    assert_error_with_code(result, RpcCode::InvalidArgument, Some("Invalid input"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 2: Stream-Unary RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_rpc() {
+    let mut env = TestEnv::new("test-service-stream-unary").await;
+
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "Sum",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            let mut total = 0;
+            let mut messages = Vec::new();
+
+            while let Some(req_result) = request_stream.next().await {
+                let req: TestRequest = req_result?;
+                total += req.value;
+                messages.push(req.message);
+            }
+
+            Ok(TestResponse {
+                result: messages.join(", "),
+                count: total,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "one".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "two".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "three".to_string(),
+            value: 3,
+        },
+    ];
+    let request_stream = stream::iter(requests);
+
+    let response: TestResponse = env
+        .channel
+        .stream_unary("TestService", "Sum", request_stream, None, None)
+        .await
+        .expect("Stream-unary call failed");
+
+    // Verify response
+    assert_eq!(response.result, "one, two, three");
+    assert_eq!(response.count, 6);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 2b: Stream-Unary RPC with Error Handling
+// ============================================================================
+//
+// This test verifies that errors in the request stream are properly handled.
+// Note: RequestStream<T> = Pin<Box<dyn Stream<Item = Result<T, RpcError>> + Send>>
+// Each item in the stream is a Result that can contain:
+// - Ok(T): Successfully received and deserialized message
+// - Err(Status): Network error, deserialization error, or transport issue
+//
+// In this test, we simulate an error condition by having the handler validate
+// input and return an error when invalid data is encountered.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_error_handling() {
+    let mut env = TestEnv::new("test-service-stream-unary-error").await;
+
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "SumWithValidation",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            let mut total = 0;
+            let mut messages = Vec::new();
+
+            // Iterate over the stream of Results
+            while let Some(req_result) = request_stream.next().await {
+                // Each item is a Result<TestRequest, RpcError>
+                // Use ? to propagate any errors from the stream (network, deserialization, etc.)
+                let req = req_result?;
+
+                // Validate input - return error if value is negative
+                if req.value < 0 {
+                    tracing::info!("Received invalid value: {}", req.value);
+                    return Err(RpcError::invalid_argument(format!(
+                        "Negative values not allowed: {}",
+                        req.value
+                    )));
+                }
+
+                total += req.value;
+                messages.push(req.message);
+            }
+
+            Ok(TestResponse {
+                result: messages.join(", "),
+                count: total,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    // Note: The client sends Stream<Item = TestRequest>, not Stream<Item = Result<...>>
+    // The Result wrapper is added by the transport layer on the server side
+    let requests = vec![
+        TestRequest {
+            message: "one".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "two".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "invalid".to_string(),
+            value: -5, // This invalid value will cause the handler to return an error
+        },
+        TestRequest {
+            message: "three".to_string(),
+            value: 3, // This won't be processed due to the error above
+        },
+    ];
+    let request_stream = stream::iter(requests);
+
+    let response: Result<TestResponse, RpcError> = env
+        .channel
+        .stream_unary(
+            "TestService",
+            "SumWithValidation",
+            request_stream,
+            None,
+            None,
+        )
+        .await;
+
+    // Verify that the error was propagated back
+    assert!(response.is_err(), "Expected an error response");
+    let err = response.unwrap_err();
+    assert_eq!(err.code(), RpcCode::InvalidArgument);
+    let msg = err.message();
+    assert!(
+        msg.contains("Negative values not allowed"),
+        "Error message was: {msg}"
+    );
+    assert!(msg.contains("-5"), "Error message was: {msg}");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 3: Unary-Stream RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_rpc() {
+    let mut env = TestEnv::new("test-service-unary-stream").await;
+
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "Generate",
+        |request: TestRequest, _ctx: Context| async move {
+            let count = request.value;
+            let message = request.message.clone();
+
+            // Create an async stream that generates responses incrementally
+
+            // register current time
+            let response_stream = async_stream::stream! {
+                for i in 1..=count {
+                    // Simulate some async work (optional)
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+
+                    yield Ok(TestResponse {
+                        result: format!("{message}-{i}"),
+                        count: i,
+                    });
+                }
+            };
+
+            Ok(response_stream)
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 5,
+    };
+
+    let responses: Vec<TestResponse> = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Generate",
+            request,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_responses(response_stream).await
+    };
+
+    // Verify responses
+    assert_eq!(responses.len(), 5);
+    assert_eq!(responses[0].result, "item-1");
+    assert_eq!(responses[0].count, 1);
+    assert_eq!(responses[4].result, "item-5");
+    assert_eq!(responses[4].count, 5);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 3b: Unary-Stream RPC with Error Handling
+// ============================================================================
+//
+// This test verifies that errors in the response stream are properly propagated.
+// The handler generates several responses successfully, then encounters an error
+// condition and yields an error in the stream. The client should receive the
+// successful responses followed by the error.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_error_handling() {
+    let mut env = TestEnv::new("test-service-unary-stream-error").await;
+
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "GenerateWithError",
+        |request: TestRequest, _ctx: Context| async move {
+            let count = request.value;
+            let message = request.message.clone();
+
+            // Create an async stream that generates some responses then an error
+            let response_stream = async_stream::stream! {
+                for i in 1..=count {
+                    // After 3 items, simulate an error condition
+                    if i > 3 {
+                        tracing::info!("Simulating error after {} responses", i - 1);
+                        yield Err(RpcError::internal(
+                            format!("Failed to generate item {i}")
+                        ));
+                        break;
+                    }
+
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+
+                    yield Ok(TestResponse {
+                        result: format!("{message}-{i}"),
+                        count: i,
+                    });
+                }
+            };
+
+            Ok(response_stream)
+        },
+    );
+
+    env.start_server().await;
+
+    // Request 10 items, but handler will error after 3
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 10,
+    };
+
+    let (responses, error_received) = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "GenerateWithError",
+            request,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+
+    // Verify we received 3 successful responses before the error
+    assert_eq!(responses.len(), 3);
+    assert_eq!(responses[0].result, "item-1");
+    assert_eq!(responses[1].result, "item-2");
+    assert_eq!(responses[2].result, "item-3");
+
+    // Verify the error was received
+    assert!(error_received.is_some(), "Expected an error in the stream");
+    let err = error_received.unwrap();
+    assert_eq!(err.code(), RpcCode::Internal);
+    assert!(err.message().contains("Failed to generate item 4"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 4: Stream-Stream RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_rpc() {
+    let mut env = TestEnv::new("test-service-stream-stream").await;
+
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "Transform",
+        |request_stream, _ctx: Context| async move {
+            // Using .map() processes items as they arrive (lazy/incremental)
+            // For more complex async processing, use async_stream or spawn a task
+            // with a channel (see the SlimRPC examples for the channel pattern)
+            Ok(request_stream.map(|req_result| {
+                req_result.map(|req: TestRequest| TestResponse {
+                    result: req.message.to_uppercase(),
+                    count: req.value * 10,
+                })
+            }))
+        },
+    );
+
+    env.start_server().await;
+
+    // Create request stream
+    let requests = vec![
+        TestRequest {
+            message: "hello".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "world".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "rpc".to_string(),
+            value: 3,
+        },
+    ];
+
+    let responses: Vec<TestResponse> = {
+        let request_stream = stream::iter(requests);
+
+        let response_stream = env.channel.stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Transform",
+            request_stream,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_responses(response_stream).await
+    };
+
+    // Verify responses
+    assert_eq!(responses.len(), 3);
+    assert_eq!(responses[0].result, "HELLO");
+    assert_eq!(responses[0].count, 10);
+    assert_eq!(responses[1].result, "WORLD");
+    assert_eq!(responses[1].count, 20);
+    assert_eq!(responses[2].result, "RPC");
+    assert_eq!(responses[2].count, 30);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 4b: Stream-Stream RPC with Channel Pattern (Async Processing)
+// ============================================================================
+//
+// This test demonstrates an alternative pattern for stream-stream handlers
+// where complex async processing is needed. It uses a channel to decouple
+// request processing from response generation, allowing true bidirectional
+// streaming with async operations.
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_with_async_processing() {
+    let mut env = TestEnv::new("test-service-stream-stream-async").await;
+
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "ProcessAsync",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            // Create channel for responses
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+            // Spawn task to process requests asynchronously
+            tokio::spawn(async move {
+                while let Some(req_result) = request_stream.next().await {
+                    match req_result {
+                        Ok(req) => {
+                            // Simulate some async processing work
+                            tokio::time::sleep(Duration::from_millis(5)).await;
+
+                            let response = TestResponse {
+                                result: format!("Processed: {}", req.message),
+                                count: req.value * 100,
+                            };
+
+                            if tx.send(Ok(response)).is_err() {
+                                tracing::warn!("Response channel closed");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(e));
+                            break;
+                        }
+                    }
+                }
+            });
+
+            // Return stream from the receiver
+            Ok(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "alpha".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "beta".to_string(),
+            value: 2,
+        },
+    ];
+
+    let responses: Vec<TestResponse> = {
+        let request_stream = stream::iter(requests);
+
+        let response_stream = env.channel.stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "ProcessAsync",
+            request_stream,
+            None,
+            None,
+        );
+        pin_mut!(response_stream);
+
+        collect_stream_responses(response_stream).await
+    };
+
+    // Verify responses
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0].result, "Processed: alpha");
+    assert_eq!(responses[0].count, 100);
+    assert_eq!(responses[1].result, "Processed: beta");
+    assert_eq!(responses[1].count, 200);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Additional Edge Case Tests
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_empty_stream_unary() {
+    let mut env = TestEnv::new("test-service-empty-stream").await;
+
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "EmptySum",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            println!("Processing empty stream...");
+
+            let mut count = 0;
+            while (request_stream.next().await).is_some() {
+                count += 1;
+            }
+
+            Ok(TestResponse {
+                result: "empty".to_string(),
+                count,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    // Empty stream
+    let request_stream = stream::iter(Vec::<TestRequest>::new());
+
+    let response: TestResponse = env
+        .channel
+        .stream_unary("TestService", "EmptySum", request_stream, None, None)
+        .await
+        .expect("Empty stream-unary call failed");
+
+    assert_eq!(response.result, "empty");
+    assert_eq!(response.count, 0);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_concurrent_unary_calls() {
+    let mut env = TestEnv::new("test-service-concurrent").await;
+
+    let call_counter = Arc::new(Mutex::new(0));
+    let counter_clone = call_counter.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Count",
+        move |request: TestRequest, _ctx: Context| {
+            let counter = counter_clone.clone();
+            async move {
+                let mut count = counter.lock().await;
+                *count += 1;
+                let current = *count;
+                drop(count);
+
+                Ok(TestResponse {
+                    result: request.message,
+                    count: current,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let channel = Arc::new(env.channel.clone());
+    let mut handles = vec![];
+    for i in 0..5 {
+        let channel_clone = channel.clone();
+        let handle = tokio::spawn(async move {
+            let request = TestRequest {
+                message: format!("call-{i}"),
+                value: i,
+            };
+            channel_clone
+                .unary::<TestRequest, TestResponse>("TestService", "Count", request, None, None)
+                .await
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all calls to complete
+    let mut results = vec![];
+    for handle in handles {
+        let result = handle.await.unwrap().unwrap();
+        results.push(result);
+    }
+
+    // All calls should succeed
+    assert_eq!(results.len(), 5);
+
+    // Counter should have been incremented 5 times
+    let final_count = *call_counter.lock().await;
+    assert_eq!(final_count, 5);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Session Reuse Tests
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_session_reused_across_rpcs() {
+    let mut env = TestEnv::new("test-session-reused-across-rpcs").await;
+
+    let call_count = Arc::new(Mutex::new(0));
+    let session_ids = Arc::new(Mutex::new(Vec::new()));
+
+    register_counting_handler(
+        &env.server,
+        "TestService",
+        "Echo",
+        call_count.clone(),
+        Some(session_ids.clone()),
+    );
+
+    env.start_server().await;
+
+    // First call — establishes the persistent session
+    let request1 = TestRequest {
+        message: "first".to_string(),
+        value: 1,
+    };
+    let response1: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request1, None, None)
+        .await
+        .expect("First RPC call failed");
+    assert_eq!(response1.count, 1);
+
+    // Second call — reuses the same session
+    let request2 = TestRequest {
+        message: "second".to_string(),
+        value: 2,
+    };
+    let response2: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request2, None, None)
+        .await
+        .expect("Second RPC call failed");
+    assert_eq!(response2.count, 2);
+
+    // Third call — still reuses the same session
+    let request3 = TestRequest {
+        message: "third".to_string(),
+        value: 3,
+    };
+    let response3: TestResponse = env
+        .channel
+        .unary("TestService", "Echo", request3, None, None)
+        .await
+        .expect("Third RPC call failed");
+    assert_eq!(response3.count, 3);
+
+    // All 3 calls should have been processed
+    let final_count = *call_count.lock().await;
+    assert_eq!(final_count, 3);
+
+    // All calls share the same persistent session
+    let id_list = session_ids.lock().await;
+    assert_eq!(id_list.len(), 3, "Should have 3 session IDs recorded");
+    let first_session_id = &id_list[0];
+    let second_session_id = &id_list[1];
+    let third_session_id = &id_list[2];
+
+    assert_eq!(
+        first_session_id, second_session_id,
+        "Session should be reused: first and second calls should share the same session"
+    );
+    assert_eq!(
+        second_session_id, third_session_id,
+        "Session should be reused: second and third calls should share the same session"
+    );
+    tracing::info!("✓ All three RPC calls reused session: {}", first_session_id);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_session_reused_after_handler_error() {
+    let mut env = TestEnv::new("test-session-reused-after-error").await;
+
+    let call_count = Arc::new(Mutex::new(0));
+    let session_ids = Arc::new(Mutex::new(Vec::new()));
+
+    let count_clone = call_count.clone();
+    let ids_clone = session_ids.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "FlakyMethod",
+        move |request: TestRequest, ctx: Context| {
+            let count = count_clone.clone();
+            let ids = ids_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                let current = *c;
+                drop(c);
+
+                let session_id = ctx.session().session_id().to_string();
+                tracing::info!(
+                    "RPC '{}' (call #{}) handled by session ID: {}",
+                    request.message,
+                    current,
+                    session_id
+                );
+
+                let mut id_list = ids.lock().await;
+                id_list.push(session_id.clone());
+                drop(id_list);
+
+                // Fail on first call
+                if current == 1 {
+                    return Err(RpcError::internal("Simulated error"));
+                }
+
+                Ok(TestResponse {
+                    result: request.message,
+                    count: current,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // First call fails
+    let request1 = TestRequest {
+        message: "first".to_string(),
+        value: 1,
+    };
+    let result1 = env
+        .channel
+        .unary::<TestRequest, TestResponse>("TestService", "FlakyMethod", request1, None, None)
+        .await;
+    assert!(result1.is_err());
+    assert_eq!(result1.unwrap_err().code(), RpcCode::Internal);
+
+    // Second call should succeed — the session is reused even after a handler error
+    let request2 = TestRequest {
+        message: "second".to_string(),
+        value: 2,
+    };
+    let response2: TestResponse = env
+        .channel
+        .unary("TestService", "FlakyMethod", request2, None, None)
+        .await
+        .expect("Second RPC call should succeed");
+    assert_eq!(response2.count, 2);
+
+    // Both calls should have been attempted
+    let final_count = *call_count.lock().await;
+    assert_eq!(final_count, 2);
+
+    // Both calls should share the same persistent session
+    let id_list = session_ids.lock().await;
+    assert_eq!(id_list.len(), 2, "Should have 2 session IDs recorded");
+    let first_session_id = &id_list[0];
+    let second_session_id = &id_list[1];
+
+    assert_eq!(
+        first_session_id, second_session_id,
+        "Session should be reused even after a handler error"
+    );
+    tracing::info!(
+        "✓ Session reused after error: first={}, second={}",
+        first_session_id,
+        second_session_id
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_different_methods_different_sessions() {
+    let mut env = TestEnv::new("test-different-sessions").await;
+
+    let method1_count = Arc::new(Mutex::new(0));
+    let method2_count = Arc::new(Mutex::new(0));
+
+    let m1_clone = method1_count.clone();
+    let m2_clone = method2_count.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Method1",
+        move |request: TestRequest, _ctx: Context| {
+            let count = m1_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                drop(c);
+
+                Ok(TestResponse {
+                    result: format!("M1: {}", request.message),
+                    count: request.value + 100,
+                })
+            }
+        },
+    );
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Method2",
+        move |request: TestRequest, _ctx: Context| {
+            let count = m2_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                drop(c);
+
+                Ok(TestResponse {
+                    result: format!("M2: {}", request.message),
+                    count: request.value + 200,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Call both methods multiple times
+    for i in 0..3 {
+        let req1 = TestRequest {
+            message: format!("call-{i}"),
+            value: i,
+        };
+        let req2 = TestRequest {
+            message: format!("call-{i}"),
+            value: i,
+        };
+
+        let resp1: TestResponse = env
+            .channel
+            .unary("TestService", "Method1", req1, None, None)
+            .await
+            .expect("Method1 call failed");
+
+        let resp2: TestResponse = env
+            .channel
+            .unary("TestService", "Method2", req2, None, None)
+            .await
+            .expect("Method2 call failed");
+
+        assert_eq!(resp1.result, format!("M1: call-{i}"));
+        assert_eq!(resp1.count, i + 100);
+
+        assert_eq!(resp2.result, format!("M2: call-{i}"));
+        assert_eq!(resp2.count, i + 200);
+    }
+
+    // Each method should have been called 3 times
+    assert_eq!(*method1_count.lock().await, 3);
+    assert_eq!(*method2_count.lock().await, 3);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_session_reused_for_streaming() {
+    let mut env = TestEnv::new("test-session-reused-streaming").await;
+
+    let call_count = Arc::new(Mutex::new(0));
+    let session_ids = Arc::new(Mutex::new(Vec::new()));
+
+    let count_clone = call_count.clone();
+    let ids_clone = session_ids.clone();
+
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "GenerateNumbers",
+        move |request: TestRequest, ctx: Context| {
+            let count = count_clone.clone();
+            let ids = ids_clone.clone();
+            async move {
+                let mut c = count.lock().await;
+                *c += 1;
+                let current = *c;
+                drop(c);
+
+                let session_id = ctx.session().session_id().to_string();
+                tracing::info!(
+                    "Streaming RPC '{}' (call #{}) handled by session ID: {}",
+                    request.message,
+                    current,
+                    session_id
+                );
+
+                let mut id_list = ids.lock().await;
+                id_list.push(session_id.clone());
+                drop(id_list);
+
+                let n = request.value;
+                let stream = stream::iter((0..n).map(|i| {
+                    Ok(TestResponse {
+                        result: format!("item-{i}"),
+                        count: i,
+                    })
+                }));
+                Ok(stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // First streaming call in a scope
+    {
+        let request1 = TestRequest {
+            message: "first".to_string(),
+            value: 3,
+        };
+        let stream1 = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "GenerateNumbers",
+            request1,
+            None,
+            None,
+        );
+        pin_mut!(stream1);
+
+        let results1 = collect_stream_responses(stream1).await;
+        assert_eq!(results1.len(), 3);
+    } // stream1 dropped here
+
+    // Second streaming call in a scope - reuses the same session
+    {
+        let request2 = TestRequest {
+            message: "second".to_string(),
+            value: 2,
+        };
+        let stream2 = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "GenerateNumbers",
+            request2,
+            None,
+            None,
+        );
+        pin_mut!(stream2);
+
+        let results2 = collect_stream_responses(stream2).await;
+        assert_eq!(results2.len(), 2);
+    } // stream2 dropped here
+
+    // Both calls should have been processed
+    let final_count = *call_count.lock().await;
+    assert_eq!(final_count, 2);
+
+    // Get all session IDs
+    let id_list = session_ids.lock().await;
+    assert_eq!(id_list.len(), 2, "Should have 2 session IDs recorded");
+    let first_session_id = id_list[0].clone();
+    let second_session_id = id_list[1].clone();
+    drop(id_list);
+
+    // Both calls share the same persistent session
+    assert_eq!(
+        first_session_id, second_session_id,
+        "Streaming RPCs should share the same persistent session"
+    );
+    tracing::info!(
+        "✓ Both streaming RPCs reused the same session: {}",
+        first_session_id
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_concurrent_calls_independent() {
+    let mut env = TestEnv::new("test-concurrent-calls").await;
+
+    // Track concurrent execution (now multiple calls can run concurrently since no session lock)
+    let active_count = Arc::new(Mutex::new(0));
+    let max_concurrent = Arc::new(Mutex::new(0));
+
+    let active_clone = active_count.clone();
+    let max_clone = max_concurrent.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowEcho",
+        move |request: TestRequest, _ctx: Context| {
+            let active = active_clone.clone();
+            let max = max_clone.clone();
+            async move {
+                // Increment active count
+                let mut a = active.lock().await;
+                *a += 1;
+                let current = *a;
+                drop(a);
+
+                // Update max
+                let mut m = max.lock().await;
+                if current > *m {
+                    *m = current;
+                }
+                drop(m);
+
+                // Simulate slow processing
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
+                // Decrement active count
+                let mut a = active.lock().await;
+                *a -= 1;
+                drop(a);
+
+                Ok(TestResponse {
+                    result: request.message,
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Launch concurrent calls - they should run concurrently since each RPC gets its own session
+    let channel = Arc::new(env.channel.clone());
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let mut handles = vec![];
+    for i in 0..3 {
+        let ch = channel.clone();
+        let b = barrier.clone();
+        let handle = tokio::spawn(async move {
+            // Wait for all tasks to be ready
+            b.wait().await;
+
+            let req = TestRequest {
+                message: format!("call-{i}"),
+                value: i + 1,
+            };
+            ch.unary::<TestRequest, TestResponse>("TestService", "SlowEcho", req, None, None)
+                .await
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all to complete
+    for handle in handles {
+        handle.await.unwrap().expect("RPC should succeed");
+    }
+
+    // Max concurrent should be 3 (all calls run concurrently, no session lock)
+    let max = *max_concurrent.lock().await;
+    assert_eq!(
+        max, 3,
+        "Calls should run concurrently since each RPC gets its own session"
+    );
+
+    env.shutdown().await;
+}
+
+/// Test that multiple calls to the same server from the same client
+/// towards different gRPC handler types all work correctly
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multiple_handler_types_same_client() {
+    let mut env = TestEnv::new("test-multi-handlers").await;
+
+    // Counters to track calls to each handler
+    let unary_count = Arc::new(Mutex::new(0));
+    let stream_unary_count = Arc::new(Mutex::new(0));
+    let unary_stream_count = Arc::new(Mutex::new(0));
+    let stream_stream_count = Arc::new(Mutex::new(0));
+
+    // Register unary-unary handler
+    let uu_counter = unary_count.clone();
+    env.server.register_unary_unary_internal(
+        "MultiService",
+        "UnaryUnary",
+        move |request: TestRequest, _ctx: Context| {
+            let counter = uu_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                Ok(TestResponse {
+                    result: format!("UnaryUnary: {}", request.message),
+                    count: request.value * 10,
+                })
+            }
+        },
+    );
+
+    // Register stream-unary handler
+    let su_counter = stream_unary_count.clone();
+    env.server.register_stream_unary_internal(
+        "MultiService",
+        "StreamUnary",
+        move |mut stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let counter = su_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                let mut sum = 0;
+                let mut messages = vec![];
+                while let Some(result) = stream.next().await {
+                    let req = result?;
+                    sum += req.value;
+                    messages.push(req.message);
+                }
+
+                Ok(TestResponse {
+                    result: format!("StreamUnary: {}", messages.join(",")),
+                    count: sum,
+                })
+            }
+        },
+    );
+
+    // Register unary-stream handler
+    let us_counter = unary_stream_count.clone();
+    env.server.register_unary_stream_internal(
+        "MultiService",
+        "UnaryStream",
+        move |request: TestRequest, _ctx: Context| {
+            let counter = us_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                let responses = (0..request.value).map(move |i| {
+                    Ok(TestResponse {
+                        result: format!("UnaryStream-{}: {}", i, request.message.clone()),
+                        count: i,
+                    })
+                });
+
+                Ok(stream::iter(responses))
+            }
+        },
+    );
+
+    // Register stream-stream handler
+    let ss_counter = stream_stream_count.clone();
+    env.server.register_stream_stream_internal(
+        "MultiService",
+        "StreamStream",
+        move |mut stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let counter = ss_counter.clone();
+            async move {
+                let mut c = counter.lock().await;
+                *c += 1;
+                drop(c);
+
+                let response_stream = async_stream::stream! {
+                    while let Some(result) = stream.next().await {
+                        match result {
+                            Ok(req) => {
+                                yield Ok(TestResponse {
+                                    result: format!("StreamStream: {}", req.message),
+                                    count: req.value * 100,
+                                });
+                            }
+                            Err(e) => {
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+                };
+
+                Ok(response_stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Now test calling each handler multiple times from the same client
+
+    // Test 1: Call unary-unary handler twice
+    for i in 0..2 {
+        let req = TestRequest {
+            message: format!("uu-call-{i}"),
+            value: i + 1,
+        };
+        let resp: TestResponse = env
+            .channel
+            .unary("MultiService", "UnaryUnary", req, None, None)
+            .await
+            .expect("UnaryUnary call failed");
+
+        assert_eq!(resp.result, format!("UnaryUnary: uu-call-{i}"));
+        assert_eq!(resp.count, (i + 1) * 10);
+    }
+
+    // Test 2: Call stream-unary handler twice
+    for i in 0..2 {
+        let requests = vec![
+            TestRequest {
+                message: format!("su-msg-{i}-1"),
+                value: 1,
+            },
+            TestRequest {
+                message: format!("su-msg-{i}-2"),
+                value: 2,
+            },
+            TestRequest {
+                message: format!("su-msg-{i}-3"),
+                value: 3,
+            },
+        ];
+
+        let resp: TestResponse = env
+            .channel
+            .stream_unary(
+                "MultiService",
+                "StreamUnary",
+                stream::iter(requests),
+                None,
+                None,
+            )
+            .await
+            .expect("StreamUnary call failed");
+
+        assert_eq!(
+            resp.result,
+            format!("StreamUnary: su-msg-{i}-1,su-msg-{i}-2,su-msg-{i}-3")
+        );
+        assert_eq!(resp.count, 6);
+    }
+
+    // Test 3: Call unary-stream handler twice
+    for i in 0..2 {
+        let req = TestRequest {
+            message: format!("us-call-{i}"),
+            value: 3,
+        };
+
+        let response_stream =
+            env.channel
+                .unary_stream("MultiService", "UnaryStream", req, None, None);
+
+        pin_mut!(response_stream);
+
+        let responses: Vec<TestResponse> = collect_stream_responses(response_stream).await;
+        assert_eq!(responses.len(), 3);
+        for (count, resp) in responses.iter().enumerate() {
+            assert_eq!(resp.result, format!("UnaryStream-{count}: us-call-{i}"));
+            assert_eq!(resp.count, count as i32);
+        }
+    }
+
+    // Test 4: Call stream-stream handler twice
+    for i in 0..2 {
+        let requests = vec![
+            TestRequest {
+                message: format!("ss-msg-{i}-1"),
+                value: 1,
+            },
+            TestRequest {
+                message: format!("ss-msg-{i}-2"),
+                value: 2,
+            },
+        ];
+
+        let response_stream = env.channel.stream_stream(
+            "MultiService",
+            "StreamStream",
+            stream::iter(requests),
+            None,
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        let received: Vec<TestResponse> = collect_stream_responses(response_stream).await;
+
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0].result, format!("StreamStream: ss-msg-{i}-1"));
+        assert_eq!(received[0].count, 100);
+        assert_eq!(received[1].result, format!("StreamStream: ss-msg-{i}-2"));
+        assert_eq!(received[1].count, 200);
+    }
+
+    // Verify each handler was called the expected number of times
+    assert_eq!(*unary_count.lock().await, 2);
+    assert_eq!(*stream_unary_count.lock().await, 2);
+    assert_eq!(*unary_stream_count.lock().await, 2);
+    assert_eq!(*stream_stream_count.lock().await, 2);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Client-side deadline enforcement (timeout)
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_client_deadline_unary_unary() {
+    let mut env = TestEnv::new("test-client-deadline-unary").await;
+
+    // Register a handler that takes longer than the timeout
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowMethod",
+        |request: TestRequest, _ctx: Context| async move {
+            // Sleep for 2 seconds
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Ok(TestResponse {
+                result: format!("Processed: {}", request.message),
+                count: request.value,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with a very short timeout (100ms)
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "SlowMethod",
+            request,
+            Some(Duration::from_millis(100)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the client side
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_client_deadline_unary_stream() {
+    let mut env = TestEnv::new("test-client-deadline-unary-stream").await;
+
+    // Register a handler that streams slowly
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "SlowStream",
+        |request: TestRequest, _ctx: Context| async move {
+            Ok(stream::iter((0..5).map(move |i| {
+                let msg = request.message.clone();
+                async move {
+                    // Each item takes 500ms
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    Ok::<_, RpcError>(TestResponse {
+                        result: format!("{msg}-{i}"),
+                        count: i,
+                    })
+                }
+            }))
+            .then(|fut| fut))
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 0,
+    };
+
+    // Call with a timeout of 1 second (should only get 2 items before timeout)
+    let (responses, last_error) = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStream",
+            request,
+            Some(Duration::from_secs(1)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+    let count = responses.len();
+
+    // Should have received some items but then timed out
+    assert!(count < 5, "Expected timeout before all items, got {count}");
+    assert!(last_error.is_some());
+    let err = last_error.unwrap();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Server-side deadline enforcement
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_unary_unary() {
+    let mut env = TestEnv::new("test-server-deadline-unary").await;
+
+    // Register a handler that takes longer than the deadline
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowHandler",
+        |request: TestRequest, _ctx: Context| async move {
+            // Handler takes 2 seconds
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Ok(TestResponse {
+                result: format!("Processed: {}", request.message),
+                count: request.value,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with a short timeout (500ms) - server should enforce this
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "SlowHandler",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the server side (handler execution)
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_unary_stream() {
+    let mut env = TestEnv::new("test-server-deadline-unary-stream").await;
+
+    // Register a handler that takes too long to start streaming
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "SlowStreamHandler",
+        |request: TestRequest, _ctx: Context| async move {
+            // Handler setup takes 2 seconds before returning stream
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Ok(stream::iter((0..3).map(move |i| {
+                Ok::<_, RpcError>(TestResponse {
+                    result: format!("{}-{}", request.message, i),
+                    count: i,
+                })
+            })))
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 0,
+    };
+
+    // Call with a short timeout (500ms)
+    let err = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStreamHandler",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        // Should get a deadline exceeded error
+        let result = response_stream.next().await;
+        assert!(result.is_some());
+        let item_result = result.unwrap();
+        assert!(item_result.is_err());
+        item_result.unwrap_err()
+    };
+
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_stream_unary() {
+    let mut env = TestEnv::new("test-server-deadline-stream-unary").await;
+
+    // Register a handler that takes too long to process the stream
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "SlowStreamUnary",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            // Collect all requests
+            let mut messages = Vec::new();
+            while let Some(req_result) = request_stream.next().await {
+                let req = req_result?;
+                messages.push(req.message);
+            }
+
+            // Then take too long to process
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            Ok(TestResponse {
+                result: messages.join(","),
+                count: messages.len() as i32,
+            })
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "msg1".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "msg2".to_string(),
+            value: 2,
+        },
+    ];
+
+    // Call with a short timeout (500ms)
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .stream_unary(
+            "TestService",
+            "SlowStreamUnary",
+            stream::iter(requests),
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the server side
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_stream_stream() {
+    let mut env = TestEnv::new("test-server-deadline-stream-stream").await;
+
+    // Register a handler that takes too long to setup
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "SlowStreamStream",
+        |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+            // Consume one request
+            if let Some(req_result) = request_stream.next().await {
+                let _ = req_result?;
+            }
+
+            // Then take too long before returning stream
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            Ok(stream::iter((0..3).map(|i| {
+                Ok::<_, RpcError>(TestResponse {
+                    result: format!("response-{i}"),
+                    count: i,
+                })
+            })))
+        },
+    );
+
+    env.start_server().await;
+
+    let requests = vec![
+        TestRequest {
+            message: "msg1".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "msg2".to_string(),
+            value: 2,
+        },
+    ];
+
+    // Call with a short timeout (500ms)
+    let err = {
+        let response_stream = env.channel.stream_stream(
+            "TestService",
+            "SlowStreamStream",
+            stream::iter(requests),
+            Some(Duration::from_millis(500)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        // Should get a deadline exceeded error
+        let result = response_stream.next().await;
+        assert!(result.is_some());
+        let item_result: Result<TestResponse, RpcError> = result.unwrap();
+        assert!(item_result.is_err());
+        item_result.unwrap_err()
+    };
+
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Server checks deadline before handler execution
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_already_exceeded() {
+    let mut env = TestEnv::new("test-server-deadline-already-exceeded").await;
+
+    let handler_called = Arc::new(Mutex::new(false));
+    let handler_called_clone = handler_called.clone();
+
+    // Register a handler
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "CheckDeadline",
+        move |request: TestRequest, _ctx: Context| {
+            let called = handler_called_clone.clone();
+            async move {
+                *called.lock().await = true;
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with an already expired deadline (1ms and then wait)
+    let channel_clone = env.channel.clone();
+    let result: Result<TestResponse, RpcError> = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        channel_clone
+            .unary(
+                "TestService",
+                "CheckDeadline",
+                request,
+                Some(Duration::from_millis(1)),
+                None,
+            )
+            .await
+    })
+    .await
+    .unwrap();
+
+    // Should fail with deadline exceeded
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), RpcCode::DeadlineExceeded);
+
+    // Handler should not have been called (deadline checked before execution)
+    // Note: There's a race condition here, but with 50ms delay + network time,
+    // the deadline should be exceeded before the handler is called
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // We can't reliably assert this due to timing, but the test verifies
+    // that deadline exceeded is returned
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Deadline propagation from client to server
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_deadline_propagation() {
+    let mut env = TestEnv::new("test-deadline-propagation").await;
+
+    let deadline_from_handler: Arc<Mutex<Option<SystemTime>>> = Arc::new(Mutex::new(None));
+    let deadline_clone = deadline_from_handler.clone();
+
+    // Register a handler that captures the deadline from context
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "CaptureDeadline",
+        move |request: TestRequest, ctx: Context| {
+            let deadline = deadline_clone.clone();
+            async move {
+                *deadline.lock().await = Some(ctx.deadline());
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Call with a specific timeout
+    let timeout = Duration::from_secs(30);
+    let start = std::time::SystemTime::now();
+
+    let _: TestResponse = env
+        .channel
+        .unary(
+            "TestService",
+            "CaptureDeadline",
+            request,
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Check that the handler received a deadline
+    let captured_deadline = deadline_from_handler.lock().await;
+    assert!(
+        captured_deadline.is_some(),
+        "Handler should receive a deadline"
+    );
+
+    let deadline = captured_deadline.unwrap();
+    let expected_deadline = start + timeout;
+
+    // The deadline should be approximately the expected value (within 1 second tolerance)
+    let diff = if deadline > expected_deadline {
+        deadline.duration_since(expected_deadline).unwrap()
+    } else {
+        expected_deadline.duration_since(deadline).unwrap()
+    };
+
+    assert!(
+        diff < Duration::from_secs(1),
+        "Deadline should match expected value within tolerance, diff: {diff:?}"
+    );
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: Server-side deadline enforcement (infrastructure checks, not handler)
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_rejects_already_expired_deadline() {
+    let mut env = TestEnv::new("test-expired-deadline").await;
+
+    let handler_called = Arc::new(Mutex::new(false));
+    let handler_called_clone = handler_called.clone();
+
+    // Register a handler that should never be called
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "ShouldNotBeCalled",
+        move |request: TestRequest, _ctx: Context| {
+            let called = handler_called_clone.clone();
+            async move {
+                tracing::error!("Handler was called when it should have been rejected!");
+                *called.lock().await = true;
+
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Use a very short deadline (1ms) and wait before making the call
+    // to ensure the deadline is already expired when the server receives it
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "ShouldNotBeCalled",
+            request,
+            Some(Duration::from_nanos(1)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded or timing-related error
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+
+    // The error might be DeadlineExceeded or Internal depending on timing
+    // (if the deadline check happens before or after session setup)
+    assert!(
+        err.code() == RpcCode::DeadlineExceeded || err.code() == RpcCode::Internal,
+        "Expected DeadlineExceeded or Internal, got {:?}",
+        err.code()
+    );
+
+    // Give some time for any potential handler execution to occur
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the handler was NOT called (server rejected the request before handler execution)
+    let was_called = *handler_called.lock().await;
+    assert!(
+        !was_called,
+        "Handler should not have been called for expired deadline"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_during_handler_execution() {
+    let mut env = TestEnv::new("test-server-enforces-deadline").await;
+
+    let handler_started = Arc::new(Mutex::new(false));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let started_clone = handler_started.clone();
+    let completed_clone = handler_completed.clone();
+
+    // Register a handler that takes a long time (ignores deadline)
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "LongRunningIgnoresDeadline",
+        move |request: TestRequest, _ctx: Context| {
+            let started = started_clone.clone();
+            let completed = completed_clone.clone();
+            async move {
+                *started.lock().await = true;
+                tracing::info!("Handler started, will run for 5 seconds");
+
+                // Handler intentionally ignores the deadline and runs for a long time
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                *completed.lock().await = true;
+                tracing::info!("Handler completed (this should not happen due to deadline)");
+
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "test".to_string(),
+        value: 42,
+    };
+
+    // Set a short deadline (500ms) while handler takes 5 seconds
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .unary(
+            "TestService",
+            "LongRunningIgnoresDeadline",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded (enforced by server, not handler)
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete (but it shouldn't)
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the handler started but did not complete
+    // (server infrastructure cancelled it due to deadline)
+    let was_started = *handler_started.lock().await;
+    let was_completed = *handler_completed.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_for_stream_unary() {
+    let mut env = TestEnv::new("test-server-deadline-stream-unary").await;
+
+    let messages_received = Arc::new(Mutex::new(0));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let message_received_clone = messages_received.clone();
+    let handler_completed_clone = handler_completed.clone();
+
+    // Register a stream-unary handler that processes messages slowly
+    env.server.register_stream_unary_internal(
+        "TestService",
+        "SlowStreamProcessor",
+        move |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let received = message_received_clone.clone();
+            let completed = handler_completed_clone.clone();
+            async move {
+                // Process incoming messages slowly (ignores deadline)
+                while let Some(req_result) = request_stream.next().await {
+                    let req = req_result?;
+                    *received.lock().await += 1;
+
+                    tracing::info!(
+                        "Processing message {}: {}",
+                        *received.lock().await,
+                        req.message
+                    );
+
+                    // Slow processing (200ms per message)
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+
+                *completed.lock().await = true;
+
+                let count = *received.lock().await;
+
+                tracing::info!("Handler completed processing {} messages", count);
+
+                Ok(TestResponse {
+                    result: format!("Processed {count} messages"),
+                    count,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Create a stream of 10 messages (would take 2 seconds to process)
+    let requests = (0..10)
+        .map(|i| TestRequest {
+            message: format!("msg-{i}"),
+            value: i,
+        })
+        .collect::<Vec<_>>();
+
+    // Set a deadline of 500ms (server should enforce this)
+    let result: Result<TestResponse, RpcError> = env
+        .channel
+        .stream_unary(
+            "TestService",
+            "SlowStreamProcessor",
+            stream::iter(requests),
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded (enforced by server infrastructure)
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let was_completed = *handler_completed.lock().await;
+    let received = *messages_received.lock().await;
+
+    assert!(!was_completed, "Server should not have completed");
+
+    // Handler should not have completed due to server-enforced deadline
+    assert!(
+        received < 10,
+        "Handler should not have processed all messages due to deadline, got {received}"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_for_unary_stream() {
+    let mut env = TestEnv::new("test-server-deadline-unary-stream").await;
+
+    let messages_sent = Arc::new(Mutex::new(0));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let sent_clone = messages_sent.clone();
+    let completed_clone = handler_completed.clone();
+
+    // Register a unary-stream handler that generates messages slowly
+    env.server.register_unary_stream_internal(
+        "TestService",
+        "SlowStreamGenerator",
+        move |request: TestRequest, _ctx: Context| {
+            let sent = sent_clone.clone();
+            let completed = completed_clone.clone();
+            async move {
+                let response_stream = async_stream::stream! {
+                    // Try to generate many messages slowly (ignores deadline)
+                    for i in 0..10 {
+                        tracing::info!("Generating message {}", i);
+
+                        // Slow generation (200ms per message)
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+
+                        let mut count = sent.lock().await;
+                        *count += 1;
+                        drop(count);
+
+                        yield Ok(TestResponse {
+                            result: format!("{}-{}", request.message, i),
+                            count: i,
+                        });
+                    }
+
+                    *completed.lock().await = true;
+                    tracing::info!("Handler completed generating all messages");
+                };
+
+                Ok(response_stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "item".to_string(),
+        value: 0,
+    };
+
+    // Set a deadline of 500ms (would take 2 seconds to generate all 10 messages)
+    let (responses, error) = {
+        let response_stream = env.channel.unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStreamGenerator",
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+    let responses_received = responses.len();
+
+    // Should have received some messages but not all due to deadline
+    assert!(
+        responses_received < 10,
+        "Should not have received all messages due to deadline, got {responses_received}"
+    );
+
+    // Should get a deadline exceeded error
+    assert!(error.is_some(), "Expected deadline exceeded error");
+    let err = error.unwrap();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let was_completed = *handler_completed.lock().await;
+    let sent = *messages_sent.lock().await;
+
+    assert!(!was_completed, "Handler should not have completed");
+    assert!(
+        sent < 10,
+        "Handler should not have sent all messages due to deadline, sent {sent}"
+    );
+
+    env.shutdown().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_for_stream_stream() {
+    let mut env = TestEnv::new("test-server-deadline-stream-stream").await;
+
+    let messages_received = Arc::new(Mutex::new(0));
+    let messages_sent = Arc::new(Mutex::new(0));
+    let handler_completed = Arc::new(Mutex::new(false));
+    let received_clone = messages_received.clone();
+    let sent_clone = messages_sent.clone();
+    let completed_clone = handler_completed.clone();
+
+    // Register a stream-stream handler that processes slowly
+    env.server.register_stream_stream_internal(
+        "TestService",
+        "SlowStreamTransform",
+        move |mut request_stream: DecodedStream<TestRequest>, _ctx: Context| {
+            let received = received_clone.clone();
+            let sent = sent_clone.clone();
+            let completed = completed_clone.clone();
+            async move {
+                let response_stream = async_stream::stream! {
+                    // Process incoming messages slowly (ignores deadline)
+                    while let Some(req_result) = request_stream.next().await {
+                        match req_result {
+                            Ok(req) => {
+                                let mut recv_count = received.lock().await;
+                                *recv_count += 1;
+                                drop(recv_count);
+
+                                tracing::info!("Processing message: {}", req.message);
+
+                                // Slow processing (300ms per message)
+                                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                                let mut send_count = sent.lock().await;
+                                *send_count += 1;
+                                drop(send_count);
+
+                                yield Ok(TestResponse {
+                                    result: format!("Processed: {}", req.message),
+                                    count: req.value * 10,
+                                });
+                            }
+                            Err(e) => {
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+
+                    *completed.lock().await = true;
+                    tracing::info!("Handler completed processing all messages");
+                };
+
+                Ok(response_stream)
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    // Create a stream of 10 messages (would take 3 seconds to process)
+    let requests = (0..10)
+        .map(|i| TestRequest {
+            message: format!("msg-{i}"),
+            value: i,
+        })
+        .collect::<Vec<_>>();
+
+    // Set a deadline of 800ms (server should enforce this)
+    let (responses, error) = {
+        let response_stream = env.channel.stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "SlowStreamTransform",
+            stream::iter(requests),
+            Some(Duration::from_millis(800)),
+            None,
+        );
+
+        pin_mut!(response_stream);
+
+        collect_stream_until_error(response_stream).await
+    };
+    let responses_received = responses.len();
+
+    // Should have received some messages but not all due to deadline
+    assert!(
+        responses_received < 10,
+        "Should not have received all messages due to deadline, got {responses_received}"
+    );
+
+    // Should get a deadline exceeded error
+    assert!(error.is_some(), "Expected deadline exceeded error");
+    let err = error.unwrap();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let was_completed = *handler_completed.lock().await;
+    let sent = *messages_sent.lock().await;
+
+    assert!(!was_completed, "Handler should not have completed");
+    assert!(
+        sent < 10,
+        "Handler should not have sent all messages due to deadline, sent {sent}"
+    );
+
+    env.shutdown().await;
+}
+
+/// Test that verifies a server can be shut down and restarted successfully
+#[tokio::test]
+async fn test_server_restart() {
+    let mut env = TestEnv::new("test-server-restart").await;
+
+    // Register a handler that counts calls
+    let call_count = Arc::new(Mutex::new(0u32));
+    let count_clone = call_count.clone();
+
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "Counter",
+        move |request: TestRequest, _ctx: Context| {
+            let count = count_clone.clone();
+            async move {
+                let mut counter = count.lock().await;
+                *counter += 1;
+                let current_count = *counter;
+                drop(counter);
+
+                Ok(TestResponse {
+                    result: format!(
+                        "Call count: {}, Message: {}",
+                        current_count, request.message
+                    ),
+                    count: current_count as i32,
+                })
+            }
+        },
+    );
+
+    // Start server first time
+    env.start_server().await;
+
+    // Make first call
+    let request1 = TestRequest {
+        message: "First call".to_string(),
+        value: 1,
+    };
+
+    let response1: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request1, None, None)
+        .await
+        .expect("First unary call failed");
+
+    assert_eq!(response1.count, 1);
+    assert!(response1.result.contains("Call count: 1"));
+    assert!(response1.result.contains("First call"));
+
+    // Make second call before shutdown
+    let request2 = TestRequest {
+        message: "Second call".to_string(),
+        value: 2,
+    };
+
+    let response2: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request2, None, None)
+        .await
+        .expect("Second unary call failed");
+
+    assert_eq!(response2.count, 2);
+    assert!(response2.result.contains("Call count: 2"));
+
+    // Shutdown the server
+    tracing::info!("Shutting down server for restart test...");
+    env.server.shutdown_async().await;
+
+    // Give a brief moment for cleanup
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Restart the server
+    tracing::info!("Restarting server...");
+    env.start_server().await;
+
+    // Make third call after restart
+    let request3 = TestRequest {
+        message: "Third call after restart".to_string(),
+        value: 3,
+    };
+
+    let response3: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request3, None, None)
+        .await
+        .expect("Third unary call after restart failed");
+
+    // The counter should continue from where it left off (state is preserved)
+    assert_eq!(response3.count, 3);
+    assert!(response3.result.contains("Call count: 3"));
+    assert!(response3.result.contains("Third call after restart"));
+
+    // Make fourth call to ensure server is fully functional
+    let request4 = TestRequest {
+        message: "Fourth call".to_string(),
+        value: 4,
+    };
+
+    let response4: TestResponse = env
+        .channel
+        .unary("TestService", "Counter", request4, None, None)
+        .await
+        .expect("Fourth unary call failed");
+
+    assert_eq!(response4.count, 4);
+    assert!(response4.result.contains("Call count: 4"));
+
+    // Final shutdown
+    env.shutdown().await;
+}
+
+/// Test that verifies shutting down the server while a handler is executing
+/// The handler is cancelled and the client receives an error
+#[tokio::test]
+async fn test_server_shutdown_during_handler_execution() {
+    let mut env = TestEnv::new("test-shutdown-during-handler").await;
+
+    let handler_started = Arc::new(Mutex::new(false));
+    let started_clone = handler_started.clone();
+
+    // Register a handler that takes some time to execute
+    env.server.register_unary_unary_internal(
+        "TestService",
+        "SlowHandler",
+        move |request: TestRequest, _ctx: Context| {
+            let started = started_clone.clone();
+            async move {
+                *started.lock().await = true;
+
+                // Simulate a long-running handler (5 seconds)
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                Ok(TestResponse {
+                    result: format!("Processed: {}", request.message),
+                    count: request.value,
+                })
+            }
+        },
+    );
+
+    env.start_server().await;
+
+    let request = TestRequest {
+        message: "Test".to_string(),
+        value: 42,
+    };
+
+    // Start the RPC call in a separate task
+    let channel = env.channel.clone();
+    let call_handle = tokio::spawn(async move {
+        channel
+            .unary::<TestRequest, TestResponse>("TestService", "SlowHandler", request, None, None)
+            .await
+    });
+
+    // Wait for handler to start
+    for _ in 0..100 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if *handler_started.lock().await {
+            break;
+        }
+    }
+
+    assert!(*handler_started.lock().await, "Handler should have started");
+
+    // Give the handler more time to be deep in execution
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Now shut down the server while the handler is still executing
+    env.server.shutdown_async().await;
+
+    // The RPC call should return an error since the handler was cancelled
+    let result = call_handle.await.expect("Task should not panic");
+
+    assert!(
+        result.is_err(),
+        "Expected an error when server shuts down during handler execution"
+    );
+
+    let error = result.unwrap_err();
+
+    // The error should be Cancelled since the handler was cancelled during shutdown
+    assert_eq!(
+        error.code(),
+        RpcCode::Cancelled,
+        "Expected Cancelled error when server shuts down during handler execution, got: {:?}",
+        error.code()
+    );
+
+    env.shutdown().await;
+}

--- a/crates/slim-bindings/tests/slimrpc_e2e.rs
+++ b/crates/slim-bindings/tests/slimrpc_e2e.rs
@@ -1,0 +1,2596 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for SlimRPC UniFFI bindings
+//!
+//! These tests verify the four RPC interaction patterns through the UniFFI bindings:
+//! - Unary-Unary: Single request, single response
+//! - Stream-Unary: Streaming requests, single response
+//! - Unary-Stream: Single request, streaming responses
+//! - Stream-Stream: Streaming requests, streaming responses
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+
+use slim_bindings::{
+    App, Channel, Direction, IdentityProviderConfig, IdentityVerifierConfig,
+    MulticastStreamMessage, Name, RpcCode, RpcError, Server, StreamMessage, StreamStreamHandler,
+    StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler, initialize_with_defaults,
+};
+
+// ============================================================================
+// Test Handlers
+// ============================================================================
+
+/// Simple echo handler for unary-unary
+struct EchoHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for EchoHandler {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        // Echo the request back
+        println!("EchoHandler received request: {request:?}");
+        Ok(request)
+    }
+}
+
+/// Handler that returns an error for unary-unary
+struct ErrorHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for ErrorHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        Err(RpcError::new(
+            RpcCode::InvalidArgument,
+            "Intentional error".to_string(),
+        ))
+    }
+}
+
+/// Handler that streams responses for unary-stream
+struct CounterHandler;
+
+#[async_trait::async_trait]
+impl UnaryStreamHandler for CounterHandler {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        // Parse count from request (simple u32 encoding)
+        let count = if request.len() >= 4 {
+            u32::from_le_bytes([request[0], request[1], request[2], request[3]])
+        } else {
+            3
+        };
+
+        // Send count messages
+        for i in 0..count {
+            let response = i.to_le_bytes().to_vec();
+            sink.send_async(response).await?;
+        }
+
+        sink.close_async().await?;
+        Ok(())
+    }
+}
+
+/// Handler that streams responses with an error for unary-stream
+struct StreamErrorHandler;
+
+#[async_trait::async_trait]
+impl UnaryStreamHandler for StreamErrorHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        // Send a couple of messages
+        sink.send_async(vec![1, 2, 3]).await?;
+        sink.send_async(vec![4, 5, 6]).await?;
+
+        // Then send an error
+        sink.send_error_async(RpcError::new(
+            RpcCode::Internal,
+            "Stream error after 2 messages".to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+}
+
+/// Handler that accumulates stream input for stream-unary
+struct AccumulatorHandler;
+
+#[async_trait::async_trait]
+impl StreamUnaryHandler for AccumulatorHandler {
+    async fn handle(
+        &self,
+        stream: Arc<slim_bindings::RequestStream>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        let mut total = 0u32;
+        let mut count = 0u32;
+
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    count += 1;
+                    if data.len() >= 4 {
+                        let value = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+                        total += value;
+                    }
+                }
+                StreamMessage::Error(e) => return Err(e),
+                StreamMessage::End => break,
+            }
+        }
+
+        // Return total and count
+        let mut result = total.to_le_bytes().to_vec();
+        result.extend_from_slice(&count.to_le_bytes());
+        Ok(result)
+    }
+}
+
+/// Handler that detects error in stream input for stream-unary
+struct StreamInputErrorHandler;
+
+#[async_trait::async_trait]
+impl StreamUnaryHandler for StreamInputErrorHandler {
+    async fn handle(
+        &self,
+        stream: Arc<slim_bindings::RequestStream>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        let mut count = 0u32;
+
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    count += 1;
+                    // Check for error marker (first byte == 255)
+                    if !data.is_empty() && data[0] == 255 {
+                        return Err(RpcError::new(
+                            RpcCode::InvalidArgument,
+                            format!("Invalid data at message {count}"),
+                        ));
+                    }
+                }
+                StreamMessage::Error(e) => return Err(e),
+                StreamMessage::End => break,
+            }
+        }
+
+        Ok(count.to_le_bytes().to_vec())
+    }
+}
+
+/// Handler that echoes stream for stream-stream
+struct StreamEchoHandler;
+
+#[async_trait::async_trait]
+impl StreamStreamHandler for StreamEchoHandler {
+    async fn handle(
+        &self,
+        stream: Arc<slim_bindings::RequestStream>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    sink.send_async(data).await?;
+                }
+                StreamMessage::Error(e) => {
+                    sink.send_error_async(e).await?;
+                    return Ok(());
+                }
+                StreamMessage::End => {
+                    sink.close_async().await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+/// Handler that transforms stream data for stream-stream
+struct TransformHandler;
+
+#[async_trait::async_trait]
+impl StreamStreamHandler for TransformHandler {
+    async fn handle(
+        &self,
+        stream: Arc<slim_bindings::RequestStream>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(data) => {
+                    // Double each value
+                    let transformed: Vec<u8> = data.iter().map(|&b| b.wrapping_mul(2)).collect();
+                    sink.send_async(transformed).await?;
+                }
+                StreamMessage::Error(e) => {
+                    sink.send_error_async(e).await?;
+                    return Ok(());
+                }
+                StreamMessage::End => {
+                    sink.close_async().await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Slow Handlers for Deadline Testing
+// ============================================================================
+
+/// Handler that sleeps for 2 seconds before responding
+struct SlowUnaryHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for SlowUnaryHandler {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        Ok(request)
+    }
+}
+
+/// Handler that generates stream items slowly
+struct SlowStreamHandler {
+    started: Arc<Mutex<bool>>,
+    completed: Arc<Mutex<bool>>,
+    items_sent: Arc<Mutex<u32>>,
+}
+
+#[async_trait::async_trait]
+impl UnaryStreamHandler for SlowStreamHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        *self.started.lock().await = true;
+
+        for i in 0u32..5 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let response = i.to_le_bytes().to_vec();
+            sink.send_async(response).await?;
+
+            let mut count = self.items_sent.lock().await;
+            *count += 1;
+            drop(count);
+        }
+
+        sink.close_async().await?;
+        *self.completed.lock().await = true;
+        Ok(())
+    }
+}
+
+/// Handler that takes long to setup before returning stream
+struct SlowSetupStreamHandler {
+    started: Arc<Mutex<bool>>,
+    completed: Arc<Mutex<bool>>,
+}
+
+#[async_trait::async_trait]
+impl UnaryStreamHandler for SlowSetupStreamHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        *self.started.lock().await = true;
+
+        // Sleep for 2 seconds before starting to stream
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        for i in 0u32..3 {
+            let response = i.to_le_bytes().to_vec();
+            sink.send_async(response).await?;
+        }
+
+        sink.close_async().await?;
+        *self.completed.lock().await = true;
+        Ok(())
+    }
+}
+
+/// Handler that processes stream input slowly
+struct SlowStreamUnaryHandler {
+    started: Arc<Mutex<bool>>,
+    completed: Arc<Mutex<bool>>,
+    messages_received: Arc<Mutex<u32>>,
+}
+
+#[async_trait::async_trait]
+impl StreamUnaryHandler for SlowStreamUnaryHandler {
+    async fn handle(
+        &self,
+        stream: Arc<slim_bindings::RequestStream>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        *self.started.lock().await = true;
+
+        let mut count = 0u32;
+
+        loop {
+            match stream.next_async().await {
+                StreamMessage::Data(_msg) => {
+                    count += 1;
+                    *self.messages_received.lock().await = count;
+
+                    // Slow processing
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    println!("Processed message {count}");
+                }
+                StreamMessage::End => break,
+                StreamMessage::Error(e) => return Err(e),
+            }
+        }
+
+        // Additional slow processing after receiving all messages
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        *self.completed.lock().await = true;
+        Ok(count.to_le_bytes().to_vec())
+    }
+}
+
+/// Handler that processes stream-to-stream slowly
+struct SlowStreamStreamHandler {
+    started: Arc<Mutex<bool>>,
+    completed: Arc<Mutex<bool>>,
+}
+
+#[async_trait::async_trait]
+impl StreamStreamHandler for SlowStreamStreamHandler {
+    async fn handle(
+        &self,
+        stream: Arc<slim_bindings::RequestStream>,
+        _context: Arc<slim_bindings::Context>,
+        sink: Arc<slim_bindings::ResponseSink>,
+    ) -> Result<(), RpcError> {
+        *self.started.lock().await = true;
+
+        // Consume one message then sleep for a long time
+        match stream.next_async().await {
+            StreamMessage::Data(_msg) => {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+            StreamMessage::End => {}
+            StreamMessage::Error(e) => return Err(e),
+        }
+
+        for i in 0u32..3 {
+            let response = i.to_le_bytes().to_vec();
+            sink.send_async(response).await?;
+        }
+
+        sink.close_async().await?;
+        *self.completed.lock().await = true;
+        Ok(())
+    }
+}
+
+/// Handler that ignores deadline and runs for a long time
+struct LongRunningHandler {
+    started: Arc<Mutex<bool>>,
+    completed: Arc<Mutex<bool>>,
+}
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for LongRunningHandler {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        _context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        *self.started.lock().await = true;
+        println!("LongRunningHandler started, will run for 5 seconds");
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        *self.completed.lock().await = true;
+        println!("LongRunningHandler completed");
+
+        Ok(request)
+    }
+}
+
+/// Handler that captures deadline from context
+struct DeadlineCaptureHandler {
+    captured_deadline: Arc<Mutex<Option<std::time::SystemTime>>>,
+}
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for DeadlineCaptureHandler {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        *self.captured_deadline.lock().await = Some(context.deadline());
+        Ok(request)
+    }
+}
+
+// ============================================================================
+// Test Environment Setup
+// ============================================================================
+
+struct TestEnv {
+    server: Arc<Server>,
+    _app: Arc<App>,
+}
+
+impl TestEnv {
+    async fn new(test_name: &str) -> Self {
+        println!("TestEnv::new starting for {test_name}");
+
+        // Initialize the runtime if not already initialized
+        initialize_with_defaults();
+        println!("Runtime initialized");
+
+        // Create server app
+        let server_name = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            test_name.to_string(),
+        ));
+        println!("Server name created");
+
+        let provider_config = IdentityProviderConfig::SharedSecret {
+            id: "test-provider".to_string(),
+            data: "test-secret-with-sufficient-length-for-hmac-key".to_string(),
+        };
+        let verifier_config = IdentityVerifierConfig::SharedSecret {
+            id: "test-verifier".to_string(),
+            data: "test-secret-with-sufficient-length-for-hmac-key".to_string(),
+        };
+
+        println!("Creating server app...");
+        let server_app = App::new_with_direction_async(
+            server_name.clone(),
+            provider_config.clone(),
+            verifier_config.clone(),
+            Direction::Bidirectional,
+        )
+        .await
+        .expect("Failed to create server app");
+        println!("Server app created");
+
+        // Create server using UniFFI constructor
+        println!("Creating RPC server...");
+        let server = Arc::new(Server::new(&server_app, server_app.name().clone()));
+        println!("RPC server created");
+
+        println!("TestEnv::new completed for {test_name}");
+        Self {
+            server,
+            _app: server_app,
+        }
+    }
+
+    async fn start_server(&self) {
+        // Start server in background
+        println!("Starting server in background...");
+        let server = self.server.clone();
+
+        // Spawn task to run the server
+        tokio::spawn(async move {
+            if let Err(e) = server.serve_async().await {
+                eprintln!("Server error: {e:?}");
+            }
+        });
+
+        // Give server time to start and subscribe
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    async fn create_client(&self, test_name: &str) -> Channel {
+        let client_name = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            format!("{test_name}-client"),
+        ));
+
+        let provider_config = IdentityProviderConfig::SharedSecret {
+            id: "test-provider-client".to_string(),
+            data: "test-secret-with-sufficient-length-for-hmac-key".to_string(),
+        };
+        let verifier_config = IdentityVerifierConfig::SharedSecret {
+            id: "test-verifier-client".to_string(),
+            data: "test-secret-with-sufficient-length-for-hmac-key".to_string(),
+        };
+
+        let client_app = App::new_with_direction_async(
+            client_name,
+            provider_config,
+            verifier_config,
+            Direction::Bidirectional,
+        )
+        .await
+        .expect("Failed to create client app");
+
+        let server_name = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            test_name.to_string(),
+        ));
+
+        Channel::new(client_app, server_name)
+    }
+}
+
+// ============================================================================
+// Test 1: Unary-Unary RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_rpc() {
+    let env = TestEnv::new("unary-echo").await;
+
+    // Register echo handler
+    println!("Registering EchoHandler...");
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Echo".to_string(),
+        Arc::new(EchoHandler),
+    );
+
+    env.start_server().await;
+
+    println!("Creating channel...");
+    let channel = env.create_client("unary-echo").await;
+
+    // Make a call
+    println!("Making unary call...");
+    let request = vec![1, 2, 3, 4, 5];
+    let response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "Echo".to_string(),
+            request.clone(),
+            Some(Duration::from_secs(5)),
+            None,
+        )
+        .await
+        .expect("Unary call failed");
+
+    assert_eq!(response, request);
+
+    println!("Unary call succeeded");
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_unary_error_handling() {
+    let env = TestEnv::new("unary-error").await;
+
+    // Register error handler
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Error".to_string(),
+        Arc::new(ErrorHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("unary-error").await;
+
+    // Make a call that should fail
+    let request = vec![1, 2, 3];
+    let result = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "Error".to_string(),
+            request,
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await;
+
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), RpcCode::InvalidArgument);
+    assert!(error.message().contains("Intentional error"));
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Test 2: Unary-Stream RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_rpc() {
+    let env = TestEnv::new("unary-stream").await;
+
+    // Register counter handler
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "Counter".to_string(),
+        Arc::new(CounterHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("unary-stream").await;
+
+    // Request 5 messages
+    let count = 5u32;
+    let request = count.to_le_bytes().to_vec();
+
+    let reader = channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "Counter".to_string(),
+            request,
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Unary stream call failed");
+
+    // Collect all responses
+    let mut responses = Vec::new();
+    loop {
+        match reader.next_async().await {
+            StreamMessage::Data(data) => {
+                responses.push(data);
+            }
+            StreamMessage::Error(e) => {
+                panic!("Unexpected error: {e:?}");
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(responses.len(), 5);
+    for (i, response) in responses.iter().enumerate() {
+        let value = u32::from_le_bytes([response[0], response[1], response[2], response[3]]);
+        assert_eq!(value, i as u32);
+    }
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_error_handling() {
+    let env = TestEnv::new("unary-stream-error").await;
+
+    // Register error handler
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "StreamError".to_string(),
+        Arc::new(StreamErrorHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("unary-stream-error").await;
+
+    let reader = channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "StreamError".to_string(),
+            vec![1],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Unary stream call failed");
+
+    // Collect responses until error
+    let mut responses = Vec::new();
+    let mut got_error = false;
+
+    loop {
+        match reader.next_async().await {
+            StreamMessage::Data(data) => {
+                responses.push(data);
+            }
+            StreamMessage::Error(e) => {
+                assert_eq!(e.code(), RpcCode::Internal);
+                assert!(e.message().contains("Stream error after 2 messages"));
+                got_error = true;
+                break;
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(responses.len(), 2);
+    assert!(got_error);
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Test 3: Stream-Unary RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_rpc() {
+    let env = TestEnv::new("stream-unary").await;
+
+    // Register accumulator handler
+    env.server.register_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Arc::new(AccumulatorHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("stream-unary").await;
+
+    // Create stream writer
+    let writer = channel.call_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    // Send multiple values
+    let values = vec![10u32, 20u32, 30u32, 40u32];
+    for value in &values {
+        writer
+            .send_async(value.to_le_bytes().to_vec())
+            .await
+            .expect("Failed to send");
+    }
+
+    // Finalize and get response
+    let response = writer
+        .finalize_stream_async()
+        .await
+        .expect("Failed to finalize");
+
+    // Parse response: total (4 bytes) + count (4 bytes)
+    assert_eq!(response.len(), 8);
+    let total = u32::from_le_bytes([response[0], response[1], response[2], response[3]]);
+    let count = u32::from_le_bytes([response[4], response[5], response[6], response[7]]);
+
+    assert_eq!(total, 100); // 10 + 20 + 30 + 40
+    assert_eq!(count, 4);
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_error_handling() {
+    let env = TestEnv::new("stream-unary-error").await;
+
+    // Register error handler
+    env.server.register_stream_unary(
+        "TestService".to_string(),
+        "StreamInputError".to_string(),
+        Arc::new(StreamInputErrorHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("stream-unary-error").await;
+
+    // Create stream writer
+    let writer = channel.call_stream_unary(
+        "TestService".to_string(),
+        "StreamInputError".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    // Send a valid message
+    writer
+        .send_async(vec![1, 2, 3])
+        .await
+        .expect("Failed to send");
+
+    // Send an invalid message (starts with 255)
+    writer
+        .send_async(vec![255, 0, 0])
+        .await
+        .expect("Failed to send");
+
+    // Finalize - should get an error
+    let result = writer.finalize_stream_async().await;
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), RpcCode::InvalidArgument);
+    assert!(error.message().contains("Invalid data"));
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Test 4: Stream-Stream RPC
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_echo() {
+    let env = TestEnv::new("stream-stream-echo").await;
+
+    // Register stream echo handler
+    env.server.register_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Arc::new(StreamEchoHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("stream-stream-echo").await;
+
+    // Create bidirectional stream
+    let handler = channel.call_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    // Send messages
+    let messages = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    for msg in &messages {
+        handler
+            .send_async(msg.clone())
+            .await
+            .expect("Failed to send");
+    }
+
+    // Close send side
+    handler.close_send_async().await.expect("Failed to close");
+
+    // Receive echoed messages
+    let mut received = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            StreamMessage::Data(data) => {
+                received.push(data);
+            }
+            StreamMessage::Error(e) => {
+                panic!("Unexpected error: {e:?}");
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(received.len(), 3);
+    assert_eq!(received, messages);
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_transform() {
+    let env = TestEnv::new("stream-stream-transform").await;
+
+    // Register transform handler
+    env.server.register_stream_stream(
+        "TestService".to_string(),
+        "Transform".to_string(),
+        Arc::new(TransformHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("stream-stream-transform").await;
+
+    // Create bidirectional stream
+    let handler = channel.call_stream_stream(
+        "TestService".to_string(),
+        "Transform".to_string(),
+        Some(Duration::from_secs(30)),
+        None,
+    );
+
+    // Send messages in a separate task
+    let handler_clone = handler.clone();
+    let send_handle = tokio::spawn(async move {
+        let messages = vec![vec![1, 2, 3], vec![10, 20, 30], vec![100]];
+        for msg in messages {
+            handler_clone.send_async(msg).await.expect("Failed to send");
+        }
+        handler_clone
+            .close_send_async()
+            .await
+            .expect("Failed to close");
+    });
+
+    // Receive transformed messages
+    let mut received = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            StreamMessage::Data(data) => {
+                received.push(data);
+            }
+            StreamMessage::Error(e) => {
+                panic!("Unexpected error: {e:?}");
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    // Wait for send to complete
+    send_handle.await.expect("Send task failed");
+
+    // Verify transformation (each byte doubled)
+    assert_eq!(received.len(), 3);
+    assert_eq!(received[0], vec![2, 4, 6]); // [1,2,3] * 2
+    assert_eq!(received[1], vec![20, 40, 60]); // [10,20,30] * 2
+    assert_eq!(received[2], vec![200]); // [100] * 2
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Test 5: Multiple concurrent calls
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_concurrent_unary_calls() {
+    let env = TestEnv::new("concurrent-unary").await;
+
+    // Register echo handler
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Echo".to_string(),
+        Arc::new(EchoHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("concurrent-unary").await;
+
+    // Make 10 concurrent calls
+    let mut handles = Vec::new();
+    for i in 0..10 {
+        let channel = channel.clone();
+        let handle = tokio::spawn(async move {
+            let request = vec![i as u8; 10];
+            let response = channel
+                .call_unary_async(
+                    "TestService".to_string(),
+                    "Echo".to_string(),
+                    request.clone(),
+                    Some(Duration::from_secs(30)),
+                    None,
+                )
+                .await
+                .expect("Unary call failed");
+
+            assert_eq!(response, request);
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all calls to complete
+    for handle in handles {
+        handle.await.expect("Task panicked");
+    }
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Test 6: Handler registration
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_handler_registration() {
+    let env = TestEnv::new("handler-registration").await;
+
+    // Register multiple handlers
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Echo1".to_string(),
+        Arc::new(EchoHandler),
+    );
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "Echo2".to_string(),
+        Arc::new(EchoHandler),
+    );
+
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "Counter".to_string(),
+        Arc::new(CounterHandler),
+    );
+
+    env.start_server().await;
+
+    // Get list of registered methods
+    let methods = env.server.methods();
+    assert!(methods.len() >= 3);
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Test 7: Context information
+// ============================================================================
+
+/// Handler that returns context information
+struct ContextInfoHandler;
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for ContextInfoHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        // Access context information
+        let session_id = context.session_id();
+
+        // Return session ID as bytes
+        Ok(session_id.as_bytes().to_vec())
+    }
+}
+
+/// Handler that captures and validates all context information
+struct ContextValidationHandler {
+    captured_session_id: Arc<Mutex<Option<String>>>,
+    captured_metadata: Arc<Mutex<Option<HashMap<String, String>>>>,
+    captured_deadline: Arc<Mutex<Option<std::time::SystemTime>>>,
+    captured_remaining: Arc<Mutex<Option<Duration>>>,
+    captured_is_exceeded: Arc<Mutex<Option<bool>>>,
+}
+
+#[async_trait::async_trait]
+impl UnaryUnaryHandler for ContextValidationHandler {
+    async fn handle(
+        &self,
+        _request: Vec<u8>,
+        context: Arc<slim_bindings::Context>,
+    ) -> Result<Vec<u8>, RpcError> {
+        // Capture session ID
+        let session_id = context.session_id();
+        *self.captured_session_id.lock().await = Some(session_id.clone());
+
+        // Capture metadata
+        let metadata = context.metadata();
+        *self.captured_metadata.lock().await = Some(metadata.clone());
+
+        // Capture deadline
+        let deadline = context.deadline();
+        *self.captured_deadline.lock().await = Some(deadline);
+
+        // Capture remaining time
+        let remaining = context.remaining_time();
+        *self.captured_remaining.lock().await = Some(remaining);
+
+        // Capture deadline exceeded status
+        let is_exceeded = context.is_deadline_exceeded();
+        *self.captured_is_exceeded.lock().await = Some(is_exceeded);
+
+        Ok(b"ok".to_vec())
+    }
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_access() {
+    let env = TestEnv::new("context-access").await;
+
+    // Register context info handler
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ContextInfo".to_string(),
+        Arc::new(ContextInfoHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-access").await;
+
+    let response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ContextInfo".to_string(),
+            vec![],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Context call failed");
+
+    // Should get a session ID back
+    assert!(!response.is_empty());
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_session_id() {
+    let env = TestEnv::new("context-session-id").await;
+
+    let captured_session_id = Arc::new(Mutex::new(None));
+    let handler = ContextValidationHandler {
+        captured_session_id: captured_session_id.clone(),
+        captured_metadata: Arc::new(Mutex::new(None)),
+        captured_deadline: Arc::new(Mutex::new(None)),
+        captured_remaining: Arc::new(Mutex::new(None)),
+        captured_is_exceeded: Arc::new(Mutex::new(None)),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-session-id").await;
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            None,
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify session ID was captured and is not empty
+    let session_id = captured_session_id.lock().await;
+    assert!(session_id.is_some(), "Session ID should be captured");
+    assert!(
+        !session_id.as_ref().unwrap().is_empty(),
+        "Session ID should not be empty"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_metadata() {
+    let env = TestEnv::new("context-metadata").await;
+
+    let captured_metadata = Arc::new(Mutex::new(None));
+    let handler = ContextValidationHandler {
+        captured_session_id: Arc::new(Mutex::new(None)),
+        captured_metadata: captured_metadata.clone(),
+        captured_deadline: Arc::new(Mutex::new(None)),
+        captured_remaining: Arc::new(Mutex::new(None)),
+        captured_is_exceeded: Arc::new(Mutex::new(None)),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-metadata").await;
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            None,
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify metadata was captured
+    let metadata = captured_metadata.lock().await;
+    assert!(metadata.is_some(), "Metadata should be captured");
+
+    // Metadata should contain at least the deadline key
+    let metadata_map = metadata.as_ref().unwrap();
+    assert!(
+        metadata_map.contains_key("slimrpc-timeout"),
+        "Metadata should contain deadline"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_custom_metadata() {
+    let env = TestEnv::new("context-custom-metadata").await;
+
+    let captured_metadata = Arc::new(Mutex::new(None));
+    let handler = ContextValidationHandler {
+        captured_session_id: Arc::new(Mutex::new(None)),
+        captured_metadata: captured_metadata.clone(),
+        captured_deadline: Arc::new(Mutex::new(None)),
+        captured_remaining: Arc::new(Mutex::new(None)),
+        captured_is_exceeded: Arc::new(Mutex::new(None)),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-custom-metadata").await;
+
+    // Create custom metadata
+    let mut custom_metadata = HashMap::new();
+    custom_metadata.insert("authorization".to_string(), "Bearer token123".to_string());
+    custom_metadata.insert("request-id".to_string(), "abc-123-xyz".to_string());
+    custom_metadata.insert("user-agent".to_string(), "test-client/1.0".to_string());
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(Duration::from_secs(30)),
+            Some(custom_metadata.clone()),
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify metadata was captured
+    let metadata = captured_metadata.lock().await;
+    assert!(metadata.is_some(), "Metadata should be captured");
+
+    let metadata_map = metadata.as_ref().unwrap();
+
+    // Verify custom metadata fields are present
+    assert_eq!(
+        metadata_map.get("authorization"),
+        Some(&"Bearer token123".to_string()),
+        "Authorization metadata should match"
+    );
+    assert_eq!(
+        metadata_map.get("request-id"),
+        Some(&"abc-123-xyz".to_string()),
+        "Request ID metadata should match"
+    );
+    assert_eq!(
+        metadata_map.get("user-agent"),
+        Some(&"test-client/1.0".to_string()),
+        "User agent metadata should match"
+    );
+
+    // Verify deadline is still present
+    assert!(
+        metadata_map.contains_key("slimrpc-timeout"),
+        "Metadata should contain deadline"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_unary_stream_with_metadata() {
+    let env = TestEnv::new("unary-stream-metadata").await;
+
+    // Register counter handler
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "Counter".to_string(),
+        Arc::new(CounterHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("unary-stream-metadata").await;
+
+    // Create custom metadata
+    let mut custom_metadata = HashMap::new();
+    custom_metadata.insert("client-id".to_string(), "test-client-123".to_string());
+    custom_metadata.insert("stream-type".to_string(), "counter".to_string());
+
+    let count = 5u32;
+    let request = count.to_le_bytes().to_vec(); // Request 5 items
+    let reader = channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "Counter".to_string(),
+            request,
+            Some(Duration::from_secs(30)),
+            Some(custom_metadata),
+        )
+        .await
+        .expect("Unary stream call with metadata failed");
+
+    // Read all responses
+    let mut count = 0;
+    loop {
+        match reader.next_async().await {
+            StreamMessage::Data(_data) => {
+                count += 1;
+            }
+            StreamMessage::Error(e) => {
+                panic!("Stream error: {e:?}");
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(count, 5, "Should receive 5 items");
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_unary_with_metadata() {
+    let env = TestEnv::new("stream-unary-metadata").await;
+
+    // Register accumulator handler
+    env.server.register_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Arc::new(AccumulatorHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("stream-unary-metadata").await;
+
+    // Create custom metadata
+    let mut custom_metadata = HashMap::new();
+    custom_metadata.insert("operation".to_string(), "sum".to_string());
+    custom_metadata.insert("client-version".to_string(), "2.0".to_string());
+
+    // Create stream writer with metadata
+    let writer = channel.call_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Some(Duration::from_secs(30)),
+        Some(custom_metadata),
+    );
+
+    // Send multiple values
+    let values = vec![1u32, 2, 3, 4, 5];
+    for val in &values {
+        writer
+            .send_async(val.to_le_bytes().to_vec())
+            .await
+            .expect("Failed to send value");
+    }
+
+    // Finalize and get response
+    let response = writer
+        .finalize_stream_async()
+        .await
+        .expect("Failed to finalize");
+    let sum = u32::from_le_bytes([response[0], response[1], response[2], response[3]]);
+
+    let expected_sum: u32 = values.iter().sum();
+    assert_eq!(sum, expected_sum, "Sum should match");
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_stream_stream_with_metadata() {
+    let env = TestEnv::new("stream-stream-metadata").await;
+
+    // Register stream echo handler
+    env.server.register_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Arc::new(StreamEchoHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("stream-stream-metadata").await;
+
+    // Create custom metadata
+    let mut custom_metadata = HashMap::new();
+    custom_metadata.insert("correlation-id".to_string(), "stream-123".to_string());
+    custom_metadata.insert("echo-mode".to_string(), "bidirectional".to_string());
+
+    // Create bidirectional stream with metadata
+    let handler = channel.call_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Some(Duration::from_secs(30)),
+        Some(custom_metadata),
+    );
+
+    // Send messages
+    let messages = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    for msg in &messages {
+        handler.send_async(msg.clone()).await.expect("Send failed");
+    }
+
+    // Close the send side
+    handler.close_send_async().await.expect("Close failed");
+
+    // Receive all echoed messages
+    let mut received = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            StreamMessage::Data(data) => {
+                received.push(data);
+            }
+            StreamMessage::Error(e) => {
+                panic!("Stream error: {e:?}");
+            }
+            StreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(
+        received.len(),
+        messages.len(),
+        "Should receive all messages"
+    );
+    for (sent, recv) in messages.iter().zip(received.iter()) {
+        assert_eq!(sent, recv, "Messages should match");
+    }
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_deadline() {
+    let env = TestEnv::new("context-deadline").await;
+
+    let captured_deadline = Arc::new(Mutex::new(None));
+    let handler = ContextValidationHandler {
+        captured_session_id: Arc::new(Mutex::new(None)),
+        captured_metadata: Arc::new(Mutex::new(None)),
+        captured_deadline: captured_deadline.clone(),
+        captured_remaining: Arc::new(Mutex::new(None)),
+        captured_is_exceeded: Arc::new(Mutex::new(None)),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-deadline").await;
+
+    let timeout = Duration::from_secs(30);
+    let start = std::time::SystemTime::now();
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify deadline was captured and is reasonable
+    let deadline = captured_deadline.lock().await;
+    assert!(deadline.is_some(), "Deadline should be captured");
+
+    let captured = deadline.unwrap();
+    let expected = start + timeout;
+
+    // Deadline should be approximately start + timeout (within 2 seconds)
+    let diff = if captured > expected {
+        captured.duration_since(expected).unwrap()
+    } else {
+        expected.duration_since(captured).unwrap()
+    };
+
+    assert!(
+        diff < Duration::from_secs(2),
+        "Deadline should be close to expected value"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_remaining_time() {
+    let env = TestEnv::new("context-remaining-time").await;
+
+    let captured_remaining = Arc::new(Mutex::new(None));
+    let handler = ContextValidationHandler {
+        captured_session_id: Arc::new(Mutex::new(None)),
+        captured_metadata: Arc::new(Mutex::new(None)),
+        captured_deadline: Arc::new(Mutex::new(None)),
+        captured_remaining: captured_remaining.clone(),
+        captured_is_exceeded: Arc::new(Mutex::new(None)),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-remaining-time").await;
+
+    let timeout = Duration::from_secs(60);
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify remaining time was captured
+    let remaining = captured_remaining.lock().await;
+    assert!(remaining.is_some(), "Remaining time should be captured");
+
+    let remaining_duration = remaining.unwrap();
+
+    // Remaining time should be positive and less than or equal to timeout
+    assert!(
+        remaining_duration > Duration::ZERO,
+        "Remaining time should be positive"
+    );
+    assert!(
+        remaining_duration <= timeout,
+        "Remaining time should not exceed timeout"
+    );
+
+    // Should be close to the timeout (within 5 seconds margin for overhead)
+    assert!(
+        remaining_duration >= timeout - Duration::from_secs(5),
+        "Remaining time should be close to timeout"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Deadline Tests - Client-side enforcement
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_client_deadline_unary_unary() {
+    let env = TestEnv::new("client-deadline-unary").await;
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "SlowMethod".to_string(),
+        Arc::new(SlowUnaryHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("client-deadline-unary").await;
+
+    let request = vec![1, 2, 3, 4];
+
+    // Call with a very short timeout (100ms) while handler takes 2 seconds
+    let result = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "SlowMethod".to_string(),
+            request,
+            Some(Duration::from_millis(100)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the client side
+    assert!(result.is_err(), "Expected timeout error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_client_deadline_unary_stream() {
+    let env = TestEnv::new("client-deadline-unary-stream").await;
+
+    let started = Arc::new(Mutex::new(false));
+    let completed = Arc::new(Mutex::new(false));
+    let items_sent = Arc::new(Mutex::new(0u32));
+
+    let handler = Arc::new(SlowStreamHandler {
+        started: started.clone(),
+        completed: completed.clone(),
+        items_sent: items_sent.clone(),
+    });
+
+    env.server
+        .register_unary_stream("TestService".to_string(), "SlowStream".to_string(), handler);
+
+    env.start_server().await;
+
+    let channel = env.create_client("client-deadline-unary-stream").await;
+
+    let request = vec![1, 2, 3];
+
+    // Call with a timeout of 1 second (should only get 2 items before timeout)
+    let reader = channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "SlowStream".to_string(),
+            request,
+            Some(Duration::from_secs(1)),
+            None,
+        )
+        .await
+        .expect("Failed to create stream");
+
+    let mut count = 0;
+    let mut got_error = false;
+
+    loop {
+        match reader.next_async().await {
+            StreamMessage::Data(_msg) => {
+                count += 1;
+            }
+            StreamMessage::End => break,
+            StreamMessage::Error(e) => {
+                got_error = true;
+                assert_eq!(
+                    e.code(),
+                    RpcCode::DeadlineExceeded,
+                    "Expected DeadlineExceeded, got {:?}",
+                    e.code()
+                );
+                break;
+            }
+        }
+    }
+
+    // Should have received some items but not all (5 total)
+    assert!(count < 5, "Expected timeout before all items, got {count}");
+    assert!(got_error, "Expected a deadline exceeded error");
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify handler started but did not complete
+    let was_started = *started.lock().await;
+    let was_completed = *completed.lock().await;
+    let sent = *items_sent.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+    assert!(
+        sent < 5,
+        "Handler should not have sent all items, sent {sent}"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Deadline Tests - Server-side enforcement
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_unary_unary() {
+    let env = TestEnv::new("server-deadline-unary").await;
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "SlowHandler".to_string(),
+        Arc::new(SlowUnaryHandler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("server-deadline-unary").await;
+
+    let request = vec![1, 2, 3, 4];
+
+    // Call with a short timeout (500ms) - server should enforce this
+    let result = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "SlowHandler".to_string(),
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should timeout on the server side
+    assert!(result.is_err(), "Expected timeout error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_unary_stream() {
+    let env = TestEnv::new("server-deadline-unary-stream").await;
+
+    let started = Arc::new(Mutex::new(false));
+    let completed = Arc::new(Mutex::new(false));
+
+    let handler = Arc::new(SlowSetupStreamHandler {
+        started: started.clone(),
+        completed: completed.clone(),
+    });
+
+    env.server.register_unary_stream(
+        "TestService".to_string(),
+        "SlowStreamHandler".to_string(),
+        handler,
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("server-deadline-unary-stream").await;
+
+    let request = vec![1, 2, 3];
+
+    // Call with a short timeout (500ms) while handler setup takes 2 seconds
+    let reader = channel
+        .call_unary_stream_async(
+            "TestService".to_string(),
+            "SlowStreamHandler".to_string(),
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await
+        .expect("Failed to create stream");
+
+    // Should get a deadline exceeded error when trying to read
+    match reader.next_async().await {
+        StreamMessage::Error(e) => {
+            assert_eq!(
+                e.code(),
+                RpcCode::DeadlineExceeded,
+                "Expected DeadlineExceeded, got {:?}",
+                e.code()
+            );
+        }
+        _ => panic!("Expected deadline exceeded error"),
+    }
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify handler started but did not complete
+    let was_started = *started.lock().await;
+    let was_completed = *completed.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_stream_unary() {
+    let env = TestEnv::new("server-deadline-stream-unary").await;
+
+    let started = Arc::new(Mutex::new(false));
+    let completed = Arc::new(Mutex::new(false));
+    let messages_received = Arc::new(Mutex::new(0u32));
+
+    let handler = Arc::new(SlowStreamUnaryHandler {
+        started: started.clone(),
+        completed: completed.clone(),
+        messages_received: messages_received.clone(),
+    });
+
+    env.server.register_stream_unary(
+        "TestService".to_string(),
+        "SlowStreamUnary".to_string(),
+        handler,
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("server-deadline-stream-unary").await;
+
+    // Create stream writer
+    let writer = channel.call_stream_unary(
+        "TestService".to_string(),
+        "SlowStreamUnary".to_string(),
+        Some(Duration::from_millis(500)),
+        None,
+    );
+
+    // Send messages
+    let messages = vec![vec![1u8], vec![2u8], vec![3u8]];
+    for msg in messages {
+        writer.send_async(msg).await.expect("Failed to send");
+    }
+
+    // Finalize and get response - should timeout on the server side
+    let result = writer.finalize_stream_async().await;
+
+    assert!(result.is_err(), "Expected timeout error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify handler started but did not complete
+    let was_started = *started.lock().await;
+    let was_completed = *completed.lock().await;
+    let received = *messages_received.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+    println!("Handler received {received} messages before deadline");
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_deadline_stream_stream() {
+    let env = TestEnv::new("server-deadline-stream-stream").await;
+
+    let started = Arc::new(Mutex::new(false));
+    let completed = Arc::new(Mutex::new(false));
+
+    let slow_handler = Arc::new(SlowStreamStreamHandler {
+        started: started.clone(),
+        completed: completed.clone(),
+    });
+
+    env.server.register_stream_stream(
+        "TestService".to_string(),
+        "SlowStreamStream".to_string(),
+        slow_handler,
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("server-deadline-stream-stream").await;
+
+    // Call with a short timeout (500ms) while handler takes 2 seconds
+    let handler = channel.call_stream_stream(
+        "TestService".to_string(),
+        "SlowStreamStream".to_string(),
+        Some(Duration::from_millis(500)),
+        None,
+    );
+
+    // Send messages
+    let messages = vec![vec![1u8], vec![2u8], vec![3u8]];
+    for msg in messages {
+        handler.send_async(msg).await.expect("Failed to send");
+    }
+
+    handler.close_send_async().await.expect("Failed to close");
+
+    // Should get a deadline exceeded error when trying to read
+    match handler.recv_async().await {
+        StreamMessage::Error(e) => {
+            assert_eq!(
+                e.code(),
+                RpcCode::DeadlineExceeded,
+                "Expected DeadlineExceeded, got {:?}",
+                e.code()
+            );
+        }
+        _ => panic!("Expected deadline exceeded error"),
+    }
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify handler started but did not complete
+    let was_started = *started.lock().await;
+    let was_completed = *completed.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Deadline Tests - Handler execution enforcement
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_server_enforces_deadline_during_handler_execution() {
+    let env = TestEnv::new("server-enforces-deadline").await;
+
+    let started = Arc::new(Mutex::new(false));
+    let completed = Arc::new(Mutex::new(false));
+
+    let handler = Arc::new(LongRunningHandler {
+        started: started.clone(),
+        completed: completed.clone(),
+    });
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "LongRunning".to_string(),
+        handler,
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("server-enforces-deadline").await;
+
+    let request = vec![1, 2, 3, 4];
+
+    // Set a short deadline (500ms) while handler takes 5 seconds
+    let result = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "LongRunning".to_string(),
+            request,
+            Some(Duration::from_millis(500)),
+            None,
+        )
+        .await;
+
+    // Should fail with deadline exceeded
+    assert!(result.is_err(), "Expected deadline exceeded error");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::DeadlineExceeded,
+        "Expected DeadlineExceeded, got {:?}",
+        err.code()
+    );
+
+    // Give handler time to potentially complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the handler started but did not complete
+    let was_started = *started.lock().await;
+    let was_completed = *completed.lock().await;
+
+    assert!(was_started, "Handler should have started execution");
+    assert!(!was_completed, "Handler should not have completed");
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Deadline Tests - Deadline propagation
+// ============================================================================
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_deadline_propagation() {
+    let env = TestEnv::new("deadline-propagation").await;
+
+    let captured_deadline = Arc::new(Mutex::new(None));
+
+    let handler = Arc::new(DeadlineCaptureHandler {
+        captured_deadline: captured_deadline.clone(),
+    });
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "CaptureDeadline".to_string(),
+        handler,
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("deadline-propagation").await;
+
+    let request = vec![1, 2, 3, 4];
+
+    // Call with a specific timeout
+    let timeout = Duration::from_secs(30);
+    let start = std::time::SystemTime::now();
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "CaptureDeadline".to_string(),
+            request,
+            Some(timeout),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Check that the handler received a deadline
+    let deadline_opt = captured_deadline.lock().await;
+    assert!(deadline_opt.is_some(), "Handler should receive a deadline");
+
+    let deadline = deadline_opt.unwrap();
+    let expected_deadline = start + timeout;
+
+    // The deadline should be approximately the expected value (within 1 second tolerance)
+    let diff = if deadline > expected_deadline {
+        deadline.duration_since(expected_deadline).unwrap()
+    } else {
+        expected_deadline.duration_since(deadline).unwrap()
+    };
+
+    assert!(
+        diff < Duration::from_secs(1),
+        "Deadline should match expected value within tolerance, diff: {diff:?}"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_deadline_not_exceeded() {
+    let env = TestEnv::new("context-not-exceeded").await;
+
+    let captured_is_exceeded = Arc::new(Mutex::new(None));
+    let handler = ContextValidationHandler {
+        captured_session_id: Arc::new(Mutex::new(None)),
+        captured_metadata: Arc::new(Mutex::new(None)),
+        captured_deadline: Arc::new(Mutex::new(None)),
+        captured_remaining: Arc::new(Mutex::new(None)),
+        captured_is_exceeded: captured_is_exceeded.clone(),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-not-exceeded").await;
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(Duration::from_secs(60)),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify deadline exceeded status
+    let is_exceeded = captured_is_exceeded.lock().await;
+    assert!(
+        is_exceeded.is_some(),
+        "Deadline exceeded status should be captured"
+    );
+    assert!(
+        !is_exceeded.unwrap(),
+        "Deadline should not be exceeded for normal calls"
+    );
+
+    env.server.shutdown_async().await;
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_context_all_fields() {
+    let env = TestEnv::new("context-all-fields").await;
+
+    let captured_session_id = Arc::new(Mutex::new(None));
+    let captured_metadata = Arc::new(Mutex::new(None));
+    let captured_deadline = Arc::new(Mutex::new(None));
+    let captured_remaining = Arc::new(Mutex::new(None));
+    let captured_is_exceeded = Arc::new(Mutex::new(None));
+
+    let handler = ContextValidationHandler {
+        captured_session_id: captured_session_id.clone(),
+        captured_metadata: captured_metadata.clone(),
+        captured_deadline: captured_deadline.clone(),
+        captured_remaining: captured_remaining.clone(),
+        captured_is_exceeded: captured_is_exceeded.clone(),
+    };
+
+    env.server.register_unary_unary(
+        "TestService".to_string(),
+        "ValidateContext".to_string(),
+        Arc::new(handler),
+    );
+
+    env.start_server().await;
+
+    let channel = env.create_client("context-all-fields").await;
+
+    let _response = channel
+        .call_unary_async(
+            "TestService".to_string(),
+            "ValidateContext".to_string(),
+            vec![],
+            Some(Duration::from_secs(30)),
+            None,
+        )
+        .await
+        .expect("Call failed");
+
+    // Verify all context fields were captured
+    {
+        let session_id = captured_session_id.lock().await;
+        assert!(session_id.is_some(), "Session ID should be captured");
+    }
+    {
+        let metadata = captured_metadata.lock().await;
+        assert!(metadata.is_some(), "Metadata should be captured");
+    }
+    {
+        let deadline = captured_deadline.lock().await;
+        assert!(deadline.is_some(), "Deadline should be captured");
+    }
+    {
+        let remaining = captured_remaining.lock().await;
+        assert!(remaining.is_some(), "Remaining time should be captured");
+    }
+    {
+        let is_exceeded = captured_is_exceeded.lock().await;
+        assert!(
+            is_exceeded.is_some(),
+            "Deadline exceeded status should be captured"
+        );
+    }
+
+    // Verify session ID is valid
+    {
+        let session_id = captured_session_id.lock().await;
+        assert!(
+            !session_id.as_ref().unwrap().is_empty(),
+            "Session ID should not be empty"
+        );
+    }
+
+    // Verify metadata contains deadline
+    {
+        let metadata = captured_metadata.lock().await;
+        assert!(
+            metadata.as_ref().unwrap().contains_key("slimrpc-timeout"),
+            "Metadata should contain deadline"
+        );
+    }
+
+    // Verify remaining time is reasonable
+    {
+        let remaining = captured_remaining.lock().await;
+        assert!(
+            remaining.unwrap() > Duration::ZERO,
+            "Remaining time should be positive"
+        );
+    }
+
+    // Verify deadline is not exceeded
+    {
+        let is_exceeded = captured_is_exceeded.lock().await;
+        assert!(!is_exceeded.unwrap(), "Deadline should not be exceeded");
+    }
+
+    env.server.shutdown_async().await;
+}
+
+// ============================================================================
+// Multicast UniFFI tests
+//
+// These tests exercise the four `call_multicast_*` wrappers exposed through
+// the UniFFI API:
+//   - call_multicast_unary / call_multicast_unary_async
+//   - call_multicast_unary_stream / call_multicast_unary_stream_async
+//   - call_multicast_stream_unary  (via MulticastBidiStreamHandler)
+//   - call_multicast_stream_stream (via MulticastBidiStreamHandler)
+//
+// Topology: N member apps each running a Server, one client App holding a
+// GROUP Channel created with Channel::new_group().
+// ============================================================================
+
+/// Helper: create `num_members` UniFFI member (App + Server) pairs and a
+/// GROUP Channel that targets all of them. Returns the server apps (kept alive
+/// for the duration of the test), the servers, the channel, and the
+/// Arc<Name>s used for the members.
+async fn setup_multicast_env(
+    test_name: &str,
+    num_members: usize,
+) -> (Vec<Arc<App>>, Vec<Arc<Server>>, Channel, Vec<Arc<Name>>) {
+    initialize_with_defaults();
+
+    let provider_config = IdentityProviderConfig::SharedSecret {
+        id: "test-provider".to_string(),
+        data: "test-secret-with-sufficient-length-for-hmac-key".to_string(),
+    };
+    let verifier_config = IdentityVerifierConfig::SharedSecret {
+        id: "test-verifier".to_string(),
+        data: "test-secret-with-sufficient-length-for-hmac-key".to_string(),
+    };
+
+    let mut server_apps = Vec::new();
+    let mut servers = Vec::new();
+    let mut member_names: Vec<Arc<Name>> = Vec::new();
+
+    for i in 0..num_members {
+        let member_name = Arc::new(Name::new(
+            "org".to_string(),
+            "test".to_string(),
+            format!("{test_name}-m{i}"),
+        ));
+        let app = App::new_with_direction_async(
+            member_name.clone(),
+            provider_config.clone(),
+            verifier_config.clone(),
+            Direction::Bidirectional,
+        )
+        .await
+        .expect("Failed to create member app");
+        let server = Arc::new(Server::new(&app, member_name.clone()));
+        server_apps.push(app);
+        servers.push(server);
+        member_names.push(member_name);
+    }
+
+    // Client app — separate identity, holds the GROUP channel
+    let client_name = Arc::new(Name::new(
+        "org".to_string(),
+        "test".to_string(),
+        format!("{test_name}-client"),
+    ));
+    let client_app = App::new_with_direction_async(
+        client_name,
+        provider_config,
+        verifier_config,
+        Direction::Bidirectional,
+    )
+    .await
+    .expect("Failed to create client app");
+
+    let channel = Channel::new_group(client_app, member_names.clone())
+        .expect("Failed to create GROUP channel");
+
+    (server_apps, servers, channel, member_names)
+}
+
+/// Start all servers in background tasks and give them time to subscribe.
+async fn start_multicast_servers(servers: &[Arc<Server>]) {
+    for s in servers {
+        let s = s.clone();
+        tokio::spawn(async move {
+            if let Err(e) = s.serve_async().await {
+                eprintln!("Member server error: {e:?}");
+            }
+        });
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+// ── Test: call_multicast_unary_async ─────────────────────────────────────────
+
+/// Broadcast one request to 2 members (echo handler). Expect 2 `Data` items
+/// each containing the original payload, then `End`. Also verify that the
+/// source names in the context match the member names.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_uniffi_multicast_unary() {
+    let (_apps, servers, channel, member_names) = setup_multicast_env("uniffi-mc-unary", 2).await;
+
+    for s in &servers {
+        s.register_unary_unary(
+            "TestService".to_string(),
+            "Echo".to_string(),
+            Arc::new(EchoHandler),
+        );
+    }
+    start_multicast_servers(&servers).await;
+
+    let request = b"hello multicast".to_vec();
+    let reader = channel
+        .call_multicast_unary_async(
+            "TestService".to_string(),
+            "Echo".to_string(),
+            request.clone(),
+            Some(Duration::from_secs(10)),
+            None,
+        )
+        .await
+        .expect("call_multicast_unary_async failed");
+
+    let mut items = Vec::new();
+    loop {
+        match reader.next_async().await {
+            MulticastStreamMessage::Data { item } => {
+                assert_eq!(item.message, request, "Each member should echo the request");
+                items.push(item);
+            }
+            MulticastStreamMessage::Error { error: e } => panic!("Unexpected error: {e:?}"),
+            MulticastStreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(items.len(), 2, "Should receive one response per member");
+
+    // Verify that both member sources are represented in the responses.
+    let sources: Vec<Vec<String>> = items
+        .iter()
+        .map(|i| i.context.source.components())
+        .collect();
+    let expected: Vec<Vec<String>> = member_names.iter().map(|n| n.components()).collect();
+    for exp in &expected {
+        assert!(
+            sources.contains(exp),
+            "Source {exp:?} missing from {sources:?}"
+        );
+    }
+
+    for s in &servers {
+        s.shutdown_async().await;
+    }
+}
+
+// ── Test: call_multicast_unary_stream_async ───────────────────────────────────
+
+/// Each of 2 members streams 3 counter responses. Expect 6 `Data` items total
+/// (3 per member) then `End`.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_uniffi_multicast_unary_stream() {
+    let (_apps, servers, channel, _member_names) =
+        setup_multicast_env("uniffi-mc-unary-stream", 2).await;
+
+    for s in &servers {
+        s.register_unary_stream(
+            "TestService".to_string(),
+            "Counter".to_string(),
+            Arc::new(CounterHandler),
+        );
+    }
+    start_multicast_servers(&servers).await;
+
+    // Request 3 items per member -> 2 members * 3 = 6 total
+    let count = 3u32;
+    let reader = channel
+        .call_multicast_unary_stream_async(
+            "TestService".to_string(),
+            "Counter".to_string(),
+            count.to_le_bytes().to_vec(),
+            Some(Duration::from_secs(10)),
+            None,
+        )
+        .await
+        .expect("call_multicast_unary_stream_async failed");
+
+    let mut data_count = 0usize;
+    loop {
+        match reader.next_async().await {
+            MulticastStreamMessage::Data { .. } => data_count += 1,
+            MulticastStreamMessage::Error { error: e } => panic!("Unexpected error: {e:?}"),
+            MulticastStreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(
+        data_count,
+        2 * 3,
+        "Should receive 3 responses from each of 2 members"
+    );
+
+    for s in &servers {
+        s.shutdown_async().await;
+    }
+}
+
+// ── Test: call_multicast_stream_unary ─────────────────────────────────────────
+
+/// Stream 3 u32 values to 2 accumulator members. Expect 2 `Data` items (one
+/// per member), each reporting total=60 and count=3, then `End`.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_uniffi_multicast_stream_unary() {
+    let (_apps, servers, channel, _member_names) =
+        setup_multicast_env("uniffi-mc-stream-unary", 2).await;
+
+    for s in &servers {
+        s.register_stream_unary(
+            "TestService".to_string(),
+            "Accumulator".to_string(),
+            Arc::new(AccumulatorHandler),
+        );
+    }
+    start_multicast_servers(&servers).await;
+
+    let handler = channel.call_multicast_stream_unary(
+        "TestService".to_string(),
+        "Accumulator".to_string(),
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    // Send three values that sum to 60
+    for v in [10u32, 20u32, 30u32] {
+        handler
+            .send_async(v.to_le_bytes().to_vec())
+            .await
+            .expect("send failed");
+    }
+    handler.close_send_async().await.expect("close_send failed");
+
+    // Collect responses - one per member
+    let mut responses = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            MulticastStreamMessage::Data { item } => responses.push(item),
+            MulticastStreamMessage::Error { error: e } => panic!("Unexpected error: {e:?}"),
+            MulticastStreamMessage::End => break,
+        }
+    }
+
+    assert_eq!(responses.len(), 2, "Should receive one response per member");
+    for item in &responses {
+        assert_eq!(
+            item.message.len(),
+            8,
+            "Response must be 8 bytes (total + count)"
+        );
+        let total = u32::from_le_bytes([
+            item.message[0],
+            item.message[1],
+            item.message[2],
+            item.message[3],
+        ]);
+        let count = u32::from_le_bytes([
+            item.message[4],
+            item.message[5],
+            item.message[6],
+            item.message[7],
+        ]);
+        assert_eq!(total, 60, "Accumulated total should be 60");
+        assert_eq!(count, 3, "Message count should be 3");
+    }
+
+    for s in &servers {
+        s.shutdown_async().await;
+    }
+}
+
+// ── Test: call_multicast_stream_stream ────────────────────────────────────────
+
+/// Send 2 messages to 2 echo members via stream-stream. Expect 4 `Data` items
+/// (each member echoes each message) with both member sources present, then
+/// `End`.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_uniffi_multicast_stream_stream() {
+    let (_apps, servers, channel, member_names) =
+        setup_multicast_env("uniffi-mc-stream-stream", 2).await;
+
+    for s in &servers {
+        s.register_stream_stream(
+            "TestService".to_string(),
+            "StreamEcho".to_string(),
+            Arc::new(StreamEchoHandler),
+        );
+    }
+    start_multicast_servers(&servers).await;
+
+    let handler = channel.call_multicast_stream_stream(
+        "TestService".to_string(),
+        "StreamEcho".to_string(),
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    // Send in a background task so receiving can proceed concurrently.
+    let handler_clone = handler.clone();
+    let send_task = tokio::spawn(async move {
+        for msg in [vec![1u8, 2, 3], vec![4u8, 5, 6]] {
+            handler_clone.send_async(msg).await.expect("send failed");
+        }
+        handler_clone
+            .close_send_async()
+            .await
+            .expect("close_send failed");
+    });
+
+    // Receive from the main task.
+    let mut received = Vec::new();
+    loop {
+        match handler.recv_async().await {
+            MulticastStreamMessage::Data { item } => received.push(item),
+            MulticastStreamMessage::Error { error: e } => panic!("Unexpected error: {e:?}"),
+            MulticastStreamMessage::End => break,
+        }
+    }
+    send_task.await.expect("send task panicked");
+
+    // 2 members * 2 messages = 4 items
+    assert_eq!(
+        received.len(),
+        4,
+        "Expected 4 items (2 members * 2 messages)"
+    );
+
+    // Both member sources should be present in the received items.
+    let sources: Vec<Vec<String>> = received
+        .iter()
+        .map(|i| i.context.source.components())
+        .collect();
+    let expected: Vec<Vec<String>> = member_names.iter().map(|n| n.components()).collect();
+    for exp in &expected {
+        assert!(
+            sources.contains(exp),
+            "Member source {exp:?} not found among received items"
+        );
+    }
+
+    for s in &servers {
+        s.shutdown_async().await;
+    }
+}

--- a/crates/slim-bindings/tests/slimrpc_multicast.rs
+++ b/crates/slim-bindings/tests/slimrpc_multicast.rs
@@ -1,0 +1,1091 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for SlimRPC multicast / GROUP RPC patterns
+//!
+//! Tests the four multicast interaction patterns plus the group-inbox observer:
+//! - multicast_unary:        one request broadcast to all members, one response per member
+//! - multicast_unary_stream: one request, each member streams multiple responses
+//! - multicast_stream_unary: client streams requests, one response per member
+//! - multicast_stream_stream: client streams requests, each member streams responses
+//! - group_inbox:            a member can observe other members' responses via subscribe_group_inbox()
+//!
+//! Topology
+//! --------
+//! All tests share the same shape:
+//!   - A shared in-process SLIM `Service` acts as the message bus.
+//!   - Multiple "member" apps are registered under the SAME name ("org/ns/member").
+//!     Each has a `Server` that handles incoming requests.
+//!   - A separate "client" app holds a `Channel` that broadcasts multicast RPCs.
+//!   - (group_inbox test only) An "observer" app also opens a multicast Channel
+//!     to the same group name and subscribes to the group inbox.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures::pin_mut;
+use futures::stream;
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::shared_secret::SharedSecret;
+use slim_config::component::id::{ID, Kind};
+use slim_datapath::api::ProtoName as Name;
+use slim_service::service::Service;
+
+const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
+
+use slim_bindings::slimrpc::{
+    Channel, Context, DecodedStream, Decoder, Encoder, MulticastItem, RpcError, Server,
+};
+
+// ============================================================================
+// Test message types
+// ============================================================================
+
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestRequest {
+    pub message: String,
+    pub value: i32,
+}
+
+impl Encoder for TestRequest {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))
+    }
+}
+
+impl Decoder for TestRequest {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (v, _): (TestRequest, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(v)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, bincode::Encode, bincode::Decode)]
+struct TestResponse {
+    pub member_id: usize,
+    pub result: String,
+    pub count: i32,
+}
+
+impl Encoder for TestResponse {
+    fn encode(self) -> Result<Vec<u8>, RpcError> {
+        bincode::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| RpcError::internal(format!("Encoding error: {e}")))
+    }
+}
+
+impl Decoder for TestResponse {
+    fn decode(buf: impl Into<Vec<u8>>) -> Result<Self, RpcError> {
+        let (v, _): (TestResponse, usize) =
+            bincode::decode_from_slice(&buf.into(), bincode::config::standard())
+                .map_err(|e| RpcError::invalid_argument(format!("Decoding error: {e}")))?;
+        Ok(v)
+    }
+}
+
+// ============================================================================
+// MulticastTestEnv
+// ============================================================================
+
+/// Test environment with `num_members` servers and one broadcaster channel.
+struct MulticastTestEnv {
+    service: Arc<Service>,
+    /// Member servers — each registered under its own unique app name.
+    member_servers: Vec<Arc<Server>>,
+    /// Channel used as the multicast broadcaster.
+    ///
+    /// Created with `Channel::new_with_members_internal` so the GROUP session
+    /// name is randomly generated and members are auto-invited on the first
+    /// multicast call.
+    channel: Channel,
+}
+
+impl MulticastTestEnv {
+    async fn new(test_name: &str, num_members: usize) -> Self {
+        let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+        let service = Arc::new(Service::new(id));
+
+        // Create N member apps, each with a UNIQUE name ("org/ns/member-{i}").
+        // Each app auto-subscribes to its own unique name via process_messages,
+        // making it reachable for the invite discovery-request sent by the Channel.
+        let mut member_servers = Vec::new();
+        let mut member_app_names = Vec::new();
+        for i in 0..num_members {
+            let member_app_name = Name::from_strings(["org", "ns", &format!("member-{i}")]);
+            let secret = SharedSecret::new("test", TEST_VALID_SECRET).unwrap();
+            let (app, notifications) = service
+                .create_app(
+                    &member_app_name,
+                    AuthProvider::shared_secret(secret.clone()),
+                    AuthVerifier::shared_secret(secret),
+                )
+                .unwrap();
+            let app = Arc::new(app);
+            let server = Arc::new(Server::new_internal(
+                app.clone(),
+                member_app_name.clone(),
+                notifications,
+            ));
+            member_app_names.push(member_app_name);
+            member_servers.push(server);
+        }
+
+        // Broadcaster app — uses new_with_members_internal so the Channel
+        // generates a random UUID group name and auto-invites all members on
+        // the first multicast call.
+        let client_name = Name::from_strings(["org", "ns", "client"]);
+        let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+        let (client_app, _) = service
+            .create_app(
+                &client_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        let channel =
+            Channel::new_with_members_internal(Arc::new(client_app), member_app_names, true, None)
+                .expect("failed to create channel");
+
+        Self {
+            service,
+            member_servers,
+            channel,
+        }
+    }
+
+    /// Start all member servers in background tasks.
+    async fn start_all_servers(&self) {
+        for server in &self.member_servers {
+            let s = server.clone();
+            tokio::spawn(async move {
+                if let Err(e) = s.serve_async().await {
+                    tracing::error!("Member server error: {:?}", e);
+                }
+            });
+        }
+        // Give all servers time to subscribe before the first invite is sent.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    async fn shutdown(&mut self) {
+        self.channel.close_async(None).await.unwrap();
+
+        for server in &self.member_servers {
+            server.shutdown_internal().await;
+        }
+
+        self.service.shutdown().await.unwrap();
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Collect exactly `n` items (successes or errors) from a multicast stream.
+///
+/// Unlike `collect_n_multicast`, this does NOT panic on errors — it stores them
+/// so tests can assert on the mix of successes and failures.
+async fn collect_n_mixed<T>(
+    stream: impl futures::Stream<Item = Result<MulticastItem<T>, RpcError>>,
+    n: usize,
+    timeout: Duration,
+    label: &str,
+) -> Vec<Result<MulticastItem<T>, RpcError>> {
+    pin_mut!(stream);
+    let mut results: Vec<Result<MulticastItem<T>, RpcError>> = Vec::with_capacity(n);
+    tokio::time::timeout(timeout, async {
+        for _ in 0..n {
+            match stream.next().await {
+                Some(item) => results.push(item),
+                None => break,
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "{label}: timed out after collecting {}/{n} items",
+            results.len()
+        )
+    });
+    results
+}
+
+/// Collect exactly `n` responses from a multicast stream, failing if:
+/// - the stream ends before `n` items arrive, or
+/// - any item is an error, or
+/// - the operation does not complete within `timeout`.
+async fn collect_n_multicast<T>(
+    stream: impl futures::Stream<Item = Result<MulticastItem<T>, RpcError>>,
+    n: usize,
+    timeout: Duration,
+    label: &str,
+) -> Vec<MulticastItem<T>> {
+    pin_mut!(stream);
+    let mut responses = Vec::with_capacity(n);
+    tokio::time::timeout(timeout, async {
+        for i in 0..n {
+            match stream.next().await {
+                Some(Ok(r)) => responses.push(r),
+                Some(Err(e)) => panic!("{label}: item {i} failed: {e:?}"),
+                None => panic!("{label}: stream ended after {i} items, expected {n}"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "{label}: timed out after collecting {}/{n} items",
+            responses.len()
+        )
+    });
+    responses
+}
+
+// ============================================================================
+// Test 1 — multicast_unary
+// ============================================================================
+
+/// Broadcast one request; each member returns one response.
+/// The client collects one `TestResponse` per member.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_unary() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-multicast-unary", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", req.message),
+                    count: req.value + i as i32,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let mut responses = collect_n_multicast(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "multicast_unary",
+    )
+    .await;
+    responses.sort_by_key(|r| r.message.member_id);
+
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    assert_eq!(responses[0].message.result, "M0: hello");
+    assert_eq!(responses[0].message.count, 10);
+    assert_eq!(responses[1].message.result, "M1: hello");
+    assert_eq!(responses[1].message.count, 11);
+    // Source should identify each member by name.
+    assert_eq!(
+        responses[0].context.source,
+        Name::from_strings(["org", "ns", "member-0"])
+    );
+    assert_eq!(
+        responses[1].context.source,
+        Name::from_strings(["org", "ns", "member-1"])
+    );
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 2 — multicast_unary_stream
+// ============================================================================
+
+/// Broadcast one request; each member returns a stream of responses.
+/// The client interleaves all per-member streams into one stream.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_unary_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const ITEMS_PER_MEMBER: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-unary-stream", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_stream_internal(
+            "TestService",
+            "Expand",
+            move |req: TestRequest, _ctx: Context| async move {
+                let items: Vec<Result<TestResponse, RpcError>> = (0..ITEMS_PER_MEMBER)
+                    .map(|j| {
+                        Ok(TestResponse {
+                            member_id: i,
+                            result: format!("M{i}-item{j}: {}", req.message),
+                            count: req.value * 10 + j as i32,
+                        })
+                    })
+                    .collect();
+                Ok(stream::iter(items))
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env
+        .channel
+        .multicast_unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Expand",
+            TestRequest {
+                message: "x".to_string(),
+                value: 1,
+            },
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let total = NUM_MEMBERS * ITEMS_PER_MEMBER;
+    let responses = collect_n_multicast(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "multicast_unary_stream",
+    )
+    .await;
+
+    assert_eq!(responses.len(), total);
+    // Each member contributed exactly ITEMS_PER_MEMBER items.
+    for mid in 0..NUM_MEMBERS {
+        let count = responses
+            .iter()
+            .filter(|r| r.message.member_id == mid)
+            .count();
+        assert_eq!(
+            count, ITEMS_PER_MEMBER,
+            "member {mid} should have sent {ITEMS_PER_MEMBER} items"
+        );
+        // Every item from this member should carry the expected source name.
+        let expected_src = Name::from_strings(["org", "ns", &format!("member-{mid}")]);
+        assert!(
+            responses
+                .iter()
+                .filter(|r| r.message.member_id == mid)
+                .all(|r| r.context.source == expected_src),
+            "member {mid} items have wrong source"
+        );
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 3 — multicast_stream_unary
+// ============================================================================
+
+/// Client streams requests to all members; each member aggregates and replies once.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_stream_unary() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-multicast-stream-unary", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_stream_unary_internal(
+            "TestService",
+            "Sum",
+            move |mut req_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+                let mut total = 0i32;
+                let mut msgs = Vec::new();
+                while let Some(item) = req_stream.next().await {
+                    let req = item?;
+                    total += req.value;
+                    msgs.push(req.message.clone());
+                }
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", msgs.join("+")),
+                    count: total,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let requests = stream::iter(vec![
+        TestRequest {
+            message: "a".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "b".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "c".to_string(),
+            value: 3,
+        },
+    ]);
+
+    let stream = env
+        .channel
+        .multicast_stream_unary::<TestRequest, TestResponse>(
+            "TestService",
+            "Sum",
+            requests,
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let mut responses = collect_n_multicast(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "multicast_stream_unary",
+    )
+    .await;
+    responses.sort_by_key(|r| r.message.member_id);
+
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    for r in &responses {
+        assert_eq!(
+            r.message.count, 6,
+            "member {} should sum to 6",
+            r.message.member_id
+        );
+        assert!(
+            r.message.result.contains("a+b+c"),
+            "member {} got: {}",
+            r.message.member_id,
+            r.message.result
+        );
+        let expected_src =
+            Name::from_strings(["org", "ns", &format!("member-{}", r.message.member_id)]);
+        assert_eq!(r.context.source, expected_src, "wrong source for member");
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 4 — multicast_stream_stream
+// ============================================================================
+
+/// Client streams requests; each member streams one response per request item.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_stream_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const NUM_REQUESTS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-stream-stream", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_stream_stream_internal(
+            "TestService",
+            "Echo",
+            move |mut req_stream: DecodedStream<TestRequest>, _ctx: Context| async move {
+                let responses: Vec<Result<TestResponse, RpcError>> = {
+                    let mut v = Vec::new();
+                    while let Some(item) = req_stream.next().await {
+                        let req = item?;
+                        v.push(Ok(TestResponse {
+                            member_id: i,
+                            result: format!("M{i}: {}", req.message),
+                            count: req.value,
+                        }));
+                    }
+                    v
+                };
+                Ok(stream::iter(responses))
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let requests = stream::iter(vec![
+        TestRequest {
+            message: "x".to_string(),
+            value: 1,
+        },
+        TestRequest {
+            message: "y".to_string(),
+            value: 2,
+        },
+        TestRequest {
+            message: "z".to_string(),
+            value: 3,
+        },
+    ]);
+
+    let stream = env
+        .channel
+        .multicast_stream_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Echo",
+            requests,
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let total = NUM_MEMBERS * NUM_REQUESTS;
+    let responses = collect_n_multicast(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "multicast_stream_stream",
+    )
+    .await;
+
+    assert_eq!(responses.len(), total);
+    for mid in 0..NUM_MEMBERS {
+        let member_responses: Vec<_> = responses
+            .iter()
+            .filter(|r| r.message.member_id == mid)
+            .collect();
+        assert_eq!(member_responses.len(), NUM_REQUESTS);
+        let values: Vec<i32> = member_responses.iter().map(|r| r.message.count).collect();
+        // Each member should have echoed all 3 request values.
+        for v in [1, 2, 3] {
+            assert!(values.contains(&v), "member {mid} missing value {v}");
+        }
+        let expected_src = Name::from_strings(["org", "ns", &format!("member-{mid}")]);
+        assert!(
+            member_responses
+                .iter()
+                .all(|r| r.context.source == expected_src),
+            "member {mid} items have wrong source"
+        );
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 5 — partial error, unary pattern
+// ============================================================================
+
+/// One member returns an error; the other members' successes must still arrive.
+///
+/// Uses `multicast_unary` (unary-unary). The server sends one data message per
+/// member — no EOS marker. The caller collects exactly NUM_MEMBERS items
+/// (mix of Ok and Err) and then drops the stream.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_partial_error_unary() {
+    const NUM_MEMBERS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-partial-error-unary", NUM_MEMBERS).await;
+
+    // Member 0 returns an error.
+    env.member_servers[0].register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        move |_req: TestRequest, _ctx: Context| async move {
+            Err::<TestResponse, _>(RpcError::internal("member 0 failed"))
+        },
+    );
+    // Members 1 and 2 succeed.
+    for i in 1..NUM_MEMBERS {
+        env.member_servers[i].register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", req.message),
+                    count: req.value + i as i32,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let results = collect_n_mixed(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "partial_error_unary",
+    )
+    .await;
+
+    assert_eq!(results.len(), NUM_MEMBERS);
+    let errors: Vec<_> = results.iter().filter(|r| r.is_err()).collect();
+    let successes: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error");
+    assert_eq!(successes.len(), 2, "expected 2 successes");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 6 — partial error, streaming pattern
+// ============================================================================
+
+/// One member errors mid-stream; the other member's full response stream must
+/// still arrive and the combined stream must terminate cleanly.
+///
+/// Uses `multicast_unary_stream`. Member 0 yields two items then an error;
+/// member 1 yields three items then EOS. The client should receive:
+///   - 2 Ok items from member 0
+///   - 1 Err from member 0 (counted as its EOS)
+///   - 3 Ok items from member 1
+///   - stream terminates after member 1's EOS
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_partial_error_unary_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const M0_OK_ITEMS: usize = 2;
+    const M1_OK_ITEMS: usize = 3;
+    let mut env =
+        MulticastTestEnv::new("test-multicast-partial-error-unary-stream", NUM_MEMBERS).await;
+
+    // Member 0: 2 ok items then an error (no server-side EOS follows the error).
+    env.member_servers[0].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M0_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 0,
+                        result: format!("M0-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .chain(std::iter::once(Err(RpcError::internal("M0 stream error"))))
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    // Member 1: 3 ok items, server sends EOS after the last one.
+    env.member_servers[1].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M1_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 1,
+                        result: format!("M1-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    env.start_all_servers().await;
+
+    let stream = env
+        .channel
+        .multicast_unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Expand",
+            TestRequest {
+                message: "x".to_string(),
+                value: 1,
+            },
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    // M0 yields M0_OK_ITEMS Ok + 1 Err; M1 yields M1_OK_ITEMS Ok.
+    // The stream terminates after M1's EOS (M0's error is counted as its EOS),
+    // so the total item count is known up front.
+    let total = M0_OK_ITEMS + 1 + M1_OK_ITEMS;
+    let results = collect_n_mixed(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "partial_error_stream",
+    )
+    .await;
+
+    let errors: Vec<_> = results.iter().filter(|r| r.is_err()).collect();
+    let successes: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error (from M0)");
+    assert_eq!(
+        successes.len(),
+        M0_OK_ITEMS + M1_OK_ITEMS,
+        "expected all ok items from both members"
+    );
+    let m1_items: Vec<_> = successes
+        .iter()
+        .filter(|r| r.as_ref().unwrap().message.member_id == 1)
+        .collect();
+    assert_eq!(m1_items.len(), M1_OK_ITEMS, "M1 should deliver all items");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 7 — MulticastRpc error carries origin (unary)
+// ============================================================================
+
+/// When a member returns an error in a multicast unary call, the yielded
+/// `RpcError` must be the `MulticastRpc` variant with the `origin` field set
+/// to the failing member's name.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_error_origin_unary() {
+    const NUM_MEMBERS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-error-origin-unary", NUM_MEMBERS).await;
+
+    // Member 0 returns an error.
+    env.member_servers[0].register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        move |_req: TestRequest, _ctx: Context| async move {
+            Err::<TestResponse, _>(RpcError::internal("member 0 exploded"))
+        },
+    );
+    // Members 1 and 2 succeed.
+    for i in 1..NUM_MEMBERS {
+        env.member_servers[i].register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: format!("M{i}: {}", req.message),
+                    count: req.value + i as i32,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let results = collect_n_mixed(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "error_origin_unary",
+    )
+    .await;
+
+    assert_eq!(results.len(), NUM_MEMBERS);
+
+    let errors: Vec<_> = results.iter().filter_map(|r| r.as_ref().err()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error");
+
+    let err = &errors[0];
+    let expected_origin = Name::from_strings(["org", "ns", "member-0"]).to_string();
+    match err {
+        RpcError::MulticastRpc {
+            origin,
+            code,
+            message,
+            ..
+        } => {
+            assert_eq!(
+                origin, &expected_origin,
+                "origin must identify the failing member"
+            );
+            assert_eq!(*code, slim_bindings::slimrpc::RpcCode::Internal);
+            assert!(
+                message.contains("member 0 exploded"),
+                "message should be preserved"
+            );
+        }
+        other => panic!("expected MulticastRpc, got: {other:?}"),
+    }
+
+    // Successes should still be plain Ok items with correct context.
+    let successes: Vec<_> = results.iter().filter_map(|r| r.as_ref().ok()).collect();
+    assert_eq!(successes.len(), 2, "expected 2 successes");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 8 — MulticastRpc error carries origin (streaming)
+// ============================================================================
+
+/// When a member errors mid-stream, the yielded error must be `MulticastRpc`
+/// with the correct `origin`.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_error_origin_stream() {
+    const NUM_MEMBERS: usize = 2;
+    const M0_OK_ITEMS: usize = 1;
+    const M1_OK_ITEMS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-multicast-error-origin-stream", NUM_MEMBERS).await;
+
+    // Member 0: 1 ok item then an error.
+    env.member_servers[0].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M0_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 0,
+                        result: format!("M0-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .chain(std::iter::once(Err(RpcError::internal("M0 broke"))))
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    // Member 1: 2 ok items, normal completion.
+    env.member_servers[1].register_unary_stream_internal(
+        "TestService",
+        "Expand",
+        move |req: TestRequest, _ctx: Context| async move {
+            let items: Vec<Result<TestResponse, RpcError>> = (0..M1_OK_ITEMS)
+                .map(|j| {
+                    Ok(TestResponse {
+                        member_id: 1,
+                        result: format!("M1-item{j}: {}", req.message),
+                        count: j as i32,
+                    })
+                })
+                .collect();
+            Ok(stream::iter(items))
+        },
+    );
+    env.start_all_servers().await;
+
+    let stream = env
+        .channel
+        .multicast_unary_stream::<TestRequest, TestResponse>(
+            "TestService",
+            "Expand",
+            TestRequest {
+                message: "x".to_string(),
+                value: 1,
+            },
+            Some(Duration::from_secs(10)),
+            None,
+        );
+
+    let total = M0_OK_ITEMS + 1 + M1_OK_ITEMS;
+    let results = collect_n_mixed(
+        stream,
+        total,
+        Duration::from_secs(10),
+        "error_origin_stream",
+    )
+    .await;
+
+    let errors: Vec<_> = results.iter().filter_map(|r| r.as_ref().err()).collect();
+    assert_eq!(errors.len(), 1, "expected exactly 1 error (from M0)");
+
+    let err = &errors[0];
+    let expected_origin = Name::from_strings(["org", "ns", "member-0"]).to_string();
+    match err {
+        RpcError::MulticastRpc { origin, code, .. } => {
+            assert_eq!(origin, &expected_origin, "origin must identify M0");
+            assert_eq!(*code, slim_bindings::slimrpc::RpcCode::Internal);
+        }
+        other => panic!("expected MulticastRpc, got: {other:?}"),
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 9 — MulticastRpc error carries origin for all failing members
+// ============================================================================
+
+/// When multiple members fail, each error must carry its own origin.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_error_origin_multiple_failures() {
+    const NUM_MEMBERS: usize = 3;
+    let mut env = MulticastTestEnv::new("test-multicast-error-origin-multi", NUM_MEMBERS).await;
+
+    // All members return errors with distinct messages.
+    for i in 0..NUM_MEMBERS {
+        env.member_servers[i].register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |_req: TestRequest, _ctx: Context| async move {
+                Err::<TestResponse, _>(RpcError::internal(format!("fail-{i}")))
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+
+    let results = collect_n_mixed(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "error_origin_multi",
+    )
+    .await;
+
+    assert_eq!(results.len(), NUM_MEMBERS);
+
+    // Every result should be a MulticastRpc error.
+    let mut origins: Vec<String> = Vec::new();
+    for result in &results {
+        match result {
+            Err(RpcError::MulticastRpc { origin, .. }) => {
+                origins.push(origin.clone());
+            }
+            Err(other) => panic!("expected MulticastRpc, got: {other:?}"),
+            Ok(item) => panic!("expected error, got success: {:?}", item.message),
+        }
+    }
+
+    // Each member should appear exactly once.
+    origins.sort();
+    let mut expected: Vec<String> = (0..NUM_MEMBERS)
+        .map(|i| Name::from_strings(["org", "ns", &format!("member-{i}")]).to_string())
+        .collect();
+    expected.sort();
+    assert_eq!(
+        origins, expected,
+        "each failing member must appear as an origin"
+    );
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 10 — channel close: idle (no session)
+// ============================================================================
+
+/// `close_async` on a channel that has never been used must succeed immediately
+/// without panicking or blocking.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_channel_close_no_session() {
+    let mut env = MulticastTestEnv::new("test-channel-close-no-session", 1).await;
+
+    env.member_servers[0].register_unary_unary_internal(
+        "TestService",
+        "Echo",
+        move |req: TestRequest, _ctx: Context| async move {
+            Ok(TestResponse {
+                member_id: 0,
+                result: req.message,
+                count: req.value,
+            })
+        },
+    );
+    env.start_all_servers().await;
+
+    // No RPC has been made — no underlying session exists yet.
+    env.channel
+        .close_async(None)
+        .await
+        .expect("close on idle channel must succeed");
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test 11 — channel close: active session, then reuse
+// ============================================================================
+
+/// After `close_async` on a channel with an active session the channel must
+/// still be usable: the next RPC call re-creates the session transparently.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_channel_close_after_rpc() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-channel-close-after-rpc", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_unary_internal(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: req.message,
+                    count: req.value,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    // First call — establishes the persistent GROUP session.
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "first".to_string(),
+            value: 1,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses =
+        collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "first call").await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+
+    // Close the session — the dispatcher task must exit naturally.
+    env.channel
+        .close_async(None)
+        .await
+        .expect("close must succeed with an active session");
+
+    // Second call — channel must re-create the session transparently.
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "second".to_string(),
+            value: 2,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses =
+        collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "second call").await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    assert!(responses.iter().all(|r| r.message.result == "second"));
+
+    env.shutdown().await;
+}


### PR DESCRIPTION
# Description

Move slim-bindings and the slimrpc compiler back to core crates.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
