### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.9"
+version = "2.0.0-alpha.10"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.7"
+version = "0.17.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -546,11 +546,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.7" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.14.0" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.9" }
-agntcy-slim-config = { path = "crates/config", version = "0.12.6" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.7" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.11.5" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.16.7" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.2.6" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.8" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.14.1" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.10" }
+agntcy-slim-config = { path = "crates/config", version = "0.13.0" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.8" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.0" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.17.0" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.0" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.4.0" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.7" }
-agntcy-slim-service = { path = "crates/service", version = "0.11.6", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.6.0" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.15" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.0" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.8" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.0", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.0" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.16" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.8" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.7" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.7" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.9" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.8" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.8" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -230,7 +230,7 @@ x25519-dalek = { version = "2", default-features = false, features = ["static_se
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/agntcy/slim/compare/slim-auth-v0.14.0...slim-auth-v0.14.1) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+
 ## [0.14.0](https://github.com/agntcy/slim/compare/slim-auth-v0.13.1...slim-auth-v0.14.0) - 2026-07-20
 
 ### Fixed

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.14.0"
+version = "0.14.1"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.7...slim-channel-manager-v2.0.0-alpha.8) - 2026-07-29
+
+### Added
+
+- *(channel-manager)* add storage ([#1901](https://github.com/agntcy/slim/pull/1901))
+- *(bindings)* expose session close/rejoin ([#1896](https://github.com/agntcy/slim/pull/1896))
+
 ## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.4...slim-channel-manager-v2.0.0-alpha.5) - 2026-07-16
 
 ### Other

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/agntcy/slim/compare/slim-config-v0.12.6...slim-config-v0.13.0) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+
 ## [0.12.6](https://github.com/agntcy/slim/compare/slim-config-v0.12.5...slim-config-v0.12.6) - 2026-07-20
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.12.6"
+version = "0.13.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.7...slim-control-plane-v2.0.0-alpha.8) - 2026-07-29
+
+### Fixed
+
+- link recreation after node restart ([#1898](https://github.com/agntcy/slim/pull/1898))
+
+### Other
+
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.4...slim-control-plane-v2.0.0-alpha.5) - 2026-07-16
 
 ### Other

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/agntcy/slim/compare/slim-controller-v0.11.5...slim-controller-v0.12.0) - 2026-07-29
+
+### Added
+
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+
+### Other
+
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [0.11.5](https://github.com/agntcy/slim/compare/slim-controller-v0.11.4...slim-controller-v0.11.5) - 2026-07-20
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.11.5"
+version = "0.12.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.7...slim-datapath-v0.17.0) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))
+
+### Other
+
+- remove sub/unsub msg cloning sent to cp ([#1897](https://github.com/agntcy/slim/pull/1897))
+
 ## [0.16.7](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.6...slim-datapath-v0.16.7) - 2026-07-20
 
 ### Added

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.16.7"
+version = "0.17.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/agntcy/slim/compare/slim-mls-v0.2.6...slim-mls-v0.3.0) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))
+
 ## [0.2.6](https://github.com/agntcy/slim/compare/slim-mls-v0.2.5...slim-mls-v0.2.6) - 2026-07-20
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.6"
+version = "0.3.0"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/persistence/CHANGELOG.md
+++ b/crates/persistence/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/agntcy/slim/releases/tag/slim-persistence-v0.1.0) - 2026-07-29
+
+### Added
+
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+
+### Fixed
+
+- *(session)* remove record + MLS state + pool entry on close (both roles) ([#1902](https://github.com/agntcy/slim/pull/1902))

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/agntcy/slim/compare/slim-proto-v0.4.0...slim-proto-v0.5.0) - 2026-07-29
+
+### Added
+
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))
+
+### Other
+
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [0.4.0](https://github.com/agntcy/slim/compare/slim-proto-v0.3.4...slim-proto-v0.4.0) - 2026-07-20
 
 ### Added

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/rpc/CHANGELOG.md
+++ b/crates/rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.7...slim-rpc-v2.0.0-alpha.8) - 2026-07-29
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [2.0.0-alpha.6](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.5...slim-rpc-v2.0.0-alpha.6) - 2026-07-20
 
 ### Fixed

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/agntcy/slim/compare/slim-service-v0.11.6...slim-service-v0.12.0) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+
+### Fixed
+
+- *(session)* remove record + MLS state + pool entry on close (both roles) ([#1902](https://github.com/agntcy/slim/pull/1902))
+- *(session)* process rejoin from online participant on MLS epoch mismatch ([#1893](https://github.com/agntcy/slim/pull/1893))
+
+### Other
+
+- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [0.11.6](https://github.com/agntcy/slim/compare/slim-service-v0.11.5...slim-service-v0.11.6) - 2026-07-20
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.11.6"
+version = "0.12.0"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/agntcy/slim/compare/slim-session-v0.6.0...slim-session-v0.7.0) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- *(channel-manager)* add storage ([#1901](https://github.com/agntcy/slim/pull/1901))
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+- *(bindings)* expose session close/rejoin ([#1896](https://github.com/agntcy/slim/pull/1896))
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))
+
+### Fixed
+
+- prevent fail if a participant is offline ([#1895](https://github.com/agntcy/slim/pull/1895))
+- *(session)* remove record + MLS state + pool entry on close (both roles) ([#1902](https://github.com/agntcy/slim/pull/1902))
+- *(session)* restore control-sender group name on session restore ([#1899](https://github.com/agntcy/slim/pull/1899))
+- *(session)* process rejoin from online participant on MLS epoch mismatch ([#1893](https://github.com/agntcy/slim/pull/1893))
+
+### Other
+
+- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
+
 ## [0.6.0](https://github.com/agntcy/slim/compare/slim-session-v0.5.5...slim-session-v0.6.0) - 2026-07-20
 
 ### Added

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.6.0"
+version = "0.7.0"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/agntcy/slim/compare/slim-signal-v0.1.15...slim-signal-v0.1.16) - 2026-07-29
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.15](https://github.com/agntcy/slim/compare/slim-signal-v0.1.14...slim-signal-v0.1.15) - 2026-07-20
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.15"
+version = "0.1.16"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.10](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.9...slim-bindings-v2.0.0-alpha.10) - 2026-07-29
+
+### Added
+
+- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
+- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
+- *(bindings)* expose session close/rejoin ([#1896](https://github.com/agntcy/slim/pull/1896))
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+
+### Other
+
+- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [2.0.0-alpha.9](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.8...slim-bindings-v2.0.0-alpha.9) - 2026-07-20
 
 ### Other

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.9"
+version = "2.0.0-alpha.10"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.7...slim-v2.0.0-alpha.8) - 2026-07-29
+
+### Other
+
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [2.0.0-alpha.5](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.4...slim-v2.0.0-alpha.5) - 2026-07-16
 
 ### Other

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.7...slimctl-v2.0.0-alpha.8) - 2026-07-29
+
+### Other
+
+- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
+- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
+
 ## [2.0.0-alpha.7](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.6...slimctl-v2.0.0-alpha.7) - 2026-07-20
 
 ### Added

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.8...slim-tracing-v0.4.9) - 2026-07-29
+
+### Added
+
+- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
+
+### Other
+
+- *(deps)* bump opentelemetry_sdk from 0.31.0 to 0.32.1 ([#1912](https://github.com/agntcy/slim/pull/1912))
+
 ## [0.4.8](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.7...slim-tracing-v0.4.8) - 2026-07-20
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.8"
+version = "0.4.9"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.7 -> 2.0.0-alpha.8
* `agntcy-slim-auth`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `agntcy-slim-config`: 0.12.6 -> 0.13.0 (⚠ API breaking changes)
* `agntcy-slim-proto`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `agntcy-slim-tracing`: 0.4.8 -> 0.4.9 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.16.7 -> 0.17.0 (⚠ API breaking changes)
* `agntcy-slim-persistence`: 0.1.0
* `agntcy-slim-mls`: 0.2.6 -> 0.3.0 (⚠ API breaking changes)
* `agntcy-slim-session`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `agntcy-slim-controller`: 0.11.5 -> 0.12.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.11.6 -> 0.12.0 (⚠ API breaking changes)
* `agntcy-slim`: 2.0.0-alpha.7 -> 2.0.0-alpha.8 (✓ API compatible changes)
* `agntcy-slim-channel-manager`: 2.0.0-alpha.7 -> 2.0.0-alpha.8 (✓ API compatible changes)
* `agntcy-slim-control-plane`: 2.0.0-alpha.7 -> 2.0.0-alpha.8 (✓ API compatible changes)
* `agntcy-slim-bindings`: 2.0.0-alpha.9 -> 2.0.0-alpha.10 (✓ API compatible changes)
* `agntcy-slim-rpc`: 2.0.0-alpha.7 -> 2.0.0-alpha.8 (✓ API compatible changes)
* `agntcy-slimctl`: 2.0.0-alpha.7 -> 2.0.0-alpha.8
* `agntcy-slim-signal`: 0.1.15 -> 0.1.16

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.enforce_pqc in /tmp/.tmpmrQ4WD/slim/crates/config/src/tls/common.rs:205
```

### ⚠ `agntcy-slim-proto` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NodeEntry.domain in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:29
  field SegmentEdge.domain_a in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:144
  field SegmentEdge.domain_b in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:146
  field SegmentEntry.domains in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:136
  field Participant.status in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:236
  field LinkNegotiationPayload.link_kem_payload in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:476
  field AddTopologyLinkRequest.domain_a in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:175
  field AddTopologyLinkRequest.domain_b in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:177
  field RemoveTopologyLinkRequest.domain_a in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:193
  field RemoveTopologyLinkRequest.domain_b in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:195
  field RegisterNodeRequest.domain_name in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controller.proto.v1.rs:181

--- failure enum_repr_variant_discriminant_changed: variant of an enum with explicit repr changed discriminant ---

Description:
An enum variant has changed its discriminant value. The enum has a defined primitive representation, so this breaks downstream code that used the discriminant value via an unsafe pointer cast.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_repr_variant_discriminant_changed.ron

Failed in:
  variant SessionMessageType::GroupWelcome 13 -> 12 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:522
  variant SessionMessageType::GroupClose 14 -> 13 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:523
  variant SessionMessageType::GroupProposal 15 -> 14 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:524
  variant SessionMessageType::GroupAck 16 -> 15 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:525
  variant SessionMessageType::GroupNack 17 -> 16 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:526
  variant SessionMessageType::Heartbeat 18 -> 17 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:527
  variant SessionMessageType::UpdateParticipantState 19 -> 18 in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:528

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionMessageType:GroupUpdate in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:521
  variant SessionMessageType:RejoinRequest in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:529
  variant SessionMessageType:RejoinReply in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:530
  variant CommandPayloadType:GroupUpdate in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:199
  variant CommandPayloadType:RejoinRequest in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:215
  variant CommandPayloadType:RejoinReply in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:217

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant SessionMessageType::GroupAdd, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:501
  variant SessionMessageType::GroupRemove, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:502
  variant CommandPayloadType::GroupAdd, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:199
  variant CommandPayloadType::GroupRemove, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:201

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  CommandPayloadBuilder::group_add, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:1402
  CommandPayloadBuilder::group_remove, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:1418
  CommandPayload::as_group_add_payload, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:1293
  CommandPayload::as_group_remove_payload, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:1293
  Message::extract_group_add, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:1210
  Message::extract_group_remove, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:1210
  ControlPlaneServiceClient::list_groups, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:732
  ControlPlaneServiceClient::add_group, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:764
  ControlPlaneServiceClient::remove_group, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:795
  RegisterNodeRequest::group_name, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controller.proto.v1.rs:174
  SessionMessageType::is_post_session_control, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/impls.rs:658

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  agntcy_slim_proto::ProtoMessageBuilder::build_link_negotiation now takes 8 parameters instead of 7, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/impls.rs:1751

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct agntcy_slim_proto::controlplane::proto::v1::ListGroupsResponse, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:205
  struct agntcy_slim_proto::controlplane::proto::v1::GroupEntry, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:210
  struct agntcy_slim_proto::controlplane::proto::v1::AddGroupResponse, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:225
  struct agntcy_slim_proto::controlplane::proto::v1::RemoveGroupResponse, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:232
  struct agntcy_slim_proto::dataplane::proto::v1::GroupAddPayload, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:326
  struct agntcy_slim_proto::dataplane::proto::v1::GroupRemovePayload, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/dataplane.proto.v1.rs:340
  struct agntcy_slim_proto::controlplane::proto::v1::ListGroupsRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:203
  struct agntcy_slim_proto::controlplane::proto::v1::AddGroupRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:218
  struct agntcy_slim_proto::controlplane::proto::v1::RemoveGroupRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:227

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field group_a of struct SegmentEdge, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:144
  field group_b of struct SegmentEdge, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:146
  field groups of struct SegmentEntry, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:136
  field group_a of struct AddTopologyLinkRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:175
  field group_b of struct AddTopologyLinkRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:177
  field group_a of struct RemoveTopologyLinkRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:193
  field group_b of struct RemoveTopologyLinkRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:195
  field group_name of struct RegisterNodeRequest, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controller.proto.v1.rs:181
  field group of struct NodeEntry, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:29

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method agntcy_slim_proto::controlplane::proto::v1::control_plane_service_server::ControlPlaneService::list_domains in file /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:938
  trait method agntcy_slim_proto::controlplane::proto::v1::control_plane_service_server::ControlPlaneService::add_domain in file /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:948
  trait method agntcy_slim_proto::controlplane::proto::v1::control_plane_service_server::ControlPlaneService::remove_domain in file /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/controlplane.proto.v1.rs:957

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method list_groups of trait ControlPlaneService, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:938
  method add_group of trait ControlPlaneService, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:948
  method remove_group of trait ControlPlaneService, previously in file /tmp/.tmpTyBTNz/agntcy-slim-proto/src/gen/controlplane.proto.v1.rs:957

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  SessionMessageType::GroupWelcome moved from position 14 to 13, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:522
  SessionMessageType::GroupClose moved from position 15 to 14, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:523
  SessionMessageType::GroupProposal moved from position 16 to 15, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:524
  SessionMessageType::GroupAck moved from position 17 to 16, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:525
  SessionMessageType::GroupNack moved from position 18 to 17, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:526
  SessionMessageType::Heartbeat moved from position 19 to 18, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:527
  SessionMessageType::UpdateParticipantState moved from position 20 to 19, in /tmp/.tmpmrQ4WD/slim/crates/proto/src/gen/dataplane.proto.v1.rs:528
```

### ⚠ `agntcy-slim-datapath` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_datapath::message_processing::MessageProcessor::new_with_service_id now takes 2 parameters instead of 1, in /tmp/.tmpmrQ4WD/slim/crates/datapath/src/message_processing.rs:150
  slim_datapath::message_processing::MessageProcessor::new_with_server_config now takes 5 parameters instead of 4, in /tmp/.tmpmrQ4WD/slim/crates/datapath/src/message_processing.rs:163
```

### ⚠ `agntcy-slim-mls` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant MlsError:NoGroupUpdatePayload in /tmp/.tmpmrQ4WD/slim/crates/mls/src/errors.rs:38

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant MlsError::NoGroupAddPayload, previously in file /tmp/.tmpTyBTNz/agntcy-slim-mls/src/errors.rs:38
  variant MlsError::NoGroupRemovePayload, previously in file /tmp/.tmpTyBTNz/agntcy-slim-mls/src/errors.rs:40
```

### ⚠ `agntcy-slim-session` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionError:InvalidGroupUpdateOp in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:31
  variant SessionError:Persistence in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:89
  variant SessionError:PersistenceSerde in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:91
  variant SessionError:PersistenceDecode in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:93
  variant SessionError:PersistenceSchemaMismatch in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:95
  variant SessionError:ModeratorNotFound in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:151
  variant SessionError:InvalidGroupUpdateOp in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:31
  variant SessionError:Persistence in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:89
  variant SessionError:PersistenceSerde in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:91
  variant SessionError:PersistenceDecode in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:93
  variant SessionError:PersistenceSchemaMismatch in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:95
  variant SessionError:ModeratorNotFound in /tmp/.tmpmrQ4WD/slim/crates/session/src/errors.rs:151

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  SessionController::leave, previously in file /tmp/.tmpTyBTNz/agntcy-slim-session/src/session_controller.rs:579

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_session::SessionLayer::new now takes 9 parameters instead of 8, in /tmp/.tmpmrQ4WD/slim/crates/session/src/session_layer.rs:154
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ControlPlaneSettings.domain_name in /tmp/.tmpmrQ4WD/slim/crates/controller/src/service.rs:65
  field Config.enforce_pqc in /tmp/.tmpmrQ4WD/slim/crates/controller/src/config.rs:21

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field group_name of struct ControlPlaneSettings, previously in file /tmp/.tmpTyBTNz/agntcy-slim-controller/src/service.rs:65
```

### ⚠ `agntcy-slim-service` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ServiceConfiguration.domain_name in /tmp/.tmpmrQ4WD/slim/crates/service/src/service.rs:94
  field ServiceConfiguration.domain_name in /tmp/.tmpmrQ4WD/slim/crates/service/src/service.rs:94

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field group_name of struct ServiceConfiguration, previously in file /tmp/.tmpTyBTNz/agntcy-slim-service/src/service.rs:85
  field group_name of struct ServiceConfiguration, previously in file /tmp/.tmpTyBTNz/agntcy-slim-service/src/service.rs:85
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.14.1](https://github.com/agntcy/slim/compare/slim-auth-v0.14.0...slim-auth-v0.14.1) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.13.0](https://github.com/agntcy/slim/compare/slim-config-v0.12.6...slim-config-v0.13.0) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.0](https://github.com/agntcy/slim/compare/slim-proto-v0.4.0...slim-proto-v0.5.0) - 2026-07-29

### Added

- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))

### Other

- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.9](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.8...slim-tracing-v0.4.9) - 2026-07-29

### Added

- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))

### Other

- *(deps)* bump opentelemetry_sdk from 0.31.0 to 0.32.1 ([#1912](https://github.com/agntcy/slim/pull/1912))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.17.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.16.7...slim-datapath-v0.17.0) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))

### Other

- remove sub/unsub msg cloning sent to cp ([#1897](https://github.com/agntcy/slim/pull/1897))
</blockquote>

## `agntcy-slim-persistence`

<blockquote>

## [0.1.0](https://github.com/agntcy/slim/releases/tag/slim-persistence-v0.1.0) - 2026-07-29

### Added

- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))

### Fixed

- *(session)* remove record + MLS state + pool entry on close (both roles) ([#1902](https://github.com/agntcy/slim/pull/1902))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.0](https://github.com/agntcy/slim/compare/slim-mls-v0.2.6...slim-mls-v0.3.0) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.0](https://github.com/agntcy/slim/compare/slim-session-v0.6.0...slim-session-v0.7.0) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- *(channel-manager)* add storage ([#1901](https://github.com/agntcy/slim/pull/1901))
- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
- *(bindings)* expose session close/rejoin ([#1896](https://github.com/agntcy/slim/pull/1896))
- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))
- *(session)* add mls re-key on rejon ([#1875](https://github.com/agntcy/slim/pull/1875))

### Fixed

- prevent fail if a participant is offline ([#1895](https://github.com/agntcy/slim/pull/1895))
- *(session)* remove record + MLS state + pool entry on close (both roles) ([#1902](https://github.com/agntcy/slim/pull/1902))
- *(session)* restore control-sender group name on session restore ([#1899](https://github.com/agntcy/slim/pull/1899))
- *(session)* process rejoin from online participant on MLS epoch mismatch ([#1893](https://github.com/agntcy/slim/pull/1893))

### Other

- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.0](https://github.com/agntcy/slim/compare/slim-controller-v0.11.5...slim-controller-v0.12.0) - 2026-07-29

### Added

- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))

### Other

- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.0](https://github.com/agntcy/slim/compare/slim-service-v0.11.6...slim-service-v0.12.0) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))

### Fixed

- *(session)* remove record + MLS state + pool entry on close (both roles) ([#1902](https://github.com/agntcy/slim/pull/1902))
- *(session)* process rejoin from online participant on MLS epoch mismatch ([#1893](https://github.com/agntcy/slim/pull/1893))

### Other

- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.7...slim-v2.0.0-alpha.8) - 2026-07-29

### Other

- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.7...slim-channel-manager-v2.0.0-alpha.8) - 2026-07-29

### Added

- *(channel-manager)* add storage ([#1901](https://github.com/agntcy/slim/pull/1901))
- *(bindings)* expose session close/rejoin ([#1896](https://github.com/agntcy/slim/pull/1896))
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.7...slim-control-plane-v2.0.0-alpha.8) - 2026-07-29

### Fixed

- link recreation after node restart ([#1898](https://github.com/agntcy/slim/pull/1898))

### Other

- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.10](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.9...slim-bindings-v2.0.0-alpha.10) - 2026-07-29

### Added

- *(slim-bindings)* browser/WASM support ([#1886](https://github.com/agntcy/slim/pull/1886))
- increase post-quantum crypto coverage for wasm and add hybrid key exchange ([#1887](https://github.com/agntcy/slim/pull/1887))
- *(bindings)* expose session close/rejoin ([#1896](https://github.com/agntcy/slim/pull/1896))
- *(session)* encrypted MLS + session state persistence and restore ([#1820](https://github.com/agntcy/slim/pull/1820))

### Other

- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.7...slim-rpc-v2.0.0-alpha.8) - 2026-07-29

### Other

- update Cargo.toml dependencies
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.7...slimctl-v2.0.0-alpha.8) - 2026-07-29

### Other

- *(session)* unify close into close() + close_with_mode(CloseMode) ([#1900](https://github.com/agntcy/slim/pull/1900))
- rename group in domain ([#1891](https://github.com/agntcy/slim/pull/1891))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.16](https://github.com/agntcy/slim/compare/slim-signal-v0.1.15...slim-signal-v0.1.16) - 2026-07-29

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).