### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -517,11 +517,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,23 +40,23 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.3" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.12.0" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.4" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.12.1" }
 agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.5" }
 agntcy-slim-config = { path = "crates/config", version = "0.12.2" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.3" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.4" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.11.1" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.3" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.2.2" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.2.3" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.3.1" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.3" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.4" }
 agntcy-slim-service = { path = "crates/service", version = "0.11.2", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.5.2" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.11" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.12" }
 agntcy-slim-testing = { path = "crates/testing" }
 agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.4" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.3" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.3" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.4" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.4" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -218,7 +218,7 @@ wiremock = "0.6"
 x25519-dalek = { version = "2", default-features = false, features = ["static_secrets"] }
 
 [workspace.package]
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/agntcy/slim/compare/slim-auth-v0.12.0...slim-auth-v0.12.1) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.12.0](https://github.com/agntcy/slim/compare/slim-auth-v0.11.0...slim-auth-v0.12.0) - 2026-07-15
 
 ### Added

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.12.0"
+version = "0.12.1"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/agntcy/slim/compare/slim-mls-v0.2.2...slim-mls-v0.2.3) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.2.2](https://github.com/agntcy/slim/compare/slim-mls-v0.2.1...slim-mls-v0.2.2) - 2026-07-15
 
 ### Added

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.2"
+version = "0.2.3"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/agntcy/slim/compare/slim-signal-v0.1.11...slim-signal-v0.1.12) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.11](https://github.com/agntcy/slim/compare/slim-signal-v0.1.10...slim-signal-v0.1.11) - 2026-07-15
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.11"
+version = "0.1.12"
 description = "Small library to handle OS signals."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.3 -> 2.0.0-alpha.4
* `agntcy-slim-config`: 0.12.1 -> 0.12.2
* `agntcy-slim-proto`: 0.3.0 -> 0.3.1
* `agntcy-slim-tracing`: 0.4.3 -> 0.4.4
* `agntcy-slim-datapath`: 0.16.2 -> 0.16.3
* `agntcy-slim-session`: 0.5.1 -> 0.5.2
* `agntcy-slim-controller`: 0.11.0 -> 0.11.1
* `agntcy-slim-service`: 0.11.1 -> 0.11.2
* `agntcy-slim`: 2.0.0-alpha.3 -> 2.0.0-alpha.4 (✓ API compatible changes)
* `agntcy-slim-channel-manager`: 2.0.0-alpha.3 -> 2.0.0-alpha.4 (✓ API compatible changes)
* `agntcy-slim-control-plane`: 2.0.0-alpha.3 -> 2.0.0-alpha.4 (✓ API compatible changes)
* `agntcy-slim-rpc`: 2.0.0-alpha.3 -> 2.0.0-alpha.4 (✓ API compatible changes)
* `agntcy-slim-bindings`: 2.0.0-alpha.4 -> 2.0.0-alpha.5
* `agntcy-slimctl`: 2.0.0-alpha.3 -> 2.0.0-alpha.4
* `agntcy-slim-auth`: 0.12.0 -> 0.12.1
* `agntcy-slim-mls`: 0.2.2 -> 0.2.3
* `agntcy-slim-signal`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.12.2](https://github.com/agntcy/slim/compare/slim-config-v0.12.1...slim-config-v0.12.2) - 2026-07-16

### Fixed

- *(config)* gate RequiredAuthMethod::Spire for windows ([#1855](https://github.com/agntcy/slim/pull/1855))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.3.1](https://github.com/agntcy/slim/compare/slim-proto-v0.3.0...slim-proto-v0.3.1) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.4](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.3...slim-tracing-v0.4.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.2...slim-datapath-v0.16.3) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.5.2](https://github.com/agntcy/slim/compare/slim-session-v0.5.1...slim-session-v0.5.2) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-datapath
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.11.1](https://github.com/agntcy/slim/compare/slim-controller-v0.11.0...slim-controller-v0.11.1) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.11.2](https://github.com/agntcy/slim/compare/slim-service-v0.11.1...slim-service-v0.11.2) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-controller
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.3...slim-v2.0.0-alpha.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-service
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.3...slim-channel-manager-v2.0.0-alpha.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.3...slim-control-plane-v2.0.0-alpha.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-service
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.3...slim-rpc-v2.0.0-alpha.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.4...slim-bindings-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-controller, agntcy-slim-service, agntcy-slim, agntcy-slim-rpc
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.4](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.3...slimctl-v2.0.0-alpha.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.12.1](https://github.com/agntcy/slim/compare/slim-auth-v0.12.0...slim-auth-v0.12.1) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.3](https://github.com/agntcy/slim/compare/slim-mls-v0.2.2...slim-mls-v0.2.3) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.12](https://github.com/agntcy/slim/compare/slim-signal-v0.1.11...slim-signal-v0.1.12) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).