### PR TITLE
fix: stream types export async interfaces

### DIFF
--- a/crates/rpc/src/ffi.rs
+++ b/crates/rpc/src/ffi.rs
@@ -20,13 +20,10 @@ use slim_datapath::api::ProtoName as Name;
 
 use crate::{
     BidiStreamHandler, Channel, Context, DecodedStream, Metadata, MulticastBidiStreamHandler,
-    MulticastResponseReader, MulticastStreamMessage, RequestStreamWriter, ResponseSink,
-    ResponseStreamReader, RpcError, Server, StreamMessage, StreamStreamHandler, StreamUnaryHandler,
-    UnaryStreamHandler, UnaryUnaryHandler, UniffiRequestStream,
+    MulticastResponseReader, RequestStreamWriter, ResponseSink, ResponseStreamReader, RpcError,
+    Server, StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler,
+    UniffiRequestStream,
 };
-// `RequestStream` is re-exported from the crate root under the alias
-// `UniffiRequestStream`; import the real name for the inherent impl below.
-use crate::stream_types::RequestStream;
 
 // ── Channel: FFI constructors ───────────────────────────────────────────────
 
@@ -555,115 +552,5 @@ impl Server {
                 }
             },
         );
-    }
-}
-
-// ── Stream types: blocking FFI wrappers ─────────────────────────────
-
-#[uniffi::export]
-impl RequestStream {
-    /// Pull the next message from the stream (blocking version)
-    ///
-    /// Returns a StreamMessage indicating the result
-    pub fn next(&self) -> StreamMessage {
-        crate::get_runtime().block_on(self.next_async())
-    }
-}
-
-#[uniffi::export]
-impl ResponseSink {
-    /// Send a message to the response stream (blocking version)
-    ///
-    /// Returns an error if the stream has been closed or if sending fails.
-    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.send_async(data))
-    }
-
-    /// Send an error to the response stream and close it (blocking version)
-    ///
-    /// This terminates the stream with an error status.
-    pub fn send_error(&self, error: RpcError) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.send_error_async(error))
-    }
-
-    /// Close the response stream (blocking version)
-    ///
-    /// Signals that no more messages will be sent.
-    /// The stream will end gracefully.
-    pub fn close(&self) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.close_async())
-    }
-
-    /// Check if the sink has been closed (blocking version)
-    pub fn is_closed(&self) -> bool {
-        crate::get_runtime().block_on(self.is_closed_async())
-    }
-}
-
-#[uniffi::export]
-impl ResponseStreamReader {
-    /// Pull the next message from the response stream (blocking version)
-    ///
-    /// Returns a StreamMessage indicating the result
-    pub fn next(&self) -> StreamMessage {
-        crate::get_runtime().block_on(self.next_async())
-    }
-}
-
-#[uniffi::export]
-impl RequestStreamWriter {
-    /// Send a request message to the stream (blocking version)
-    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.send_async(data))
-    }
-
-    /// Finalize the stream and get the response (blocking version)
-    pub fn finalize_stream(&self) -> Result<Vec<u8>, RpcError> {
-        crate::get_runtime().block_on(self.finalize_stream_async())
-    }
-}
-
-#[uniffi::export]
-impl BidiStreamHandler {
-    /// Send a request message to the stream (blocking version)
-    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.send_async(data))
-    }
-
-    /// Close the request stream (no more messages will be sent)
-    pub fn close_send(&self) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.close_send_async())
-    }
-
-    /// Receive the next response message (blocking version)
-    pub fn recv(&self) -> StreamMessage {
-        crate::get_runtime().block_on(self.recv_async())
-    }
-}
-
-#[uniffi::export]
-impl MulticastResponseReader {
-    /// Pull the next item from the multicast response stream (blocking).
-    pub fn next(&self) -> MulticastStreamMessage {
-        crate::get_runtime().block_on(self.next_async())
-    }
-}
-
-#[uniffi::export]
-impl MulticastBidiStreamHandler {
-    /// Send a request message to the stream (blocking).
-    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.send_async(data))
-    }
-
-    /// Close the request stream — signals that no more messages will be sent
-    /// (blocking).
-    pub fn close_send(&self) -> Result<(), RpcError> {
-        crate::get_runtime().block_on(self.close_send_async())
-    }
-
-    /// Receive the next response item (blocking).
-    pub fn recv(&self) -> MulticastStreamMessage {
-        crate::get_runtime().block_on(self.recv_async())
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -133,6 +133,7 @@ mod server;
 mod session_wrapper;
 
 // UniFFI-specific modules
+#[cfg(feature = "uniffi")]
 mod handler_traits;
 mod stream_types;
 
@@ -153,19 +154,13 @@ pub use slim_bindings::get_runtime;
 /// Native builds spawn onto the ambient tokio runtime (the caller is always
 /// inside one). The `uniffi` build spawns onto the runtime owned by
 /// `agntcy-slim-bindings`, because FFI callers have no ambient runtime.
+#[cfg(feature = "uniffi")]
 pub(crate) fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
 where
     F: std::future::Future + Send + 'static,
     F::Output: Send + 'static,
 {
-    #[cfg(feature = "uniffi")]
-    {
-        get_runtime().spawn(future)
-    }
-    #[cfg(not(feature = "uniffi"))]
-    {
-        tokio::spawn(future)
-    }
+    get_runtime().spawn(future)
 }
 
 pub use channel::{Channel, MessageContext, MulticastItem};
@@ -178,15 +173,20 @@ pub use rpc_session::{
 pub use server::{HandlerType, RpcHandler, Server, StreamRpcHandler};
 pub use session_wrapper::{ReceivedMessage, SessionRx, SessionTx, new_session};
 
-// UniFFI handler traits and stream types
+// Native/shared stream types.
+pub use stream_types::{DecodedStream, RawStream, StreamSource};
+
+// UniFFI handler traits and FFI stream wrapper types (compiled only under the
+// `uniffi` feature).
+#[cfg(feature = "uniffi")]
 pub use handler_traits::{
     StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler,
 };
+#[cfg(feature = "uniffi")]
 pub use stream_types::{
-    BidiStreamHandler, DecodedStream, MulticastBidiStreamHandler, MulticastResponseReader,
-    MulticastStreamMessage, RawStream, RequestStream as UniffiRequestStream, RequestStreamWriter,
-    ResponseSink, ResponseStreamReader, RpcMessageContext, RpcMulticastItem, StreamMessage,
-    StreamSource,
+    BidiStreamHandler, MulticastBidiStreamHandler, MulticastResponseReader, MulticastStreamMessage,
+    RequestStream as UniffiRequestStream, RequestStreamWriter, ResponseSink, ResponseStreamReader,
+    RpcMessageContext, RpcMulticastItem, StreamMessage,
 };
 
 /// Key used in metadata for RPC deadline/timeout

--- a/crates/rpc/src/stream_types.rs
+++ b/crates/rpc/src/stream_types.rs
@@ -176,6 +176,7 @@ impl RequestStream {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl RequestStream {
     /// Pull the next message from the stream (async version)
     ///
@@ -228,6 +229,7 @@ impl ResponseSink {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl ResponseSink {
     /// Send a message to the response stream (async version)
     ///
@@ -295,6 +297,7 @@ impl ResponseStreamReader {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl ResponseStreamReader {
     /// Pull the next message from the response stream (async version)
     ///
@@ -360,6 +363,7 @@ impl RequestStreamWriter {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl RequestStreamWriter {
     /// Send a request message to the stream (async version)
     pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
@@ -461,6 +465,7 @@ impl BidiStreamHandler {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl BidiStreamHandler {
     /// Send a request message to the stream (async version)
     pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
@@ -570,6 +575,7 @@ impl MulticastResponseReader {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl MulticastResponseReader {
     /// Pull the next item from the multicast response stream (async).
     pub async fn next_async(&self) -> MulticastStreamMessage {
@@ -639,6 +645,7 @@ impl MulticastBidiStreamHandler {
     }
 }
 
+#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl MulticastBidiStreamHandler {
     /// Send a request message to the stream (async).
     pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {

--- a/crates/rpc/src/stream_types.rs
+++ b/crates/rpc/src/stream_types.rs
@@ -7,26 +7,37 @@
 //! Since UniFFI doesn't support Rust async streams, we provide synchronous
 //! pull/push interfaces backed by async channels.
 
-#[cfg(not(feature = "uniffi"))]
-use slim_datapath::api::ProtoName as Name;
 use std::pin::Pin;
 use std::task::Poll;
 
+use tokio::sync::mpsc;
+
+use super::{ReceivedMessage, RpcCode, RpcError, STATUS_CODE_KEY};
+
+// The UniFFI FFI stream wrapper types below use these; the native raw stream
+// (`RawStream`/`StreamSource`/`DecodedStream`) does not.
+#[cfg(feature = "uniffi")]
+use super::{Channel, MulticastItem};
+#[cfg(feature = "uniffi")]
 use futures::StreamExt;
+#[cfg(feature = "uniffi")]
 use parking_lot::Mutex;
+#[cfg(feature = "uniffi")]
 use std::sync::Arc;
+#[cfg(feature = "uniffi")]
 use tokio::sync::{
     Mutex as TokioMutex,
-    mpsc::{self, UnboundedReceiver, UnboundedSender, unbounded_channel},
+    mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
 };
 
-use super::{Channel, MulticastItem, ReceivedMessage, RpcCode, RpcError, STATUS_CODE_KEY};
-
 /// Result type for raw byte payloads flowing through the RPC streams.
+#[cfg(feature = "uniffi")]
 type RpcBytesResult = Result<Vec<u8>, RpcError>;
 /// Sender end of a channel carrying RPC byte results.
+#[cfg(feature = "uniffi")]
 type RpcBytesSender = UnboundedSender<RpcBytesResult>;
 /// Tokio JoinHandle producing a final RPC byte result.
+#[cfg(feature = "uniffi")]
 type RpcBytesJoinHandle = tokio::task::JoinHandle<RpcBytesResult>;
 
 /// Raw byte stream for a stream-input RPC call.
@@ -156,6 +167,7 @@ impl StreamSource {
     }
 }
 
+#[cfg(feature = "uniffi")]
 /// Request stream reader
 ///
 /// Allows pulling messages from a client request stream.
@@ -167,6 +179,7 @@ pub struct RequestStream {
     inner: TokioMutex<DecodedStream<Vec<u8>>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl RequestStream {
     /// Create a new request stream wrapper
     pub fn new(stream: DecodedStream<Vec<u8>>) -> Self {
@@ -199,6 +212,7 @@ impl RequestStream {
     }
 }
 
+#[cfg(feature = "uniffi")]
 /// Message from a stream
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum StreamMessage {
@@ -210,6 +224,7 @@ pub enum StreamMessage {
     End,
 }
 
+#[cfg(feature = "uniffi")]
 /// Response stream writer
 ///
 /// Allows pushing messages to a client response stream.
@@ -221,6 +236,7 @@ pub struct ResponseSink {
     sender: Mutex<Option<RpcBytesSender>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl ResponseSink {
     /// Create a new response sink wrapper
     pub fn new(sender: UnboundedSender<Result<Vec<u8>, RpcError>>) -> Self {
@@ -315,6 +331,7 @@ impl ResponseSink {
     }
 }
 
+#[cfg(feature = "uniffi")]
 /// Response stream reader for unary-to-stream RPC calls
 ///
 /// Allows pulling messages from a server response stream one at a time.
@@ -324,6 +341,7 @@ pub struct ResponseStreamReader {
     inner: TokioMutex<UnboundedReceiver<Result<Vec<u8>, RpcError>>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl ResponseStreamReader {
     /// Create a new response stream reader
     pub fn new(rx: UnboundedReceiver<Result<Vec<u8>, RpcError>>) -> Self {
@@ -356,6 +374,7 @@ impl ResponseStreamReader {
     }
 }
 
+#[cfg(feature = "uniffi")]
 /// Request stream writer for stream-to-unary RPC calls
 ///
 /// Allows sending multiple request messages and getting a final response.
@@ -365,6 +384,7 @@ pub struct RequestStreamWriter {
     response: TokioMutex<Option<RpcBytesJoinHandle>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl RequestStreamWriter {
     pub fn new(
         channel: Channel,
@@ -468,6 +488,7 @@ impl RequestStreamWriter {
     }
 }
 
+#[cfg(feature = "uniffi")]
 /// Bidirectional stream handler for stream-to-stream RPC calls
 ///
 /// Allows sending and receiving messages concurrently.
@@ -477,6 +498,7 @@ pub struct BidiStreamHandler {
     receiver: TokioMutex<UnboundedReceiver<Result<Vec<u8>, RpcError>>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl BidiStreamHandler {
     pub fn new(
         channel: Channel,
@@ -573,6 +595,7 @@ impl BidiStreamHandler {
 
 // ── Multicast stream types ────────────────────────────────────────────────────
 
+#[cfg(feature = "uniffi")]
 /// Per-message context for a multicast RPC response — identifies which group
 /// member sent the response.
 #[derive(Clone, Debug)]
@@ -586,6 +609,7 @@ pub struct RpcMessageContext {
     pub source: Arc<slim_bindings::Name>,
 }
 
+#[cfg(feature = "uniffi")]
 /// A single item in a multicast response stream, pairing the response payload
 /// with the identity of the member that produced it.
 #[derive(Clone, Debug)]
@@ -597,6 +621,7 @@ pub struct RpcMulticastItem {
     pub message: Vec<u8>,
 }
 
+#[cfg(feature = "uniffi")]
 /// Message from a multicast response stream.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum MulticastStreamMessage {
@@ -608,6 +633,7 @@ pub enum MulticastStreamMessage {
     End,
 }
 
+#[cfg(feature = "uniffi")]
 /// Response stream reader for multicast RPC calls.
 ///
 /// Allows pulling `RpcMulticastItem`s from a GROUP response stream one at a
@@ -617,6 +643,7 @@ pub struct MulticastResponseReader {
     inner: TokioMutex<UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl MulticastResponseReader {
     /// Create a new reader backed by the given mpsc receiver.
     pub fn new(rx: UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>) -> Self {
@@ -665,6 +692,7 @@ impl MulticastResponseReader {
     }
 }
 
+#[cfg(feature = "uniffi")]
 /// Bidirectional stream handler for multicast stream-to-unary and
 /// stream-to-stream RPC calls.
 ///
@@ -678,6 +706,7 @@ pub struct MulticastBidiStreamHandler {
     receiver: TokioMutex<UnboundedReceiver<Result<MulticastItem<Vec<u8>>, RpcError>>>,
 }
 
+#[cfg(feature = "uniffi")]
 impl MulticastBidiStreamHandler {
     /// Create a new handler that pipes a request stream through a multicast
     /// `stream_stream` call on `channel`.
@@ -773,7 +802,9 @@ impl MulticastBidiStreamHandler {
     }
 }
 
-#[cfg(test)]
+// These tests exercise the UniFFI stream wrapper types (`RequestStream`,
+// `ResponseSink`, …), which are compiled only under the `uniffi` feature.
+#[cfg(all(test, feature = "uniffi"))]
 mod tests {
     use super::*;
 

--- a/crates/rpc/src/stream_types.rs
+++ b/crates/rpc/src/stream_types.rs
@@ -176,8 +176,16 @@ impl RequestStream {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl RequestStream {
+    /// Pull the next message from the stream (blocking version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub fn next(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
     /// Pull the next message from the stream (async version)
     ///
     /// Returns a StreamMessage indicating the result
@@ -229,8 +237,36 @@ impl ResponseSink {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl ResponseSink {
+    /// Send a message to the response stream (blocking version)
+    ///
+    /// Returns an error if the stream has been closed or if sending fails.
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Send an error to the response stream and close it (blocking version)
+    ///
+    /// This terminates the stream with an error status.
+    pub fn send_error(&self, error: RpcError) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_error_async(error))
+    }
+
+    /// Close the response stream (blocking version)
+    ///
+    /// Signals that no more messages will be sent.
+    /// The stream will end gracefully.
+    pub fn close(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_async())
+    }
+
+    /// Check if the sink has been closed (blocking version)
+    pub fn is_closed(&self) -> bool {
+        crate::get_runtime().block_on(self.is_closed_async())
+    }
+
     /// Send a message to the response stream (async version)
     ///
     /// Returns an error if the stream has been closed or if sending fails.
@@ -297,8 +333,16 @@ impl ResponseStreamReader {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl ResponseStreamReader {
+    /// Pull the next message from the response stream (blocking version)
+    ///
+    /// Returns a StreamMessage indicating the result
+    pub fn next(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
     /// Pull the next message from the response stream (async version)
     ///
     /// Returns a StreamMessage indicating the result
@@ -363,8 +407,19 @@ impl RequestStreamWriter {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl RequestStreamWriter {
+    /// Send a request message to the stream (blocking version)
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Finalize the stream and get the response (blocking version)
+    pub fn finalize_stream(&self) -> Result<Vec<u8>, RpcError> {
+        crate::get_runtime().block_on(self.finalize_stream_async())
+    }
+
     /// Send a request message to the stream (async version)
     pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
         let sender = self.sender.lock().await;
@@ -402,7 +457,8 @@ impl RequestStreamWriter {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl RequestStreamWriter {
     /// Finalize the stream and get the response (async version)
     ///
@@ -465,8 +521,24 @@ impl BidiStreamHandler {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl BidiStreamHandler {
+    /// Send a request message to the stream (blocking version)
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Close the request stream (no more messages will be sent)
+    pub fn close_send(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_send_async())
+    }
+
+    /// Receive the next response message (blocking version)
+    pub fn recv(&self) -> StreamMessage {
+        crate::get_runtime().block_on(self.recv_async())
+    }
+
     /// Send a request message to the stream (async version)
     pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
         let sender = self.sender.lock().await;
@@ -575,8 +647,14 @@ impl MulticastResponseReader {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl MulticastResponseReader {
+    /// Pull the next item from the multicast response stream (blocking).
+    pub fn next(&self) -> MulticastStreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
     /// Pull the next item from the multicast response stream (async).
     pub async fn next_async(&self) -> MulticastStreamMessage {
         let mut rx = self.inner.lock().await;
@@ -645,8 +723,25 @@ impl MulticastBidiStreamHandler {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
 impl MulticastBidiStreamHandler {
+    /// Send a request message to the stream (blocking).
+    pub fn send(&self, data: Vec<u8>) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.send_async(data))
+    }
+
+    /// Close the request stream — signals that no more messages will be sent
+    /// (blocking).
+    pub fn close_send(&self) -> Result<(), RpcError> {
+        crate::get_runtime().block_on(self.close_send_async())
+    }
+
+    /// Receive the next response item (blocking).
+    pub fn recv(&self) -> MulticastStreamMessage {
+        crate::get_runtime().block_on(self.recv_async())
+    }
+
     /// Send a request message to the stream (async).
     pub async fn send_async(&self, data: Vec<u8>) -> Result<(), RpcError> {
         let sender = self.sender.lock().await;


### PR DESCRIPTION
# Description

Include UniFFI export of async interfaces of stream_types.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
