### PR TITLE
refactor(session): unify close into close() + close_with_mode(CloseMode)

### DIFF
--- a/crates/service/tests/session_restore_test.rs
+++ b/crates/service/tests/session_restore_test.rs
@@ -28,7 +28,7 @@ use slim_persistence::PersistenceConfig;
 use slim_service::app::App;
 use slim_service::{Service, SlimHeaderFlags};
 use slim_session::session_config::MlsSettings;
-use slim_session::{Direction, Notification, SessionConfig};
+use slim_session::{CloseMode, Direction, Notification, SessionConfig};
 use slim_testing::build_client_service;
 use slim_testing::common::{reserve_local_port, run_slim_node};
 use slim_testing::utils::TEST_VALID_SECRET;
@@ -593,9 +593,9 @@ async fn test_participant_rejoin_after_epoch_advance() {
         .expect("baseline publish failed");
     wait_for_message(&member2_messages, "before-close", Duration::from_secs(10)).await;
 
-    // 7. Member2 goes offline.
+    // 7. Member2 goes offline (soft close — in-memory, no persistence needed).
     member2_session
-        .close()
+        .close_with_mode(CloseMode::Soft)
         .await
         .expect("close failed")
         .await

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -64,4 +64,5 @@ pub use common::{AppChannelReceiver, SESSION_UNSPECIFIED};
 // Re-export specific items that need to be publicly accessible
 pub use completion_handle::CompletionHandle;
 pub use notification::Notification;
+pub use session_controller::CloseMode;
 pub use subscription_manager::{AutoAckManager, SubscriptionOps};

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -129,6 +129,19 @@ where
     Ok(())
 }
 
+/// How a session should be closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseMode {
+    /// Soft close: notify the group that this participant is going offline so it
+    /// can be brought back later via [`SessionController::rejoin`]. This is an
+    /// in-memory group operation; if the session is also persisted it survives a
+    /// process restart, but persistence is not required. Not valid for
+    /// point-to-point sessions.
+    Soft,
+    /// Hard close: terminate the session permanently (cancel the processing loop).
+    Hard,
+}
+
 pub struct SessionController {
     /// session id
     pub(crate) id: u32,
@@ -585,23 +598,31 @@ impl SessionController {
             .map_err(|_e| SessionError::SessionControllerSendFailed)
     }
 
-    /// Leave the session: cancels the controller and returns the join handle.
-    /// This terminates the session permanently.
-    pub fn leave(&self) -> Result<tokio::task::JoinHandle<()>, SessionError> {
-        self.cancellation_token.cancel();
-
-        self.handle
-            .lock()
-            .take()
-            .ok_or(SessionError::SessionAlreadyClosed)
+    /// Hard-close the session: terminate it permanently by cancelling the
+    /// processing loop (this is what `leave()` used to do). Convenience wrapper
+    /// for [`Self::close_with_mode`] with [`CloseMode::Hard`].
+    pub fn close(&self) -> Result<CompletionHandle, SessionError> {
+        self.terminate()
     }
 
-    /// Close the session: notifies the group that this participant is going offline.
-    /// The returned CompletionHandle resolves when ACKs are collected or on timeout
-    /// (callers should not assume all participants have acknowledged).
-    /// After completion, the caller should persist the session state and may
-    /// later rejoin using `rejoin()`.
-    pub async fn close(&self) -> Result<CompletionHandle, SessionError> {
+    /// Close the session with an explicit [`CloseMode`].
+    ///
+    /// * [`CloseMode::Soft`] — notify the group that this participant is going
+    ///   offline (`UpdateParticipantState(Offline)`). The session state stays
+    ///   persisted and can be brought back later via [`Self::rejoin`]. The
+    ///   returned handle resolves when the group's ACKs are collected or on
+    ///   timeout (callers should not assume every participant acknowledged).
+    ///   This is an in-memory group operation and does not require persistence.
+    ///   Not valid for point-to-point sessions (returns `CannotCloseP2P`).
+    ///
+    /// * [`CloseMode::Hard`] — terminate the session permanently by cancelling
+    ///   the processing loop. The returned handle wraps the loop's join handle
+    ///   and resolves once it has stopped.
+    pub async fn close_with_mode(&self, mode: CloseMode) -> Result<CompletionHandle, SessionError> {
+        if mode == CloseMode::Hard {
+            return self.terminate();
+        }
+
         if self.session_type() == ProtoSessionType::PointToPoint {
             return Err(SessionError::CannotCloseP2P);
         }
@@ -626,6 +647,19 @@ impl SessionController {
             .build_publish()?;
 
         self.publish_message(msg).await
+    }
+
+    /// Hard teardown: cancel the processing loop and hand back its join handle.
+    /// Shared by the hard path of [`Self::close`] and the session layer's
+    /// synchronous removal paths (`remove_session` / `clear_all_sessions`).
+    pub(crate) fn terminate(&self) -> Result<CompletionHandle, SessionError> {
+        self.cancellation_token.cancel();
+        let handle = self
+            .handle
+            .lock()
+            .take()
+            .ok_or(SessionError::SessionAlreadyClosed)?;
+        Ok(CompletionHandle::from_join_handle(handle))
     }
 
     /// Rejoin the session: notifies the group that this participant is back online.
@@ -1517,7 +1551,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_leave_success() {
+    async fn test_close_success() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new()
             .with_graceful_shutdown_timeout(std::time::Duration::from_secs(2))
             .build();
@@ -1525,7 +1559,7 @@ mod tests {
         let token = controller.cancellation_token.clone();
         assert!(!token.is_cancelled());
 
-        let handle = controller.leave();
+        let handle = controller.close();
         assert!(handle.is_ok(), "got error {}", handle.unwrap_err());
         assert!(token.is_cancelled());
 
@@ -1537,11 +1571,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_leave_already_closed() {
+    async fn test_close_already_closed() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new().build();
 
         // Leave once - should succeed
-        let handle = controller.leave();
+        let handle = controller.close();
         assert!(handle.is_ok());
         handle
             .unwrap()
@@ -1549,7 +1583,7 @@ mod tests {
             .expect("processing task should complete");
 
         // Leave again - should fail with appropriate error
-        let result = controller.leave();
+        let result = controller.close();
         assert!(result.is_err());
         match result {
             Err(SessionError::SessionAlreadyClosed) => {
@@ -1560,16 +1594,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_leave_cancels_token_immediately() {
+    async fn test_close_cancels_token_immediately() {
         let (controller, _rx_slim, _rx_app) = SessionControllerTestBuilder::new().build();
 
         let token = controller.cancellation_token.clone();
 
-        // Verify token is not cancelled before leave
+        // Verify token is not cancelled before close
         assert!(!token.is_cancelled());
 
         // Leave returns immediately after cancelling token
-        let handle = controller.leave();
+        let handle = controller.close();
         assert!(handle.is_ok());
 
         // Token should be cancelled immediately

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -785,11 +785,8 @@ where
         let binding = self.pool.read();
         let session = binding.get(&id).ok_or(SessionError::SessionNotFound(id))?;
 
-        // leave the session and get the join handle
-        let join_handle = session.leave()?;
-
-        // Return a CompletionHandle wrapping the oneshot receiver
-        Ok(CompletionHandle::from_join_handle(join_handle))
+        // hard close: cancel the processing loop and return a handle to wait on
+        session.terminate()
     }
 
     /// Clear all sessions and return completion handles to await on
@@ -804,7 +801,7 @@ where
         // Leave all sessions and return completion handles
         pool.iter()
             .map(|(id, session)| {
-                let result = session.leave().map(CompletionHandle::from_join_handle);
+                let result = session.terminate();
                 (*id, result)
             })
             .collect()

--- a/crates/slim-bindings/src/session.rs
+++ b/crates/slim-bindings/src/session.rs
@@ -45,6 +45,27 @@ impl From<ProtoSessionType> for SessionType {
     }
 }
 
+/// How a session should be closed.
+#[derive(Debug, Clone, Copy, PartialEq, uniffi::Enum)]
+pub enum CloseMode {
+    /// Soft close: go offline so the session can be brought back later with
+    /// `rejoin()`. This is an in-memory group operation and does not require
+    /// persistence (though a persisted session also survives a process restart).
+    /// Not valid for point-to-point sessions.
+    Soft,
+    /// Hard close: terminate the session permanently.
+    Hard,
+}
+
+impl From<CloseMode> for slim_session::CloseMode {
+    fn from(mode: CloseMode) -> Self {
+        match mode {
+            CloseMode::Soft => slim_session::CloseMode::Soft,
+            CloseMode::Hard => slim_session::CloseMode::Hard,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, uniffi::Record)]
 pub struct MlsSettings {
     /// 0 = disable header-integrity checks; 1–100 = percent of messages to verify after decrypt.
@@ -632,17 +653,13 @@ impl Session {
         completion_handle.wait_async().await
     }
 
-    /// Notify the group that this participant is going offline (blocking version).
-    ///
-    /// Only valid for Group sessions; returns an error for PointToPoint sessions.
-    /// Returns a completion handle that resolves when ACKs are collected or on timeout.
-    /// After the handle completes the caller should persist the session state and may
-    /// later rejoin with `rejoin()`.
+    /// Hard-close the session (blocking version): terminate it permanently.
+    /// For a soft, restorable close use [`Self::close_with_mode`].
     pub fn close(&self) -> Result<Arc<CompletionHandle>, SlimError> {
         crate::config::get_runtime().block_on(async { self.close_async().await })
     }
 
-    /// Notify the group that this participant is going offline (async version).
+    /// Hard-close the session (async version). See [`Self::close`].
     pub async fn close_async(&self) -> Result<Arc<CompletionHandle>, SlimError> {
         let session = self
             .session
@@ -651,18 +668,58 @@ impl Session {
                 message: "Session already closed or dropped".to_string(),
             })?;
 
-        let completion = session.close().await?;
+        let completion = session.close()?;
         Ok(Arc::new(CompletionHandle::from(completion)))
     }
 
-    /// Notify the group that this participant is going offline and wait for completion (blocking version).
+    /// Hard-close the session and wait for completion (blocking version). See [`Self::close`].
     pub fn close_and_wait(&self) -> Result<(), SlimError> {
         crate::config::get_runtime().block_on(async { self.close_and_wait_async().await })
     }
 
-    /// Notify the group that this participant is going offline and wait for completion (async version).
+    /// Hard-close the session and wait for completion (async version). See [`Self::close`].
     pub async fn close_and_wait_async(&self) -> Result<(), SlimError> {
         let completion_handle = self.close_async().await?;
+        completion_handle.wait_async().await
+    }
+
+    /// Close the session with an explicit [`CloseMode`] (blocking version).
+    ///
+    /// [`CloseMode::Soft`] notifies the group that this participant is going
+    /// offline so it can be brought back with `rejoin()` (an in-memory group
+    /// operation; persistence is not required). Only valid for Group sessions;
+    /// returns an error for PointToPoint sessions. [`CloseMode::Hard`] terminates
+    /// the session permanently. Returns a completion handle that resolves when
+    /// ACKs are collected or on timeout.
+    pub fn close_with_mode(&self, mode: CloseMode) -> Result<Arc<CompletionHandle>, SlimError> {
+        crate::config::get_runtime().block_on(async { self.close_with_mode_async(mode).await })
+    }
+
+    /// Close the session with an explicit [`CloseMode`] (async version). See [`Self::close_with_mode`].
+    pub async fn close_with_mode_async(
+        &self,
+        mode: CloseMode,
+    ) -> Result<Arc<CompletionHandle>, SlimError> {
+        let session = self
+            .session
+            .upgrade()
+            .ok_or_else(|| SlimError::SessionError {
+                message: "Session already closed or dropped".to_string(),
+            })?;
+
+        let completion = session.close_with_mode(mode.into()).await?;
+        Ok(Arc::new(CompletionHandle::from(completion)))
+    }
+
+    /// Close the session with an explicit [`CloseMode`] and wait for completion (blocking version).
+    pub fn close_with_mode_and_wait(&self, mode: CloseMode) -> Result<(), SlimError> {
+        crate::config::get_runtime()
+            .block_on(async { self.close_with_mode_and_wait_async(mode).await })
+    }
+
+    /// Close the session with an explicit [`CloseMode`] and wait for completion (async version).
+    pub async fn close_with_mode_and_wait_async(&self, mode: CloseMode) -> Result<(), SlimError> {
+        let completion_handle = self.close_with_mode_async(mode).await?;
         completion_handle.wait_async().await
     }
 

--- a/crates/slimctl/src/commands/bench.rs
+++ b/crates/slimctl/src/commands/bench.rs
@@ -1106,7 +1106,7 @@ async fn run_pub_worker(
         }
     }
 
-    controller.leave()?.await?;
+    controller.close()?.await?;
 
     let end = Instant::now();
 
@@ -1409,7 +1409,7 @@ async fn run_channel_pub_worker(
             .context("publish completion failed")?;
     }
 
-    controller.leave()?.await?;
+    controller.close()?.await?;
 
     let end = Instant::now();
 


### PR DESCRIPTION
## Summary

Unifies session teardown into a single, clear API on `SessionController`.

Before, there were two overlapping methods: `leave()` (hard, synchronous — terminate the session) and `close()` (soft, async — announce the participant offline). This replaces them with:

- **`close()`** — hard close: terminate the session permanently by cancelling the processing loop (what `leave()` used to do).
- **`close_with_mode(CloseMode)`** — explicit close:
  - `CloseMode::Soft` — announce the participant offline so it can `rejoin()` later.
  - `CloseMode::Hard` — same as `close()`.