### PR TITLE
chore(rpc): version agntcy-slim-rpc on the 2.0.0-alpha line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "0.1.0"
+version = "2.0.0-alpha.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ agntcy-slim-controller = { path = "crates/controller", version = "0.10.0" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.1" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.2.1" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.2.0" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "0.1.0" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.2" }
 agntcy-slim-service = { path = "crates/service", version = "0.11.0", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.5.0" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.10" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -5,7 +5,7 @@
 name = "agntcy-slim-rpc"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.0"
+version.workspace = true
 description = "SlimRPC: a gRPC-like RPC framework over SLIM (native Rust)."
 
 [lib]


### PR DESCRIPTION
`agntcy-slim-rpc` was `0.1.0`, but it's part of the v2 user-facing surface (its sibling `slim-bindings` and `slim`/`control-plane` are all `2.0.0-alpha`) and is what a2a-slimrpc/SHADI consume. Align it to the shared alpha line via `version.workspace = true`, and bump the workspace dep requirement to `2.0.0-alpha.2`.

Never published, so no crates.io version conflict. release-plz will now include it in the release PR as **`agntcy-slim-rpc 2.0.0-alpha.3`** alongside the other alpha crates instead of `0.1.0`. Builds clean.