### PR TITLE
feat(slim-bindings): hierarchical config loading and stable identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -21,7 +21,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-test",
@@ -29,13 +29,14 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.14.0"
+version = "0.15.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
  "agntcy-slim-version",
  "aws-lc-rs",
  "base64 0.22.1",
+ "cel",
  "cfg-if",
  "criterion",
  "display-error-chain",
@@ -57,13 +58,14 @@ dependencies = [
  "pin-project",
  "prost-types",
  "rand 0.9.5",
- "reqwest",
- "schemars 1.2.1",
+ "regorus",
+ "reqwest 0.12.28",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
  "spiffe",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -80,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.9"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -93,28 +95,29 @@ dependencies = [
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
- "async-trait",
+ "cfg-if",
  "clap",
- "dirs",
  "display-error-chain",
  "futures",
  "futures-timer",
+ "getrandom 0.4.3",
  "humantime-serde",
  "parking_lot",
  "serde",
  "serde_json",
- "serde_yaml",
  "tempfile",
  "test-fork",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
+ "tokio_with_wasm",
  "tracing",
  "uniffi",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -141,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.6"
+version = "0.16.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -154,7 +157,9 @@ dependencies = [
  "drain",
  "duration-string",
  "fastwebsockets",
+ "fs2",
  "futures",
+ "getrandom 0.4.3",
  "gloo-net",
  "http",
  "http-body-util",
@@ -171,12 +176,13 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha1",
- "thiserror 2.0.19",
+ "tempfile",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -198,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -229,7 +235,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -243,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.5"
+version = "0.13.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -262,7 +268,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -275,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.7"
+version = "0.18.6"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -292,6 +298,7 @@ dependencies = [
  "fastwebsockets",
  "futures",
  "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "gloo-net",
  "h2",
  "hkdf",
@@ -310,7 +317,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -331,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.6"
+version = "0.3.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -347,7 +354,7 @@ dependencies = [
  "mls-rs-crypto-webcrypto",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -365,7 +372,7 @@ dependencies = [
  "mls-rs-provider-sqlite",
  "serde",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "zeroize",
@@ -373,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -381,7 +388,7 @@ dependencies = [
  "prost-types",
  "protoc-bin-vendored",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -391,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -409,7 +416,7 @@ dependencies = [
  "parking_lot",
  "tempfile",
  "test-fork",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -420,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.6"
+version = "0.12.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -442,10 +449,11 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "test-fork",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "tracing-test",
  "twox-hash",
@@ -454,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.6.0"
+version = "0.7.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -477,7 +485,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tokio_with_wasm",
@@ -490,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.15"
+version = "0.1.25"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -510,6 +518,7 @@ dependencies = [
  "agntcy-slim-session",
  "agntcy-slim-tracing",
  "anyhow",
+ "assert_cmd",
  "aws-lc-rs",
  "base64 0.22.1",
  "bollard",
@@ -518,10 +527,13 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "parking_lot",
+ "predicates",
  "rand 0.9.5",
+ "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "tempfile",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -530,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.8"
+version = "0.4.19"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -543,7 +555,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -553,11 +565,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -573,8 +585,12 @@ dependencies = [
  "chrono",
  "clap",
  "duration-string",
+ "jsonwebtoken",
+ "oauth2",
  "prost",
  "prost-types",
+ "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -595,15 +611,16 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -616,9 +633,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -677,6 +694,23 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "antlr4rust"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093d520274bfff7278d776f7ea12981a0a0a6f96db90964658e0f38fc6e9a6a6"
+dependencies = [
+ "better_any",
+ "bit-set",
+ "byteorder",
+ "lazy_static",
+ "murmur3",
+ "once_cell",
+ "parking_lot",
+ "typed-arena",
+ "uuid",
 ]
 
 [[package]]
@@ -748,7 +782,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -783,6 +817,21 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -821,13 +870,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -970,6 +1019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1063,21 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1084,6 +1154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,10 +1169,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1106,9 +1205,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -1133,7 +1232,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1144,14 +1243,30 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex 2.0.1",
+]
+
+[[package]]
+name = "cel"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82399e72d100a28a0cac14251a8aba16d124af2a237d8a60ab7997ba7380cc3"
+dependencies = [
+ "antlr4rust",
+ "chrono",
+ "lazy_static",
+ "nom",
+ "pastey",
+ "regex",
+ "serde",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1168,6 +1283,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1192,6 +1313,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -1223,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -1234,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1244,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1263,7 +1394,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1288,19 +1419,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "const-oid"
@@ -1570,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -1646,7 +1777,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1679,7 +1810,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1727,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.11"
+version = "2.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54d1f576cd3a3460f212a4615fd12ce1b6303c095b79a44449ffbe627753dc1"
+checksum = "715377c6e464cb44bb89bd8487584240516c8d5052bc645d6babc50bb8be46c3"
 dependencies = [
  "diesel_derives",
  "downcast-rs",
@@ -1787,6 +1918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,13 +1974,13 @@ checksum = "0bc2146e86bc19f52f4c064a64782f05f139ca464ed72937301631e73f8d6cf5"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1948,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -1972,6 +2109,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,22 +2140,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2018,11 +2176,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2050,6 +2207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,7 +2235,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "pin-project",
- "rand 0.8.7",
+ "rand 0.8.8",
  "sha1",
  "simdutf8",
  "thiserror 1.0.69",
@@ -2093,15 +2261,35 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -2131,12 +2319,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2156,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2171,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2181,15 +2389,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2198,32 +2406,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -2233,9 +2441,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2293,9 +2501,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2303,6 +2513,18 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gloo-net"
@@ -2370,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2520,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2540,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2581,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "ctutils",
  "typenum",
@@ -2721,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2735,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2748,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2762,16 +2984,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2782,15 +3005,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2853,9 +3076,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
  "inotify-sys",
@@ -2873,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-terminal"
@@ -2949,17 +3172,19 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link",
 ]
 
 [[package]]
@@ -2973,14 +3198,29 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2995,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3013,20 +3253,20 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dbe0623574defe58ba113596c848797f131727e8f54d4b4d10793e1fe14d40"
+checksum = "8edb06feabbd4c3fe17e2572f391510e08a011b92f53a7b76236eeb18191cfbe"
 dependencies = [
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3037,6 +3277,42 @@ checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3071,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3091,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -3148,7 +3424,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tower",
@@ -3171,7 +3447,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3195,7 +3471,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3231,9 +3507,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -3257,9 +3533,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -3272,18 +3548,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3318,6 +3600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "migrations_internals"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,9 +3634,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+checksum = "c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0"
 dependencies = [
  "cc",
  "walkdir",
@@ -3408,9 +3696,9 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "spin",
+ "spin 0.10.1",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -3423,7 +3711,7 @@ checksum = "45bd834f164dc06c1fed805540ae307a460b7ed7c2769a35a376f1de577a0dc1"
 dependencies = [
  "itertools 0.14.0",
  "mls-rs-codec-derive",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
 ]
 
@@ -3450,7 +3738,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-codec",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -3469,7 +3757,7 @@ dependencies = [
  "mls-rs-crypto-hpke",
  "mls-rs-crypto-traits",
  "mls-rs-identity-x509",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
@@ -3484,7 +3772,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-core",
  "mls-rs-crypto-traits",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
@@ -3516,7 +3804,7 @@ dependencies = [
  "mls-rs-crypto-traits",
  "serde",
  "serde-wasm-bindgen",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3532,7 +3820,7 @@ dependencies = [
  "async-trait",
  "maybe-async",
  "mls-rs-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
 ]
 
@@ -3547,7 +3835,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-core",
  "rusqlite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
@@ -3563,10 +3851,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "murmur3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "nom"
@@ -3577,6 +3883,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -3615,12 +3927,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3632,10 +3983,31 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3669,8 +4041,8 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.7",
- "reqwest",
+ "rand 0.8.8",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3714,36 +4086,36 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -3751,18 +4123,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
- "thiserror 2.0.19",
+ "reqwest 0.13.4",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3773,15 +4145,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3790,17 +4162,18 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -3819,6 +4192,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -3862,6 +4241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,9 +4264,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3889,9 +4274,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3899,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3912,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -3929,6 +4314,24 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3979,9 +4382,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -4019,9 +4422,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 dependencies = [
  "critical-section",
 ]
@@ -4036,10 +4439,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.5"
+name = "postcard"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4057,6 +4472,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -4226,11 +4671,67 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4256,9 +4757,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4331,6 +4832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,22 +4882,39 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4404,9 +4931,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4418,6 +4945,39 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "regorus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc4dc91481b1d4001ba7f2e81f7faf674142e0ac36d37d79e5f02764d06571e"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "data-encoding",
+ "globset",
+ "indexmap 2.14.0",
+ "ipnet",
+ "jsonschema",
+ "lazy_static",
+ "lru",
+ "msvc_spectre_libs",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "parking_lot",
+ "postcard",
+ "rand 0.10.2",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "spin 0.12.3",
+ "thiserror 2.0.20",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "relative-path"
@@ -4449,7 +5009,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4457,6 +5019,37 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
  "tower",
  "tower-http",
  "tower-service",
@@ -4506,7 +5099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4592,13 +5185,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4623,6 +5217,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4682,9 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4695,14 +5290,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4835,18 +5430,18 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4881,7 +5476,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4907,9 +5502,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4917,8 +5512,9 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "time",
@@ -5028,9 +5624,9 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -5107,7 +5703,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-util",
@@ -5127,6 +5723,12 @@ checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
 
 [[package]]
 name = "spki"
@@ -5197,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5261,6 +5863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "test-fork"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,11 +5919,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5331,13 +5939,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5351,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5381,9 +5989,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5433,13 +6041,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5571,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -5668,6 +6276,17 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]
@@ -5768,9 +6387,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -5861,6 +6480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5877,6 +6502,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -6074,14 +6705,25 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "rand 0.10.2",
  "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -6107,6 +6749,21 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -6144,9 +6801,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6157,9 +6814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6167,9 +6824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6177,9 +6834,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6190,18 +6847,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+checksum = "895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1"
 dependencies = [
  "async-trait",
  "cast",
@@ -6221,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+checksum = "4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6232,15 +6889,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
+checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6637,9 +7294,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x25519-dalek"
@@ -6664,7 +7321,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -6693,18 +7350,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6754,9 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6765,9 +7422,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6776,13 +7433,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-test",
@@ -63,7 +63,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "spiffe",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -93,15 +93,20 @@ dependencies = [
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
+ "async-trait",
  "clap",
+ "dirs",
  "display-error-chain",
  "futures",
  "futures-timer",
+ "humantime-serde",
  "parking_lot",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "test-fork",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "uniffi",
@@ -171,7 +176,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -224,7 +229,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -257,7 +262,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -305,7 +310,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -342,7 +347,7 @@ dependencies = [
  "mls-rs-crypto-webcrypto",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -360,7 +365,7 @@ dependencies = [
  "mls-rs-provider-sqlite",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "zeroize",
@@ -376,7 +381,7 @@ dependencies = [
  "prost-types",
  "protoc-bin-vendored",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -402,7 +407,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "parking_lot",
- "thiserror 2.0.18",
+ "tempfile",
+ "test-fork",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -425,13 +432,17 @@ dependencies = [
  "agntcy-slim-testing",
  "agntcy-slim-version",
  "async-trait",
+ "dirs",
  "display-error-chain",
  "futures",
+ "humantime-serde",
  "parking_lot",
  "rstest",
  "serde",
+ "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
+ "test-fork",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -466,7 +477,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tokio_with_wasm",
@@ -510,7 +521,7 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "uuid",
@@ -532,7 +543,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -670,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -710,7 +721,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -737,7 +748,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -749,7 +760,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -761,7 +772,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -805,18 +816,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -833,9 +844,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.15"
+version = "0.13.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1"
+checksum = "37b00953a69b2cfb471d13d72538d2e66930832340b0f31deadd404b48c573c5"
 dependencies = [
  "bindgen",
  "cc",
@@ -984,7 +995,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -995,7 +1006,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1006,9 +1017,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -1122,7 +1133,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1133,9 +1144,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1223,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1233,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1245,14 +1256,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1484,7 +1495,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1518,7 +1529,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1532,7 +1543,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1543,7 +1554,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1554,7 +1565,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1626,7 +1637,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1635,7 +1646,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1681,7 +1692,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1711,7 +1722,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1752,7 +1763,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1772,7 +1783,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1798,6 +1809,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "display-error-chain"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,7 +1843,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1842,7 +1874,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1911,7 +1943,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1965,7 +1997,7 @@ checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2019,9 +2051,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fastwebsockets"
@@ -2124,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2139,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2149,15 +2181,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2166,32 +2198,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -2201,9 +2233,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2268,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-net"
@@ -2532,6 +2564,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2565,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-named-pipe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
 dependencies = [
  "hex",
  "hyper",
@@ -2575,7 +2623,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
- "winapi",
 ]
 
 [[package]]
@@ -2810,7 +2857,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -2902,11 +2949,12 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -2915,14 +2963,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2955,20 +3013,20 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4222e00941bfe18bf81b79fa23ad933e233bfa18f3ee27254c5dd9b1543b5d5f"
+checksum = "a2dbe0623574defe58ba113596c848797f131727e8f54d4b4d10793e1fe14d40"
 dependencies = [
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3047,7 +3105,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -3090,7 +3148,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower",
@@ -3113,7 +3171,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3137,7 +3195,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3151,9 +3209,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -3170,6 +3228,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3241,7 +3308,7 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3343,7 +3410,7 @@ dependencies = [
  "serde",
  "spin",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -3356,7 +3423,7 @@ checksum = "45bd834f164dc06c1fed805540ae307a460b7ed7c2769a35a376f1de577a0dc1"
 dependencies = [
  "itertools 0.14.0",
  "mls-rs-codec-derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
 ]
 
@@ -3369,7 +3436,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3383,7 +3450,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-codec",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -3402,7 +3469,7 @@ dependencies = [
  "mls-rs-crypto-hpke",
  "mls-rs-crypto-traits",
  "mls-rs-identity-x509",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -3417,7 +3484,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-core",
  "mls-rs-crypto-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -3449,7 +3516,7 @@ dependencies = [
  "mls-rs-crypto-traits",
  "serde",
  "serde-wasm-bindgen",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3465,7 +3532,7 @@ dependencies = [
  "async-trait",
  "maybe-async",
  "mls-rs-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
 ]
 
@@ -3480,7 +3547,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-core",
  "rusqlite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -3517,7 +3584,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3535,7 +3602,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3655,7 +3722,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3685,7 +3752,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tracing",
@@ -3733,10 +3800,16 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3806,9 +3879,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3816,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3826,22 +3899,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -3875,7 +3948,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3946,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 dependencies = [
  "critical-section",
 ]
@@ -3993,7 +4066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4016,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4040,7 +4113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4050,7 +4123,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -4061,10 +4134,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4146,7 +4219,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -4162,9 +4235,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -4283,34 +4356,45 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4320,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4422,7 +4506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4451,7 +4535,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -4461,7 +4545,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4499,7 +4583,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4535,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -4618,7 +4702,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4644,7 +4728,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4676,7 +4760,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4705,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4736,22 +4820,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4762,14 +4846,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4791,13 +4875,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4946,7 +5030,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -5023,7 +5107,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-util",
@@ -5112,6 +5196,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5128,7 +5223,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5137,7 +5232,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5183,7 +5278,7 @@ checksum = "8597f6b65c2c328b5c1f2f0c0a0f0b77c1d2eaec95ace746438ce1db0e9195e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5192,7 +5287,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "538d31f35d5795e671f34748cb8541cf6606587a8f3bb61e8214a06eb0545814"
 dependencies = [
- "syn",
+ "syn 2.0.119",
  "test-fork-core",
 ]
 
@@ -5216,11 +5311,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5231,18 +5326,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5256,9 +5351,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5276,9 +5371,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5321,9 +5416,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5338,13 +5433,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5370,9 +5465,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5392,13 +5487,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -5425,7 +5521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8aa1d26c1550eef93cfb2dafadc145b3220432dae8d156b5ba485880594ffe"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5526,7 +5622,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5551,7 +5647,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -5600,7 +5696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -5646,7 +5742,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5722,7 +5818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5740,13 +5836,13 @@ dependencies = [
 
 [[package]]
 name = "trait-variant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5757,11 +5853,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 dependencies = [
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -5864,7 +5960,7 @@ dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5879,7 +5975,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.119",
  "toml",
  "uniffi_meta",
 ]
@@ -5978,9 +6074,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6088,7 +6184,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6131,7 +6227,7 @@ checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6221,7 +6317,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6232,7 +6328,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6272,6 +6368,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6295,6 +6400,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6332,6 +6452,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6344,6 +6470,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6353,6 +6485,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6380,6 +6518,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6389,6 +6533,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6404,6 +6554,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6413,6 +6569,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6502,7 +6664,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -6525,28 +6687,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6566,7 +6728,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6587,7 +6749,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6620,7 +6782,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.3.0"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,14 +29,13 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.15.3"
+version = "0.14.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
  "agntcy-slim-version",
  "aws-lc-rs",
  "base64 0.22.1",
- "cel",
  "cfg-if",
  "criterion",
  "display-error-chain",
@@ -58,9 +57,8 @@ dependencies = [
  "pin-project",
  "prost-types",
  "rand 0.9.5",
- "regorus",
- "reqwest 0.12.28",
- "schemars 1.2.2",
+ "reqwest",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2",
@@ -82,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.3.0"
+version = "2.0.0-alpha.9"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -95,27 +93,28 @@ dependencies = [
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
- "cfg-if",
+ "async-trait",
  "clap",
+ "dirs",
  "display-error-chain",
  "futures",
  "futures-timer",
- "getrandom 0.4.3",
+ "humantime-serde",
  "parking_lot",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "test-fork",
  "thiserror 2.0.19",
  "tokio",
- "tokio_with_wasm",
  "tracing",
  "uniffi",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.3.0"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -142,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.16.0"
+version = "0.12.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -155,9 +154,7 @@ dependencies = [
  "drain",
  "duration-string",
  "fastwebsockets",
- "fs2",
  "futures",
- "getrandom 0.4.3",
  "gloo-net",
  "http",
  "http-body-util",
@@ -174,12 +171,11 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha1",
- "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tokio-retry",
@@ -202,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.3.0"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -247,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.13.0"
+version = "0.11.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -279,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.6"
+version = "0.16.7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -296,7 +292,6 @@ dependencies = [
  "fastwebsockets",
  "futures",
  "getrandom 0.3.4",
- "getrandom 0.4.3",
  "gloo-net",
  "h2",
  "hkdf",
@@ -336,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.9"
+version = "0.2.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -378,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.6.0"
+version = "0.4.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -396,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.3.0"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -412,6 +407,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "parking_lot",
+ "tempfile",
+ "test-fork",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -423,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.10"
+version = "0.11.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -435,17 +432,20 @@ dependencies = [
  "agntcy-slim-testing",
  "agntcy-slim-version",
  "async-trait",
+ "dirs",
  "display-error-chain",
  "futures",
+ "humantime-serde",
  "parking_lot",
  "rstest",
  "serde",
+ "serde_yaml",
  "tempfile",
+ "test-fork",
  "thiserror 2.0.19",
  "tokio",
  "tokio-test",
  "tokio-util",
- "tokio_with_wasm",
  "tracing",
  "tracing-test",
  "twox-hash",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.10"
+version = "0.6.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.25"
+version = "0.1.15"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -510,7 +510,6 @@ dependencies = [
  "agntcy-slim-session",
  "agntcy-slim-tracing",
  "anyhow",
- "assert_cmd",
  "aws-lc-rs",
  "base64 0.22.1",
  "bollard",
@@ -519,12 +518,9 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "parking_lot",
- "predicates",
  "rand 0.9.5",
- "regex",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -534,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.19"
+version = "0.4.8"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -557,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.3.0"
+version = "2.0.0-alpha.7"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.3.0"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -577,12 +573,8 @@ dependencies = [
  "chrono",
  "clap",
  "duration-string",
- "jsonwebtoken",
- "oauth2",
  "prost",
  "prost-types",
- "reqwest 0.12.28",
- "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -603,16 +595,15 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -686,23 +677,6 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "antlr4rust"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093d520274bfff7278d776f7ea12981a0a0a6f96db90964658e0f38fc6e9a6a6"
-dependencies = [
- "better_any",
- "bit-set",
- "byteorder",
- "lazy_static",
- "murmur3",
- "once_cell",
- "parking_lot",
- "typed-arena",
- "uuid",
 ]
 
 [[package]]
@@ -809,21 +783,6 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "assert_cmd"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
-dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
 ]
 
 [[package]]
@@ -1011,12 +970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "better_any"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
-
-[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,21 +1008,6 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1146,12 +1084,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borrow-or-share"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,33 +1093,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1197,9 +1106,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.5"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -1246,22 +1155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cel"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f836899841a6a942956b4252d070ada1b379c3476ff181ad5defcf9383e5851d"
-dependencies = [
- "antlr4rust",
- "chrono",
- "lazy_static",
- "nom",
- "pastey",
- "regex",
- "serde",
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,12 +1168,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1305,16 +1192,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
-dependencies = [
- "chrono",
- "phf",
 ]
 
 [[package]]
@@ -1346,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.9.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -1357,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1367,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1411,19 +1288,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -1693,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -1802,7 +1679,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.8",
+ "num-bigint",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1910,12 +1787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +1809,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "display-error-chain"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,13 +1837,13 @@ checksum = "0bc2146e86bc19f52f4c064a64782f05f139ca464ed72937301631e73f8d6cf5"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2056,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -2080,27 +1972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "email_address"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,22 +1982,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2147,10 +2018,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.2"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
+ "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2176,17 +2048,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fancy-regex"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "fastrand"
@@ -2243,26 +2104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "fluent-uri"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
-dependencies = [
- "borrow-or-share",
- "ref-cast",
- "serde",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,32 +2131,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fraction"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
-dependencies = [
- "lazy_static",
- "num",
-]
-
-[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2472,11 +2293,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2484,18 +2303,6 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
-name = "globset"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
-dependencies = [
- "aho-corasick",
- "bstr",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "gloo-net"
@@ -2713,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2757,10 +2564,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.14"
+name = "humantime"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "ctutils",
  "typenum",
@@ -3050,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
@@ -3126,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.35"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -3150,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.35"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -3195,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
+checksum = "a2dbe0623574defe58ba113596c848797f131727e8f54d4b4d10793e1fe14d40"
 dependencies = [
  "pest",
  "pest_derive",
@@ -3214,42 +3037,6 @@ checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "jsonschema"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
-dependencies = [
- "ahash",
- "bytecount",
- "data-encoding",
- "email_address",
- "fancy-regex",
- "fraction",
- "getrandom 0.3.4",
- "idna",
- "itoa",
- "jsonschema-regex",
- "num-cmp",
- "num-traits",
- "percent-encoding",
- "referencing",
- "regex",
- "serde",
- "serde_json",
- "unicode-general-category",
- "uuid-simd",
-]
-
-[[package]]
-name = "jsonschema-regex"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
-dependencies = [
- "regex-syntax",
 ]
 
 [[package]]
@@ -3304,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -3443,6 +3230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,18 +3278,12 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3526,12 +3316,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "micromap"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "migrations_internals"
@@ -3624,7 +3408,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "spin 0.10.1",
+ "spin",
  "subtle",
  "thiserror 2.0.19",
  "wasm-bindgen",
@@ -3779,28 +3563,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "msvc_spectre_libs"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "murmur3"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "nom"
@@ -3811,12 +3577,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -3855,51 +3615,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint 0.4.8",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-cmp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
  "num-traits",
 ]
 
@@ -3915,27 +3636,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.8",
- "num-integer",
  "num-traits",
 ]
 
@@ -3970,7 +3670,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.7",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4014,9 +3714,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4028,22 +3728,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.32.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -4051,18 +3751,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.19",
  "tokio",
  "tonic",
- "tonic-types",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -4073,15 +3773,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.32.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
+checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4090,21 +3790,26 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.32.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -4114,12 +3819,6 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -4161,12 +3860,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -4236,24 +3929,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "serde",
-]
-
-[[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4361,18 +4036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,36 +4057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
 ]
 
 [[package]]
@@ -4601,62 +4234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.19",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4754,15 +4331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4792,6 +4360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,23 +4391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "referencing"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
-dependencies = [
- "ahash",
- "fluent-uri",
- "getrandom 0.3.4",
- "hashbrown 0.17.1",
- "itoa",
- "micromap",
- "parking_lot",
- "percent-encoding",
- "serde_json",
-]
-
-[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.18"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4856,39 +4418,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "regorus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc4dc91481b1d4001ba7f2e81f7faf674142e0ac36d37d79e5f02764d06571e"
-dependencies = [
- "anyhow",
- "chrono",
- "chrono-tz",
- "data-encoding",
- "globset",
- "indexmap 2.14.0",
- "ipnet",
- "jsonschema",
- "lazy_static",
- "lru",
- "msvc_spectre_libs",
- "num-bigint 0.5.1",
- "num-traits",
- "parking_lot",
- "postcard",
- "rand 0.10.2",
- "regex",
- "semver",
- "serde",
- "serde_json",
- "serde_yaml",
- "spin 0.12.2",
- "thiserror 2.0.19",
- "url",
- "uuid",
-]
 
 [[package]]
 name = "relative-path"
@@ -4920,9 +4449,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4930,37 +4457,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-service",
@@ -5096,14 +4592,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5128,7 +4623,6 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -5188,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5201,14 +4695,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5346,13 +4840,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.30.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5424,7 +4918,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "time",
@@ -5534,7 +5028,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint 0.4.8",
+ "num-bigint",
  "num-traits",
  "thiserror 2.0.19",
  "time",
@@ -5633,12 +5127,6 @@ checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "portable-atomic",
 ]
-
-[[package]]
-name = "spin"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 
 [[package]]
 name = "spki"
@@ -5773,12 +5261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "test-fork"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5869,9 +5351,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.55"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5951,13 +5433,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6089,9 +5571,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -6186,17 +5668,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "tonic-types"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
 ]
 
 [[package]]
@@ -6297,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.33.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -6390,12 +5861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6412,12 +5877,6 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
-name = "unicode-general-category"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -6615,25 +6074,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.2",
  "sha1_smol",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "uuid-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
-dependencies = [
- "outref",
- "vsimd",
 ]
 
 [[package]]
@@ -6659,21 +6107,6 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -6935,6 +6368,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6958,6 +6400,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6995,6 +6452,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7007,6 +6470,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7016,6 +6485,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7043,6 +6518,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7052,6 +6533,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7067,6 +6554,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7076,6 +6569,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ diesel-async = { version = "0.9", features = [
     "migrations",
 ] }
 diesel_migrations = { version = "2" }
+dirs = "5.0.1"
 display-error-chain = { version = "0.2" }
 drain = { version = "0.2", features = ["retain"] }
 duration-string = { version = "0.5.3", features = ["serde"] }
@@ -99,6 +100,7 @@ gloo-net = { version = "0.6", default-features = false, features = [
 h2 = "0.4.7"
 headers = "0.4.1"
 hex = "0.4.3"
+humantime-serde = "1.1.1"
 # Pure-Rust HKDF-SHA256 for the wasm32 inter-node link key derivation.
 hkdf = "0.12"
 # Pure-Rust HMAC-SHA256 for the wasm32 build of SharedSecret (aws-lc-rs is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ diesel-async = { version = "0.9", features = [
     "migrations",
 ] }
 diesel_migrations = { version = "2" }
+dirs = "5.0.1"
 display-error-chain = { version = "0.2" }
 drain = { version = "0.2", features = ["retain"] }
 duration-string = { version = "0.5.3", features = ["serde"] }
@@ -103,6 +104,7 @@ gloo-net = { version = "0.6", default-features = false, features = [
 h2 = "0.4.7"
 headers = "0.4.1"
 hex = "0.4.3"
+humantime-serde = "1.1.1"
 # Pure-Rust HKDF-SHA256 for the wasm32 inter-node link key derivation.
 hkdf = "0.12"
 # Pure-Rust HMAC-SHA256 for the wasm32 build of SharedSecret (aws-lc-rs is

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -100,6 +100,20 @@ tasks:
           BIN: "slim"
           BIN_ARGS: "--config ./config/telemetry/server-config.yaml"
 
+  run:example:receiver:
+    desc: "Run the slim-bindings receiver example (pass ARGS for extra flags, e.g. ARGS='--slim-config /path/to/slim.yaml')"
+    cmds:
+      - cargo run {{.RELEASE}} -p agntcy-slim-bindings --example receiver -- {{.ARGS}}
+    vars:
+      ARGS: '{{.ARGS | default ""}}'
+
+  run:example:sender:
+    desc: "Run the slim-bindings sender example (pass ARGS for flags, e.g. ARGS='--local org/ns/app --shared-secret s --session-type p2p --participants org/ns/other')"
+    cmds:
+      - cargo run {{.RELEASE}} -p agntcy-slim-bindings --example sender -- {{.ARGS}}
+    vars:
+      ARGS: '{{.ARGS | default ""}}'
+
   slimctl:run:
     desc: "Run the Rust slimctl binary"
     cmds:

--- a/crates/config/src/auth/identity.rs
+++ b/crates/config/src/auth/identity.rs
@@ -14,6 +14,7 @@ use crate::auth::static_jwt::Config as StaticJwtConfig;
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum IdentityProviderConfig {
     SharedSecret {
+        #[serde(default)]
         id: String,
         data: String,
     },
@@ -29,6 +30,7 @@ pub enum IdentityProviderConfig {
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum IdentityVerifierConfig {
     SharedSecret {
+        #[serde(default)]
         id: String,
         data: String,
     },

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -22,7 +22,7 @@ uniffi = ["dep:uniffi", "dep:agntcy-slim-bindings"]
 agntcy-slim-auth = { workspace = true }
 agntcy-slim-bindings = { workspace = true, optional = true }
 agntcy-slim-datapath = { workspace = true }
-agntcy-slim-service = { workspace = true, features = ["session"] }
+agntcy-slim-service = { workspace = true, features = ["session", "slim-config"] }
 agntcy-slim-session = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
@@ -41,5 +41,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 agntcy-slim-config = { workspace = true }
 bincode = { workspace = true }
+tempfile = { workspace = true }
+test-fork = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing-test = { workspace = true }

--- a/crates/rpc/tests/slim_config_integration_test.rs
+++ b/crates/rpc/tests/slim_config_integration_test.rs
@@ -1,0 +1,165 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the hierarchical slim.yaml config loading and
+//! `create_app_from_slim_config` one-call API.
+//!
+//! Tests that require a live SLIM node start one in-process using
+//! `Service::run_server` on a random free port.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use slim_config::component::id::{ID, Kind};
+use slim_config::server::ServerConfig;
+use slim_config::tls::server::TlsServerConfig;
+use slim_service::{Service, KIND};
+use slim_service::node_config::load_slim_node_config;
+use tempfile::TempDir;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Bind to port 0 to let the OS pick a free port, then release and return it.
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Minimal slim.yaml content that points at the given endpoint with a shared-secret identity.
+fn slim_yaml(endpoint: &str, app_name: &str, secret: &str) -> String {
+    format!(
+        "node:\n  endpoint: \"{endpoint}\"\napp:\n  name: \"{app_name}\"\n  identity:\n    type: shared_secret\n    data: \"{secret}\"\n  identity_verifier:\n    type: shared_secret\n    data: \"{secret}\"\n"
+    )
+}
+
+fn make_service(name: &str) -> Service {
+    Service::new(ID::new_with_name(Kind::new(KIND).unwrap(), name).unwrap())
+}
+
+fn insecure_server_config(endpoint: String) -> ServerConfig {
+    ServerConfig {
+        endpoint,
+        tls_setting: TlsServerConfig::insecure(),
+        ..Default::default()
+    }
+}
+
+// ============================================================================
+// Test 1: create_app_from_slim_config — end-to-end with a real server
+// ============================================================================
+
+/// Verifies that `load_slim_node_config` + `Service::create_app_from_slim_config` produces
+/// a connected, subscribed app against a live in-process SLIM node.
+#[tokio::test]
+async fn test_create_app_from_slim_config() {
+    let port = free_port();
+    let endpoint = format!("http://127.0.0.1:{port}");
+    let secret = "test-secret-with-sufficient-length-for-hmac-key";
+
+    // Start a SLIM server on the chosen port
+    let server_svc = make_service("cfg-integ-server");
+    server_svc
+        .run_server(&insecure_server_config(format!("127.0.0.1:{port}")))
+        .await
+        .expect("server should start");
+
+    // Give the server a moment to accept connections
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Write slim.yaml to a temporary directory
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("slim.yaml");
+    std::fs::write(
+        &config_path,
+        slim_yaml(&endpoint, "test/config/receiver", secret),
+    )
+    .unwrap();
+
+    // Load config from the explicit path (bypasses CWD discovery)
+    let config = load_slim_node_config(Some(config_path.to_str().unwrap()))
+        .expect("slim.yaml should parse");
+
+    // Create the app using the one-call API on a separate client service
+    let client_svc = make_service("cfg-integ-client");
+    let handle = client_svc
+        .create_app_from_slim_config(config)
+        .await
+        .expect("create_app_from_slim_config should succeed");
+
+    // The connection ID must be non-zero
+    assert!(handle.conn_id > 0, "conn_id should be non-zero");
+
+    // The name should be the 3-component app name from the config.
+    let (c0, c1, c2) = handle.name.str_components();
+    let name_str = format!("{c0}/{c1}/{c2}");
+    assert_eq!(
+        name_str, "test/config/receiver",
+        "name should match the app name from slim.yaml, got: {name_str}"
+    );
+}
+
+// ============================================================================
+// Test 2: env-var override
+// ============================================================================
+
+/// Verifies that `SLIM_NODE_ADDRESS` takes precedence over the endpoint in slim.yaml.
+/// Uses `test_fork::fork` so env-var mutations don't leak to parallel tests.
+#[test_fork::fork]
+#[test]
+fn test_load_slim_config_env_var_override() {
+    // SAFETY: runs in a forked child process — no concurrent threads.
+    unsafe {
+        std::env::set_var("SLIM_NODE_ADDRESS", "http://override.example.com:9999");
+        std::env::remove_var("SLIM_APP_NAME");
+        std::env::remove_var("SLIM_NODE_CERT_PATH");
+        std::env::remove_var("SLIM_IDENTITY_TOKEN");
+        std::env::remove_var("SLIM_IDENTITY_SHARED_SECRET");
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("slim.yaml");
+    std::fs::write(
+        &config_path,
+        "node:\n  endpoint: \"http://original.example.com:46357\"\n",
+    )
+    .unwrap();
+
+    let config = load_slim_node_config(Some(config_path.to_str().unwrap()))
+        .expect("config should load");
+
+    assert_eq!(
+        config.node.endpoint,
+        "http://override.example.com:9999",
+        "SLIM_NODE_ADDRESS should override the file endpoint"
+    );
+}
+
+// ============================================================================
+// Test 3: missing config returns an error
+// ============================================================================
+
+/// Verifies that `load_slim_node_config` fails gracefully when no config can be found
+/// and no env vars are set.
+#[test_fork::fork]
+#[test]
+fn test_load_slim_config_missing_returns_error() {
+    // SAFETY: forked child process.
+    unsafe {
+        std::env::remove_var("SLIM_NODE_ADDRESS");
+        std::env::remove_var("SLIM_APP_NAME");
+        std::env::remove_var("SLIM_NODE_CERT_PATH");
+        std::env::remove_var("SLIM_IDENTITY_TOKEN");
+        std::env::remove_var("SLIM_IDENTITY_SHARED_SECRET");
+    }
+
+    let result = load_slim_node_config(Some("/nonexistent/path/slim.yaml"));
+    assert!(
+        result.is_err(),
+        "loading a non-existent config file should return an error"
+    );
+}

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["lib"]
 default = ["session"]
 kubernetes = ["agntcy-slim-datapath/kubernetes"]
 session = ["agntcy-slim-session", "agntcy-slim-persistence"]
+slim-config = ["dirs", "serde_yaml", "humantime-serde"]
 
 [dependencies]
 agntcy-slim-version = { workspace = true }
@@ -26,6 +27,9 @@ agntcy-slim-mls = { workspace = true }
 agntcy-slim-persistence = { workspace = true, optional = true }
 agntcy-slim-session = { workspace = true, optional = true }
 async-trait = { workspace = true }
+dirs = { workspace = true, optional = true }
+humantime-serde = { workspace = true, optional = true }
+serde_yaml = { workspace = true, optional = true }
 display-error-chain = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
@@ -41,5 +45,6 @@ uuid = { workspace = true }
 agntcy-slim-testing = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
+test-fork = { workspace = true }
 tokio-test = { workspace = true }
 tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["lib"]
 default = ["session"]
 kubernetes = ["agntcy-slim-datapath/kubernetes"]
 session = ["agntcy-slim-session", "agntcy-slim-persistence"]
+slim-config = ["dirs", "serde_yaml", "humantime-serde"]
 
 [dependencies]
 agntcy-slim-auth = { workspace = true }
@@ -21,6 +22,10 @@ agntcy-slim-datapath = { workspace = true }
 agntcy-slim-persistence = { workspace = true, optional = true }
 agntcy-slim-session = { workspace = true, optional = true }
 agntcy-slim-version = { workspace = true }
+async-trait = { workspace = true }
+dirs = { workspace = true, optional = true }
+humantime-serde = { workspace = true, optional = true }
+serde_yaml = { workspace = true, optional = true }
 display-error-chain = { workspace = true }
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
@@ -45,5 +50,6 @@ uuid = { workspace = true, features = ["v4", "js"] }
 agntcy-slim-testing = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
+test-fork = { workspace = true }
 tokio-test = { workspace = true }
 tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -41,6 +41,9 @@ pub mod service;
 #[cfg(feature = "session")]
 pub mod app;
 
+#[cfg(feature = "slim-config")]
+pub mod node_config;
+
 // Third-party crates
 pub use slim_datapath::messages::utils::SlimHeaderFlags;
 
@@ -49,3 +52,5 @@ pub use errors::ServiceError;
 #[cfg(feature = "session")]
 pub use errors::SubscriptionAckError;
 pub use service::{KIND, Service, ServiceBuilder, ServiceConfiguration};
+#[cfg(all(feature = "slim-config", feature = "session"))]
+pub use service::AppHandle;

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -39,6 +39,9 @@ pub mod service;
 #[cfg(feature = "session")]
 pub mod app;
 
+#[cfg(feature = "slim-config")]
+pub mod node_config;
+
 // Third-party crates
 pub use slim_datapath::messages::utils::SlimHeaderFlags;
 
@@ -46,6 +49,6 @@ pub use slim_datapath::messages::utils::SlimHeaderFlags;
 pub use errors::ServiceError;
 #[cfg(feature = "session")]
 pub use errors::SubscriptionAckError;
-#[cfg(not(target_arch = "wasm32"))]
-pub use service::ServiceBuilder;
-pub use service::{KIND, Service, ServiceConfiguration};
+pub use service::{KIND, Service, ServiceBuilder, ServiceConfiguration};
+#[cfg(all(feature = "slim-config", feature = "session"))]
+pub use service::AppHandle;

--- a/crates/service/src/node_config.rs
+++ b/crates/service/src/node_config.rs
@@ -429,5 +429,4 @@ mod tests {
             other => panic!("Expected SharedSecret, got {other:?}"),
         }
     }
-
 }

--- a/crates/service/src/node_config.rs
+++ b/crates/service/src/node_config.rs
@@ -194,42 +194,6 @@ fn expand_tilde_in_tls(tls: &mut TlsClientConfig) {
 }
 
 // ============================================================================
-// Cache management
-// ============================================================================
-
-/// Load the Ed25519 signature key pair from the cache directory.
-///
-/// Returns `None` if either key file is missing or unreadable.
-pub fn load_signature_keys(cache_dir: &Path) -> Option<(Vec<u8>, Vec<u8>)> {
-    let priv_path = cache_dir.join("signature_private.key");
-    let pub_path = cache_dir.join("signature_public.key");
-    if priv_path.is_file() && pub_path.is_file() {
-        let priv_key = std::fs::read(&priv_path).ok()?;
-        let pub_key = std::fs::read(&pub_path).ok()?;
-        if priv_key.is_empty() || pub_key.is_empty() {
-            return None;
-        }
-        debug!("Loaded signature keys from cache");
-        Some((priv_key, pub_key))
-    } else {
-        None
-    }
-}
-
-/// Persist the Ed25519 signature key pair to the cache directory.
-pub fn save_signature_keys(
-    cache_dir: &Path,
-    priv_key: &[u8],
-    pub_key: &[u8],
-) -> Result<(), ServiceError> {
-    std::fs::create_dir_all(cache_dir)?;
-    std::fs::write(cache_dir.join("signature_private.key"), priv_key)?;
-    std::fs::write(cache_dir.join("signature_public.key"), pub_key)?;
-    debug!("Saved signature keys to cache");
-    Ok(())
-}
-
-// ============================================================================
 // Public entry point
 // ============================================================================
 
@@ -466,22 +430,4 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_save_and_load_signature_keys() {
-        let tmp = TempDir::new().unwrap();
-        let priv_key = vec![0xde, 0xad, 0xbe, 0xef];
-        let pub_key = vec![0xca, 0xfe, 0xba, 0xbe];
-
-        save_signature_keys(tmp.path(), &priv_key, &pub_key).unwrap();
-
-        let loaded = load_signature_keys(tmp.path()).unwrap();
-        assert_eq!(loaded.0, priv_key);
-        assert_eq!(loaded.1, pub_key);
-    }
-
-    #[test]
-    fn test_load_signature_keys_missing_returns_none() {
-        let tmp = TempDir::new().unwrap();
-        assert!(load_signature_keys(tmp.path()).is_none());
-    }
 }

--- a/crates/service/src/node_config.rs
+++ b/crates/service/src/node_config.rs
@@ -1,0 +1,487 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hierarchical SLIM node configuration discovery.
+//!
+//! Implements git-style config file search:
+//! 1. Walk up from CWD looking for `slim.yaml`
+//! 2. Fall back to `~/.slim/config.yaml` as user-level default
+//! 3. Environment variables override any file-based value (highest priority)
+//!
+//! A `.slim-cache/` directory next to the discovered config file persists
+//! the app instance UUID and Ed25519 signature key pair so the agent keeps
+//! a stable identity across restarts.
+
+use std::path::{Path, PathBuf};
+
+use tracing::debug;
+
+use slim_config::auth::identity::{IdentityProviderConfig, IdentityVerifierConfig};
+use slim_config::auth::static_jwt::Config as StaticJwtConfig;
+use slim_config::grpc::client::ClientConfig;
+use slim_config::tls::client::TlsClientConfig;
+use slim_config::tls::common::{CaSource, TlsSource};
+
+use crate::errors::ServiceError;
+
+// ============================================================================
+// Public configuration types
+// ============================================================================
+
+/// App identity settings (from the `app:` section of `slim.yaml`).
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SlimAppConfig {
+    /// Local agent name in `"org/namespace/app"` format.
+    #[serde(default)]
+    pub name: String,
+    /// Identity provider — which credential the app presents to the SLIM node.
+    #[serde(default)]
+    pub identity: IdentityProviderConfig,
+    /// Identity verifier — how the app verifies credentials from the SLIM node.
+    #[serde(default)]
+    pub identity_verifier: IdentityVerifierConfig,
+}
+
+/// Resolved SLIM configuration returned by [`load_slim_node_config`].
+///
+/// Contains the merged result of all config sources (files + env vars) plus
+/// resolved cache metadata.
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+pub struct SlimNodeConfig {
+    /// Node connection settings.
+    #[serde(default)]
+    pub node: ClientConfig,
+    /// App identity settings. Only set when `app.name` is configured.
+    #[serde(default)]
+    pub app: Option<SlimAppConfig>,
+    /// Path of the config file that was used (for debugging / logging).
+    #[serde(skip)]
+    pub source_path: Option<String>,
+    /// Cache directory path, derived from the config file location.
+    #[serde(skip)]
+    pub cache_dir: Option<String>,
+}
+
+// ============================================================================
+// Config file search
+// ============================================================================
+
+fn find_slim_yaml(start_dir: &Path) -> Option<PathBuf> {
+    let mut dir = start_dir.to_path_buf();
+    loop {
+        let candidate = dir.join("slim.yaml");
+        if candidate.is_file() {
+            debug!(?candidate, "Found slim.yaml");
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
+fn user_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".slim").join("config.yaml"))
+}
+
+fn cache_dir_for(config_path: &Path) -> PathBuf {
+    if let (Some(config_dir), Some(home)) = (config_path.parent(), dirs::home_dir()) {
+        let user_slim = home.join(".slim");
+        if config_dir == user_slim {
+            return user_slim.join("cache");
+        }
+    }
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(".slim-cache")
+}
+
+fn load_config_silent(path: &Path) -> Option<SlimNodeConfig> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_yaml::from_str(&content).ok()
+}
+
+fn load_config(path: &Path) -> Result<SlimNodeConfig, ServiceError> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| ServiceError::InvalidConfig(format!(
+            "Failed to read {}: {}",
+            path.display(),
+            e
+        )))?;
+    serde_yaml::from_str(&content).map_err(|e| ServiceError::InvalidConfig(format!(
+        "Failed to parse {}: {}",
+        path.display(),
+        e
+    )))
+}
+
+// ============================================================================
+// Merging and env var overrides
+// ============================================================================
+
+fn merge_configs(base: &mut SlimNodeConfig, overlay: &SlimNodeConfig) {
+    if !overlay.node.endpoint.is_empty() {
+        base.node = overlay.node.clone();
+    }
+    if overlay.app.is_some() {
+        base.app = overlay.app.clone();
+    }
+}
+
+fn default_slim_app() -> SlimAppConfig {
+    SlimAppConfig {
+        name: String::new(),
+        identity: IdentityProviderConfig::None,
+        identity_verifier: IdentityVerifierConfig::None,
+    }
+}
+
+fn apply_env_overrides(cfg: &mut SlimNodeConfig) {
+    if let Ok(v) = std::env::var("SLIM_NODE_ADDRESS") {
+        cfg.node.endpoint = v;
+    }
+    if let Ok(v) = std::env::var("SLIM_APP_NAME") {
+        cfg.app.get_or_insert_with(default_slim_app).name = v;
+    }
+    if let Ok(v) = std::env::var("SLIM_NODE_CERT_PATH") {
+        let p = expand_tilde(&v);
+        cfg.node.tls_setting.config.source = TlsSource::File {
+            cert: p.clone(),
+            key: p,
+        };
+    }
+    if let Ok(v) = std::env::var("SLIM_IDENTITY_TOKEN") {
+        let token_file = expand_tilde(&v);
+        cfg.app.get_or_insert_with(default_slim_app).identity =
+            IdentityProviderConfig::StaticJwt(
+                StaticJwtConfig::with_file(&token_file)
+                    .with_duration(std::time::Duration::from_secs(3600)),
+            );
+    }
+    if let Ok(v) = std::env::var("SLIM_IDENTITY_SHARED_SECRET") {
+        cfg.app.get_or_insert_with(default_slim_app).identity =
+            IdentityProviderConfig::SharedSecret {
+                id: String::new(),
+                data: v,
+            };
+    }
+}
+
+// ============================================================================
+// Tilde expansion
+// ============================================================================
+
+/// Expand a leading `~` to the user's home directory.
+pub fn expand_tilde(path: &str) -> String {
+    if path == "~" || path.starts_with("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return path.replacen('~', &home.to_string_lossy(), 1);
+        }
+    }
+    path.to_string()
+}
+
+fn expand_tilde_in_tls(tls: &mut TlsClientConfig) {
+    if let TlsSource::File { cert, key } = &mut tls.config.source {
+        *cert = expand_tilde(cert);
+        *key = expand_tilde(key);
+    }
+    if let CaSource::File { path } = &mut tls.config.ca_source {
+        *path = expand_tilde(path);
+    }
+}
+
+// ============================================================================
+// Cache management
+// ============================================================================
+
+/// Load the Ed25519 signature key pair from the cache directory.
+///
+/// Returns `None` if either key file is missing or unreadable.
+pub fn load_signature_keys(cache_dir: &Path) -> Option<(Vec<u8>, Vec<u8>)> {
+    let priv_path = cache_dir.join("signature_private.key");
+    let pub_path = cache_dir.join("signature_public.key");
+    if priv_path.is_file() && pub_path.is_file() {
+        let priv_key = std::fs::read(&priv_path).ok()?;
+        let pub_key = std::fs::read(&pub_path).ok()?;
+        if priv_key.is_empty() || pub_key.is_empty() {
+            return None;
+        }
+        debug!("Loaded signature keys from cache");
+        Some((priv_key, pub_key))
+    } else {
+        None
+    }
+}
+
+/// Persist the Ed25519 signature key pair to the cache directory.
+pub fn save_signature_keys(
+    cache_dir: &Path,
+    priv_key: &[u8],
+    pub_key: &[u8],
+) -> Result<(), ServiceError> {
+    std::fs::create_dir_all(cache_dir)?;
+    std::fs::write(cache_dir.join("signature_private.key"), priv_key)?;
+    std::fs::write(cache_dir.join("signature_public.key"), pub_key)?;
+    debug!("Saved signature keys to cache");
+    Ok(())
+}
+
+// ============================================================================
+// Public entry point
+// ============================================================================
+
+/// Load SLIM configuration using hierarchical file discovery plus env var overrides.
+///
+/// **Search order** (highest priority first):
+/// 1. Environment variables (`SLIM_NODE_ADDRESS`, `SLIM_APP_NAME`,
+///    `SLIM_NODE_CERT_PATH`, `SLIM_IDENTITY_TOKEN`, `SLIM_IDENTITY_SHARED_SECRET`)
+/// 2. `slim.yaml` found by walking up from the current working directory
+/// 3. `~/.slim/config.yaml` as the user-level default
+///
+/// # Errors
+///
+/// Returns [`ServiceError::InvalidConfig`] if no node address could be resolved from
+/// any source, or if a specified config file cannot be read / parsed.
+pub fn load_slim_node_config(config_path: Option<&str>) -> Result<SlimNodeConfig, ServiceError> {
+    // 1. Load user-level config (lowest priority)
+    let user_path = user_config_path();
+    let mut merged: SlimNodeConfig = user_path
+        .as_deref()
+        .and_then(load_config_silent)
+        .unwrap_or_default();
+
+    // 2. Determine source config file
+    let (source_path, cache_dir) = if let Some(explicit) = config_path {
+        let p = Path::new(explicit);
+        if !p.is_file() {
+            return Err(ServiceError::InvalidConfig(format!(
+                "Config file not found: {explicit}"
+            )));
+        }
+        let cfg = load_config(p)?;
+        merge_configs(&mut merged, &cfg);
+        let cache = cache_dir_for(p);
+        (
+            Some(p.to_string_lossy().to_string()),
+            Some(cache.to_string_lossy().to_string()),
+        )
+    } else {
+        let cwd = std::env::current_dir().map_err(|e| {
+            ServiceError::InvalidConfig(format!("Failed to get current directory: {e}"))
+        })?;
+        let local_path = find_slim_yaml(&cwd);
+        if let Some(ref lp) = local_path {
+            let local_cfg = load_config(lp)?;
+            merge_configs(&mut merged, &local_cfg);
+            let cache = cache_dir_for(lp);
+            (
+                Some(lp.to_string_lossy().to_string()),
+                Some(cache.to_string_lossy().to_string()),
+            )
+        } else if let Some(ref up) = user_path {
+            if up.is_file() {
+                let cache = cache_dir_for(up);
+                (
+                    Some(up.to_string_lossy().to_string()),
+                    Some(cache.to_string_lossy().to_string()),
+                )
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        }
+    };
+
+    // 3. Apply environment variable overrides (highest priority)
+    apply_env_overrides(&mut merged);
+
+    // 4. Fail if no endpoint was resolved
+    if merged.node.endpoint.is_empty() {
+        return Err(ServiceError::InvalidConfig(
+            "No SLIM node address found. Set the SLIM_NODE_ADDRESS environment variable \
+             or add 'node.endpoint' to slim.yaml (or ~/.slim/config.yaml)."
+                .to_string(),
+        ));
+    }
+
+    // 5. Tilde-expand TLS file paths; infer insecure from URL scheme when no tls block set
+    expand_tilde_in_tls(&mut merged.node.tls_setting);
+    if merged.node.tls_setting == TlsClientConfig::default() {
+        merged.node.tls_setting.insecure = !merged.node.endpoint.starts_with("https://")
+            && !merged.node.endpoint.starts_with("wss://");
+    }
+
+    // 6. Drop app if name is empty; fill SharedSecret id from app name when unset
+    let app = merged
+        .app
+        .take()
+        .filter(|a| !a.name.is_empty())
+        .map(|mut a| {
+            if let IdentityProviderConfig::SharedSecret { id, .. } = &mut a.identity {
+                if id.is_empty() {
+                    *id = a.name.clone();
+                }
+            }
+            if let IdentityVerifierConfig::SharedSecret { id, .. } = &mut a.identity_verifier {
+                if id.is_empty() {
+                    *id = a.name.clone();
+                }
+            }
+            a
+        });
+
+    debug!(?source_path, ?cache_dir, "SLIM config resolved");
+
+    Ok(SlimNodeConfig {
+        node: merged.node,
+        app,
+        source_path,
+        cache_dir,
+    })
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn clear_env() {
+        for var in &[
+            "SLIM_NODE_ADDRESS",
+            "SLIM_APP_NAME",
+            "SLIM_NODE_CERT_PATH",
+            "SLIM_IDENTITY_TOKEN",
+            "SLIM_IDENTITY_SHARED_SECRET",
+        ] {
+            // SAFETY: tests run in forked processes (test_fork::fork)
+            unsafe { std::env::remove_var(var) };
+        }
+    }
+
+    fn set_test_env(key: &str, value: impl AsRef<std::ffi::OsStr>) {
+        // SAFETY: tests run in forked processes (test_fork::fork)
+        unsafe { std::env::set_var(key, value) }
+    }
+
+    fn write_slim_yaml(dir: &Path, content: &str) {
+        fs::write(dir.join("slim.yaml"), content).expect("write slim.yaml");
+    }
+
+    fn write_user_config(slim_dir: &Path, content: &str) {
+        fs::create_dir_all(slim_dir).expect("create .slim dir");
+        fs::write(slim_dir.join("config.yaml"), content).expect("write config.yaml");
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_env_overrides_local_file() {
+        clear_env();
+        let tmp = TempDir::new().unwrap();
+        write_slim_yaml(
+            tmp.path(),
+            "node:\n  endpoint: \"https://file.example.com:46357\"\n",
+        );
+        std::env::set_current_dir(tmp.path()).unwrap();
+        set_test_env("HOME", tmp.path());
+        set_test_env("SLIM_NODE_ADDRESS", "https://env.example.com:9999");
+
+        let config = load_slim_node_config(None).unwrap();
+        assert_eq!(config.node.endpoint, "https://env.example.com:9999");
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_local_file_overrides_user_config() {
+        clear_env();
+        let tmp = TempDir::new().unwrap();
+        let fake_home = tmp.path().join("home");
+        let slim_dir = fake_home.join(".slim");
+        fs::create_dir_all(&slim_dir).unwrap();
+        write_user_config(
+            &slim_dir,
+            "node:\n  endpoint: \"https://user.example.com:46357\"\n",
+        );
+
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        write_slim_yaml(
+            &project,
+            "node:\n  endpoint: \"https://project.example.com:46357\"\n",
+        );
+
+        set_test_env("HOME", &fake_home);
+        std::env::set_current_dir(&project).unwrap();
+
+        let config = load_slim_node_config(None).unwrap();
+        assert_eq!(config.node.endpoint, "https://project.example.com:46357");
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_no_config_returns_error() {
+        clear_env();
+        let tmp = TempDir::new().unwrap();
+        set_test_env("HOME", tmp.path());
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let result = load_slim_node_config(None);
+        assert!(result.is_err());
+        let ServiceError::InvalidConfig(msg) = result.unwrap_err() else {
+            panic!("Expected InvalidConfig");
+        };
+        assert!(
+            msg.contains("No SLIM node address"),
+            "Unexpected message: {msg}"
+        );
+    }
+
+    #[test_fork::fork]
+    #[test]
+    fn test_yaml_identity_shared_secret_defaults_id_to_app_name() {
+        clear_env();
+        let tmp = TempDir::new().unwrap();
+        set_test_env("HOME", tmp.path());
+        write_slim_yaml(
+            tmp.path(),
+            "node:\n  endpoint: \"https://example.com:46357\"\napp:\n  name: \"org/ns/alice\"\n  identity:\n    type: shared_secret\n    data: \"longlonglonglonglonglonglonglonglong-secret\"\n",
+        );
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let config = load_slim_node_config(None).unwrap();
+        match config.app.unwrap().identity {
+            IdentityProviderConfig::SharedSecret { id, data } => {
+                assert_eq!(id, "org/ns/alice");
+                assert_eq!(data, "longlonglonglonglonglonglonglonglong-secret");
+            }
+            other => panic!("Expected SharedSecret, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_save_and_load_signature_keys() {
+        let tmp = TempDir::new().unwrap();
+        let priv_key = vec![0xde, 0xad, 0xbe, 0xef];
+        let pub_key = vec![0xca, 0xfe, 0xba, 0xbe];
+
+        save_signature_keys(tmp.path(), &priv_key, &pub_key).unwrap();
+
+        let loaded = load_signature_keys(tmp.path()).unwrap();
+        assert_eq!(loaded.0, priv_key);
+        assert_eq!(loaded.1, pub_key);
+    }
+
+    #[test]
+    fn test_load_signature_keys_missing_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_signature_keys(tmp.path()).is_none());
+    }
+}

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -45,6 +45,28 @@ use {
     tokio::sync::mpsc,
 };
 
+// slim-config feature imports
+#[cfg(all(feature = "slim-config", feature = "session"))]
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+
+/// Handle returned by [`Service::create_app_from_slim_config`].
+///
+/// Bundles together the created `App`, its registered name, and the outbound
+/// connection ID so callers have everything they need to start publishing and
+/// receiving messages.
+#[cfg(all(feature = "slim-config", feature = "session"))]
+pub struct AppHandle {
+    /// The fully-initialised application instance.
+    pub app: App<AuthProvider, AuthVerifier>,
+    /// Notification receiver for incoming sessions and events.
+    pub notification_rx:
+        mpsc::Receiver<Result<slim_session::notification::Notification, slim_session::SessionError>>,
+    /// The canonical name the app is subscribed under.
+    pub name: ProtoName,
+    /// Connection ID of the outbound link to the SLIM node.
+    pub conn_id: u64,
+}
+
 // Define the kind of the component as static string
 pub const KIND: &str = "slim";
 
@@ -633,6 +655,79 @@ impl Service {
 
         // return the app instance and the rx channel
         Ok((app, rx_app))
+    }
+
+    /// Create, connect, and subscribe a new `App` using a fully-resolved [`SlimNodeConfig`].
+    ///
+    /// This is a one-call API that:
+    /// 1. Builds `AuthProvider` / `AuthVerifier` from the config's identity settings.
+    /// 2. Loads / saves Ed25519 signature keys from the cache directory.
+    /// 3. Creates the app, connects to the SLIM node, and subscribes.
+    ///
+    /// Only available when the `slim-config` and `session` Cargo features are both enabled.
+    #[cfg(all(feature = "slim-config", feature = "session"))]
+    pub async fn create_app_from_slim_config(
+        &self,
+        config: crate::node_config::SlimNodeConfig,
+    ) -> Result<AppHandle, ServiceError> {
+        let app_cfg = config.app.as_ref().ok_or(ServiceError::NoAppName)?;
+
+        let name = ProtoName::parse_name(&app_cfg.name)
+            .map_err(|e| ServiceError::InvalidConfig(format!("app.name: {e}")))?;
+
+        let mut identity_provider: AuthProvider = app_cfg
+            .identity
+            .build_auth_provider()
+            .map_err(|e| ServiceError::InvalidConfig(format!("identity provider: {e}")))?;
+
+        let mut identity_verifier: AuthVerifier = app_cfg
+            .identity_verifier
+            .build_auth_verifier()
+            .map_err(|e| ServiceError::InvalidConfig(format!("identity verifier: {e}")))?;
+
+        // Restore signature keys from cache (stable identity across restarts)
+        if let Some(ref cache_dir) = config.cache_dir {
+            let p = std::path::Path::new(cache_dir);
+            if let Some((priv_key, pub_key)) = crate::node_config::load_signature_keys(p) {
+                info!(cache_dir, "restoring signature keys from cache");
+                identity_provider
+                    .set_signature_keys(priv_key, pub_key)
+                    .await
+                    .map_err(|e| ServiceError::InvalidConfig(format!("restore keys: {e}")))?;
+            }
+        }
+
+        identity_provider.initialize().await?;
+        identity_verifier.initialize().await?;
+        let _ = identity_provider.get_token()?;
+
+        // Persist updated signature keys
+        if let Some(ref cache_dir) = config.cache_dir {
+            let p = std::path::Path::new(cache_dir);
+            if let Ok((priv_key, pub_key)) = identity_provider.get_signature_keys() {
+                if !priv_key.is_empty() {
+                    let _ = crate::node_config::save_signature_keys(p, &priv_key, &pub_key);
+                }
+            }
+        }
+
+        let (app, notification_rx) = self.create_app_with_direction(
+            &name,
+            identity_provider,
+            identity_verifier,
+            Direction::Bidirectional,
+        )?;
+
+        let conn_id = self.connect(&config.node).await?;
+
+        app.subscribe(&name, Some(conn_id)).await?;
+
+        Ok(AppHandle {
+            app,
+            notification_rx,
+            name,
+            conn_id,
+        })
     }
 
     #[tracing::instrument(skip_all, fields(service_id = %self.id))]

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -675,47 +675,26 @@ impl Service {
         let name = ProtoName::parse_name(&app_cfg.name)
             .map_err(|e| ServiceError::InvalidConfig(format!("app.name: {e}")))?;
 
-        let mut identity_provider: AuthProvider = app_cfg
+        let identity_provider: AuthProvider = app_cfg
             .identity
             .build_auth_provider()
             .map_err(|e| ServiceError::InvalidConfig(format!("identity provider: {e}")))?;
 
-        let mut identity_verifier: AuthVerifier = app_cfg
+        let identity_verifier: AuthVerifier = app_cfg
             .identity_verifier
             .build_auth_verifier()
             .map_err(|e| ServiceError::InvalidConfig(format!("identity verifier: {e}")))?;
 
-        // Restore signature keys from cache (stable identity across restarts)
-        if let Some(ref cache_dir) = config.cache_dir {
-            let p = std::path::Path::new(cache_dir);
-            if let Some((priv_key, pub_key)) = crate::node_config::load_signature_keys(p) {
-                info!(cache_dir, "restoring signature keys from cache");
-                identity_provider
-                    .set_signature_keys(priv_key, pub_key)
-                    .await
-                    .map_err(|e| ServiceError::InvalidConfig(format!("restore keys: {e}")))?;
-            }
-        }
+        let persistence = config.cache_dir.as_deref().map(|dir| {
+            slim_persistence::PersistenceConfig::new(std::path::Path::new(dir).join("mls"))
+        });
 
-        identity_provider.initialize().await?;
-        identity_verifier.initialize().await?;
-        let _ = identity_provider.get_token()?;
-
-        // Persist updated signature keys
-        if let Some(ref cache_dir) = config.cache_dir {
-            let p = std::path::Path::new(cache_dir);
-            if let Ok((priv_key, pub_key)) = identity_provider.get_signature_keys() {
-                if !priv_key.is_empty() {
-                    let _ = crate::node_config::save_signature_keys(p, &priv_key, &pub_key);
-                }
-            }
-        }
-
-        let (app, notification_rx) = self.create_app_with_direction(
+        let (app, notification_rx) = self.create_app_with_direction_and_persistence(
             &name,
             identity_provider,
             identity_verifier,
             Direction::Bidirectional,
+            persistence,
         )?;
 
         let conn_id = self.connect(&config.node).await?;

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -50,6 +50,28 @@ use {
     tokio::sync::mpsc,
 };
 
+// slim-config feature imports
+#[cfg(all(feature = "slim-config", feature = "session"))]
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+
+/// Handle returned by [`Service::create_app_from_slim_config`].
+///
+/// Bundles together the created `App`, its registered name, and the outbound
+/// connection ID so callers have everything they need to start publishing and
+/// receiving messages.
+#[cfg(all(feature = "slim-config", feature = "session"))]
+pub struct AppHandle {
+    /// The fully-initialised application instance.
+    pub app: App<AuthProvider, AuthVerifier>,
+    /// Notification receiver for incoming sessions and events.
+    pub notification_rx:
+        mpsc::Receiver<Result<slim_session::notification::Notification, slim_session::SessionError>>,
+    /// The canonical name the app is subscribed under.
+    pub name: ProtoName,
+    /// Connection ID of the outbound link to the SLIM node.
+    pub conn_id: u64,
+}
+
 // Define the kind of the component as static string
 pub const KIND: &str = "slim";
 
@@ -778,6 +800,79 @@ impl Service {
             controller.deregister().await?;
         }
         Ok(())
+    }
+
+    /// Create, connect, and subscribe a new `App` using a fully-resolved [`SlimNodeConfig`].
+    ///
+    /// This is a one-call API that:
+    /// 1. Builds `AuthProvider` / `AuthVerifier` from the config's identity settings.
+    /// 2. Loads / saves Ed25519 signature keys from the cache directory.
+    /// 3. Creates the app, connects to the SLIM node, and subscribes.
+    ///
+    /// Only available when the `slim-config` and `session` Cargo features are both enabled.
+    #[cfg(all(feature = "slim-config", feature = "session"))]
+    pub async fn create_app_from_slim_config(
+        &self,
+        config: crate::node_config::SlimNodeConfig,
+    ) -> Result<AppHandle, ServiceError> {
+        let app_cfg = config.app.as_ref().ok_or(ServiceError::NoAppName)?;
+
+        let name = ProtoName::parse_name(&app_cfg.name)
+            .map_err(|e| ServiceError::InvalidConfig(format!("app.name: {e}")))?;
+
+        let mut identity_provider: AuthProvider = app_cfg
+            .identity
+            .build_auth_provider()
+            .map_err(|e| ServiceError::InvalidConfig(format!("identity provider: {e}")))?;
+
+        let mut identity_verifier: AuthVerifier = app_cfg
+            .identity_verifier
+            .build_auth_verifier()
+            .map_err(|e| ServiceError::InvalidConfig(format!("identity verifier: {e}")))?;
+
+        // Restore signature keys from cache (stable identity across restarts)
+        if let Some(ref cache_dir) = config.cache_dir {
+            let p = std::path::Path::new(cache_dir);
+            if let Some((priv_key, pub_key)) = crate::node_config::load_signature_keys(p) {
+                info!(cache_dir, "restoring signature keys from cache");
+                identity_provider
+                    .set_signature_keys(priv_key, pub_key)
+                    .await
+                    .map_err(|e| ServiceError::InvalidConfig(format!("restore keys: {e}")))?;
+            }
+        }
+
+        identity_provider.initialize().await?;
+        identity_verifier.initialize().await?;
+        let _ = identity_provider.get_token()?;
+
+        // Persist updated signature keys
+        if let Some(ref cache_dir) = config.cache_dir {
+            let p = std::path::Path::new(cache_dir);
+            if let Ok((priv_key, pub_key)) = identity_provider.get_signature_keys() {
+                if !priv_key.is_empty() {
+                    let _ = crate::node_config::save_signature_keys(p, &priv_key, &pub_key);
+                }
+            }
+        }
+
+        let (app, notification_rx) = self.create_app_with_direction(
+            &name,
+            identity_provider,
+            identity_verifier,
+            Direction::Bidirectional,
+        )?;
+
+        let conn_id = self.connect(&config.node).await?;
+
+        app.subscribe(&name, Some(conn_id)).await?;
+
+        Ok(AppHandle {
+            app,
+            notification_rx,
+            name,
+            conn_id,
+        })
     }
 
     #[tracing::instrument(skip_all, fields(service_id = %self.id))]

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -820,47 +820,26 @@ impl Service {
         let name = ProtoName::parse_name(&app_cfg.name)
             .map_err(|e| ServiceError::InvalidConfig(format!("app.name: {e}")))?;
 
-        let mut identity_provider: AuthProvider = app_cfg
+        let identity_provider: AuthProvider = app_cfg
             .identity
             .build_auth_provider()
             .map_err(|e| ServiceError::InvalidConfig(format!("identity provider: {e}")))?;
 
-        let mut identity_verifier: AuthVerifier = app_cfg
+        let identity_verifier: AuthVerifier = app_cfg
             .identity_verifier
             .build_auth_verifier()
             .map_err(|e| ServiceError::InvalidConfig(format!("identity verifier: {e}")))?;
 
-        // Restore signature keys from cache (stable identity across restarts)
-        if let Some(ref cache_dir) = config.cache_dir {
-            let p = std::path::Path::new(cache_dir);
-            if let Some((priv_key, pub_key)) = crate::node_config::load_signature_keys(p) {
-                info!(cache_dir, "restoring signature keys from cache");
-                identity_provider
-                    .set_signature_keys(priv_key, pub_key)
-                    .await
-                    .map_err(|e| ServiceError::InvalidConfig(format!("restore keys: {e}")))?;
-            }
-        }
+        let persistence = config.cache_dir.as_deref().map(|dir| {
+            slim_persistence::PersistenceConfig::new(std::path::Path::new(dir).join("mls"))
+        });
 
-        identity_provider.initialize().await?;
-        identity_verifier.initialize().await?;
-        let _ = identity_provider.get_token()?;
-
-        // Persist updated signature keys
-        if let Some(ref cache_dir) = config.cache_dir {
-            let p = std::path::Path::new(cache_dir);
-            if let Ok((priv_key, pub_key)) = identity_provider.get_signature_keys() {
-                if !priv_key.is_empty() {
-                    let _ = crate::node_config::save_signature_keys(p, &priv_key, &pub_key);
-                }
-            }
-        }
-
-        let (app, notification_rx) = self.create_app_with_direction(
+        let (app, notification_rx) = self.create_app_with_direction_and_persistence(
             &name,
             identity_provider,
             identity_verifier,
             Direction::Bidirectional,
+            persistence,
         )?;
 
         let conn_id = self.connect(&config.node).await?;

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -16,18 +16,22 @@ agntcy-slim-config = { workspace = true }
 agntcy-slim-controller = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-persistence = { workspace = true }
-agntcy-slim-service = { workspace = true, features = ["session"] }
+agntcy-slim-service = { workspace = true, features = ["session", "slim-config"] }
 agntcy-slim-session = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
 agntcy-slim-version = { workspace = true }
 
+async-trait = { workspace = true }
+dirs = { workspace = true }
 display-error-chain = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
+humantime-serde = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -39,6 +43,7 @@ uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 clap = { workspace = true }
+tempfile = { workspace = true }
 test-fork = { workspace = true }
 
 [[example]]

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -37,6 +37,7 @@ agntcy-slim-session = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
 agntcy-slim-version = { workspace = true }
+humantime-serde = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -32,7 +32,7 @@ agntcy-slim-config = { workspace = true }
 agntcy-slim-controller = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
 agntcy-slim-persistence = { workspace = true }
-agntcy-slim-service = { workspace = true, features = ["session"] }
+agntcy-slim-service = { workspace = true, features = ["session", "slim-config"] }
 agntcy-slim-session = { workspace = true }
 agntcy-slim-signal = { workspace = true }
 agntcy-slim-tracing = { workspace = true }
@@ -57,6 +57,7 @@ uniffi = { workspace = true, features = ["build"] }
 [dev-dependencies]
 cfg-if = { workspace = true }
 clap = { workspace = true }
+tempfile = { workspace = true }
 test-fork = { workspace = true }
 
 [[example]]

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -27,6 +27,21 @@
 //!   --local agntcy/ns/alice \
 //!   --shared-secret a-very-long-shared-secret-abcdef1234567890
 //! ```
+//!
+//! ## Rejoin mode
+//!
+//! After receiving some messages, press Ctrl+C to shut down the receiver. The
+//! MLS session state is persisted (requires config mode so the cache directory
+//! is known). Restart with `--rejoin` to restore the session and continue:
+//!
+//! ```bash
+//! # First run — join and receive
+//! cargo run --example receiver -- --slim-config /path/to/slim.yaml
+//! # ... Ctrl+C to stop ...
+//!
+//! # Second run — rejoin the persisted session
+//! cargo run --example receiver -- --slim-config /path/to/slim.yaml --rejoin
+//! ```
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -58,6 +73,15 @@ struct Args {
     /// SLIM node endpoint (manual mode only, ignored when --slim-config is used)
     #[arg(long, default_value = "http://localhost:46357")]
     slim: String,
+
+    /// Rejoin a previously persisted group session instead of waiting for a
+    /// new invitation.
+    ///
+    /// Requires config mode (slim.yaml provides a stable cache directory for
+    /// MLS state persistence). The receiver must have joined the session in a
+    /// prior run before `--rejoin` can be used.
+    #[arg(long, default_value = "false")]
+    rejoin: bool,
 }
 
 /// Parse a name string in format "org/namespace/app" into a Name object
@@ -84,11 +108,20 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let service = get_global_service();
 
-    // Determine which mode to use
-    let use_slim_config = args.slim_config.is_some()
+    // --rejoin requires config mode for stable identity + persistent cache dir.
+    if args.rejoin && (args.local.is_some() || args.shared_secret.is_some()) {
+        println!(
+            "Warning: --rejoin requires config mode. Ignoring --local / --shared-secret."
+        );
+    }
+
+    // Determine which mode to use.
+    // --rejoin forces config mode; otherwise the existing heuristic applies.
+    let use_slim_config = args.rejoin
+        || args.slim_config.is_some()
         || (args.local.is_none() && args.shared_secret.is_none());
 
-    let (app, full_name) = if use_slim_config {
+    let (app, full_name, conn_id) = if use_slim_config {
         // ── Config-based mode ─────────────────────────────────────────────
         // load_slim_config discovers slim.yaml (or uses the explicit path),
         // applies env-var overrides, then create_app_from_slim_config does
@@ -105,8 +138,9 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
         let handle = service.create_app_from_slim_config_async(config).await?;
         let full_name = handle.name.to_string();
-        println!("Connected via slim.yaml (app: {full_name}, conn: {})", handle.conn_id);
-        (handle.app, full_name)
+        let conn_id = handle.conn_id;
+        println!("Connected via slim.yaml (app: {full_name}, conn: {conn_id})");
+        (handle.app, full_name, conn_id)
     } else {
         // ── Manual mode (legacy) ──────────────────────────────────────────
         let local = args.local.ok_or("--local is required in manual mode")?;
@@ -127,17 +161,32 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         let full_name = app.name().to_string();
 
         app.subscribe_async(local_name_arc, Some(conn_id)).await?;
-        (app, full_name)
+        (app, full_name, conn_id)
     };
 
-    println!("[{full_name}] Waiting for incoming session...");
+    // Obtain the active session — either by restoring a persisted one or by
+    // waiting for a new invitation from the sender.
+    let session = if args.rejoin {
+        println!("[{full_name}] Restoring persisted session...");
 
-    // Wait for one incoming session (no timeout)
-    let session = app.listen_for_session_async(None).await?;
+        let mut sessions = app.restore_sessions_async(conn_id).await?;
+        let session = sessions.pop().ok_or(
+            "No persisted session found. Run without --rejoin first to join a group session.",
+        )?;
 
-    let session_id = session.session_id()?;
-    let destination = session.destination()?;
-    println!("[{full_name}] New session {session_id} established from {destination}");
+        let session_id = session.session_id()?;
+        println!("[{full_name}] Rejoined session {session_id}");
+        session
+    } else {
+        println!("[{full_name}] Waiting for incoming session...");
+
+        let session = app.listen_for_session_async(None).await?;
+
+        let session_id = session.session_id()?;
+        let destination = session.destination()?;
+        println!("[{full_name}] New session {session_id} established from {destination}");
+        session
+    };
 
     // Loop to receive messages and reply
     loop {
@@ -179,12 +228,13 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             },
             _ = signal::ctrl_c() => {
                 println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
+                println!("[{full_name}] Session state persisted — restart with --rejoin to resume.");
                 break;
             }
         }
     }
 
-    // Cleanup
+    // Cleanup — do NOT delete the session so it can be restored on rejoin.
     shutdown().await?;
     println!("[{full_name}] Receiver stopped");
 

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -9,7 +9,19 @@
 //! 3. Receives messages from that session
 //! 4. Replies to each message using publish_to
 //!
-//! Usage:
+//! ## Modes
+//!
+//! **Config-based (recommended):** Supply `--slim-config` with a path to a `slim.yaml`
+//! file, or omit it to use hierarchical discovery (walks up from CWD, then
+//! `~/.slim/config.yaml`).
+//!
+//! ```bash
+//! cargo run --example receiver -- --slim-config /path/to/slim.yaml
+//! cargo run --example receiver  # discovery mode — needs slim.yaml in CWD or above
+//! ```
+//!
+//! **Manual:** Supply `--local` and `--shared-secret` (legacy, backward-compatible).
+//!
 //! ```bash
 //! cargo run --example receiver -- \
 //!   --local agntcy/ns/alice \
@@ -21,22 +33,29 @@ use std::time::Duration;
 
 use clap::Parser;
 use slim_bindings::{
-    Name, get_global_service, initialize_with_defaults, new_insecure_client_config, shutdown,
+    Name, get_global_service, initialize_with_defaults, load_slim_config,
+    new_insecure_client_config, shutdown,
 };
 use tokio::signal;
 
 /// Command-line arguments for the receiver application
 #[derive(Parser, Debug)]
 struct Args {
-    /// Local identity in format: organization/namespace/application
+    /// Path to a slim.yaml config file. When absent the receiver searches
+    /// upward from the current directory (then ~/.slim/config.yaml).
+    /// Mutually exclusive with --local / --shared-secret.
     #[arg(long)]
-    local: String,
+    slim_config: Option<String>,
 
-    /// Shared secret for authentication
+    /// Local identity in format: organization/namespace/application (manual mode)
     #[arg(long)]
-    shared_secret: String,
+    local: Option<String>,
 
-    /// SLIM control plane endpoint
+    /// Shared secret for authentication (manual mode)
+    #[arg(long)]
+    shared_secret: Option<String>,
+
+    /// SLIM node endpoint (manual mode only, ignored when --slim-config is used)
     #[arg(long, default_value = "http://localhost:46357")]
     slim: String,
 }
@@ -60,29 +79,56 @@ fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
 
 /// Main receiver loop
 async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
-    // Parse the local identity
-    let local_name = parse_name(&args.local)?;
-    let local_name_arc = Arc::new(local_name);
-
     // Initialize SLIM with default configuration
     initialize_with_defaults();
 
-    // Get the global service and connect to the control plane
     let service = get_global_service();
-    let client_config = new_insecure_client_config(args.slim);
-    let conn_id = service.connect_async(client_config).await?;
 
-    println!("Connected to control plane with connection ID: {conn_id}");
+    // Determine which mode to use
+    let use_slim_config = args.slim_config.is_some()
+        || (args.local.is_none() && args.shared_secret.is_none());
 
-    // Create the slim application using global service with shared secret
-    let app = service
-        .create_app_with_secret_async(local_name_arc.clone(), args.shared_secret)
-        .await?;
+    let (app, full_name) = if use_slim_config {
+        // ── Config-based mode ─────────────────────────────────────────────
+        // load_slim_config discovers slim.yaml (or uses the explicit path),
+        // applies env-var overrides, then create_app_from_slim_config does
+        // connect + create_app + subscribe in one call.
+        let config = load_slim_config(args.slim_config.clone()).map_err(|e| {
+            format!(
+                "Failed to load SLIM config{}: {e}",
+                args.slim_config
+                    .as_deref()
+                    .map(|p| format!(" from '{p}'"))
+                    .unwrap_or_default()
+            )
+        })?;
 
-    let full_name = app.name();
+        let handle = service.create_app_from_slim_config_async(config).await?;
+        let full_name = handle.name.to_string();
+        println!("Connected via slim.yaml (app: {full_name}, conn: {})", handle.conn_id);
+        (handle.app, full_name)
+    } else {
+        // ── Manual mode (legacy) ──────────────────────────────────────────
+        let local = args.local.ok_or("--local is required in manual mode")?;
+        let secret = args.shared_secret.ok_or("--shared-secret is required in manual mode")?;
 
-    // Subscribe to local name
-    app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+        let local_name = parse_name(&local)?;
+        let local_name_arc = Arc::new(local_name);
+
+        let client_config = new_insecure_client_config(args.slim);
+        let conn_id = service.connect_async(client_config).await?;
+
+        println!("Connected to control plane with connection ID: {conn_id}");
+
+        let app = service
+            .create_app_with_secret_async(local_name_arc.clone(), secret)
+            .await?;
+
+        let full_name = app.name().to_string();
+
+        app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+        (app, full_name)
+    };
 
     println!("[{full_name}] Waiting for incoming session...");
 

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -228,6 +228,9 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             },
             _ = signal::ctrl_c() => {
                 println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
+                if let Err(e) = session.close_and_wait_async().await {
+                    println!("[{full_name}] Warning: failed to send offline notification: {e}");
+                }
                 println!("[{full_name}] Session state persisted — restart with --rejoin to resume.");
                 break;
             }

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -27,6 +27,21 @@
 //!   --local agntcy/ns/alice \
 //!   --shared-secret a-very-long-shared-secret-abcdef1234567890
 //! ```
+//!
+//! ## Rejoin mode
+//!
+//! After receiving some messages, press Ctrl+C to shut down the receiver. The
+//! MLS session state is persisted (requires config mode so the cache directory
+//! is known). Restart with `--rejoin` to restore the session and continue:
+//!
+//! ```bash
+//! # First run — join and receive
+//! cargo run --example receiver -- --slim-config /path/to/slim.yaml
+//! # ... Ctrl+C to stop ...
+//!
+//! # Second run — rejoin the persisted session
+//! cargo run --example receiver -- --slim-config /path/to/slim.yaml --rejoin
+//! ```
 
 #[cfg(feature = "web")]
 fn main() {}
@@ -61,6 +76,15 @@ struct Args {
     /// SLIM node endpoint (manual mode only, ignored when --slim-config is used)
     #[arg(long, default_value = "http://localhost:46357")]
     slim: String,
+
+    /// Rejoin a previously persisted group session instead of waiting for a
+    /// new invitation.
+    ///
+    /// Requires config mode (slim.yaml provides a stable cache directory for
+    /// MLS state persistence). The receiver must have joined the session in a
+    /// prior run before `--rejoin` can be used.
+    #[arg(long, default_value = "false")]
+    rejoin: bool,
 }
 
 /// Parse a name string in format "org/namespace/app" into a Name object
@@ -87,11 +111,20 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let service = get_global_service();
 
-    // Determine which mode to use
-    let use_slim_config = args.slim_config.is_some()
+    // --rejoin requires config mode for stable identity + persistent cache dir.
+    if args.rejoin && (args.local.is_some() || args.shared_secret.is_some()) {
+        println!(
+            "Warning: --rejoin requires config mode. Ignoring --local / --shared-secret."
+        );
+    }
+
+    // Determine which mode to use.
+    // --rejoin forces config mode; otherwise the existing heuristic applies.
+    let use_slim_config = args.rejoin
+        || args.slim_config.is_some()
         || (args.local.is_none() && args.shared_secret.is_none());
 
-    let (app, full_name) = if use_slim_config {
+    let (app, full_name, conn_id) = if use_slim_config {
         // ── Config-based mode ─────────────────────────────────────────────
         // load_slim_config discovers slim.yaml (or uses the explicit path),
         // applies env-var overrides, then create_app_from_slim_config does
@@ -108,8 +141,9 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
         let handle = service.create_app_from_slim_config_async(config).await?;
         let full_name = handle.name.to_string();
-        println!("Connected via slim.yaml (app: {full_name}, conn: {})", handle.conn_id);
-        (handle.app, full_name)
+        let conn_id = handle.conn_id;
+        println!("Connected via slim.yaml (app: {full_name}, conn: {conn_id})");
+        (handle.app, full_name, conn_id)
     } else {
         // ── Manual mode (legacy) ──────────────────────────────────────────
         let local = args.local.ok_or("--local is required in manual mode")?;
@@ -130,17 +164,32 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         let full_name = app.name().to_string();
 
         app.subscribe_async(local_name_arc, Some(conn_id)).await?;
-        (app, full_name)
+        (app, full_name, conn_id)
     };
 
-    println!("[{full_name}] Waiting for incoming session...");
+    // Obtain the active session — either by restoring a persisted one or by
+    // waiting for a new invitation from the sender.
+    let session = if args.rejoin {
+        println!("[{full_name}] Restoring persisted session...");
 
-    // Wait for one incoming session (no timeout)
-    let session = app.listen_for_session_async(None).await?;
+        let mut sessions = app.restore_sessions_async(conn_id).await?;
+        let session = sessions.pop().ok_or(
+            "No persisted session found. Run without --rejoin first to join a group session.",
+        )?;
 
-    let session_id = session.session_id()?;
-    let destination = session.destination()?;
-    println!("[{full_name}] New session {session_id} established from {destination}");
+        let session_id = session.session_id()?;
+        println!("[{full_name}] Rejoined session {session_id}");
+        session
+    } else {
+        println!("[{full_name}] Waiting for incoming session...");
+
+        let session = app.listen_for_session_async(None).await?;
+
+        let session_id = session.session_id()?;
+        let destination = session.destination()?;
+        println!("[{full_name}] New session {session_id} established from {destination}");
+        session
+    };
 
     // Loop to receive messages and reply
     loop {
@@ -182,12 +231,13 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             },
             _ = signal::ctrl_c() => {
                 println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
+                println!("[{full_name}] Session state persisted — restart with --rejoin to resume.");
                 break;
             }
         }
     }
 
-    // Cleanup
+    // Cleanup — do NOT delete the session so it can be restored on rejoin.
     shutdown().await?;
     println!("[{full_name}] Receiver stopped");
 

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -9,7 +9,19 @@
 //! 3. Receives messages from that session
 //! 4. Replies to each message using publish_to
 //!
-//! Usage:
+//! ## Modes
+//!
+//! **Config-based (recommended):** Supply `--slim-config` with a path to a `slim.yaml`
+//! file, or omit it to use hierarchical discovery (walks up from CWD, then
+//! `~/.slim/config.yaml`).
+//!
+//! ```bash
+//! cargo run --example receiver -- --slim-config /path/to/slim.yaml
+//! cargo run --example receiver  # discovery mode — needs slim.yaml in CWD or above
+//! ```
+//!
+//! **Manual:** Supply `--local` and `--shared-secret` (legacy, backward-compatible).
+//!
 //! ```bash
 //! cargo run --example receiver -- \
 //!   --local agntcy/ns/alice \
@@ -19,144 +31,174 @@
 #[cfg(feature = "web")]
 fn main() {}
 
-cfg_if::cfg_if! {
-    if #[cfg(not(feature = "web"))] {
-        use std::sync::Arc;
-        use std::time::Duration;
+use std::sync::Arc;
+use std::time::Duration;
 
-        use clap::Parser;
-        use slim_bindings::{
-            Name, get_global_service, initialize_with_defaults, new_insecure_client_config, shutdown,
-        };
-        use tokio::signal;
+use clap::Parser;
+use slim_bindings::{
+    Name, get_global_service, initialize_with_defaults, load_slim_config,
+    new_insecure_client_config, shutdown,
+};
+use tokio::signal;
 
-        /// Command-line arguments for the receiver application
-        #[derive(Parser, Debug)]
-        struct Args {
-            /// Local identity in format: organization/namespace/application
-            #[arg(long)]
-            local: String,
+/// Command-line arguments for the receiver application
+#[derive(Parser, Debug)]
+struct Args {
+    /// Path to a slim.yaml config file. When absent the receiver searches
+    /// upward from the current directory (then ~/.slim/config.yaml).
+    /// Mutually exclusive with --local / --shared-secret.
+    #[arg(long)]
+    slim_config: Option<String>,
 
-            /// Shared secret for authentication
-            #[arg(long)]
-            shared_secret: String,
+    /// Local identity in format: organization/namespace/application (manual mode)
+    #[arg(long)]
+    local: Option<String>,
 
-            /// SLIM control plane endpoint
-            #[arg(long, default_value = "http://localhost:46357")]
-            slim: String,
-        }
+    /// Shared secret for authentication (manual mode)
+    #[arg(long)]
+    shared_secret: Option<String>,
 
-        /// Parse a name string in format "org/namespace/app" into a Name object
-        fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
-            let parts: Vec<&str> = id.split('/').collect();
-            if parts.len() != 3 {
-                return Err(format!(
-                    "Invalid name format '{id}'. Expected format: organization/namespace/application"
-                )
-                .into());
-            }
+    /// SLIM node endpoint (manual mode only, ignored when --slim-config is used)
+    #[arg(long, default_value = "http://localhost:46357")]
+    slim: String,
+}
 
-            Ok(Name::new(
-                parts[0].to_string(),
-                parts[1].to_string(),
-                parts[2].to_string(),
-            ))
-        }
+/// Parse a name string in format "org/namespace/app" into a Name object
+fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
+    let parts: Vec<&str> = id.split('/').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "Invalid name format '{id}'. Expected format: organization/namespace/application"
+        )
+        .into());
+    }
 
-        /// Main receiver loop
-        async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
-            // Parse the local identity
-            let local_name = parse_name(&args.local)?;
-            let local_name_arc = Arc::new(local_name);
+    Ok(Name::new(
+        parts[0].to_string(),
+        parts[1].to_string(),
+        parts[2].to_string(),
+    ))
+}
 
-            // Initialize SLIM with default configuration
-            initialize_with_defaults();
+/// Main receiver loop
+async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize SLIM with default configuration
+    initialize_with_defaults();
 
-            // Get the global service and connect to the control plane
-            let service = get_global_service();
-            let client_config = new_insecure_client_config(args.slim);
-            let conn_id = service.connect_async(client_config).await?;
+    let service = get_global_service();
 
-            println!("Connected to control plane with connection ID: {conn_id}");
+    // Determine which mode to use
+    let use_slim_config = args.slim_config.is_some()
+        || (args.local.is_none() && args.shared_secret.is_none());
 
-            // Create the slim application using global service with shared secret
-            let app = service
-                .create_app_with_secret_async(local_name_arc.clone(), args.shared_secret)
-                .await?;
+    let (app, full_name) = if use_slim_config {
+        // ── Config-based mode ─────────────────────────────────────────────
+        // load_slim_config discovers slim.yaml (or uses the explicit path),
+        // applies env-var overrides, then create_app_from_slim_config does
+        // connect + create_app + subscribe in one call.
+        let config = load_slim_config(args.slim_config.clone()).map_err(|e| {
+            format!(
+                "Failed to load SLIM config{}: {e}",
+                args.slim_config
+                    .as_deref()
+                    .map(|p| format!(" from '{p}'"))
+                    .unwrap_or_default()
+            )
+        })?;
 
-            let full_name = app.name();
+        let handle = service.create_app_from_slim_config_async(config).await?;
+        let full_name = handle.name.to_string();
+        println!("Connected via slim.yaml (app: {full_name}, conn: {})", handle.conn_id);
+        (handle.app, full_name)
+    } else {
+        // ── Manual mode (legacy) ──────────────────────────────────────────
+        let local = args.local.ok_or("--local is required in manual mode")?;
+        let secret = args.shared_secret.ok_or("--shared-secret is required in manual mode")?;
 
-            // Subscribe to local name
-            app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+        let local_name = parse_name(&local)?;
+        let local_name_arc = Arc::new(local_name);
 
-            println!("[{full_name}] Waiting for incoming session...");
+        let client_config = new_insecure_client_config(args.slim);
+        let conn_id = service.connect_async(client_config).await?;
 
-            // Wait for one incoming session (no timeout)
-            let session = app.listen_for_session_async(None).await?;
+        println!("Connected to control plane with connection ID: {conn_id}");
 
-            let session_id = session.session_id()?;
-            let destination = session.destination()?;
-            println!("[{full_name}] New session {session_id} established from {destination}");
+        let app = service
+            .create_app_with_secret_async(local_name_arc.clone(), secret)
+            .await?;
 
-            // Loop to receive messages and reply
-            loop {
-                tokio::select! {
-                    result = session.get_message_async(Some(Duration::from_secs(5))) => {
-                        match result {
-                            Ok(received_msg) => {
-                                let payload = String::from_utf8_lossy(&received_msg.payload);
-                                let source = &received_msg.context.source_name;
+        let full_name = app.name().to_string();
 
-                                println!(
-                                    "[{full_name}] Received from {source}: {payload}"
-                                );
+        app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+        (app, full_name)
+    };
 
-                                // Reply to the sender using publish_to
-                                let reply = format!("{payload} from {full_name}");
-                                session
-                                    .publish_to_and_wait_async(
-                                        received_msg.context,
-                                        reply.as_bytes().to_vec(),
-                                        None,
-                                        None,
-                                    )
-                                    .await?;
+    println!("[{full_name}] Waiting for incoming session...");
 
-                                println!("[{full_name}] Sent reply: {reply}");
-                            }
-                            Err(e) => {
-                                let error_msg = e.to_string().to_lowercase();
-                                if error_msg.contains("timeout") {
-                                    // Timeout is expected, just continue waiting
-                                    continue;
-                                } else {
-                                    println!("[{full_name}] Error receiving message: {e}");
-                                    break;
-                                }
-                            }
+    // Wait for one incoming session (no timeout)
+    let session = app.listen_for_session_async(None).await?;
+
+    let session_id = session.session_id()?;
+    let destination = session.destination()?;
+    println!("[{full_name}] New session {session_id} established from {destination}");
+
+    // Loop to receive messages and reply
+    loop {
+        tokio::select! {
+            result = session.get_message_async(Some(Duration::from_secs(5))) => {
+                match result {
+                    Ok(received_msg) => {
+                        let payload = String::from_utf8_lossy(&received_msg.payload);
+                        let source = &received_msg.context.source_name;
+
+                        println!(
+                            "[{full_name}] Received from {source}: {payload}"
+                        );
+
+                        // Reply to the sender using publish_to
+                        let reply = format!("{payload} from {full_name}");
+                        session
+                            .publish_to_and_wait_async(
+                                received_msg.context,
+                                reply.as_bytes().to_vec(),
+                                None,
+                                None,
+                            )
+                            .await?;
+
+                        println!("[{full_name}] Sent reply: {reply}");
+                    }
+                    Err(e) => {
+                        let error_msg = e.to_string().to_lowercase();
+                        if error_msg.contains("timeout") {
+                            // Timeout is expected, just continue waiting
+                            continue;
+                        } else {
+                            println!("[{full_name}] Error receiving message: {e}");
+                            break;
                         }
-                    },
-                    _ = signal::ctrl_c() => {
-                        println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
-                        break;
                     }
                 }
+            },
+            _ = signal::ctrl_c() => {
+                println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
+                break;
             }
-
-            // Cleanup
-            shutdown().await?;
-            println!("[{full_name}] Receiver stopped");
-
-            Ok(())
-        }
-
-        #[tokio::main]
-        async fn main() -> Result<(), Box<dyn std::error::Error>> {
-            // Parse command-line arguments
-            let args = Args::parse();
-
-            // Run the receiver
-            run_receiver(args).await
         }
     }
+
+    // Cleanup
+    shutdown().await?;
+    println!("[{full_name}] Receiver stopped");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command-line arguments
+    let args = Args::parse();
+
+    // Run the receiver
+    run_receiver(args).await
 }

--- a/crates/slim-bindings/examples/receiver.rs
+++ b/crates/slim-bindings/examples/receiver.rs
@@ -231,6 +231,9 @@ async fn run_receiver(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             },
             _ = signal::ctrl_c() => {
                 println!("\n[{full_name}] Received Ctrl+C, shutting down gracefully...");
+                if let Err(e) = session.close_and_wait_async().await {
+                    println!("[{full_name}] Warning: failed to send offline notification: {e}");
+                }
                 println!("[{full_name}] Session state persisted — restart with --rejoin to resume.");
                 break;
             }

--- a/crates/slim-bindings/examples/sender.rs
+++ b/crates/slim-bindings/examples/sender.rs
@@ -9,6 +9,13 @@
 //! 3. Sends messages at regular intervals
 //! 4. Receives and validates replies from participants
 //!
+//! ## Keep-alive / broadcast mode
+//!
+//! Pass `--keep-alive` (group sessions only) to broadcast indefinitely until
+//! Ctrl+C. The session is **not** deleted on exit so receivers can persist and
+//! rejoin after restarting. Combine with `--slim-config` on the receiver side
+//! to demo the full persist-and-rejoin flow.
+//!
 //! Usage:
 //! ```bash
 //! # Point-to-point
@@ -18,12 +25,21 @@
 //!   --session-type p2p \
 //!   --participants agntcy/ns/alice
 //!
-//! # Group
+//! # Group (bounded)
 //! cargo run --example sender -- \
 //!   --local agntcy/ns/bob \
 //!   --shared-secret a-very-long-shared-secret-abcdef1234567890 \
 //!   --session-type group \
 //!   --participants agntcy/ns/alice agntcy/ns/charlie
+//!
+//! # Group broadcast — keep sending until Ctrl+C, leave session open for rejoin
+//! cargo run --example sender -- \
+//!   --local agntcy/ns/bob \
+//!   --shared-secret a-very-long-shared-secret-abcdef1234567890 \
+//!   --session-type group \
+//!   --participants agntcy/ns/alice \
+//!   --interval-ms 1000 \
+//!   --keep-alive
 //! ```
 
 use std::collections::HashMap;
@@ -35,6 +51,7 @@ use slim_bindings::{
     MlsSettings, Name, SessionConfig, SessionType, get_global_service, initialize_with_defaults,
     new_insecure_client_config, shutdown,
 };
+use tokio::signal;
 
 /// Command-line arguments for the sender application
 #[derive(Parser, Debug)]
@@ -61,13 +78,20 @@ struct Args {
     #[arg(long, required = true, num_args = 1..)]
     participants: Vec<String>,
 
-    /// Number of messages to send
+    /// Number of messages to send (ignored in --keep-alive mode after initial burst)
     #[arg(long, default_value = "10")]
     count: usize,
 
     /// Interval between messages in milliseconds
     #[arg(long, default_value = "100")]
     interval_ms: u64,
+
+    /// Keep broadcasting indefinitely after --count messages until Ctrl+C.
+    ///
+    /// Only valid with --session-type group. The session is NOT deleted on
+    /// exit so receivers can persist their state and rejoin after a restart.
+    #[arg(long, default_value = "false")]
+    keep_alive: bool,
 }
 
 /// Parse a name string in format "org/namespace/app" into a Name object
@@ -107,6 +131,10 @@ async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     if args.participants.is_empty() {
         return Err("At least 1 participant is required".into());
+    }
+
+    if args.keep_alive && session_type != SessionType::Group {
+        return Err("--keep-alive is only valid with --session-type group".into());
     }
 
     // Parse the local identity
@@ -188,19 +216,24 @@ async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let interval = Duration::from_millis(args.interval_ms);
-    let expected_replies_per_message = participant_names.len();
+
+    // In keep-alive mode replies are fire-and-forget (receivers may come and go).
+    // In bounded mode we track expected replies to know when we're done.
+    let expected_replies_per_message = if args.keep_alive {
+        0
+    } else {
+        participant_names.len()
+    };
     let total_expected_replies = args.count * expected_replies_per_message;
 
-    println!(
-        "[{}] Sending {} messages with {}ms interval...",
-        full_name, args.count, args.interval_ms
-    );
-
-    // Spawn a background task to collect replies
+    // Spawn a background task to collect replies.
+    // In keep-alive mode: log every reply but never exit early.
+    // In bounded mode: exit once all expected replies arrive.
     let session_clone = session.clone();
     let full_name_clone = full_name.clone();
+    let keep_alive = args.keep_alive;
     let reply_task = tokio::spawn(async move {
-        let mut total_replies_received = 0;
+        let mut total_replies_received = 0usize;
 
         loop {
             match session_clone
@@ -215,18 +248,23 @@ async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
                     total_replies_received += 1;
 
-                    // Stop if we've received all expected replies
-                    if total_replies_received >= total_expected_replies {
+                    // In bounded mode stop once all replies are in.
+                    if !keep_alive && total_replies_received >= total_expected_replies {
                         break;
                     }
                 }
                 Err(e) => {
                     let error_msg = e.to_string().to_lowercase();
                     if error_msg.contains("timeout") {
-                        // Continue waiting
+                        // Expected — no reply within the window, keep waiting.
                         continue;
                     } else {
-                        println!("[{full_name_clone}] Error receiving reply: {e}");
+                        // In keep-alive mode a receiver going offline produces
+                        // transient errors; log and continue rather than abort.
+                        println!("[{full_name_clone}] Reply channel error (continuing): {e}");
+                        if keep_alive {
+                            continue;
+                        }
                         break;
                     }
                 }
@@ -236,57 +274,104 @@ async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         total_replies_received
     });
 
-    // Send messages at fixed intervals
-    for i in 0..args.count {
-        let message = format!("Message {}", i + 1);
-        println!("[{full_name}] Sending: {message}");
-
-        if let Err(e) = session
-            .publish_and_wait_async(message.as_bytes().to_vec(), None, None)
-            .await
-        {
-            println!("[{full_name}] Error sending message: {e}");
-        }
-
-        tokio::time::sleep(interval).await;
-    }
-
-    println!("[{full_name}] Finished sending messages, waiting for remaining replies...");
-
-    // Wait for reply collection task to finish or timeout
-    let total_replies_received = tokio::select! {
-        result = reply_task => {
-            match result {
-                Ok(data) => data,
-                Err(e) => {
-                    println!("[{full_name}] Reply collection task error: {e}");
-                    0
-                }
-            }
-        }
-        _ = tokio::time::sleep(Duration::from_secs(30)) => {
-            println!("[{full_name}] Timeout waiting for replies");
-            0
-        }
-    };
-
-    // Summary
-    println!("\n[{full_name}] === Summary ===");
-    println!("[{full_name}] Replies received: {total_replies_received}/{total_expected_replies}");
-
-    if total_replies_received == total_expected_replies {
-        println!("[{full_name}] ✓ All participants replied correctly");
+    if args.keep_alive {
+        println!(
+            "[{full_name}] Keep-alive mode: broadcasting every {}ms. Press Ctrl+C to stop.",
+            args.interval_ms
+        );
     } else {
         println!(
-            "[{}] ✗ Missing {} replies",
-            full_name,
-            total_expected_replies - total_replies_received
+            "[{}] Sending {} messages with {}ms interval...",
+            full_name, args.count, args.interval_ms
         );
     }
 
-    // Delete session
-    println!("[{full_name}] Deleting session...");
-    app.delete_session_and_wait_async(session).await?;
+    // Send loop — bounded or indefinite depending on --keep-alive.
+    let mut msg_index: usize = 0;
+    let mut shutdown_requested = false;
+
+    loop {
+        if !args.keep_alive && msg_index >= args.count {
+            break;
+        }
+
+        msg_index += 1;
+        let message = format!("Message {msg_index}");
+        println!("[{full_name}] Sending: {message}");
+
+        tokio::select! {
+            result = session.publish_and_wait_async(message.as_bytes().to_vec(), None, None) => {
+                if let Err(e) = result {
+                    println!("[{full_name}] Error sending message: {e}");
+                }
+            }
+            _ = signal::ctrl_c() => {
+                println!("\n[{full_name}] Received Ctrl+C, stopping broadcast...");
+                shutdown_requested = true;
+                break;
+            }
+        }
+
+        // Sleep between messages, also interruptible by Ctrl+C.
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = signal::ctrl_c() => {
+                println!("\n[{full_name}] Received Ctrl+C, stopping broadcast...");
+                shutdown_requested = true;
+                break;
+            }
+        }
+    }
+
+    if !args.keep_alive {
+        println!("[{full_name}] Finished sending messages, waiting for remaining replies...");
+    }
+
+    // Wait for reply collection task to finish or timeout.
+    // In keep-alive mode we just abort the background task.
+    let total_replies_received = if args.keep_alive || shutdown_requested {
+        reply_task.abort();
+        0
+    } else {
+        tokio::select! {
+            result = reply_task => {
+                match result {
+                    Ok(data) => data,
+                    Err(e) => {
+                        println!("[{full_name}] Reply collection task error: {e}");
+                        0
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_secs(30)) => {
+                println!("[{full_name}] Timeout waiting for replies");
+                0
+            }
+        }
+    };
+
+    // Summary (bounded mode only)
+    if !args.keep_alive {
+        println!("\n[{full_name}] === Summary ===");
+        println!("[{full_name}] Replies received: {total_replies_received}/{total_expected_replies}");
+
+        if total_replies_received == total_expected_replies {
+            println!("[{full_name}] ✓ All participants replied correctly");
+        } else {
+            println!(
+                "[{}] ✗ Missing {} replies",
+                full_name,
+                total_expected_replies - total_replies_received
+            );
+        }
+
+        // Delete session only in bounded mode — in keep-alive mode the session
+        // is left open so receivers can persist and rejoin after a restart.
+        println!("[{full_name}] Deleting session...");
+        app.delete_session_and_wait_async(session).await?;
+    } else {
+        println!("[{full_name}] Session left open for receiver rejoin.");
+    }
 
     // Cleanup
     shutdown().await?;

--- a/crates/slim-bindings/examples/sender.rs
+++ b/crates/slim-bindings/examples/sender.rs
@@ -9,6 +9,13 @@
 //! 3. Sends messages at regular intervals
 //! 4. Receives and validates replies from participants
 //!
+//! ## Keep-alive / broadcast mode
+//!
+//! Pass `--keep-alive` (group sessions only) to broadcast indefinitely until
+//! Ctrl+C. The session is **not** deleted on exit so receivers can persist and
+//! rejoin after restarting. Combine with `--slim-config` on the receiver side
+//! to demo the full persist-and-rejoin flow.
+//!
 //! Usage:
 //! ```bash
 //! # Point-to-point
@@ -18,295 +25,366 @@
 //!   --session-type p2p \
 //!   --participants agntcy/ns/alice
 //!
-//! # Group
+//! # Group (bounded)
 //! cargo run --example sender -- \
 //!   --local agntcy/ns/bob \
 //!   --shared-secret a-very-long-shared-secret-abcdef1234567890 \
 //!   --session-type group \
 //!   --participants agntcy/ns/alice agntcy/ns/charlie
+//!
+//! # Group broadcast — keep sending until Ctrl+C, leave session open for rejoin
+//! cargo run --example sender -- \
+//!   --local agntcy/ns/bob \
+//!   --shared-secret a-very-long-shared-secret-abcdef1234567890 \
+//!   --session-type group \
+//!   --participants agntcy/ns/alice \
+//!   --interval-ms 1000 \
+//!   --keep-alive
 //! ```
 
-#[cfg(feature = "web")]
-fn main() {}
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
-cfg_if::cfg_if! {
-    if #[cfg(not(feature = "web"))] {
-        use std::collections::HashMap;
-        use std::sync::Arc;
-        use std::time::Duration;
+use clap::Parser;
+use slim_bindings::{
+    MlsSettings, Name, SessionConfig, SessionType, get_global_service, initialize_with_defaults,
+    new_insecure_client_config, shutdown,
+};
+use tokio::signal;
 
-        use clap::Parser;
-        use slim_bindings::{
-            MlsSettings, Name, SessionConfig, SessionType, get_global_service,
-            initialize_with_defaults, new_insecure_client_config, shutdown,
-        };
+/// Command-line arguments for the sender application
+#[derive(Parser, Debug)]
+struct Args {
+    /// Local identity in format: organization/namespace/application
+    #[arg(long)]
+    local: String,
 
-        /// Command-line arguments for the sender application
-        #[derive(Parser, Debug)]
-        struct Args {
-            /// Local identity in format: organization/namespace/application
-            #[arg(long)]
-            local: String,
+    /// Shared secret for authentication
+    #[arg(long)]
+    shared_secret: String,
 
-            /// Shared secret for authentication
-            #[arg(long)]
-            shared_secret: String,
+    /// SLIM control plane endpoint
+    #[arg(long, default_value = "http://localhost:46357")]
+    slim: String,
 
-            /// SLIM control plane endpoint
-            #[arg(long, default_value = "http://localhost:46357")]
-            slim: String,
+    /// Session type: "p2p" or "group"
+    #[arg(long)]
+    session_type: String,
 
-            /// Session type: "p2p" or "group"
-            #[arg(long)]
-            session_type: String,
+    /// List of participant identities (format: organization/namespace/application)
+    /// For p2p: exactly 1 participant
+    /// For group: at least 1 participant
+    #[arg(long, required = true, num_args = 1..)]
+    participants: Vec<String>,
 
-            /// List of participant identities (format: organization/namespace/application)
-            /// For p2p: exactly 1 participant
-            /// For group: at least 1 participant
-            #[arg(long, required = true, num_args = 1..)]
-            participants: Vec<String>,
+    /// Number of messages to send (ignored in --keep-alive mode after initial burst)
+    #[arg(long, default_value = "10")]
+    count: usize,
 
-            /// Number of messages to send
-            #[arg(long, default_value = "10")]
-            count: usize,
+    /// Interval between messages in milliseconds
+    #[arg(long, default_value = "100")]
+    interval_ms: u64,
 
-            /// Interval between messages in milliseconds
-            #[arg(long, default_value = "100")]
-            interval_ms: u64,
-        }
+    /// Keep broadcasting indefinitely after --count messages until Ctrl+C.
+    ///
+    /// Only valid with --session-type group. The session is NOT deleted on
+    /// exit so receivers can persist their state and rejoin after a restart.
+    #[arg(long, default_value = "false")]
+    keep_alive: bool,
+}
 
-        /// Parse a name string in format "org/namespace/app" into a Name object
-        fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
-            let parts: Vec<&str> = id.split('/').collect();
-            if parts.len() != 3 {
-                return Err(format!(
-                    "Invalid name format '{id}'. Expected format: organization/namespace/application"
-                )
-                .into());
-            }
+/// Parse a name string in format "org/namespace/app" into a Name object
+fn parse_name(id: &str) -> Result<Name, Box<dyn std::error::Error>> {
+    let parts: Vec<&str> = id.split('/').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "Invalid name format '{id}'. Expected format: organization/namespace/application"
+        )
+        .into());
+    }
 
-            Ok(Name::new(
-                parts[0].to_string(),
-                parts[1].to_string(),
-                parts[2].to_string(),
-            ))
-        }
+    Ok(Name::new(
+        parts[0].to_string(),
+        parts[1].to_string(),
+        parts[2].to_string(),
+    ))
+}
 
-        /// Parse session type from string
-        fn parse_session_type(s: &str) -> Result<SessionType, Box<dyn std::error::Error>> {
-            match s.to_lowercase().as_str() {
-                "p2p" | "point-to-point" | "pointtopoint" => Ok(SessionType::PointToPoint),
-                "group" | "multicast" => Ok(SessionType::Group),
-                _ => Err(format!("Invalid session type '{s}'. Expected 'p2p' or 'group'").into()),
-            }
-        }
+/// Parse session type from string
+fn parse_session_type(s: &str) -> Result<SessionType, Box<dyn std::error::Error>> {
+    match s.to_lowercase().as_str() {
+        "p2p" | "point-to-point" | "pointtopoint" => Ok(SessionType::PointToPoint),
+        "group" | "multicast" => Ok(SessionType::Group),
+        _ => Err(format!("Invalid session type '{s}'. Expected 'p2p' or 'group'").into()),
+    }
+}
 
-        /// Main sender loop
-        async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
-            // Validate arguments
-            let session_type = parse_session_type(&args.session_type)?;
+/// Main sender loop
+async fn run_sender(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate arguments
+    let session_type = parse_session_type(&args.session_type)?;
 
-            if session_type == SessionType::PointToPoint && args.participants.len() != 1 {
-                return Err("Point-to-point sessions require exactly 1 participant".into());
-            }
+    if session_type == SessionType::PointToPoint && args.participants.len() != 1 {
+        return Err("Point-to-point sessions require exactly 1 participant".into());
+    }
 
-            if args.participants.is_empty() {
-                return Err("At least 1 participant is required".into());
-            }
+    if args.participants.is_empty() {
+        return Err("At least 1 participant is required".into());
+    }
 
-            // Parse the local identity
-            let local_name = parse_name(&args.local)?;
-            let local_name_arc = Arc::new(local_name);
+    if args.keep_alive && session_type != SessionType::Group {
+        return Err("--keep-alive is only valid with --session-type group".into());
+    }
 
-            // Parse participant names
-            let participant_names: Result<Vec<Name>, _> =
-                args.participants.iter().map(|s| parse_name(s)).collect();
-            let participant_names = participant_names?;
+    // Parse the local identity
+    let local_name = parse_name(&args.local)?;
+    let local_name_arc = Arc::new(local_name);
 
-            // Initialize SLIM with default configuration
-            initialize_with_defaults();
+    // Parse participant names
+    let participant_names: Result<Vec<Name>, _> =
+        args.participants.iter().map(|s| parse_name(s)).collect();
+    let participant_names = participant_names?;
 
-            // Get the global service and connect to the control plane
-            let service = get_global_service();
-            let client_config = new_insecure_client_config(args.slim);
-            let conn_id = service.connect_async(client_config).await?;
+    // Initialize SLIM with default configuration
+    initialize_with_defaults();
 
-            println!("Connected to control plane with connection ID: {conn_id}");
+    // Get the global service and connect to the control plane
+    let service = get_global_service();
+    let client_config = new_insecure_client_config(args.slim);
+    let conn_id = service.connect_async(client_config).await?;
 
-            // Create the slim application using global service with shared secret
-            let app = service
-                .create_app_with_secret_async(local_name_arc.clone(), args.shared_secret)
+    println!("Connected to control plane with connection ID: {conn_id}");
+
+    // Create the slim application using global service with shared secret
+    let app = service
+        .create_app_with_secret_async(local_name_arc.clone(), args.shared_secret)
+        .await?;
+
+    let full_name = app.name();
+    println!("[{full_name}] Application created");
+
+    // Subscribe to local name
+    app.subscribe_async(local_name_arc, Some(conn_id)).await?;
+
+    // Create session configuration
+    let session_config = SessionConfig {
+        session_type: session_type.clone(),
+        max_retries: Some(5),
+        interval: Some(Duration::from_secs(1)),
+        metadata: HashMap::new(),
+        mls_settings: Some(MlsSettings::default()),
+    };
+
+    // For p2p, destination is the single participant
+    // For group, destination is the group channel name
+    let destination = if session_type == SessionType::Group {
+        Arc::new(parse_name("agntcy/slim/test-app-channel")?)
+    } else {
+        Arc::new(participant_names[0].clone())
+    };
+
+    println!("[{full_name}] Creating {session_type:?} session with destination {destination}...");
+
+    // Set routes for all participants to ensure they can receive the session invite
+    for participant in &participant_names {
+        println!("[{full_name}] Setting route for {participant}");
+        app.set_route_async(Arc::new(participant.clone()), conn_id)
+            .await?;
+    }
+
+    let session_with_completion = app
+        .create_session_async(session_config, destination)
+        .await?;
+
+    // Wait for session establishment
+    session_with_completion.completion.wait_async().await?;
+    let session = session_with_completion.session;
+
+    let session_id = session.session_id()?;
+    println!("[{full_name}] Session {session_id} established");
+
+    // For group sessions, invite all participants
+    if session_type == SessionType::Group {
+        for participant in &participant_names {
+            println!("[{full_name}] Inviting {participant} to session...");
+            session
+                .invite_and_wait_async(Arc::new(participant.clone()))
                 .await?;
-
-            let full_name = app.name();
-            println!("[{full_name}] Application created");
-
-            // Subscribe to local name
-            app.subscribe_async(local_name_arc, Some(conn_id)).await?;
-
-            // Create session configuration
-            let session_config = SessionConfig {
-                session_type: session_type.clone(),
-                max_retries: Some(5),
-                interval: Some(Duration::from_secs(1)),
-                metadata: HashMap::new(),
-                mls_settings: Some(MlsSettings::default()),
-            };
-
-            // For p2p, destination is the single participant
-            // For group, destination is the group channel name
-            let destination = if session_type == SessionType::Group {
-                Arc::new(parse_name("agntcy/slim/test-app-channel")?)
-            } else {
-                Arc::new(participant_names[0].clone())
-            };
-
-            println!("[{full_name}] Creating {session_type:?} session with destination {destination}...");
-
-            // Set routes for all participants to ensure they can receive the session invite
-            for participant in &participant_names {
-                println!("[{full_name}] Setting route for {participant}");
-                app.set_route_async(Arc::new(participant.clone()), conn_id)
-                    .await?;
-            }
-
-            let session_with_completion = app
-                .create_session_async(session_config, destination)
-                .await?;
-
-            // Wait for session establishment
-            session_with_completion.completion.wait_async().await?;
-            let session = session_with_completion.session;
-
-            let session_id = session.session_id()?;
-            println!("[{full_name}] Session {session_id} established");
-
-            // For group sessions, invite all participants
-            if session_type == SessionType::Group {
-                for participant in &participant_names {
-                    println!("[{full_name}] Inviting {participant} to session...");
-                    session
-                        .invite_and_wait_async(Arc::new(participant.clone()))
-                        .await?;
-                    println!("[{full_name}] {participant} joined session");
-                }
-            }
-
-            let interval = Duration::from_millis(args.interval_ms);
-            let expected_replies_per_message = participant_names.len();
-            let total_expected_replies = args.count * expected_replies_per_message;
-
-            println!(
-                "[{}] Sending {} messages with {}ms interval...",
-                full_name, args.count, args.interval_ms
-            );
-
-            // Spawn a background task to collect replies
-            let session_clone = session.clone();
-            let full_name_clone = full_name.clone();
-            let reply_task = tokio::spawn(async move {
-                let mut total_replies_received = 0;
-
-                loop {
-                    match session_clone
-                        .get_message_async(Some(Duration::from_secs(10)))
-                        .await
-                    {
-                        Ok(received_msg) => {
-                            let payload = String::from_utf8_lossy(&received_msg.payload);
-                            let source = received_msg.context.source_name.to_string();
-
-                            println!("[{full_name_clone}] Reply from {source}: {payload}");
-
-                            total_replies_received += 1;
-
-                            // Stop if we've received all expected replies
-                            if total_replies_received >= total_expected_replies {
-                                break;
-                            }
-                        }
-                        Err(e) => {
-                            let error_msg = e.to_string().to_lowercase();
-                            if error_msg.contains("timeout") {
-                                // Continue waiting
-                                continue;
-                            } else {
-                                println!("[{full_name_clone}] Error receiving reply: {e}");
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                total_replies_received
-            });
-
-            // Send messages at fixed intervals
-            for i in 0..args.count {
-                let message = format!("Message {}", i + 1);
-                println!("[{full_name}] Sending: {message}");
-
-                if let Err(e) = session
-                    .publish_and_wait_async(message.as_bytes().to_vec(), None, None)
-                    .await
-                {
-                    println!("[{full_name}] Error sending message: {e}");
-                }
-
-                tokio::time::sleep(interval).await;
-            }
-
-            println!("[{full_name}] Finished sending messages, waiting for remaining replies...");
-
-            // Wait for reply collection task to finish or timeout
-            let total_replies_received = tokio::select! {
-                result = reply_task => {
-                    match result {
-                        Ok(data) => data,
-                        Err(e) => {
-                            println!("[{full_name}] Reply collection task error: {e}");
-                            0
-                        }
-                    }
-                }
-                _ = tokio::time::sleep(Duration::from_secs(30)) => {
-                    println!("[{full_name}] Timeout waiting for replies");
-                    0
-                }
-            };
-
-            // Summary
-            println!("\n[{full_name}] === Summary ===");
-            println!("[{full_name}] Replies received: {total_replies_received}/{total_expected_replies}");
-
-            if total_replies_received == total_expected_replies {
-                println!("[{full_name}] ✓ All participants replied correctly");
-            } else {
-                println!(
-                    "[{}] ✗ Missing {} replies",
-                    full_name,
-                    total_expected_replies - total_replies_received
-                );
-            }
-
-            // Delete session
-            println!("[{full_name}] Deleting session...");
-            app.delete_session_and_wait_async(session).await?;
-
-            // Cleanup
-            shutdown().await?;
-            println!("[{full_name}] Sender stopped");
-
-            Ok(())
-        }
-
-        #[tokio::main]
-        async fn main() -> Result<(), Box<dyn std::error::Error>> {
-            // Parse command-line arguments
-            let args = Args::parse();
-
-            // Run the sender
-            run_sender(args).await
+            println!("[{full_name}] {participant} joined session");
         }
     }
+
+    let interval = Duration::from_millis(args.interval_ms);
+
+    // In keep-alive mode replies are fire-and-forget (receivers may come and go).
+    // In bounded mode we track expected replies to know when we're done.
+    let expected_replies_per_message = if args.keep_alive {
+        0
+    } else {
+        participant_names.len()
+    };
+    let total_expected_replies = args.count * expected_replies_per_message;
+
+    // Spawn a background task to collect replies.
+    // In keep-alive mode: log every reply but never exit early.
+    // In bounded mode: exit once all expected replies arrive.
+    let session_clone = session.clone();
+    let full_name_clone = full_name.clone();
+    let keep_alive = args.keep_alive;
+    let reply_task = tokio::spawn(async move {
+        let mut total_replies_received = 0usize;
+
+        loop {
+            match session_clone
+                .get_message_async(Some(Duration::from_secs(10)))
+                .await
+            {
+                Ok(received_msg) => {
+                    let payload = String::from_utf8_lossy(&received_msg.payload);
+                    let source = received_msg.context.source_name.to_string();
+
+                    println!("[{full_name_clone}] Reply from {source}: {payload}");
+
+                    total_replies_received += 1;
+
+                    // In bounded mode stop once all replies are in.
+                    if !keep_alive && total_replies_received >= total_expected_replies {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let error_msg = e.to_string().to_lowercase();
+                    if error_msg.contains("timeout") {
+                        // Expected — no reply within the window, keep waiting.
+                        continue;
+                    } else {
+                        // In keep-alive mode a receiver going offline produces
+                        // transient errors; log and continue rather than abort.
+                        println!("[{full_name_clone}] Reply channel error (continuing): {e}");
+                        if keep_alive {
+                            continue;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        total_replies_received
+    });
+
+    if args.keep_alive {
+        println!(
+            "[{full_name}] Keep-alive mode: broadcasting every {}ms. Press Ctrl+C to stop.",
+            args.interval_ms
+        );
+    } else {
+        println!(
+            "[{}] Sending {} messages with {}ms interval...",
+            full_name, args.count, args.interval_ms
+        );
+    }
+
+    // Send loop — bounded or indefinite depending on --keep-alive.
+    let mut msg_index: usize = 0;
+    let mut shutdown_requested = false;
+
+    loop {
+        if !args.keep_alive && msg_index >= args.count {
+            break;
+        }
+
+        msg_index += 1;
+        let message = format!("Message {msg_index}");
+        println!("[{full_name}] Sending: {message}");
+
+        tokio::select! {
+            result = session.publish_and_wait_async(message.as_bytes().to_vec(), None, None) => {
+                if let Err(e) = result {
+                    println!("[{full_name}] Error sending message: {e}");
+                }
+            }
+            _ = signal::ctrl_c() => {
+                println!("\n[{full_name}] Received Ctrl+C, stopping broadcast...");
+                shutdown_requested = true;
+                break;
+            }
+        }
+
+        // Sleep between messages, also interruptible by Ctrl+C.
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = signal::ctrl_c() => {
+                println!("\n[{full_name}] Received Ctrl+C, stopping broadcast...");
+                shutdown_requested = true;
+                break;
+            }
+        }
+    }
+
+    if !args.keep_alive {
+        println!("[{full_name}] Finished sending messages, waiting for remaining replies...");
+    }
+
+    // Wait for reply collection task to finish or timeout.
+    // In keep-alive mode we just abort the background task.
+    let total_replies_received = if args.keep_alive || shutdown_requested {
+        reply_task.abort();
+        0
+    } else {
+        tokio::select! {
+            result = reply_task => {
+                match result {
+                    Ok(data) => data,
+                    Err(e) => {
+                        println!("[{full_name}] Reply collection task error: {e}");
+                        0
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_secs(30)) => {
+                println!("[{full_name}] Timeout waiting for replies");
+                0
+            }
+        }
+    };
+
+    // Summary (bounded mode only)
+    if !args.keep_alive {
+        println!("\n[{full_name}] === Summary ===");
+        println!("[{full_name}] Replies received: {total_replies_received}/{total_expected_replies}");
+
+        if total_replies_received == total_expected_replies {
+            println!("[{full_name}] ✓ All participants replied correctly");
+        } else {
+            println!(
+                "[{}] ✗ Missing {} replies",
+                full_name,
+                total_expected_replies - total_replies_received
+            );
+        }
+
+        // Delete session only in bounded mode — in keep-alive mode the session
+        // is left open so receivers can persist and rejoin after a restart.
+        println!("[{full_name}] Deleting session...");
+        app.delete_session_and_wait_async(session).await?;
+    } else {
+        println!("[{full_name}] Session left open for receiver rejoin.");
+    }
+
+    // Cleanup
+    shutdown().await?;
+    println!("[{full_name}] Sender stopped");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command-line arguments
+    let args = Args::parse();
+
+    // Run the sender
+    run_sender(args).await
 }

--- a/crates/slim-bindings/src/client_config.rs
+++ b/crates/slim-bindings/src/client_config.rs
@@ -21,7 +21,8 @@ use crate::errors::SlimError;
 use slim_config::component::configuration::Configuration;
 
 /// Compression type for gRPC messages
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum CompressionType {
     Gzip,
     Zlib,
@@ -258,57 +259,73 @@ impl From<CoreBackoffConfig> for BackoffConfig {
 }
 
 /// Client configuration for connecting to a SLIM server
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ClientConfig {
     /// The target endpoint the client will connect to.
     ///
     /// The transport protocol is inferred from the endpoint scheme:
     /// `ws://`/`wss://` → WebSocket, otherwise gRPC.
+    #[serde(default)]
     pub endpoint: String,
 
     /// TLS client configuration
+    #[serde(default)]
     pub tls: TlsClientConfig,
 
     /// Origin (HTTP Host authority override) for the client
+    #[serde(default)]
     pub origin: Option<String>,
 
     /// Optional TLS SNI server name override
+    #[serde(default)]
     pub server_name: Option<String>,
 
     /// Compression type
+    #[serde(default)]
     pub compression: Option<CompressionType>,
 
     /// Rate limit string (e.g., "100/s" for 100 requests per second)
+    #[serde(default)]
     pub rate_limit: Option<String>,
 
     /// Keepalive parameters
+    #[serde(skip, default)]
     pub keepalive: Option<KeepaliveConfig>,
 
     /// HTTP Proxy configuration
+    #[serde(skip, default)]
     pub proxy: Option<ProxyConfig>,
 
     /// Connection timeout
+    #[serde(default, with = "humantime_serde::option")]
     pub connect_timeout: Option<Duration>,
 
     /// Request timeout
+    #[serde(default, with = "humantime_serde::option")]
     pub request_timeout: Option<Duration>,
 
     /// Read buffer size in bytes
+    #[serde(default)]
     pub buffer_size: Option<u64>,
 
     /// Headers associated with gRPC requests
+    #[serde(default)]
     pub headers: Option<HashMap<String, String>>,
 
     /// Authentication configuration for outgoing RPCs
+    #[serde(skip, default)]
     pub auth: Option<ClientAuthenticationConfig>,
 
     /// Backoff retry configuration
+    #[serde(skip, default)]
     pub backoff: Option<BackoffConfig>,
 
     /// Arbitrary user-provided metadata as JSON string
+    #[serde(default)]
     pub metadata: Option<String>,
 
     /// When true, reject inter-node messages without a valid header MAC (strict mode).
+    #[serde(default)]
     pub require_header_mac: Option<bool>,
 }
 

--- a/crates/slim-bindings/src/common_config.rs
+++ b/crates/slim-bindings/src/common_config.rs
@@ -8,7 +8,7 @@ use slim_config::tls::server::TlsServerConfig as CoreTlsServerConfig;
 use crate::identity_config::{ClientJwtAuth, JwtAuth, StaticJwtAuth};
 
 /// SPIRE configuration for SPIFFE Workload API integration
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SpireConfig {
     /// Path to the SPIFFE Workload API socket (None => use SPIFFE_ENDPOINT_SOCKET env var)
     pub socket_path: Option<String>,
@@ -56,7 +56,8 @@ impl From<slim_config::auth::spire::SpireConfig> for SpireConfig {
 }
 
 /// TLS certificate and key source configuration
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum TlsSource {
     /// Load certificate and key from PEM strings
     Pem { cert: String, key: String },
@@ -65,6 +66,7 @@ pub enum TlsSource {
     /// Load certificate and key from SPIRE Workload API
     Spire { config: SpireConfig },
     /// No certificate/key configured
+    #[default]
     None,
 }
 
@@ -105,7 +107,8 @@ impl From<slim_config::tls::common::TlsSource> for TlsSource {
 }
 
 /// CA certificate source configuration
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum CaSource {
     /// Load CA from file
     File { path: String },
@@ -114,6 +117,7 @@ pub enum CaSource {
     /// Load CA from SPIRE Workload API
     Spire { config: SpireConfig },
     /// No CA configured
+    #[default]
     None,
 }
 
@@ -149,21 +153,35 @@ impl From<slim_config::tls::common::CaSource> for CaSource {
     }
 }
 
+fn serde_default_include_system_ca_certs_pool() -> bool {
+    true
+}
+
+fn serde_default_tls_version() -> String {
+    "tls1.3".to_string()
+}
+
 /// TLS configuration for client connections
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TlsClientConfig {
     /// Disable TLS entirely (plain text connection)
+    #[serde(default)]
     pub insecure: bool,
     /// Skip server certificate verification (enables TLS but doesn't verify certs)
     /// WARNING: Only use for testing - insecure in production!
+    #[serde(default)]
     pub insecure_skip_verify: bool,
     /// Certificate and key source for client authentication
+    #[serde(default)]
     pub source: TlsSource,
     /// CA certificate source for verifying server certificates
+    #[serde(default)]
     pub ca_source: CaSource,
     /// Include system CA certificates pool (default: true)
+    #[serde(default = "serde_default_include_system_ca_certs_pool")]
     pub include_system_ca_certs_pool: bool,
     /// TLS version to use: "tls1.2" or "tls1.3" (default: "tls1.3")
+    #[serde(default = "serde_default_tls_version")]
     pub tls_version: String,
 }
 

--- a/crates/slim-bindings/src/common_config.rs
+++ b/crates/slim-bindings/src/common_config.rs
@@ -11,7 +11,7 @@ use slim_config::tls::server::TlsServerConfig as CoreTlsServerConfig;
 use crate::identity_config::{ClientJwtAuth, JwtAuth, StaticJwtAuth};
 
 /// SPIRE configuration for SPIFFE Workload API integration
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SpireConfig {
     /// Path to the SPIFFE Workload API socket (None => use SPIFFE_ENDPOINT_SOCKET env var)
     pub socket_path: Option<String>,
@@ -59,7 +59,8 @@ impl From<slim_config::auth::spire::SpireConfig> for SpireConfig {
 }
 
 /// TLS certificate and key source configuration
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum TlsSource {
     /// Load certificate and key from PEM strings
     Pem { cert: String, key: String },
@@ -68,6 +69,7 @@ pub enum TlsSource {
     /// Load certificate and key from SPIRE Workload API
     Spire { config: SpireConfig },
     /// No certificate/key configured
+    #[default]
     None,
 }
 
@@ -108,7 +110,8 @@ impl From<slim_config::tls::common::TlsSource> for TlsSource {
 }
 
 /// CA certificate source configuration
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum CaSource {
     /// Load CA from file
     File { path: String },
@@ -117,6 +120,7 @@ pub enum CaSource {
     /// Load CA from SPIRE Workload API
     Spire { config: SpireConfig },
     /// No CA configured
+    #[default]
     None,
 }
 
@@ -152,21 +156,35 @@ impl From<slim_config::tls::common::CaSource> for CaSource {
     }
 }
 
+fn serde_default_include_system_ca_certs_pool() -> bool {
+    true
+}
+
+fn serde_default_tls_version() -> String {
+    "tls1.3".to_string()
+}
+
 /// TLS configuration for client connections
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TlsClientConfig {
     /// Disable TLS entirely (plain text connection)
+    #[serde(default)]
     pub insecure: bool,
     /// Skip server certificate verification (enables TLS but doesn't verify certs)
     /// WARNING: Only use for testing - insecure in production!
+    #[serde(default)]
     pub insecure_skip_verify: bool,
     /// Certificate and key source for client authentication
+    #[serde(default)]
     pub source: TlsSource,
     /// CA certificate source for verifying server certificates
+    #[serde(default)]
     pub ca_source: CaSource,
     /// Include system CA certificates pool (default: true)
+    #[serde(default = "serde_default_include_system_ca_certs_pool")]
     pub include_system_ca_certs_pool: bool,
     /// TLS version to use: "tls1.2" or "tls1.3" (default: "tls1.3")
+    #[serde(default = "serde_default_tls_version")]
     pub tls_version: String,
 }
 

--- a/crates/slim-bindings/src/identity_config.rs
+++ b/crates/slim-bindings/src/identity_config.rs
@@ -15,13 +15,18 @@ use std::time::Duration;
 use crate::common_config::SpireConfig;
 use crate::errors::SlimError;
 
+fn default_jwt_duration() -> Duration {
+    Duration::from_secs(3600)
+}
+
 /// Static JWT (Bearer token) authentication configuration
 /// The token is loaded from a file and automatically reloaded when changed
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct StaticJwtAuth {
     /// Path to file containing the JWT token
     pub token_file: String,
     /// Duration for caching the token before re-reading from file (default: 3600 seconds)
+    #[serde(default = "default_jwt_duration", with = "humantime_serde")]
     pub duration: Duration,
 }
 
@@ -41,7 +46,7 @@ impl From<StaticJwtConfig> for StaticJwtAuth {
 }
 
 /// JWT signing/verification algorithm
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum JwtAlgorithm {
     HS256,
     HS384,
@@ -96,7 +101,8 @@ impl From<slim_auth::jwt::Algorithm> for JwtAlgorithm {
 }
 
 /// JWT key format
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum JwtKeyFormat {
     Pem,
     Jwk,
@@ -124,7 +130,8 @@ impl From<slim_auth::jwt::KeyFormat> for JwtKeyFormat {
 }
 
 /// JWT key data source
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum JwtKeyData {
     /// String with encoded key(s)
     Data { value: String },
@@ -151,7 +158,7 @@ impl From<slim_auth::jwt::KeyData> for JwtKeyData {
 }
 
 /// JWT key configuration
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JwtKeyConfig {
     /// Algorithm used for signing/verifying the JWT
     pub algorithm: JwtAlgorithm,
@@ -182,7 +189,7 @@ impl From<slim_auth::jwt::Key> for JwtKeyConfig {
 }
 
 /// JWT key type (encoding, decoding, or autoresolve)
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum JwtKeyType {
     /// Encoding key for signing JWTs (client-side)
     Encoding { key: JwtKeyConfig },
@@ -213,17 +220,21 @@ impl From<JwtKey> for JwtKeyType {
 }
 
 /// JWT authentication configuration for client-side signing
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ClientJwtAuth {
     /// JWT key configuration (encoding key for signing)
     pub key: JwtKeyType,
     /// JWT audience claims to include
+    #[serde(default)]
     pub audience: Option<Vec<String>>,
     /// JWT issuer to include
+    #[serde(default)]
     pub issuer: Option<String>,
     /// JWT subject to include
+    #[serde(default)]
     pub subject: Option<String>,
     /// Token validity duration (default: 3600 seconds)
+    #[serde(default = "default_jwt_duration", with = "humantime_serde")]
     pub duration: Duration,
 }
 
@@ -261,17 +272,21 @@ impl From<JwtAuthConfig> for ClientJwtAuth {
 }
 
 /// JWT authentication configuration for server-side verification
-#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JwtAuth {
     /// JWT key configuration (decoding key for verification)
     pub key: JwtKeyType,
     /// JWT audience claims to verify
+    #[serde(default)]
     pub audience: Option<Vec<String>>,
     /// JWT issuer to verify
+    #[serde(default)]
     pub issuer: Option<String>,
     /// JWT subject to verify
+    #[serde(default)]
     pub subject: Option<String>,
     /// Token validity duration (default: 3600 seconds)
+    #[serde(default = "default_jwt_duration", with = "humantime_serde")]
     pub duration: Duration,
 }
 
@@ -309,10 +324,17 @@ impl From<JwtAuthConfig> for JwtAuth {
 }
 
 /// Identity provider configuration - used to prove identity to others
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(
+    uniffi::Enum, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum IdentityProviderConfig {
     /// Shared secret authentication (symmetric key)
-    SharedSecret { id: String, data: String },
+    SharedSecret {
+        #[serde(default)]
+        id: String,
+        data: String,
+    },
     /// Static JWT loaded from file with auto-reload
     StaticJwt { config: StaticJwtAuth },
     /// Dynamic JWT generation with signing key
@@ -321,6 +343,7 @@ pub enum IdentityProviderConfig {
     #[cfg(not(target_family = "windows"))]
     Spire { config: SpireConfig },
     /// No identity provider configured
+    #[default]
     None,
 }
 
@@ -367,16 +390,24 @@ impl From<CoreIdentityProviderConfig> for IdentityProviderConfig {
 }
 
 /// Identity verifier configuration - used to verify identity of others
-#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+#[derive(
+    uniffi::Enum, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum IdentityVerifierConfig {
     /// Shared secret verification (symmetric key)
-    SharedSecret { id: String, data: String },
+    SharedSecret {
+        #[serde(default)]
+        id: String,
+        data: String,
+    },
     /// JWT verification with decoding key
     Jwt { config: JwtAuth },
     /// SPIRE-based identity verifier (non-Windows only)
     #[cfg(not(target_family = "windows"))]
     Spire { config: SpireConfig },
     /// No identity verifier configured
+    #[default]
     None,
 }
 

--- a/crates/slim-bindings/src/lib.rs
+++ b/crates/slim-bindings/src/lib.rs
@@ -59,6 +59,7 @@ mod persistence;
 mod server_config;
 mod service;
 mod session;
+mod slim_node_config;
 mod transport_protocol;
 
 // Public re-exports
@@ -95,9 +96,10 @@ pub use server_config::{
     KeepaliveServerParameters, ServerConfig, new_insecure_server_config, new_server_config,
 };
 pub use service::{
-    DataplaneConfig, Service, ServiceConfig, create_service, create_service_with_config,
-    new_dataplane_config, new_service_configuration,
+    DataplaneConfig, Service, ServiceConfig, SlimAppHandle, create_service,
+    create_service_with_config, new_dataplane_config, new_service_configuration,
 };
+pub use slim_node_config::{SlimAppConfig, SlimConfig, load_slim_config};
 pub use session::{MlsSettings, Session, SessionConfig, SessionType};
 pub use transport_protocol::TransportProtocol;
 pub use transport_protocol::TransportProtocol as ClientTransportProtocol;

--- a/crates/slim-bindings/src/lib.rs
+++ b/crates/slim-bindings/src/lib.rs
@@ -69,6 +69,8 @@ mod server_config;
 mod service;
 mod session;
 #[cfg(not(feature = "web"))]
+mod slim_node_config;
+#[cfg(not(feature = "web"))]
 mod transport_protocol;
 
 // Public re-exports
@@ -115,9 +117,11 @@ pub use server_config::{
 pub use service::Service;
 #[cfg(not(feature = "web"))]
 pub use service::{
-    DataplaneConfig, ServiceConfig, create_service, create_service_with_config,
+    DataplaneConfig, ServiceConfig, SlimAppHandle, create_service, create_service_with_config,
     new_dataplane_config, new_service_configuration,
 };
+#[cfg(not(feature = "web"))]
+pub use slim_node_config::{SlimAppConfig, SlimConfig, load_slim_config};
 pub use session::{MlsSettings, Session, SessionConfig, SessionType};
 #[cfg(not(feature = "web"))]
 pub use transport_protocol::TransportProtocol;

--- a/crates/slim-bindings/src/message_context.rs
+++ b/crates/slim-bindings/src/message_context.rs
@@ -347,13 +347,15 @@ mod tests {
                     "ns".to_string(),
                     "app".to_string(),
                     "00000000-0000-0000-0000-00000000007b".to_string(),
-                ),
+                )
+                .unwrap(),
                 Some(Name::new_with_id(
                     "org".to_string(),
                     "ns".to_string(),
                     "dest".to_string(),
                     "00000000-0000-0000-0000-000000012345".to_string(),
-                )),
+                )
+                .unwrap()),
                 "application/json".to_string(),
                 std::collections::HashMap::new(),
                 789,

--- a/crates/slim-bindings/src/name.rs
+++ b/crates/slim-bindings/src/name.rs
@@ -86,15 +86,22 @@ impl Name {
         component1: String,
         component2: String,
         id: String,
-    ) -> Self {
-        let id: u128 = NameId::try_from(id)
-            .unwrap_or_else(|_| panic!("invalid ID format: expected UUID string"))
+    ) -> Result<Self, crate::errors::SlimError> {
+        let id_val: u128 = NameId::try_from(id.clone())
+            .map_err(|_| crate::errors::SlimError::InvalidArgument {
+                message: format!("invalid ID format: expected UUID string, got {id:?}"),
+            })?
             .into();
-        if NameId::is_reserved_id(id) {
-            panic!("id {id:#x} is a reserved value and cannot be used as a name id");
+        if NameId::is_reserved_id(id_val) {
+            return Err(crate::errors::SlimError::InvalidArgument {
+                message: format!(
+                    "id {id_val:#x} is a reserved value and cannot be used as a name id"
+                ),
+            });
         }
-        let inner = ProtoName::from_strings([component0, component1, component2]).with_id(id);
-        Name { inner }
+        let inner =
+            ProtoName::from_strings([component0, component1, component2]).with_id(id_val);
+        Ok(Name { inner })
     }
 
     /// Get the name components as a vector of strings
@@ -137,7 +144,8 @@ mod tests {
             "namespace".to_string(),
             "app".to_string(),
             "00000000-0000-0000-0000-000000012345".to_string(),
-        );
+        )
+        .unwrap();
 
         let proto_name: ProtoName = name.into();
         let (c0, c1, c2) = proto_name.str_components();
@@ -197,7 +205,8 @@ mod tests {
             "namespace".to_string(),
             "app".to_string(),
             "00000000-0000-0000-0000-0000000186a0".to_string(),
-        );
+        )
+        .unwrap();
 
         let proto_name: ProtoName = original.clone().into();
         let converted = Name::from(&proto_name);
@@ -218,7 +227,8 @@ mod tests {
             "b".to_string(),
             "c".to_string(),
             "00000000-0000-0000-0000-000000000064".to_string(),
-        );
+        )
+        .unwrap();
         let name2 = name1.clone();
 
         // PartialEq
@@ -230,7 +240,8 @@ mod tests {
             "y".to_string(),
             "z".to_string(),
             "00000000-0000-0000-0000-0000000000c8".to_string(),
-        );
+        )
+        .unwrap();
         assert_ne!(name1, name3);
 
         // Debug
@@ -247,7 +258,8 @@ mod tests {
             "namespace".to_string(),
             "app".to_string(),
             "00000000-0000-0000-0000-00000000007b".to_string(),
-        );
+        )
+        .unwrap();
         let display_str = format!("{name}");
 
         // Should display the ProtoName format
@@ -262,7 +274,8 @@ mod tests {
             "ns".to_string(),
             "app".to_string(),
             "00000000-0000-0000-0000-00000000002a".to_string(),
-        );
+        )
+        .unwrap();
         assert_eq!(
             name_with_id.id(),
             "00000000-0000-0000-0000-00000000002a".to_string()

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-
 use crate::client_config::ClientConfig;
 use crate::errors::SlimError;
 use crate::get_runtime;

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+
 use crate::client_config::ClientConfig;
 use crate::errors::SlimError;
 use crate::get_runtime;
@@ -117,6 +118,21 @@ impl From<&SlimServiceConfiguration> for ServiceConfig {
             dataplane: config.dataplane.clone().into(),
         }
     }
+}
+
+/// The result of [`Service::create_app_from_slim_config`].
+///
+/// Bundles the ready-to-use App with the routing Name and the connection ID
+/// established to the SLIM node, so downstream consumers have everything they
+/// need for sending, subscribing to additional channels, etc.
+#[derive(uniffi::Record)]
+pub struct SlimAppHandle {
+    /// The created, connected, and subscribed App.
+    pub app: Arc<crate::app::App>,
+    /// The fully-qualified routing name (including the persisted instance UUID).
+    pub name: Arc<Name>,
+    /// Connection ID returned by the SLIM node for the active transport connection.
+    pub conn_id: u64,
 }
 
 /// Service wrapper for uniffi bindings
@@ -431,6 +447,47 @@ impl Service {
     ) -> Result<Arc<crate::app::App>, SlimError> {
         get_runtime().block_on(self.create_app_with_secret_async(name, secret))
     }
+
+    /// Create a fully-connected App from hierarchical SLIM configuration (async version).
+    pub async fn create_app_from_slim_config_async(
+        &self,
+        config: crate::slim_node_config::SlimConfig,
+    ) -> Result<SlimAppHandle, SlimError> {
+        // Convert FFI config → core config and delegate to the service crate
+        let core_config = slim_service::node_config::SlimNodeConfig::from(config);
+
+        let handle = self
+            .inner
+            .create_app_from_slim_config(core_config)
+            .await
+            .map_err(|e| SlimError::ConfigError {
+                message: e.to_string(),
+            })?;
+
+        // Wrap the core AppHandle into the FFI App type.
+        // Use app.app_name() — the fully-qualified name with UUID assigned by the
+        // session layer — rather than handle.name which is the base name without UUID.
+        let app = Arc::new(crate::app::App::from_parts(
+            Arc::new(handle.app),
+            Arc::new(tokio::sync::RwLock::new(handle.notification_rx)),
+            self.inner.clone(),
+        ));
+        let name = app.name();
+        Ok(SlimAppHandle {
+            app,
+            name,
+            conn_id: handle.conn_id,
+        })
+    }
+
+    /// Create a fully-connected App from hierarchical SLIM configuration (blocking version).
+    #[uniffi::method]
+    pub fn create_app_from_slim_config(
+        &self,
+        config: crate::slim_node_config::SlimConfig,
+    ) -> Result<SlimAppHandle, SlimError> {
+        get_runtime().block_on(self.create_app_from_slim_config_async(config))
+    }
 }
 
 /// Internal async app creation logic (used by both service and app constructors)
@@ -466,6 +523,28 @@ pub(crate) async fn create_app_async_internal(
     // Validate token
     let _identity_token = identity_provider.get_token()?;
 
+    create_app_from_providers(
+        base_name,
+        identity_provider,
+        identity_verifier,
+        service,
+        direction,
+    )
+    .await
+}
+
+/// Create an App from already-initialized identity providers.
+///
+/// This is the shared implementation that both `create_app_async_internal` (which converts
+/// configs to providers first) and `create_app_from_slim_config_async` (which manages
+/// providers directly for caching) call.
+pub(crate) async fn create_app_from_providers(
+    base_name: SlimName,
+    identity_provider: AuthProvider,
+    identity_verifier: AuthVerifier,
+    service: Arc<SlimService>,
+    direction: crate::app::Direction,
+) -> Result<crate::app::App, SlimError> {
     // Create the app using the provided service
     let (app, rx) = service.create_app_with_direction(
         &base_name,

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use crate::client_config::ClientConfig;
 use crate::errors::SlimError;
 use crate::name::Name;
 use slim_config::component::id::{ID, Kind};
@@ -137,6 +138,21 @@ impl From<&SlimServiceConfiguration> for ServiceConfig {
             dataplane: config.dataplane.clone().into(),
         }
     }
+}
+
+/// The result of [`Service::create_app_from_slim_config`].
+///
+/// Bundles the ready-to-use App with the routing Name and the connection ID
+/// established to the SLIM node, so downstream consumers have everything they
+/// need for sending, subscribing to additional channels, etc.
+#[derive(uniffi::Record)]
+pub struct SlimAppHandle {
+    /// The created, connected, and subscribed App.
+    pub app: Arc<crate::app::App>,
+    /// The fully-qualified routing name (including the persisted instance UUID).
+    pub name: Arc<Name>,
+    /// Connection ID returned by the SLIM node for the active transport connection.
+    pub conn_id: u64,
 }
 
 /// Service wrapper for uniffi bindings
@@ -454,6 +470,47 @@ impl Service {
     ) -> Result<Arc<crate::app::App>, SlimError> {
         get_runtime().block_on(self.create_app_with_secret_async(name, secret))
     }
+
+    /// Create a fully-connected App from hierarchical SLIM configuration (async version).
+    pub async fn create_app_from_slim_config_async(
+        &self,
+        config: crate::slim_node_config::SlimConfig,
+    ) -> Result<SlimAppHandle, SlimError> {
+        // Convert FFI config → core config and delegate to the service crate
+        let core_config = slim_service::node_config::SlimNodeConfig::from(config);
+
+        let handle = self
+            .inner
+            .create_app_from_slim_config(core_config)
+            .await
+            .map_err(|e| SlimError::ConfigError {
+                message: e.to_string(),
+            })?;
+
+        // Wrap the core AppHandle into the FFI App type.
+        // Use app.app_name() — the fully-qualified name with UUID assigned by the
+        // session layer — rather than handle.name which is the base name without UUID.
+        let app = Arc::new(crate::app::App::from_parts(
+            Arc::new(handle.app),
+            Arc::new(tokio::sync::RwLock::new(handle.notification_rx)),
+            self.inner.clone(),
+        ));
+        let name = app.name();
+        Ok(SlimAppHandle {
+            app,
+            name,
+            conn_id: handle.conn_id,
+        })
+    }
+
+    /// Create a fully-connected App from hierarchical SLIM configuration (blocking version).
+    #[uniffi::method]
+    pub fn create_app_from_slim_config(
+        &self,
+        config: crate::slim_node_config::SlimConfig,
+    ) -> Result<SlimAppHandle, SlimError> {
+        get_runtime().block_on(self.create_app_from_slim_config_async(config))
+    }
 }
 
 /// Internal async app creation logic — native only (uses IdentityProviderConfig/IdentityVerifierConfig)
@@ -478,6 +535,28 @@ pub(crate) async fn create_app_async_internal(
     // Validate token
     let _identity_token = identity_provider.get_token()?;
 
+    create_app_from_providers(
+        base_name,
+        identity_provider,
+        identity_verifier,
+        service,
+        direction,
+    )
+    .await
+}
+
+/// Create an App from already-initialized identity providers.
+///
+/// This is the shared implementation that both `create_app_async_internal` (which converts
+/// configs to providers first) and `create_app_from_slim_config_async` (which manages
+/// providers directly for caching) call.
+pub(crate) async fn create_app_from_providers(
+    base_name: SlimName,
+    identity_provider: AuthProvider,
+    identity_verifier: AuthVerifier,
+    service: Arc<SlimService>,
+    direction: crate::app::Direction,
+) -> Result<crate::app::App, SlimError> {
     // Create the app using the provided service
     let (app, rx) = service.create_app_with_direction(
         &base_name,

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use crate::client_config::ClientConfig;
 use crate::errors::SlimError;
 use crate::name::Name;
 use slim_config::component::id::{ID, Kind};

--- a/crates/slim-bindings/src/session.rs
+++ b/crates/slim-bindings/src/session.rs
@@ -1247,7 +1247,7 @@ mod tests {
             "ns".to_string(),
             "dest".to_string(),
             "00000000-0000-0000-0000-000000012345".to_string(),
-        ));
+        ).unwrap());
 
         let mut metadata = HashMap::new();
         metadata.insert("key".to_string(), "value".to_string());

--- a/crates/slim-bindings/src/session.rs
+++ b/crates/slim-bindings/src/session.rs
@@ -1405,7 +1405,7 @@ mod tests {
             "ns".to_string(),
             "dest".to_string(),
             "00000000-0000-0000-0000-000000012345".to_string(),
-        ));
+        ).unwrap());
 
         let mut metadata = HashMap::new();
         metadata.insert("key".to_string(), "value".to_string());

--- a/crates/slim-bindings/src/slim_node_config.rs
+++ b/crates/slim-bindings/src/slim_node_config.rs
@@ -1,0 +1,131 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hierarchical SLIM node configuration discovery (FFI/UniFFI adapter).
+//!
+//! The actual config-loading logic lives in `agntcy-slim-service::node_config`.
+//! This module keeps the UniFFI-exported record types (`SlimConfig`, `SlimAppConfig`)
+//! and a thin `load_slim_config` wrapper that delegates to the core implementation
+//! and converts the result back to FFI types.
+
+use slim_service::node_config as core_node_config;
+
+use crate::client_config::ClientConfig;
+use crate::errors::SlimError;
+use crate::identity_config::{IdentityProviderConfig, IdentityVerifierConfig};
+
+// ============================================================================
+// UniFFI-exported record types
+// ============================================================================
+
+/// App identity settings (from the `app:` section of `slim.yaml`)
+#[derive(uniffi::Record, Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct SlimAppConfig {
+    /// Local agent name in `"org/namespace/app"` format
+    #[serde(default)]
+    pub name: String,
+    /// Identity provider — which credential the app presents to the SLIM node.
+    #[serde(default)]
+    pub identity: IdentityProviderConfig,
+    /// Identity verifier — how the app verifies credentials from the SLIM node.
+    #[serde(default)]
+    pub identity_verifier: IdentityVerifierConfig,
+}
+
+/// Resolved SLIM configuration returned by [`load_slim_config`].
+///
+/// Contains the merged result of all config sources (files + env vars) plus
+/// resolved cache metadata.
+#[derive(
+    uniffi::Record, Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+pub struct SlimConfig {
+    /// Node connection settings
+    #[serde(default)]
+    pub node: ClientConfig,
+    /// App identity settings. Only set when `app.name` is configured.
+    #[serde(default)]
+    pub app: Option<SlimAppConfig>,
+    /// Path of the config file that was used (for debugging / logging).
+    #[serde(skip, default)]
+    pub source_path: Option<String>,
+    /// Cache directory path, derived from the config file location.
+    #[serde(skip, default)]
+    pub cache_dir: Option<String>,
+}
+
+// ============================================================================
+// Conversions between FFI types and core types
+// ============================================================================
+
+fn ffi_app_to_core(app: SlimAppConfig) -> core_node_config::SlimAppConfig {
+    use slim_config::auth::identity::IdentityProviderConfig as CoreIdP;
+    use slim_config::auth::identity::IdentityVerifierConfig as CoreIdV;
+    core_node_config::SlimAppConfig {
+        name: app.name,
+        identity: CoreIdP::from(IdentityProviderConfig::from(app.identity)),
+        identity_verifier: CoreIdV::from(IdentityVerifierConfig::from(app.identity_verifier)),
+    }
+}
+
+fn core_app_to_ffi(app: core_node_config::SlimAppConfig) -> SlimAppConfig {
+    use slim_config::auth::identity::IdentityProviderConfig as CoreIdP;
+    use slim_config::auth::identity::IdentityVerifierConfig as CoreIdV;
+    SlimAppConfig {
+        name: app.name,
+        identity: IdentityProviderConfig::from(CoreIdP::from(app.identity)),
+        identity_verifier: IdentityVerifierConfig::from(CoreIdV::from(app.identity_verifier)),
+    }
+}
+
+impl From<SlimConfig> for core_node_config::SlimNodeConfig {
+    fn from(ffi: SlimConfig) -> Self {
+        core_node_config::SlimNodeConfig {
+            node: ffi.node.into(),
+            app: ffi.app.map(ffi_app_to_core),
+            source_path: ffi.source_path,
+            cache_dir: ffi.cache_dir,
+        }
+    }
+}
+
+impl From<core_node_config::SlimNodeConfig> for SlimConfig {
+    fn from(core: core_node_config::SlimNodeConfig) -> Self {
+        SlimConfig {
+            node: core.node.into(),
+            app: core.app.map(core_app_to_ffi),
+            source_path: core.source_path,
+            cache_dir: core.cache_dir,
+        }
+    }
+}
+
+// ============================================================================
+// Public exported function
+// ============================================================================
+
+/// Load SLIM configuration using hierarchical file discovery plus env var overrides.
+///
+/// Delegates to [`slim_service::node_config::load_slim_node_config`] and converts
+/// the result back to UniFFI-compatible FFI types.
+///
+/// **Search order** (highest priority first):
+/// 1. Environment variables (`SLIM_NODE_ADDRESS`, `SLIM_APP_NAME`,
+///    `SLIM_NODE_CERT_PATH`, `SLIM_IDENTITY_TOKEN`, `SLIM_IDENTITY_SHARED_SECRET`)
+/// 2. `slim.yaml` found by walking up from the current working directory
+/// 3. `~/.slim/config.yaml` as the user-level default
+///
+/// # Errors
+///
+/// Returns [`SlimError::ConfigError`] if no node address could be resolved from
+/// any source, or if a specified config file cannot be read / parsed.
+#[uniffi::export]
+pub fn load_slim_config(config_path: Option<String>) -> Result<SlimConfig, SlimError> {
+    let core_config =
+        core_node_config::load_slim_node_config(config_path.as_deref()).map_err(|e| {
+            SlimError::ConfigError {
+                message: e.to_string(),
+            }
+        })?;
+    Ok(SlimConfig::from(core_config))
+}

--- a/crates/slim-bindings/src/slim_node_config.rs
+++ b/crates/slim-bindings/src/slim_node_config.rs
@@ -63,18 +63,16 @@ fn ffi_app_to_core(app: SlimAppConfig) -> core_node_config::SlimAppConfig {
     use slim_config::auth::identity::IdentityVerifierConfig as CoreIdV;
     core_node_config::SlimAppConfig {
         name: app.name,
-        identity: CoreIdP::from(IdentityProviderConfig::from(app.identity)),
-        identity_verifier: CoreIdV::from(IdentityVerifierConfig::from(app.identity_verifier)),
+        identity: CoreIdP::from(app.identity),
+        identity_verifier: CoreIdV::from(app.identity_verifier),
     }
 }
 
 fn core_app_to_ffi(app: core_node_config::SlimAppConfig) -> SlimAppConfig {
-    use slim_config::auth::identity::IdentityProviderConfig as CoreIdP;
-    use slim_config::auth::identity::IdentityVerifierConfig as CoreIdV;
     SlimAppConfig {
         name: app.name,
-        identity: IdentityProviderConfig::from(CoreIdP::from(app.identity)),
-        identity_verifier: IdentityVerifierConfig::from(CoreIdV::from(app.identity_verifier)),
+        identity: IdentityProviderConfig::from(app.identity),
+        identity_verifier: IdentityVerifierConfig::from(app.identity_verifier),
     }
 }
 

--- a/slim.yaml
+++ b/slim.yaml
@@ -1,0 +1,23 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# slim.yaml — default local development configuration for slim-bindings examples.
+#
+# Run the local SLIM server first:
+#   task run:server
+#
+# Then run the receiver and sender examples:
+#   task run:example:receiver
+#   task run:example:sender ARGS='--session-type p2p --participants agntcy/default/receiver'
+
+node:
+  endpoint: "http://localhost:46357"
+
+app:
+  name: "agntcy/default/receiver"
+  identity:
+    type: shared_secret
+    data: "slim-dev-shared-secret-change-in-production"
+  identity_verifier:
+    type: shared_secret
+    data: "slim-dev-shared-secret-change-in-production"


### PR DESCRIPTION
## Description

This PR ports the hierarchical SLIM configuration loading feature from the [`slim-bindings` PR #21](https://github.com/agntcy/slim-bindings/pull/21) into the SLIM monorepo, and then lifts the core logic into `agntcy-slim-service` so any Rust consumer can use it without the UniFFI layer.

### Commit 1 — `feat(slim-bindings): hierarchical config loading and stable identity`

Adds `crates/slim-bindings/src/slim_node_config.rs` and extends `crates/slim-bindings/src/service.rs` with:
- `SlimConfig` / `SlimAppConfig` UniFFI record types
- `load_slim_config()` — git-style `slim.yaml` discovery + env-var overrides
- `Service::create_app_from_slim_config` — one-call API: load config → init identity → connect → subscribe → return `SlimAppHandle`
- Signature key caching in `.slim-cache/` for stable agent identity across restarts

### Commit 2 — `feat(service): add slim-config feature with hierarchical config loading`

Moves the config-loading logic into `agntcy-slim-service` behind a new `slim-config` Cargo feature, so downstream consumers using core crates directly can benefit:

- New `crates/service/src/node_config.rs` module using core types (`slim_config::client::ClientConfig`, `slim_config::auth::identity::*`)
- `Service::create_app_from_slim_config(&self, config: SlimNodeConfig) -> Result<AppHandle, ServiceError>` (gated on `slim-config + session`)
- `AppHandle` struct bundling app, notification receiver, name, and conn_id
- `#[serde(default)]` added to `IdentityProviderConfig::SharedSecret::id` so the field is optional in YAML
- `slim-bindings` refactored to delegate to the service crate — `load_slim_config` and `create_app_from_slim_config` are now thin FFI adapters

## Type of Change

- [x] New Feature
- [x] Refactor

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass