### PR TITLE
chore(docs): update Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ It should be considered a map to help you navigate the process.
 The [Discord community][dev] is available for any concerns not covered in this guide,
 please join us!
 
-[dev]: https://discord.gg/nbeEENusy
+[dev]: https://discord.gg/FbEnSHXD34
 
 ## Contributing in Issues
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ task lint
 
 - 📚 [Documentation](https://docs.agntcy.org/slim/overview)
 - 📖 [IETF Specification](https://datatracker.ietf.org/doc/draft-slim-protocol/)
-- 💬 [Discord Community](https://discord.gg/nbeEENusy)
+- 💬 [Discord Community](https://discord.gg/FbEnSHXD34)
 - 🎥 [YouTube Channel](https://www.youtube.com/@agntcy-lf)
 
 ## License

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -25,7 +25,7 @@ infrastructure for open, vendor-neutral agent communication.
 
 Stay involved with the AGNTCY community and SLIM contributors:
 
-- **[AGNTCY Discord server](https://discord.gg/nbeEENusy)** — chat with maintainers and contributors
+- **[AGNTCY Discord server](https://discord.gg/FbEnSHXD34)** — chat with maintainers and contributors
 - **[AGNTCY Meeting Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/agntcy?view=week)** — working group and community meetings
 - **[AGNTCY on GitHub](https://github.com/agntcy)** — organization home for all IoA projects
 - **[AGNTCY Blogs](https://blogs.agntcy.org/)** — announcements, tutorials, and project updates

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -199,7 +199,7 @@ hide:
   <div class="slim-community-social">
     <a
       class="slim-community-card"
-      href="https://discord.gg/nbeEENusy"
+      href="https://discord.gg/FbEnSHXD34"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/docs/content/slim/slim-howto.md
+++ b/docs/content/slim/slim-howto.md
@@ -429,8 +429,8 @@ You've installed SLIM! Here's what to do next:
 1. Read the [messaging layer documentation](./slim-data-plane.md)
 2. Explore the [example applications](https://github.com/agntcy/slim-bindings)
 3. Learn about [configuration options](./slim-data-plane-config.md)
-4. Join us on [Discord](https://discord.gg/nbeEENusy)
+4. Join us on [Discord](https://discord.gg/FbEnSHXD34)
 
 ## Need Help?
 
-If you get stuck, check the [detailed documentation](../index.md), ask questions in our [Discord community](https://discord.gg/nbeEENusy), or report issues on [GitHub](https://github.com/agntcy/slim).
+If you get stuck, check the [detailed documentation](../index.md), ask questions in our [Discord community](https://discord.gg/FbEnSHXD34), or report issues on [GitHub](https://github.com/agntcy/slim).


### PR DESCRIPTION
Updates the AGNTCY Discord invite URL across documentation and README.

- old: https://discord.gg/nbeEENusy
- new: https://discord.gg/FbEnSHXD34