### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.8"
+version = "2.0.0-alpha.9"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.6"
+version = "0.16.7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -513,11 +513,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,23 +40,23 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.6" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.13.1" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.8" }
-agntcy-slim-config = { path = "crates/config", version = "0.12.5" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.6" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.11.4" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.6" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.2.5" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.3.4" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.6" }
-agntcy-slim-service = { path = "crates/service", version = "0.11.5", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.5.5" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.14" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.7" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.13.2" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.9" }
+agntcy-slim-config = { path = "crates/config", version = "0.12.6" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.7" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.11.5" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.7" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.2.6" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.4.0" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.7" }
+agntcy-slim-service = { path = "crates/service", version = "0.11.6", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.6.0" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.15" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.7" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.6" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.6" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.8" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.7" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.7" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -218,7 +218,7 @@ wiremock = "0.6"
 x25519-dalek = { version = "2", default-features = false, features = ["static_secrets"] }
 
 [workspace.package]
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2](https://github.com/agntcy/slim/compare/slim-auth-v0.13.1...slim-auth-v0.13.2) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.13.1](https://github.com/agntcy/slim/compare/slim-auth-v0.13.0...slim-auth-v0.13.1) - 2026-07-20
 
 ### Fixed

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.13.1"
+version = "0.13.2"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6](https://github.com/agntcy/slim/compare/slim-config-v0.12.5...slim-config-v0.12.6) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.12.5](https://github.com/agntcy/slim/compare/slim-config-v0.12.4...slim-config-v0.12.5) - 2026-07-20
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.12.5"
+version = "0.12.6"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/agntcy/slim/compare/slim-controller-v0.11.4...slim-controller-v0.11.5) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-proto, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-signal
+
 ## [0.11.4](https://github.com/agntcy/slim/compare/slim-controller-v0.11.3...slim-controller-v0.11.4) - 2026-07-20
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.11.4"
+version = "0.11.5"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.7](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.6...slim-datapath-v0.16.7) - 2026-07-20
+
+### Added
+
+- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
+- *(session)* Heartbeat-Based Disconnection Detection with Epoch ([#1868](https://github.com/agntcy/slim/pull/1868))
+
 ## [0.16.6](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.5...slim-datapath-v0.16.6) - 2026-07-20
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.16.6"
+version = "0.16.7"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/agntcy/slim/compare/slim-mls-v0.2.5...slim-mls-v0.2.6) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.2.5](https://github.com/agntcy/slim/compare/slim-mls-v0.2.4...slim-mls-v0.2.5) - 2026-07-20
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.5"
+version = "0.2.6"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/agntcy/slim/compare/slim-proto-v0.3.4...slim-proto-v0.4.0) - 2026-07-20
+
+### Added
+
+- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
+- *(session)* Heartbeat-Based Disconnection Detection with Epoch ([#1868](https://github.com/agntcy/slim/pull/1868))
+
 ## [0.3.4](https://github.com/agntcy/slim/compare/slim-proto-v0.3.3...slim-proto-v0.3.4) - 2026-07-20
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.6](https://github.com/agntcy/slim/compare/slim-service-v0.11.5...slim-service-v0.11.6) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-mls, agntcy-slim-controller
+
 ## [0.11.5](https://github.com/agntcy/slim/compare/slim-service-v0.11.4...slim-service-v0.11.5) - 2026-07-20
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.11.5"
+version = "0.11.6"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/agntcy/slim/compare/slim-session-v0.5.5...slim-session-v0.6.0) - 2026-07-20
+
+### Added
+
+- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
+- *(session)* Heartbeat-Based Disconnection Detection with Epoch ([#1868](https://github.com/agntcy/slim/pull/1868))
+
 ## [0.5.5](https://github.com/agntcy/slim/compare/slim-session-v0.5.4...slim-session-v0.5.5) - 2026-07-20
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.5"
+version = "0.6.0"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/agntcy/slim/compare/slim-signal-v0.1.14...slim-signal-v0.1.15) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.14](https://github.com/agntcy/slim/compare/slim-signal-v0.1.13...slim-signal-v0.1.14) - 2026-07-20
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.14"
+version = "0.1.15"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.9](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.8...slim-bindings-v2.0.0-alpha.9) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-signal, agntcy-slim-controller, agntcy-slim-service
+
 ## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.7...slim-bindings-v2.0.0-alpha.8) - 2026-07-20
 
 ### Other

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.8"
+version = "2.0.0-alpha.9"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.7](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.6...slimctl-v2.0.0-alpha.7) - 2026-07-20
+
+### Added
+
+- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
+
 ## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.4...slimctl-v2.0.0-alpha.5) - 2026-07-16
 
 ### Other

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.7...slim-tracing-v0.4.8) - 2026-07-20
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.7](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.6...slim-tracing-v0.4.7) - 2026-07-20
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.7"
+version = "0.4.8"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.6 -> 2.0.0-alpha.7
* `agntcy-slim-proto`: 0.3.4 -> 0.4.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.16.6 -> 0.16.7 (✓ API compatible changes)
* `agntcy-slim-session`: 0.5.5 -> 0.6.0 (⚠ API breaking changes)
* `agntcy-slim`: 2.0.0-alpha.6 -> 2.0.0-alpha.7
* `agntcy-slim-channel-manager`: 2.0.0-alpha.6 -> 2.0.0-alpha.7
* `agntcy-slim-control-plane`: 2.0.0-alpha.6 -> 2.0.0-alpha.7
* `agntcy-slim-rpc`: 2.0.0-alpha.6 -> 2.0.0-alpha.7
* `agntcy-slimctl`: 2.0.0-alpha.6 -> 2.0.0-alpha.7
* `agntcy-slim-auth`: 0.13.1 -> 0.13.2
* `agntcy-slim-config`: 0.12.5 -> 0.12.6
* `agntcy-slim-tracing`: 0.4.7 -> 0.4.8
* `agntcy-slim-mls`: 0.2.5 -> 0.2.6
* `agntcy-slim-signal`: 0.1.14 -> 0.1.15
* `agntcy-slim-controller`: 0.11.4 -> 0.11.5
* `agntcy-slim-service`: 0.11.5 -> 0.11.6
* `agntcy-slim-bindings`: 2.0.0-alpha.8 -> 2.0.0-alpha.9

### ⚠ `agntcy-slim-proto` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionMessageType:Heartbeat in /tmp/.tmpcA360K/slim/crates/proto/src/gen/dataplane.proto.v1.rs:508
  variant SessionMessageType:UpdateParticipantState in /tmp/.tmpcA360K/slim/crates/proto/src/gen/dataplane.proto.v1.rs:509
  variant CommandPayloadType:Heartbeat in /tmp/.tmpcA360K/slim/crates/proto/src/gen/dataplane.proto.v1.rs:213
  variant CommandPayloadType:UpdateParticipantState in /tmp/.tmpcA360K/slim/crates/proto/src/gen/dataplane.proto.v1.rs:215

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CommandPayloadType::Ping, previously in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:213
  variant SessionMessageType::Ping, previously in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:488

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  CommandPayloadBuilder::ping, previously in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/impls.rs:1474
  CommandPayload::as_ping_payload, previously in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/impls.rs:1288
  Message::extract_ping, previously in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/impls.rs:1206

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DISCONNECTION_DETECTED in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/impls.rs:62

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct agntcy_slim_proto::dataplane::proto::v1::PingPayload, previously in file /tmp/.tmpfTDqea/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:388
```

### ⚠ `agntcy-slim-session` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionError:MissingNewParticipantInGroupAdd in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:33
  variant SessionError:CannotCloseP2P in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:109
  variant SessionError:CannotRejoinP2P in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:111
  variant SessionError:ParticipantOffLine in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:135
  variant SessionError:RejoinFailed in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:137
  variant SessionError:StatusChangeInProgress in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:139
  variant SessionError:MissingNewParticipantInGroupAdd in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:33
  variant SessionError:CannotCloseP2P in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:109
  variant SessionError:CannotRejoinP2P in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:111
  variant SessionError:ParticipantOffLine in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:135
  variant SessionError:RejoinFailed in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:137
  variant SessionError:StatusChangeInProgress in /tmp/.tmpcA360K/slim/crates/session/src/errors.rs:139

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant SessionError::PingStateNotInitialized, previously in file /tmp/.tmpfTDqea/agntcy-slim-session/src/errors.rs:35
  variant SessionError::PingStateNotInitialized, previously in file /tmp/.tmpfTDqea/agntcy-slim-session/src/errors.rs:35

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  PING_INTERVAL in file /tmp/.tmpfTDqea/agntcy-slim-session/src/controller_sender.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.4.0](https://github.com/agntcy/slim/compare/slim-proto-v0.3.4...slim-proto-v0.4.0) - 2026-07-20

### Added

- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
- *(session)* Heartbeat-Based Disconnection Detection with Epoch ([#1868](https://github.com/agntcy/slim/pull/1868))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.16.7](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.6...slim-datapath-v0.16.7) - 2026-07-20

### Added

- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
- *(session)* Heartbeat-Based Disconnection Detection with Epoch ([#1868](https://github.com/agntcy/slim/pull/1868))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.6.0](https://github.com/agntcy/slim/compare/slim-session-v0.5.5...slim-session-v0.6.0) - 2026-07-20

### Added

- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
- *(session)* Heartbeat-Based Disconnection Detection with Epoch ([#1868](https://github.com/agntcy/slim/pull/1868))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.4...slim-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-service
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.4...slim-channel-manager-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.4...slim-control-plane-v2.0.0-alpha.5) - 2026-07-16

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-service
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.6](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.5...slim-rpc-v2.0.0-alpha.6) - 2026-07-20

### Fixed

- stream types export async interfaces ([#1880](https://github.com/agntcy/slim/pull/1880))

### Other

- remove slimrpc from bindings ([#1864](https://github.com/agntcy/slim/pull/1864))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.7](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.6...slimctl-v2.0.0-alpha.7) - 2026-07-20

### Added

- *(session)* add close and rejoin functions ([#1873](https://github.com/agntcy/slim/pull/1873))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.13.2](https://github.com/agntcy/slim/compare/slim-auth-v0.13.1...slim-auth-v0.13.2) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.12.6](https://github.com/agntcy/slim/compare/slim-config-v0.12.5...slim-config-v0.12.6) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.8](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.7...slim-tracing-v0.4.8) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.2.6](https://github.com/agntcy/slim/compare/slim-mls-v0.2.5...slim-mls-v0.2.6) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.15](https://github.com/agntcy/slim/compare/slim-signal-v0.1.14...slim-signal-v0.1.15) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.11.5](https://github.com/agntcy/slim/compare/slim-controller-v0.11.4...slim-controller-v0.11.5) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-proto, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.11.6](https://github.com/agntcy/slim/compare/slim-service-v0.11.5...slim-service-v0.11.6) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-mls, agntcy-slim-controller
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.9](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.8...slim-bindings-v2.0.0-alpha.9) - 2026-07-20

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-signal, agntcy-slim-controller, agntcy-slim-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).