### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -517,11 +517,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,23 +40,23 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.4" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.12.1" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.6" }
-agntcy-slim-config = { path = "crates/config", version = "0.12.3" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.4" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.11.2" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.4" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.2.3" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.3.2" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.4" }
-agntcy-slim-service = { path = "crates/service", version = "0.11.3", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.5.3" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.12" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.5" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.13.0" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.7" }
+agntcy-slim-config = { path = "crates/config", version = "0.12.4" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.5" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.11.3" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.5" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.2.4" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.3.3" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.5" }
+agntcy-slim-service = { path = "crates/service", version = "0.11.4", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.5.4" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.13" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.5" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.4" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.4" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.6" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.5" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.5" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -218,7 +218,7 @@ wiremock = "0.6"
 x25519-dalek = { version = "2", default-features = false, features = ["static_secrets"] }
 
 [workspace.package]
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/agntcy/slim/compare/slim-auth-v0.12.1...slim-auth-v0.13.0) - 2026-07-16
+
+### Fixed
+
+- *(auth,mls)* stop mid-handshake MLS signing-key rotation ([#1869](https://github.com/agntcy/slim/pull/1869))
+
 ## [0.12.1](https://github.com/agntcy/slim/compare/slim-auth-v0.12.0...slim-auth-v0.12.1) - 2026-07-16
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.12.1"
+version = "0.13.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4](https://github.com/agntcy/slim/compare/slim-config-v0.12.3...slim-config-v0.12.4) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.12.3](https://github.com/agntcy/slim/compare/slim-config-v0.12.2...slim-config-v0.12.3) - 2026-07-16
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.12.3"
+version = "0.12.4"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/agntcy/slim/compare/slim-controller-v0.11.2...slim-controller-v0.11.3) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-session, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-signal
+
 ## [0.11.2](https://github.com/agntcy/slim/compare/slim-controller-v0.11.1...slim-controller-v0.11.2) - 2026-07-16
 
 ### Fixed

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.11.2"
+version = "0.11.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.4...slim-datapath-v0.16.5) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
+
 ## [0.16.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.3...slim-datapath-v0.16.4) - 2026-07-16
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.16.4"
+version = "0.16.5"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/agntcy/slim/compare/slim-mls-v0.2.3...slim-mls-v0.2.4) - 2026-07-16
+
+### Fixed
+
+- *(auth,mls)* stop mid-handshake MLS signing-key rotation ([#1869](https://github.com/agntcy/slim/pull/1869))
+
 ## [0.2.3](https://github.com/agntcy/slim/compare/slim-mls-v0.2.2...slim-mls-v0.2.3) - 2026-07-16
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.3"
+version = "0.2.4"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/agntcy/slim/compare/slim-proto-v0.3.2...slim-proto-v0.3.3) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.3.2](https://github.com/agntcy/slim/compare/slim-proto-v0.3.1...slim-proto-v0.3.2) - 2026-07-16
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/agntcy/slim/compare/slim-service-v0.11.3...slim-service-v0.11.4) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-controller
+
 ## [0.11.3](https://github.com/agntcy/slim/compare/slim-service-v0.11.2...slim-service-v0.11.3) - 2026-07-16
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.11.3"
+version = "0.11.4"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/agntcy/slim/compare/slim-session-v0.5.3...slim-session-v0.5.4) - 2026-07-16
+
+### Fixed
+
+- *(auth,mls)* stop mid-handshake MLS signing-key rotation ([#1869](https://github.com/agntcy/slim/pull/1869))
+
 ## [0.5.3](https://github.com/agntcy/slim/compare/slim-session-v0.5.2...slim-session-v0.5.3) - 2026-07-16
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.3"
+version = "0.5.4"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/agntcy/slim/compare/slim-signal-v0.1.12...slim-signal-v0.1.13) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.12](https://github.com/agntcy/slim/compare/slim-signal-v0.1.11...slim-signal-v0.1.12) - 2026-07-16
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.12"
+version = "0.1.13"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.7](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.6...slim-bindings-v2.0.0-alpha.7) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-auth, agntcy-slim-session, agntcy-slim, agntcy-slim-rpc, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-signal, agntcy-slim-controller, agntcy-slim-service
+
 ## [2.0.0-alpha.6](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.5...slim-bindings-v2.0.0-alpha.6) - 2026-07-16
 
 ### Other

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.5...slim-tracing-v0.4.6) - 2026-07-16
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.5](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.4...slim-tracing-v0.4.5) - 2026-07-16
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.5"
+version = "0.4.6"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.4 -> 2.0.0-alpha.5
* `agntcy-slim-auth`: 0.12.1 -> 0.13.0 (⚠ API breaking changes)
* `agntcy-slim-mls`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `agntcy-slim-session`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `agntcy-slim`: 2.0.0-alpha.4 -> 2.0.0-alpha.5 (✓ API compatible changes)
* `agntcy-slim-channel-manager`: 2.0.0-alpha.4 -> 2.0.0-alpha.5 (✓ API compatible changes)
* `agntcy-slim-control-plane`: 2.0.0-alpha.4 -> 2.0.0-alpha.5 (✓ API compatible changes)
* `agntcy-slim-rpc`: 2.0.0-alpha.4 -> 2.0.0-alpha.5 (✓ API compatible changes)
* `agntcy-slimctl`: 2.0.0-alpha.4 -> 2.0.0-alpha.5
* `agntcy-slim-config`: 0.12.3 -> 0.12.4
* `agntcy-slim-proto`: 0.3.2 -> 0.3.3
* `agntcy-slim-tracing`: 0.4.5 -> 0.4.6
* `agntcy-slim-datapath`: 0.16.4 -> 0.16.5
* `agntcy-slim-signal`: 0.1.12 -> 0.1.13
* `agntcy-slim-controller`: 0.11.2 -> 0.11.3
* `agntcy-slim-service`: 0.11.3 -> 0.11.4
* `agntcy-slim-bindings`: 2.0.0-alpha.6 -> 2.0.0-alpha.7

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method get_signature_secret_key of trait TokenProvider, previously in file /tmp/.tmpkhY2mY/agntcy-slim-auth/src/traits.rs:125
  method get_signature_public_key of trait TokenProvider, previously in file /tmp/.tmpkhY2mY/agntcy-slim-auth/src/traits.rs:131
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.13.0](https://github.com/agntcy/slim/compare/slim-auth-v0.12.1...slim-auth-v0.13.0) - 2026-07-16

### Fixed

- *(auth,mls)* stop mid-handshake MLS signing-key rotation ([#1869](https://github.com/agntcy/slim/pull/1869))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.4](https://github.com/agntcy/slim/compare/slim-mls-v0.2.3...slim-mls-v0.2.4) - 2026-07-16

### Fixed

- *(auth,mls)* stop mid-handshake MLS signing-key rotation ([#1869](https://github.com/agntcy/slim/pull/1869))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.5.4](https://github.com/agntcy/slim/compare/slim-session-v0.5.3...slim-session-v0.5.4) - 2026-07-16

### Fixed

- *(auth,mls)* stop mid-handshake MLS signing-key rotation ([#1869](https://github.com/agntcy/slim/pull/1869))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.4...slim-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-service
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.4...slim-channel-manager-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.4...slim-control-plane-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-service
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.4...slim-rpc-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.4...slimctl-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.12.4](https://github.com/agntcy/slim/compare/slim-config-v0.12.3...slim-config-v0.12.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.3.3](https://github.com/agntcy/slim/compare/slim-proto-v0.3.2...slim-proto-v0.3.3) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.6](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.5...slim-tracing-v0.4.6) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.4...slim-datapath-v0.16.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.13](https://github.com/agntcy/slim/compare/slim-signal-v0.1.12...slim-signal-v0.1.13) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.11.3](https://github.com/agntcy/slim/compare/slim-controller-v0.11.2...slim-controller-v0.11.3) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-session, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.11.4](https://github.com/agntcy/slim/compare/slim-service-v0.11.3...slim-service-v0.11.4) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-controller
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.7](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.6...slim-bindings-v2.0.0-alpha.7) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-auth, agntcy-slim-session, agntcy-slim, agntcy-slim-rpc, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-signal, agntcy-slim-controller, agntcy-slim-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).