### PR TITLE
feat(bindings): expose session close/rejoin

### DIFF
--- a/crates/channel-manager/src/service.rs
+++ b/crates/channel-manager/src/service.rs
@@ -266,7 +266,10 @@ impl ChannelManagerServer {
             }
         };
 
-        let participant_names: Vec<String> = participants.iter().map(|p| p.to_string()).collect();
+        let participant_names: Vec<String> = participants
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect();
 
         info!(
             "Listing participants for channel {channel_name}, count: {}",

--- a/crates/session/src/common.rs
+++ b/crates/session/src/common.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use tonic::Status;
 
 use slim_datapath::api::{
-    EncodedName, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
+    EncodedName, ParticipantState, ProtoMessage as Message, ProtoName, ProtoSessionMessageType,
 };
 
 // Local crate
@@ -139,7 +139,7 @@ pub enum SessionMessage {
     DeleteSession { session_id: u32 },
     /// Query the participants list from the handler
     GetParticipantsList {
-        tx: tokio::sync::oneshot::Sender<Vec<ProtoName>>,
+        tx: tokio::sync::oneshot::Sender<Vec<(ProtoName, ParticipantState)>>,
     },
     /// Deferred cleanup after leave reply has been dispatched.
     /// Performs route/subscription cleanup that must happen after the LeaveReply

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -522,7 +522,9 @@ impl SessionController {
         self.config.initiator
     }
 
-    pub async fn participants_list(&self) -> Result<Vec<ProtoName>, SessionError> {
+    pub async fn participants_list(
+        &self,
+    ) -> Result<Vec<(ProtoName, ParticipantState)>, SessionError> {
         let (tx, rx) = oneshot::channel();
 
         // Send query to the processing loop

--- a/crates/session/src/session_moderator.rs
+++ b/crates/session/src/session_moderator.rs
@@ -363,7 +363,7 @@ where
         self.common.processing_state
     }
 
-    fn participants_list(&self) -> Vec<ProtoName> {
+    fn participants_list(&self) -> Vec<(ProtoName, ParticipantState)> {
         self.group_list
             .iter()
             .map(|(name, entry)| {
@@ -372,7 +372,9 @@ where
                     .as_ref()
                     .map(|n| n.id())
                     .unwrap_or(NameId::NULL_COMPONENT); // the name should always be present
-                name.clone().with_id(id)
+                let status =
+                    ParticipantState::try_from(entry.status).unwrap_or(ParticipantState::Online);
+                (name.clone().with_id(id), status)
             })
             .collect()
     }

--- a/crates/session/src/session_participant.rs
+++ b/crates/session/src/session_participant.rs
@@ -383,8 +383,15 @@ where
         self.common.processing_state
     }
 
-    fn participants_list(&self) -> Vec<ProtoName> {
-        self.group_list.keys().cloned().collect()
+    fn participants_list(&self) -> Vec<(ProtoName, ParticipantState)> {
+        self.group_list
+            .iter()
+            .map(|(name, entry)| {
+                let status =
+                    ParticipantState::try_from(entry.status).unwrap_or(ParticipantState::Online);
+                (name.clone(), status)
+            })
+            .collect()
     }
 
     async fn on_shutdown(&mut self) -> Result<(), SessionError> {

--- a/crates/session/src/traits.rs
+++ b/crates/session/src/traits.rs
@@ -72,9 +72,14 @@ pub trait MessageHandler {
         async { Ok(()) }
     }
 
-    /// Get the current participants list (participants in the session)
+    /// Get the current participants list with their online/offline status.
     /// Default implementation returns an empty list.
-    fn participants_list(&self) -> Vec<slim_datapath::api::ProtoName> {
+    fn participants_list(
+        &self,
+    ) -> Vec<(
+        slim_datapath::api::ProtoName,
+        slim_datapath::api::ParticipantState,
+    )> {
         vec![]
     }
 }

--- a/crates/slim-bindings/src/session.rs
+++ b/crates/slim-bindings/src/session.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use slim_datapath::api::ParticipantState as SlimParticipantState;
 use slim_session::CompletionHandle as SlimCompletionHandle;
 use slim_session::session_controller::SessionController;
 use std::collections::HashMap;
@@ -73,6 +74,29 @@ impl From<slim_session::session_config::MlsSettings> for MlsSettings {
             header_integrity_validation_percent: s.header_integrity_validation_percent,
         }
     }
+}
+
+/// Online/offline status of a session participant
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum ParticipantStatus {
+    Online,
+    Offline,
+}
+
+impl From<SlimParticipantState> for ParticipantStatus {
+    fn from(s: SlimParticipantState) -> Self {
+        match s {
+            SlimParticipantState::Online => ParticipantStatus::Online,
+            SlimParticipantState::Offline => ParticipantStatus::Offline,
+        }
+    }
+}
+
+/// A participant in a session together with their current status
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct ParticipantInfo {
+    pub name: Arc<Name>,
+    pub status: ParticipantStatus,
 }
 
 /// Session configuration
@@ -608,6 +632,73 @@ impl Session {
         completion_handle.wait_async().await
     }
 
+    /// Notify the group that this participant is going offline (blocking version).
+    ///
+    /// Only valid for Group sessions; returns an error for PointToPoint sessions.
+    /// Returns a completion handle that resolves when ACKs are collected or on timeout.
+    /// After the handle completes the caller should persist the session state and may
+    /// later rejoin with `rejoin()`.
+    pub fn close(&self) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.close_async().await })
+    }
+
+    /// Notify the group that this participant is going offline (async version).
+    pub async fn close_async(&self) -> Result<Arc<CompletionHandle>, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        let completion = session.close().await?;
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Notify the group that this participant is going offline and wait for completion (blocking version).
+    pub fn close_and_wait(&self) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(async { self.close_and_wait_async().await })
+    }
+
+    /// Notify the group that this participant is going offline and wait for completion (async version).
+    pub async fn close_and_wait_async(&self) -> Result<(), SlimError> {
+        let completion_handle = self.close_async().await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Notify the group that this participant is back online (blocking version).
+    ///
+    /// Only valid for Group sessions; returns an error for PointToPoint sessions.
+    /// Returns a completion handle that resolves when ACKs/NACKs are collected.
+    /// If any participant NACKs due to an MLS epoch mismatch, the rejoin fails.
+    pub fn rejoin(&self) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.rejoin_async().await })
+    }
+
+    /// Notify the group that this participant is back online (async version).
+    pub async fn rejoin_async(&self) -> Result<Arc<CompletionHandle>, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        let completion = session.rejoin().await?;
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Notify the group that this participant is back online and wait for completion (blocking version).
+    pub fn rejoin_and_wait(&self) -> Result<(), SlimError> {
+        crate::config::get_runtime().block_on(async { self.rejoin_and_wait_async().await })
+    }
+
+    /// Notify the group that this participant is back online and wait for completion (async version).
+    pub async fn rejoin_and_wait_async(&self) -> Result<(), SlimError> {
+        let completion_handle = self.rejoin_async().await?;
+        completion_handle.wait_async().await
+    }
+
     /// Get the destination name for this session
     pub fn destination(&self) -> Result<Name, SlimError> {
         let session = self
@@ -697,8 +788,8 @@ impl Session {
         Ok(session.session_config().into())
     }
 
-    /// Get list of participants in the session
-    pub async fn participants_list_async(&self) -> Result<Vec<Arc<Name>>, SlimError> {
+    /// Get list of participants in the session with their online/offline status (async version)
+    pub async fn participants_list_async(&self) -> Result<Vec<ParticipantInfo>, SlimError> {
         let session = self
             .session
             .upgrade()
@@ -707,11 +798,17 @@ impl Session {
             })?;
 
         let list = session.participants_list().await?;
-        Ok(list.into_iter().map(|n| Arc::new(Name::from(n))).collect())
+        Ok(list
+            .into_iter()
+            .map(|(name, state)| ParticipantInfo {
+                name: Arc::new(Name::from(name)),
+                status: ParticipantStatus::from(state),
+            })
+            .collect())
     }
 
-    /// Get list of participants in the session (blocking version for FFI)
-    pub fn participants_list(&self) -> Result<Vec<Arc<Name>>, SlimError> {
+    /// Get list of participants in the session with their online/offline status (blocking version for FFI)
+    pub fn participants_list(&self) -> Result<Vec<ParticipantInfo>, SlimError> {
         crate::config::get_runtime().block_on(async { self.participants_list_async().await })
     }
 }
@@ -722,7 +819,8 @@ mod tests {
     use crate::Name as FfiName;
     use crate::errors::SlimError;
     use slim_datapath::api::{
-        ApplicationPayload, ProtoMessage, ProtoPublish, ProtoPublishType, SessionHeader, SlimHeader,
+        ApplicationPayload, ParticipantState as SlimParticipantState, ProtoMessage, ProtoPublish,
+        ProtoPublishType, SessionHeader, SlimHeader,
     };
     use slim_session::SessionError;
     use std::time::Duration;
@@ -1285,6 +1383,52 @@ mod tests {
             }
             _ => panic!("Expected SessionError"),
         }
+    }
+
+    // ==================== ParticipantStatus Conversion Tests ====================
+
+    #[test]
+    fn test_participant_status_from_online() {
+        assert_eq!(
+            ParticipantStatus::from(SlimParticipantState::Online),
+            ParticipantStatus::Online
+        );
+    }
+
+    #[test]
+    fn test_participant_status_from_offline() {
+        assert_eq!(
+            ParticipantStatus::from(SlimParticipantState::Offline),
+            ParticipantStatus::Offline
+        );
+    }
+
+    // ==================== Close/Rejoin Tests (Session Missing) ====================
+
+    #[tokio::test]
+    async fn test_close_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.close_async().await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("closed") || message.contains("dropped")
+            } else {
+                false
+            }
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_rejoin_async_session_missing() {
+        let (ctx, _tx) = make_context();
+        let result = ctx.rejoin_async().await;
+        assert!(result.is_err_and(|e| {
+            if let SlimError::SessionError { message } = e {
+                message.contains("closed") || message.contains("dropped")
+            } else {
+                false
+            }
+        }));
     }
 
     // ==================== Publish Internal with Metadata Tests ====================

--- a/crates/testing/src/bin/test_group.rs
+++ b/crates/testing/src/bin/test_group.rs
@@ -303,7 +303,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             assert!(
                 list.iter()
-                    .all(|n| n.str_components() != participants[to_remove].str_components()),
+                    .all(|(n, _)| n.str_components() != participants[to_remove].str_components()),
                 "Participants to remove is still present in the session"
             );
 
@@ -325,7 +325,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             assert!(
                 list.iter()
-                    .any(|n| n.str_components() == participants[to_add].str_components()),
+                    .any(|(n, _)| n.str_components() == participants[to_add].str_components()),
                 "Participants to add is not present in the session"
             );
 

--- a/crates/testing/src/bin/test_p2p.rs
+++ b/crates/testing/src/bin/test_p2p.rs
@@ -100,9 +100,9 @@ async fn run_client_task(name: Name, moderator_name: Name, port: u16) -> Result<
                                 println!("Participant {}: session participants: {:?}", name_clone_session, list);
                                 // check participants list
                                 assert_eq!(list.len(), 2, "Expected 2 participants in the session");
-                                assert!(list.iter().any(|n| n.str_components() == name_clone_session.str_components()),
+                                assert!(list.iter().any(|(n, _)| n.str_components() == name_clone_session.str_components()),
                                     "Participants list should contain the client name");
-                                assert!(list.iter().any(|n| n.str_components() == moderator_name.str_components()),
+                                assert!(list.iter().any(|(n, _)| n.str_components() == moderator_name.str_components()),
                                     "Participants list should contain the moderator name");
 
                                 session_ctx.spawn_receiver(move |mut rx, weak| async move {
@@ -287,13 +287,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             assert!(
                 list.iter()
-                    .any(|n| n.str_components() == moderator_name.str_components()),
+                    .any(|(n, _)| n.str_components() == moderator_name.str_components()),
                 "Participants list should contain the moderator name"
             );
             assert!(
-                list.iter()
-                    .any(|n| n.str_components() == client_1_name.str_components()
-                        || n.str_components() == client_2_name.str_components()),
+                list.iter().any(
+                    |(n, _)| n.str_components() == client_1_name.str_components()
+                        || n.str_components() == client_2_name.str_components()
+                ),
                 "Participants list should contain the client name"
             );
         } else {
@@ -305,12 +306,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             assert!(
                 list.iter()
-                    .any(|n| n.str_components() == moderator_name.str_components()),
+                    .any(|(n, _)| n.str_components() == moderator_name.str_components()),
                 "Participants list should contain the moderator name"
             );
             assert!(
                 list.iter()
-                    .any(|n| n.str_components() == client_1_name.str_components()),
+                    .any(|(n, _)| n.str_components() == client_1_name.str_components()),
                 "Participants list should contain the client-1 name"
             );
         }


### PR DESCRIPTION
# Description

This PR exposes two new session lifecycle operations and enriches the participants list API in the language bindings (slim-bindings).

New: close and rejoin on Session

Exposes SessionController::close() and SessionController::rejoin() through the UniFFI bindings, allowing application-layer code to participate in the group session lifecycle:
- close — notifies the group that this participant is going offline. Returns a CompletionHandle that resolves when ACKs are collected (or on timeout). 
- rejoin — notifies the group that this participant is back online, including the current MLS epoch for validation. 

Changed: participants_list now includes online/offline status

Previously participants_list returned Vec<Name>. Since participants can now be online or offline (via close/rejoin), the return type is updated to carry status alongside the name.

New binding types:
ParticipantStatus { Online, Offline }
ParticipantInfo   { name: Name, status: ParticipantStatus }

The change is propagated through the full stack: MessageHandler trait → SessionModerator / SessionParticipant → SessionController → bindings. Call sites in channel-manager and integration tests are updated accordingly.


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
