### PR TITLE
ci: exempt org members from DCO + scope release secrets to an environment

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,4 @@
+# DCO app config: org members (incl. the release-plz automation bot) are exempt
+# from the Signed-off-by requirement; external contributions still require it.
+require:
+  members: false

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       - name: Run release-plz
+        id: release-pr
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release-pr
@@ -63,3 +64,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      # release-plz commits are not signed off, so the release PR fails the DCO
+      # check. Amend the PR head commit with a Signed-off-by matching its author
+      # and force-push, so the release PR passes DCO with no manual step.
+      - name: Sign off release PR commit for DCO
+        if: ${{ steps.release-pr.outputs.prs != '' && steps.release-pr.outputs.prs != '[]' }}
+        env:
+          GH_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
+          PRS: ${{ steps.release-pr.outputs.prs }}
+        run: |
+          set -euo pipefail
+          branch="$(printf '%s' "$PRS" | jq -r '.[0].head_branch // empty')"
+          if [ -z "$branch" ]; then
+            echo "No release PR branch to sign off."
+            exit 0
+          fi
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch origin "$branch"
+          git checkout "$branch"
+          if git log -1 --pretty=%B | grep -qiE '^Signed-off-by:'; then
+            echo "Release commit already signed off."
+            exit 0
+          fi
+          git config user.name "$(git log -1 --pretty=%an)"
+          git config user.email "$(git log -1 --pretty=%ae)"
+          git commit --amend --no-edit --signoff
+          git push --force-with-lease origin "$branch"

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -14,6 +14,9 @@ jobs:
   release-crates:
     name: Release slim crates
     runs-on: ubuntu-latest
+    # Scope the publish/token secrets to a dedicated environment (zizmor
+    # secrets-outside-env); add protection rules to it in repo settings as needed.
+    environment: release
     permissions:
       contents: write
       pull-requests: read
@@ -40,6 +43,7 @@ jobs:
   release-crates-pr:
     name: Release slim crates - PR
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       - name: Run release-plz
-        id: release-pr
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release-pr
@@ -68,31 +67,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      # release-plz commits are not signed off, so the release PR fails the DCO
-      # check. Amend the PR head commit with a Signed-off-by matching its author
-      # and force-push, so the release PR passes DCO with no manual step.
-      - name: Sign off release PR commit for DCO
-        if: ${{ steps.release-pr.outputs.prs != '' && steps.release-pr.outputs.prs != '[]' }}
-        env:
-          GH_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
-          PRS: ${{ steps.release-pr.outputs.prs }}
-        run: |
-          set -euo pipefail
-          branch="$(printf '%s' "$PRS" | jq -r '.[0].head_branch // empty')"
-          if [ -z "$branch" ]; then
-            echo "No release PR branch to sign off."
-            exit 0
-          fi
-          git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git fetch origin "$branch"
-          git checkout "$branch"
-          if git log -1 --pretty=%B | grep -qiE '^Signed-off-by:'; then
-            echo "Release commit already signed off."
-            exit 0
-          fi
-          git config user.name "$(git log -1 --pretty=%an)"
-          git config user.email "$(git log -1 --pretty=%ae)"
-          git commit --amend --no-edit --signoff
-          git push --force-with-lease origin "$branch"


### PR DESCRIPTION
Two small hardening fixes to the release flow (no shell):

1. **DCO** — release-plz's bot commit has no `Signed-off-by`, so every "chore: release" PR fails DCO. Add `.github/dco.yml` with `require: members: false` so org members (incl. the release automation bot) are exempt; external contributions still require sign-off.
2. **zizmor `secrets-outside-env`** (pre-existing on main, alert #602) — bind both release jobs to a dedicated `release` environment so the GH/crates.io secrets are scoped.