### PR TITLE
chore/add slim missing contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,7 @@ Copyright AGNTCY Contributors (https://github.com/agntcy)
 SPDX-License-Identifier: Apache-2.0
 
 1. Cisco Systems Inc.
+2. Oracle Corp.
+3. Dell Inc.
+4. SourceFuse
+5. Infosys


### PR DESCRIPTION
- **docs: restrict contributors file to actual copyright-holding employers**
- **docs: map manual contributors to git history for slim**
