### PR TITLE
fix(controller): gate AuthenticationConfig::Spire match for windows

### DIFF
--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -212,10 +212,12 @@ pub(crate) fn from_server_config(server_config: &ServerConfig) -> ConnectionDeta
     }
 
     let tls_required = !server_config.tls_setting.insecure || spire_socket_path.is_some();
-    let auth_method = if spire_socket_path.is_some()
-        || trust_domain.is_some()
-        || matches!(server_config.auth, AuthenticationConfig::Spire(_))
-    {
+    // AuthenticationConfig::Spire is gated to non-windows in slim-config.
+    #[cfg(not(target_family = "windows"))]
+    let auth_is_spire = matches!(server_config.auth, AuthenticationConfig::Spire(_));
+    #[cfg(target_family = "windows")]
+    let auth_is_spire = false;
+    let auth_method = if spire_socket_path.is_some() || trust_domain.is_some() || auth_is_spire {
         AuthMethod::Spire
     } else {
         match &server_config.auth {


### PR DESCRIPTION
Follow-up to #1855. `AuthenticationConfig::Spire` is `cfg(not(windows))` in slim-config, but `controller`'s `derive_auth` matched on it unconditionally (`service.rs:217`), so the crate fails to compile on windows (`no variant Spire`). Compute `auth_is_spire` behind a `cfg` (false on windows).

Surfaced by a2a-rs windows CI ([#104](https://github.com/a2aproject/a2a-rs/pull/104)) once slim-config 0.12.2 fixed the config-internal refs. control-plane also references the gated variant but isn't in a2a-slimrpc's tree; controller is the last one on that path. Host build + clippy + fmt clean.