### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 # Local dependencies
 agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.3" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.12.0" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.3" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.4" }
 agntcy-slim-config = { path = "crates/config", version = "0.12.1" }
 agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.3" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.11.0" }

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.3...slim-bindings-v2.0.0-alpha.4) - 2026-07-15
+
+### Other
+
+- release ([#1853](https://github.com/agntcy/slim/pull/1853))
+- *(slim-bindings)* reuse agntcy-slim-rpc, drop duplicated slimrpc ([#1850](https://github.com/agntcy/slim/pull/1850))
+- move slim-bindings back to slim core ([#1846](https://github.com/agntcy/slim/pull/1846))
+
 ## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.2...slim-bindings-v2.0.0-alpha.3) - 2026-07-15
 
 ### Other

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-auth`: 0.11.0 -> 0.12.0
* `agntcy-slim-config`: 0.12.0 -> 0.12.1
* `agntcy-slim-proto`: 0.2.0 -> 0.3.0
* `agntcy-slim-tracing`: 0.4.2 -> 0.4.3
* `agntcy-slim-datapath`: 0.16.1 -> 0.16.2
* `agntcy-slim-mls`: 0.2.1 -> 0.2.2
* `agntcy-slim-session`: 0.5.0 -> 0.5.1
* `agntcy-slim-signal`: 0.1.10 -> 0.1.11
* `agntcy-slim-controller`: 0.10.0 -> 0.11.0
* `agntcy-slim-service`: 0.11.0 -> 0.11.1
* `agntcy-slim`: 2.0.0-alpha.2 -> 2.0.0-alpha.3
* `agntcy-slim-channel-manager`: 2.0.0-alpha.2 -> 2.0.0-alpha.3
* `agntcy-slim-control-plane`: 2.0.0-alpha.2 -> 2.0.0-alpha.3
* `agntcy-slim-rpc`: 2.0.0-alpha.3
* `agntcy-slim-bindings`: 2.0.0-alpha.3 -> 2.0.0-alpha.4 (✓ API compatible changes)
* `agntcy-slimctl`: 2.0.0-alpha.2 -> 2.0.0-alpha.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-auth`

<blockquote>

## [0.12.0](https://github.com/agntcy/slim/compare/slim-auth-v0.11.0...slim-auth-v0.12.0) - 2026-07-15

### Added

- *(mls)* share one signing identity across an app and its sessions ([#1825](https://github.com/agntcy/slim/pull/1825))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.12.1](https://github.com/agntcy/slim/compare/slim-config-v0.12.0...slim-config-v0.12.1) - 2026-07-15

### Added

- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))

### Fixed

- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.3.0](https://github.com/agntcy/slim/compare/slim-proto-v0.2.0...slim-proto-v0.3.0) - 2026-07-15

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
- group registration via slimctl ([#1795](https://github.com/agntcy/slim/pull/1795))

### Fixed

- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.3](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.2...slim-tracing-v0.4.3) - 2026-07-15

### Added

- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.1...slim-datapath-v0.16.2) - 2026-07-15

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.2](https://github.com/agntcy/slim/compare/slim-mls-v0.2.1...slim-mls-v0.2.2) - 2026-07-15

### Added

- *(mls)* share one signing identity across an app and its sessions ([#1825](https://github.com/agntcy/slim/pull/1825))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.5.1](https://github.com/agntcy/slim/compare/slim-session-v0.5.0...slim-session-v0.5.1) - 2026-07-15

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
- add websocket supports for the browser ([#1775](https://github.com/agntcy/slim/pull/1775))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.11](https://github.com/agntcy/slim/compare/slim-signal-v0.1.10...slim-signal-v0.1.11) - 2026-07-15

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.11.0](https://github.com/agntcy/slim/compare/slim-controller-v0.10.0...slim-controller-v0.11.0) - 2026-07-15

### Fixed

- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.11.1](https://github.com/agntcy/slim/compare/slim-service-v0.11.0...slim-service-v0.11.1) - 2026-07-15

### Added

- *(session)* use uuid for channel ids ([#1809](https://github.com/agntcy/slim/pull/1809))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.2...slim-v2.0.0-alpha.3) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-service, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.2...slim-channel-manager-v2.0.0-alpha.3) - 2026-07-15

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.2...slim-control-plane-v2.0.0-alpha.3) - 2026-07-15

### Added

- group registration via slimctl ([#1795](https://github.com/agntcy/slim/pull/1795))

### Fixed

- *(control-plane)* re-expand routes when a node reconnects over a claimed link ([#1836](https://github.com/agntcy/slim/pull/1836))
- separate server connection config ([#1778](https://github.com/agntcy/slim/pull/1778))

### Other

- *(control-plane)* fix auth-link flake by making the connector dialer-only ([#1831](https://github.com/agntcy/slim/pull/1831))
- *(control-plane)* de-flake integration tests ([#1829](https://github.com/agntcy/slim/pull/1829))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.2...slim-rpc-v2.0.0-alpha.3) - 2026-07-15

### Added

- *(rpc)* extract native agntcy-slim-rpc crate from the FFI bindings ([#1830](https://github.com/agntcy/slim/pull/1830))

### Other

- *(rpc)* version agntcy-slim-rpc on the 2.0.0-alpha line ([#1852](https://github.com/agntcy/slim/pull/1852))
- *(slim-bindings)* reuse agntcy-slim-rpc, drop duplicated slimrpc ([#1850](https://github.com/agntcy/slim/pull/1850))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.3...slim-bindings-v2.0.0-alpha.4) - 2026-07-15

### Other

- release ([#1853](https://github.com/agntcy/slim/pull/1853))
- *(slim-bindings)* reuse agntcy-slim-rpc, drop duplicated slimrpc ([#1850](https://github.com/agntcy/slim/pull/1850))
- move slim-bindings back to slim core ([#1846](https://github.com/agntcy/slim/pull/1846))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.3](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.2...slimctl-v2.0.0-alpha.3) - 2026-07-06

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-session, agntcy-slim-service, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).