### PR TITLE
fix: link recreation after node restart

### DIFF
--- a/crates/control-plane/src/route_service/node_lifecycle.rs
+++ b/crates/control-plane/src/route_service/node_lifecycle.rs
@@ -518,8 +518,15 @@ impl super::RouteService {
             if link.source_node_id == departing_node {
                 // Outgoing link: move source to new gateway, reset to Pending
                 // so reconciler re-establishes the connection from new node.
+                //
+                // Clear dest_node_id so the destination group can re-claim the
+                // link. claim_link only matches unclaimed links (dest_node_id
+                // == ""); if we keep the old claimant here the sibling connects
+                // but the dest side's claim is rejected as "already claimed",
+                // leaving the link Pending forever and no routes expand over it.
                 let mut updated = link.clone();
                 updated.source_node_id = new_gateway.clone();
+                updated.dest_node_id = String::new();
                 updated.status = LinkStatus::Pending;
                 updated.last_updated = SystemTime::now();
 


### PR DESCRIPTION
# Description

**Problem**
When a gateway node that is the source of an inter-group link disconnects, reassign_gateway_links moves the link to a sibling node and resets it to Pending, but keeps the old dest_node_id. Since claim_link only matches unclaimed links (dest_node_id == ""), the destination group can never re-claim the reassigned link. It stays Pending forever, no routes are expanded over it, and cross-group traffic through that gateway is permanently broken after the failover.

The incoming-link branch already avoids this (it deletes and recreates the link unclaimed); only the outgoing-link branch was affected.

**Fix**
Clear dest_node_id on the reassigned outgoing link so the destination group re-claims it just like a freshly created link.

```
updated.source_node_id = new_gateway.clone();
updated.dest_node_id = String::new();
updated.status = LinkStatus::Pending;
```

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
