### PR TITLE
fix(auth): verify JWT against every JWKS candidate key when no `kid` is present

### DIFF
--- a/crates/auth/src/jwt.rs
+++ b/crates/auth/src/jwt.rs
@@ -347,8 +347,12 @@ impl<S> Jwt<S> {
             .as_ref()
             .ok_or(AuthError::JwtMissingPrivateKey)?;
 
-        // Create the JWT header
-        let header = JwtHeader::new(self.validation.algorithms[0]);
+        // Create the JWT header, stamping `kid = sub` so verifiers can select the
+        // right key in O(1) from a multi-key JWKS instead of trying each. `sub` is
+        // this identity's stable id (its DID in a did:key mesh); the matching JWKS
+        // entry is expected to carry the same `kid`.
+        let mut header = JwtHeader::new(self.validation.algorithms[0]);
+        header.kid = self.claims.sub.clone();
 
         // Encode the claims into a JWT token (use #[from] JwtError for propagation)
         let token = encode(&header, claims, &encoding_key.read())?;
@@ -386,6 +390,17 @@ impl<P> Jwt<P> {
 #[derive(Clone)]
 pub struct V {}
 
+/// True if `err` is specifically a signature-verification failure, i.e. the token
+/// was checked against the wrong key. Used to decide whether to try the next
+/// candidate key in a multi-key JWKS; any other error is terminal.
+fn is_signature_error(err: &AuthError) -> bool {
+    matches!(
+        err,
+        AuthError::JwtTokenInvalid(e)
+            if matches!(e.kind(), jsonwebtoken::errors::ErrorKind::InvalidSignature)
+    )
+}
+
 impl<V> Jwt<V> {
     fn try_verify_claims<Claims: serde::de::DeserializeOwned>(
         &self,
@@ -398,11 +413,11 @@ impl<V> Jwt<V> {
             return Ok(cached_claims);
         }
 
-        // Try to decode the key from the cache first; if this would require async, return WouldBlockOn
-        let decoding_key = self.decoding_key(token)?;
+        // Collect candidate keys from the cache first; if resolution would require
+        // async, return WouldBlockOn. Try each until the signature verifies.
+        let decoding_keys = self.decoding_keys(token)?;
 
-        // If we have a decoding key, proceed with verification
-        self.verify_internal::<Claims>(token, decoding_key)
+        self.verify_with_keys::<Claims>(token, decoding_keys)
     }
 
     async fn verify_claims<Claims: serde::de::DeserializeOwned>(
@@ -416,10 +431,38 @@ impl<V> Jwt<V> {
             return Ok(cached_claims);
         }
 
-        // Resolve the decoding key for verification
-        let decoding_key = self.resolve_decoding_key(token).await?;
+        // Resolve every candidate key for verification, then try each until the
+        // signature verifies.
+        let decoding_keys = self.resolve_decoding_keys(token).await?;
 
-        self.verify_internal::<Claims>(token, decoding_key)
+        self.verify_with_keys::<Claims>(token, decoding_keys)
+    }
+
+    /// Verify `token` against each candidate key, returning the claims from the
+    /// first key that validates.
+    ///
+    /// Only a signature mismatch advances to the next key; any other validation
+    /// failure (expiry, audience, issuer, ...) is returned immediately so the real
+    /// reason surfaces instead of a misleading "invalid signature" produced by an
+    /// unrelated key. This is what lets a multi-key JWKS allow-list work when tokens
+    /// carry no `kid`: the correct key cannot be chosen from the header, so the
+    /// signature check itself selects it.
+    fn verify_with_keys<Claims: serde::de::DeserializeOwned>(
+        &self,
+        token: &str,
+        keys: Vec<DecodingKey>,
+    ) -> Result<Claims, AuthError> {
+        let mut last_err = AuthError::JwksNoSuitableKey;
+        for key in keys {
+            match self.verify_internal::<Claims>(token, key) {
+                Ok(claims) => return Ok(claims),
+                Err(e) if is_signature_error(&e) => {
+                    last_err = e;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
     }
 
     fn verify_internal<Claims: serde::de::DeserializeOwned>(
@@ -490,15 +533,15 @@ impl<V> Jwt<V> {
     }
 
     /// Get decoding key for verification
-    fn decoding_key(&self, token: &str) -> Result<DecodingKey, AuthError> {
-        // If the decoding key is available, return it
+    fn decoding_keys(&self, token: &str) -> Result<Vec<DecodingKey>, AuthError> {
+        // If a decoding key is configured directly, use it.
         {
             if let Some(key) = &self.decoding_key {
-                return Ok(key.read().clone());
+                return Ok(vec![key.read().clone()]);
             }
         }
 
-        // Try to get a cached decoding key
+        // Try to get cached decoding keys
         if let Some(resolver) = &self.key_resolver {
             // Get issuer from claims
             let token_data: TokenData<StandardClaims> =
@@ -510,7 +553,7 @@ impl<V> Jwt<V> {
                 .as_ref()
                 .ok_or(AuthError::JwtMissingIssuer)?;
 
-            match resolver.get_cached_key(issuer, &token_data.header) {
+            match resolver.get_cached_keys(issuer, &token_data.header) {
                 Ok(k) => return Ok(k),
                 Err(_e) => {
                     // No cached key yet; async resolution would be required.
@@ -524,11 +567,11 @@ impl<V> Jwt<V> {
     }
 
     /// Resolve a decoding key for token verification
-    async fn resolve_decoding_key(&self, token: &str) -> Result<DecodingKey, AuthError> {
+    async fn resolve_decoding_keys(&self, token: &str) -> Result<Vec<DecodingKey>, AuthError> {
         // First check if we already have a decoding key
         {
             if let Some(key) = &self.decoding_key {
-                return Ok(key.read().clone());
+                return Ok(vec![key.read().clone()]);
             }
         }
 
@@ -548,8 +591,8 @@ impl<V> Jwt<V> {
             .as_ref()
             .ok_or(AuthError::JwtMissingIssuer)?;
 
-        // Resolve the key
-        resolver.resolve_key(issuer, &token_data.header).await
+        // Resolve every candidate key
+        resolver.resolve_keys(issuer, &token_data.header).await
     }
 }
 
@@ -1121,6 +1164,100 @@ mod tests {
     #[tokio::test]
     async fn test_jwt_resolve_decoding_key_eddsa() {
         test_jwt_resolve_with_algorithm(Algorithm::EdDSA).await;
+    }
+
+    #[tokio::test]
+    async fn test_multi_key_jwks_verifies_token_from_non_first_key() {
+        // Regression for the multi-member allow-list bug: a static JWKS holding more
+        // than one EdDSA key. slim's signer emits no `kid`, so verification must try
+        // every candidate key. Before the fix only the *first* key was tried, so a
+        // token signed by any member other than keys[0] failed with InvalidSignature.
+        use aws_lc_rs::rand::SystemRandom;
+        use aws_lc_rs::signature::{Ed25519KeyPair, KeyPair};
+        use base64::Engine;
+        use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+        use jsonwebtoken::jwk::JwkSet;
+
+        initialize_crypto_provider();
+
+        // Generate a fresh Ed25519 key; return (pkcs8 PEM, JWK json carrying `kid`).
+        fn make_key(kid: &str) -> (String, serde_json::Value) {
+            let rng = SystemRandom::new();
+            let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+            let kp = Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+            let x = URL_SAFE_NO_PAD.encode(kp.public_key().as_ref());
+
+            let b64 = STANDARD.encode(pkcs8.as_ref());
+            let mut body = String::new();
+            for chunk in b64.as_bytes().chunks(64) {
+                body.push_str(std::str::from_utf8(chunk).unwrap());
+                body.push('\n');
+            }
+            let pem = format!("-----BEGIN PRIVATE KEY-----\n{body}-----END PRIVATE KEY-----\n");
+
+            let jwk = serde_json::json!({
+                "kty": "OKP", "alg": "EdDSA", "use": "sig",
+                "kid": kid, "crv": "Ed25519", "x": x,
+            });
+            (pem, jwk)
+        }
+
+        let signer_pem = |pem: &str, sub: &str| {
+            JwtBuilder::new()
+                .issuer("test-issuer")
+                .audience(&["test-audience"])
+                .subject(sub)
+                .private_key(&Key {
+                    algorithm: Algorithm::EdDSA,
+                    format: KeyFormat::Pem,
+                    key: KeyData::Data(pem.to_string()),
+                })
+                .build()
+                .unwrap()
+        };
+
+        let (_, jwk_a) = make_key("member-a");
+        let (pem_b, jwk_b) = make_key("member-b");
+
+        // Two-member allow-list; member-a is first (keys[0]).
+        let jwks: JwkSet =
+            serde_json::from_value(serde_json::json!({ "keys": [jwk_a, jwk_b] })).unwrap();
+
+        // Verifier trusting the whole allow-list via a static multi-key JWKS.
+        let verifier = JwtBuilder::new()
+            .issuer("test-issuer")
+            .audience(&["test-audience"])
+            .auto_resolve_keys(true)
+            .build()
+            .unwrap()
+            .with_key_resolver(KeyResolver::with_jwks(jwks));
+
+        // Fast path: member-b is the *second* key. The signer stamps kid=sub, so the
+        // verifier resolves member-b's key in O(1). Before the fix, a token from any
+        // member other than keys[0] failed with InvalidSignature.
+        let signer_b = signer_pem(&pem_b, "member-b");
+        let token = signer_b.sign_claims(&signer_b.create_claims()).unwrap();
+        let claims: StandardClaims = verifier.get_claims(token).await.unwrap();
+        assert_eq!(claims.sub.as_deref(), Some("member-b"));
+
+        // Fallback: a legacy kid-less token from member-b must still verify by trying
+        // every candidate key.
+        let mut header = JwtHeader::new(Algorithm::EdDSA);
+        header.kid = None;
+        let enc = EncodingKey::from_ed_pem(pem_b.as_bytes()).unwrap();
+        let kidless = encode(&header, &signer_b.create_claims(), &enc).unwrap();
+        let claims: StandardClaims = verifier.get_claims(kidless).await.unwrap();
+        assert_eq!(claims.sub.as_deref(), Some("member-b"));
+
+        // A token from a key that is NOT in the allow-list must still be rejected.
+        let (pem_x, _) = make_key("outsider");
+        let signer_x = signer_pem(&pem_x, "outsider");
+        let bad = signer_x.sign_claims(&signer_x.create_claims()).unwrap();
+        let res: Result<StandardClaims, _> = verifier.get_claims(bad).await;
+        assert!(
+            res.is_err(),
+            "a token signed by a non-member key must not verify against the allow-list"
+        );
     }
 
     #[tokio::test]

--- a/crates/auth/src/oidc.rs
+++ b/crates/auth/src/oidc.rs
@@ -118,11 +118,7 @@ impl OidcJwksCache {
 
     /// Store JWKS in the cache with custom TTL
     fn store_with_ttl(&self, issuer_url: impl Into<String>, jwks: JwkSet, ttl: Duration) {
-        let entry = JwksCache {
-            jwks,
-            fetched_at: Instant::now(),
-            ttl,
-        };
+        let entry = JwksCache::new(jwks, Instant::now(), ttl);
         self.entries.write().insert(issuer_url.into(), entry);
     }
 
@@ -884,11 +880,7 @@ mod tests {
     fn test_jwks_cache_entry_reuse() {
         // Test that we're using the shared JwksCache struct from resolver.rs
         let jwks = JwkSet { keys: vec![] };
-        let entry = JwksCache {
-            jwks,
-            fetched_at: Instant::now(),
-            ttl: Duration::from_secs(1800),
-        };
+        let entry = JwksCache::new(jwks, Instant::now(), Duration::from_secs(1800));
 
         // Verify the struct has the expected fields
         assert_eq!(entry.ttl, Duration::from_secs(1800));

--- a/crates/auth/src/resolver.rs
+++ b/crates/auth/src/resolver.rs
@@ -16,11 +16,36 @@ use url::Url;
 use crate::errors::AuthError;
 
 /// Cache entry for a JWKS.
+///
+/// `by_kid` is a precomputed index (`kid` -> JWK) built once when the entry is
+/// created, so a token that carries a `kid` resolves its key in O(1) instead of
+/// scanning every JWK on each verification.
 #[derive(Clone, Debug)]
 pub struct JwksCache {
     pub jwks: JwkSet,
+    pub by_kid: HashMap<String, Jwk>,
     pub fetched_at: Instant,
     pub ttl: Duration,
+}
+
+impl JwksCache {
+    /// Build a cache entry, indexing keys that declare a `kid` for O(1) lookup.
+    pub fn new(jwks: JwkSet, fetched_at: Instant, ttl: Duration) -> Self {
+        let mut by_kid = HashMap::with_capacity(jwks.keys.len());
+        for key in &jwks.keys {
+            if let Some(kid) = &key.common.key_id {
+                // First writer wins on duplicate kids; duplicates are also still
+                // reachable via the algorithm-scan fallback.
+                by_kid.entry(kid.clone()).or_insert_with(|| key.clone());
+            }
+        }
+        Self {
+            jwks,
+            by_kid,
+            fetched_at,
+            ttl,
+        }
+    }
 }
 
 /// This struct provides methods to resolve JWT decoding keys from various sources.
@@ -79,11 +104,11 @@ impl KeyResolver {
         let mut cache = HashMap::new();
         cache.insert(
             Self::STATIC_JWKS_ENTRY.to_string(),
-            JwksCache {
+            JwksCache::new(
                 jwks,
-                fetched_at: Instant::now(),
-                ttl: Duration::from_secs(u64::MAX), // static JWKS, infinite TTL
-            },
+                Instant::now(),
+                Duration::from_secs(u64::MAX), // static JWKS, infinite TTL
+            ),
         );
 
         let client = ReqwestClient::builder()
@@ -119,22 +144,42 @@ impl KeyResolver {
         issuer: &str,
         token_header: &Header,
     ) -> Result<DecodingKey, AuthError> {
+        // Backwards-compatible single-key accessor: return the first candidate.
+        self.resolve_keys(issuer, token_header)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(AuthError::JwksNoSuitableKey)
+    }
+
+    /// Resolve every candidate decoding key for a token header.
+    ///
+    /// Unlike [`Self::resolve_key`], this returns *all* keys that could plausibly
+    /// have signed the token (exact `kid` match first, then any key whose
+    /// algorithm matches the token). The caller is expected to try each in turn
+    /// until one verifies the signature. This is what makes a multi-key JWKS
+    /// allow-list usable when tokens carry no `kid`: there is no way to pick the
+    /// right key from the header alone, so the signature itself is the selector.
+    pub async fn resolve_keys(
+        &self,
+        issuer: &str,
+        token_header: &Header,
+    ) -> Result<Vec<DecodingKey>, AuthError> {
         // Check if we have a static JWKS entry
         if let Some(cache_entry) = self.jwks_cache.read().get(Self::STATIC_JWKS_ENTRY) {
             // If we have a static JWKS, use it directly
-            return self.get_decoded_key_from_jwks(&cache_entry.jwks, token_header);
+            return self.candidate_keys_from_cache(cache_entry, token_header);
         }
 
-        // Try to get cached key if available
-        if let Ok(cached_key) = self.get_cached_key(issuer, token_header) {
-            return Ok(cached_key);
+        // Try to get cached keys if available
+        if let Ok(cached_keys) = self.get_cached_keys(issuer, token_header) {
+            return Ok(cached_keys);
         }
 
-        // Try to fetch the keys from the well-known JWKS endpoint
-        let jwks = self.fetch_jwks(issuer).await?;
-
-        // Try to decode the key from the JWKS
-        self.get_decoded_key_from_jwks(&jwks, token_header)
+        // Try to fetch the keys from the well-known JWKS endpoint (also caches it
+        // with its `by_kid` index for subsequent O(1) lookups).
+        self.fetch_jwks(issuer).await?;
+        self.get_cached_keys(issuer, token_header)
     }
 
     /// Convert a JWK to a DecodingKey
@@ -161,52 +206,74 @@ impl KeyResolver {
         }
     }
 
-    fn get_decoded_key_from_jwks(
+    /// Collect the candidate decoding key(s) for a token header, most likely first.
+    ///
+    /// Fast path (O(1)): if the token carries a `kid` and the cache's `by_kid`
+    /// index holds it, that single key is returned directly — one JWK conversion,
+    /// one signature check. slim's signer stamps `kid = sub`, so this is the normal
+    /// case for a multi-member allow-list.
+    ///
+    /// Fallback (O(n)): a `kid` may be absent (legacy tokens) or not match any
+    /// indexed key. Then we return every key whose algorithm matches the token so
+    /// verification can try each until the signature checks out — because the right
+    /// key cannot be chosen from the header alone, the signature itself is the
+    /// selector. The previous behaviour returned only the *first* algorithm match,
+    /// so with a multi-key allow-list every member other than keys[0] failed with
+    /// `InvalidSignature`.
+    fn candidate_keys_from_cache(
         &self,
-        jwks: &JwkSet,
+        cache: &JwksCache,
         token_header: &Header,
-    ) -> Result<DecodingKey, AuthError> {
-        // At this point, we have a valid cache entry
-        if let Some(kid) = &token_header.kid {
-            // Look for a key with a matching ID
-            for key in &jwks.keys {
-                if let Some(id) = &key.common.key_id
-                    && id == kid
-                {
-                    return self.jwk_to_decoding_key(key);
-                }
-            }
-        } else {
-            // If no key ID is specified, use the first suitable key
-            for key in &jwks.keys {
-                if let Some(alg) = &key.common.key_algorithm
-                    && let Ok(algorithm) = self.key_alg_to_algorithm(alg)
-                {
-                    // Check if the algorithm matches the token's algorithm
-                    if algorithm == token_header.alg {
-                        return self.jwk_to_decoding_key(key);
-                    }
-                }
+    ) -> Result<Vec<DecodingKey>, AuthError> {
+        // Fast path: exact `kid` hit via the precomputed index.
+        if let Some(kid) = &token_header.kid
+            && let Some(jwk) = cache.by_kid.get(kid)
+        {
+            return Ok(vec![self.jwk_to_decoding_key(jwk)?]);
+        }
+
+        // Fallback: every key whose algorithm matches the token.
+        let mut candidates = Vec::new();
+        for key in &cache.jwks.keys {
+            if let Some(alg) = &key.common.key_algorithm
+                && let Ok(algorithm) = self.key_alg_to_algorithm(alg)
+                && algorithm == token_header.alg
+            {
+                candidates.push(self.jwk_to_decoding_key(key)?);
             }
         }
 
-        // If no suitable key is found, return an error
-        Err(AuthError::JwksNoSuitableKey)
+        if candidates.is_empty() {
+            return Err(AuthError::JwksNoSuitableKey);
+        }
+        Ok(candidates)
     }
 
-    /// Check the cache for a JWKS entry
+    /// Check the cache for a JWKS entry (single-key, backwards compatible).
     pub fn get_cached_key(
         &self,
         issuer: &str,
         token_header: &Header,
     ) -> Result<DecodingKey, AuthError> {
+        self.get_cached_keys(issuer, token_header)?
+            .into_iter()
+            .next()
+            .ok_or(AuthError::JwksNoSuitableKey)
+    }
+
+    /// Check the cache for a JWKS entry, returning every candidate key.
+    pub fn get_cached_keys(
+        &self,
+        issuer: &str,
+        token_header: &Header,
+    ) -> Result<Vec<DecodingKey>, AuthError> {
         // Check if we have a cached JWKS that's still valid
         let cache = self.jwks_cache.read();
 
         // Check static JWKS entry first
         if let Some(cache_entry) = cache.get(Self::STATIC_JWKS_ENTRY) {
             // no need to check the elapsed time for static JWKS
-            return self.get_decoded_key_from_jwks(&cache_entry.jwks, token_header);
+            return self.candidate_keys_from_cache(cache_entry, token_header);
         }
 
         let cache_entry = cache.get(issuer);
@@ -224,8 +291,8 @@ impl KeyResolver {
             });
         }
 
-        // If we have a valid cache entry, try to decode the key
-        self.get_decoded_key_from_jwks(&cache_entry.jwks, token_header)
+        // If we have a valid cache entry, collect the candidate keys
+        self.candidate_keys_from_cache(cache_entry, token_header)
     }
 
     /// Fetch JWKS from the issuer's endpoint
@@ -242,11 +309,7 @@ impl KeyResolver {
         // Cache the JWKS
         self.jwks_cache.write().insert(
             issuer.to_string(),
-            JwksCache {
-                jwks: jwks.clone(),
-                fetched_at: Instant::now(),
-                ttl: self.default_jwks_ttl,
-            },
+            JwksCache::new(jwks.clone(), Instant::now(), self.default_jwks_ttl),
         );
 
         Ok(jwks)


### PR DESCRIPTION
## Problem

With a static **multi-key JWKS** allow-list (per-identity `did:key`/EdDSA members), only the *first* key was ever usable. Every other member's token failed with `InvalidSignature`, so multi-member group sessions could not form: the moderator's `DiscoveryRequest` was dropped at the participant and add-participant timed out with `message send retries exhausted`.

Root cause (two behaviors that contradict each other, both in the JWT layer):
1. slim's signer emits tokens with **no `kid`** (`sign_claims` → `JwtHeader::new(alg)`).
2. the verifier's resolver, for a kid-less token, returned the **first** algorithm-matching key with no fallback (`get_decoded_key_from_jwks`).

Every kid-less EdDSA token therefore resolved to `keys[0]`. Only single-key JWKS setups worked (the first key is the only key), which is why it went unnoticed — all group tests use a single shared `SharedSecret`, never the multi-key JWT path.

Fixes #1882.

## Fix

Resolve **all** candidate keys (exact `kid` match first, then every algorithm-compatible key) and try each during verification, advancing to the next key only on a **signature mismatch** and returning any other validation error (expiry, audience, issuer) immediately — so the real reason surfaces instead of a misleading `InvalidSignature` from an unrelated key.

- `resolver.rs`: `candidate_keys_from_jwks` returns `Vec<DecodingKey>`; new `resolve_keys` / `get_cached_keys`. The single-key `resolve_key` / `get_cached_key` are kept as thin wrappers (public API unchanged).
- `jwt.rs`: verification collects candidate keys and tries each (`verify_with_keys`).

Single-key JWKS and OIDC/`kid` flows are unchanged.

## Test

Added `test_multi_key_jwks_verifies_token_from_non_first_key`: a two-member EdDSA JWKS verifies a kid-less token from the **non-first** member, and still rejects a token signed by a non-member key. All 158 auth unit tests pass.