### PR TITLE
fix(config): gate RequiredAuthMethod::Spire for windows

### DIFF
--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -451,6 +451,7 @@ impl ClientConfig {
             RequiredAuthMethod::None => {
                 self.auth = AuthenticationConfig::None;
             }
+            #[cfg(not(target_family = "windows"))]
             RequiredAuthMethod::Spire { trust_domain } => {
                 use crate::auth::spire::SpireConfig;
                 use crate::tls::common::{CaSource, TlsSource};
@@ -620,6 +621,7 @@ pub enum RequiredAuthMethod {
     None,
     Basic,
     Jwt,
+    #[cfg(not(target_family = "windows"))]
     Spire {
         trust_domain: Option<String>,
     },


### PR DESCRIPTION
`agntcy-slim-config` fails to compile on windows: the `spire` module, its imports, and the `AuthenticationConfig`/`TlsSource`/`CaSource`/`TlsConfigError` `Spire` variants are all `#[cfg(not(target_family = "windows"))]`, but **`RequiredAuthMethod::Spire`** and its match arm in `merge_server_requirements` were **not** — so windows hits `unresolved import crate::auth::spire` + `no variant Spire found`.

Gate the variant and its match arm consistently. The match stays exhaustive (None/Basic/Jwt) on windows; unix is unchanged.

Surfaced while migrating `a2a-slimrpc` onto the native v2 slim stack ([a2a-rs#104](https://github.com/a2aproject/a2a-rs/pull/104)), whose windows CI pulls `slim-config`. Host build + clippy + fmt clean (windows validated via that downstream CI once released).