### PR TITLE
fix(ci): add --repo flag to gh release create in release-slimctl workflow

### DIFF
--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -23,7 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"
 
   build-binaries:
     name: "${{ matrix.platform.target }}"


### PR DESCRIPTION
# Description

The ensure-release job has no checkout step, so
gh cannot infer the repository from a local git remote.

Passing --repo "$GITHUB_REPOSITORY"
(always set by the Actions runner) fixes the
fatal: not a git repository error.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
