### PR TITLE
feat(channel-manager): add storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
  "agntcy-slim-datapath",
+ "agntcy-slim-persistence",
  "agntcy-slim-proto",
  "agntcy-slim-service",
  "agntcy-slim-session",

--- a/crates/channel-manager/Cargo.toml
+++ b/crates/channel-manager/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/bin/cmctl.rs"
 agntcy-slim-auth = { workspace = true }
 agntcy-slim-config = { workspace = true }
 agntcy-slim-datapath = { workspace = true }
+agntcy-slim-persistence = { workspace = true }
 agntcy-slim-proto = { workspace = true }
 agntcy-slim-service = { workspace = true, features = ["session"] }
 agntcy-slim-session = { workspace = true }

--- a/crates/channel-manager/base-config.yaml
+++ b/crates/channel-manager/base-config.yaml
@@ -16,6 +16,11 @@ channel-manager:
 
   auth:
     type: shared_secret
-    secret: "a-very-long-shared-secret-abcdef1234567890"
+    secret: "1234567890-1234567890-1234567890-123456"
 
   channels: []
+
+  persistence:
+    path: /tmp/slim/channel-manager
+    encryption-passphrase: "a-strong-passphrase"
+    delete-sessions-on-shutdown: false

--- a/crates/channel-manager/base-config.yaml
+++ b/crates/channel-manager/base-config.yaml
@@ -16,11 +16,33 @@ channel-manager:
 
   auth:
     type: shared_secret
+    # In production inject the secret at runtime, e.g.:
+    #   secret: ${env:CM_AUTH_SECRET}
+    #   secret: ${file:/run/secrets/cm-auth-secret}
     secret: "1234567890-1234567890-1234567890-123456"
 
+  # Channel definition controls the operating mode:
+  #
+  # Config mode (channels non-empty): the config file is the source of truth.
+  #   Channels and participants are reconciled against the DB on startup.
+  #   gRPC write APIs (create/delete channel, add/remove participant) are
+  #   disabled — modify this file and restart to change the topology.
+  #
+  # API mode (channels empty): the DB is the source of truth.
+  #   All sessions restored from the DB are used as-is and the full gRPC
+  #   API is available for dynamic channel management.
   channels: []
-
+    
   persistence:
+    # Both path and passphrase support ${ENV_VAR} substitution and can be
+    # injected at runtime via a secrets manager (Kubernetes Secret, Vault,
+    # External Secrets Operator, etc.), for example:
+    #   path: ${env:CM_PERSISTENCE_PATH}
+    #   encryption-passphrase: ${env:CM_PASSPHRASE}
+    # A file-based secret is also supported:
+    #   encryption-passphrase: ${file:/run/secrets/cm-passphrase}
+    # In production use a private directory with restrictive permissions
+    # and never store the passphrase in the config file directly.
     path: /tmp/slim/channel-manager
-    encryption-passphrase: "a-strong-passphrase"
+    insecure: true
     delete-sessions-on-shutdown: false

--- a/crates/channel-manager/src/bin/channel_manager.rs
+++ b/crates/channel-manager/src/bin/channel_manager.rs
@@ -21,6 +21,7 @@ use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_config::component::ComponentBuilder;
 use slim_datapath::api::{ProtoName, ProtoSessionType};
+use slim_persistence::{MlsEncryptionKey, PersistenceConfig};
 use slim_service::app::App;
 use slim_session::{Direction, SessionConfig, session_config::MlsSettings};
 use slim_tracing::TracingConfiguration;
@@ -44,6 +45,12 @@ async fn create_channels_from_config(
     config: &Config,
 ) -> anyhow::Result<()> {
     for channel_cfg in &config.manager.channels {
+        // Skip channels already restored from persistent storage.
+        if sessions.get_session(&channel_cfg.name).await.is_some() {
+            info!(channel = %channel_cfg.name, "Channel already restored from persistent storage, skipping");
+            continue;
+        }
+
         let channel_name =
             ProtoName::parse_name(&channel_cfg.name).map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -185,8 +192,25 @@ async fn main() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to initialize identity verifier: {e}"))?;
 
-    let (app, _rx) =
-        service.create_app_with_direction(&app_name, provider, verifier, Direction::None)?;
+    let persistence = config
+        .manager
+        .persistence
+        .as_ref()
+        .map(|p| match &p.encryption_passphrase {
+            Some(passphrase) => PersistenceConfig::with_key(
+                &p.path,
+                MlsEncryptionKey::Passphrase(passphrase.clone()),
+            ),
+            None => PersistenceConfig::new(&p.path),
+        });
+
+    let (app, _rx) = service.create_app_with_direction_and_persistence(
+        &app_name,
+        provider,
+        verifier,
+        Direction::None,
+        persistence,
+    )?;
 
     // Subscribe to the local name
     app.subscribe(app.app_name(), Some(conn_id))
@@ -201,6 +225,36 @@ async fn main() -> anyhow::Result<()> {
     // Create sessions list
     let sessions = Arc::new(SessionsList::new());
     let arc_app = Arc::new(app);
+
+    // Restore sessions persisted by a previous run (no-op when persistence is disabled).
+    match arc_app.restore_sessions(conn_id).await {
+        Ok(restored) => {
+            info!(
+                count = restored.len(),
+                "Sessions found in persistent storage"
+            );
+            for ctx in restored {
+                match ctx.session_arc() {
+                    None => warn!("Restored session context has no live session arc; skipping"),
+                    Some(session) => {
+                        let dst = session.dst();
+                        if dst.str_name.is_none() {
+                            warn!("Skipping restored session with no string name in destination");
+                            continue;
+                        }
+                        let (c0, c1, c2) = dst.str_components();
+                        let channel_name = format!("{c0}/{c1}/{c2}");
+                        if let Err(e) = sessions.add_session(channel_name.clone(), ctx).await {
+                            warn!(channel = %channel_name, "failed to restore session: {e}");
+                        } else {
+                            info!(channel = %channel_name, "Restored session from persistent storage");
+                        }
+                    }
+                }
+            }
+        }
+        Err(e) => warn!("Failed to restore sessions: {e}"),
+    }
 
     // Create channels from configuration
     if let Err(e) = create_channels_from_config(&arc_app, conn_id, &sessions, &config).await {
@@ -235,11 +289,24 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Cleanup with timeout to avoid hanging on shutdown
+    // Cleanup: either delete sessions from SLIM or just go offline, depending on config.
     info!("Shutting down...");
-    match tokio::time::timeout(Duration::from_secs(5), sessions.delete_all(&arc_app)).await {
-        Ok(()) => info!("All sessions cleaned up"),
-        Err(_) => warn!("Session cleanup timed out, forcing shutdown"),
+    let delete_on_shutdown = config
+        .manager
+        .persistence
+        .as_ref()
+        .map(|p| p.delete_sessions_on_shutdown)
+        .unwrap_or(true);
+    if delete_on_shutdown {
+        match tokio::time::timeout(Duration::from_secs(5), sessions.delete_all(&arc_app)).await {
+            Ok(()) => info!("All sessions deleted"),
+            Err(_) => warn!("Session deletion timed out, forcing shutdown"),
+        }
+    } else {
+        match tokio::time::timeout(Duration::from_secs(5), sessions.close_all()).await {
+            Ok(()) => info!("All sessions closed gracefully"),
+            Err(_) => warn!("Session close timed out, forcing shutdown"),
+        }
     }
     service
         .shutdown()

--- a/crates/channel-manager/src/bin/channel_manager.rs
+++ b/crates/channel-manager/src/bin/channel_manager.rs
@@ -37,55 +37,132 @@ struct Args {
     config_file: PathBuf,
 }
 
-/// Create channels from the configuration file
+/// Reconcile channels defined in the config file against the live session state.
+///
+/// For each channel in the config:
+/// - If restored from DB: perform a full roster reconciliation against the config —
+///   remove participants no longer in the config, invite participants not yet in the
+///   session. The channel-manager's own identity is always in the roster and is skipped.
+/// - If freshly created: invite all configured participants; any error is fatal.
 async fn create_channels_from_config(
     app: &Arc<App<AuthProvider, AuthVerifier>>,
     conn_id: u64,
     sessions: &Arc<SessionsList>,
     config: &Config,
 ) -> anyhow::Result<()> {
+    // 3-component key of the channel-manager itself — always present in every roster,
+    // never a user-configured participant, so excluded from all reconciliation checks.
+    let self_key = {
+        let n = app.app_name();
+        let (c0, c1, c2) = n.str_components();
+        format!("{c0}/{c1}/{c2}")
+    };
+
     for channel_cfg in &config.manager.channels {
-        // Skip channels already restored from persistent storage.
-        if sessions.get_session(&channel_cfg.name).await.is_some() {
-            info!(channel = %channel_cfg.name, "Channel already restored from persistent storage, skipping");
-            continue;
-        }
+        let (controller, restored) = if let Some(ctrl) =
+            sessions.get_session(&channel_cfg.name).await
+        {
+            info!(channel = %channel_cfg.name, "Channel restored from DB; reconciling participants");
+            (ctrl, true)
+        } else {
+            let channel_name =
+                ProtoName::parse_name(&channel_cfg.name).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let channel_name =
-            ProtoName::parse_name(&channel_cfg.name).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let session_config = SessionConfig {
+                session_type: ProtoSessionType::Multicast,
+                mls_settings: if channel_cfg.mls_enabled {
+                    Some(MlsSettings::default())
+                } else {
+                    None
+                },
+                max_retries: Some(10),
+                interval: Some(Duration::from_millis(1000)),
+                initiator: true,
+                metadata: std::collections::HashMap::new(),
+            };
 
-        // Create a new session for the channel
-        let session_config = SessionConfig {
-            session_type: ProtoSessionType::Multicast,
-            mls_settings: if channel_cfg.mls_enabled {
-                Some(MlsSettings::default())
-            } else {
-                None
-            },
-            max_retries: Some(10),
-            interval: Some(Duration::from_millis(1000)),
-            initiator: true,
-            metadata: std::collections::HashMap::new(),
+            let (session, completion) = app
+                .create_session(session_config, channel_name, None)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("failed to create session for {}: {e}", channel_cfg.name)
+                })?;
+            completion.await.map_err(|e| {
+                anyhow::anyhow!("session creation failed for {}: {e}", channel_cfg.name)
+            })?;
+
+            let ctrl = session.session_arc().ok_or_else(|| {
+                anyhow::anyhow!("session already closed for {}", channel_cfg.name)
+            })?;
+
+            sessions
+                .add_session(channel_cfg.name.clone(), session)
+                .await?;
+
+            info!(channel = %channel_cfg.name, "Created channel");
+            (ctrl, false)
         };
 
-        let (session, completion) = app
-            .create_session(session_config, channel_name, None)
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!("failed to create session for {}: {e}", channel_cfg.name)
-            })?;
-        completion.await.map_err(|e| {
-            anyhow::anyhow!("session creation failed for {}: {e}", channel_cfg.name)
-        })?;
+        // Build the set of 3-component names declared in the config for this channel.
+        let config_set: std::collections::HashSet<String> = channel_cfg
+            .participants
+            .iter()
+            .filter_map(|p| ProtoName::parse_name(p).ok())
+            .map(|n| {
+                let (c0, c1, c2) = n.str_components();
+                format!("{c0}/{c1}/{c2}")
+            })
+            .collect();
 
-        // Get the session controller for participant invitations
-        let controller = session
-            .session_arc()
-            .ok_or_else(|| anyhow::anyhow!("session already closed for {}", channel_cfg.name))?;
+        // For restored sessions: build the roster map and reconcile.
+        // roster_set holds the 3-component keys of participants already in the session
+        // (excluding the channel-manager itself) so we can skip redundant invites.
+        let roster_set: std::collections::HashSet<String> = if restored {
+            let roster = controller.participants_list().await.unwrap_or_default();
 
+            // Remove participants no longer in the config (skip self).
+            for (name, _) in &roster {
+                let (c0, c1, c2) = name.str_components();
+                let key = format!("{c0}/{c1}/{c2}");
+                if key == self_key || config_set.contains(&key) {
+                    continue;
+                }
+                info!(channel = %channel_cfg.name, participant = %name, "Removing participant no longer in config");
+                match controller.remove_participant(name).await {
+                    Ok(completion) => {
+                        if let Err(e) = completion.await {
+                            warn!(channel = %channel_cfg.name, participant = %name, "Failed to remove participant: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        warn!(channel = %channel_cfg.name, participant = %name, "Failed to remove participant: {e}");
+                    }
+                }
+            }
+
+            roster
+                .into_iter()
+                .filter_map(|(name, _)| {
+                    let (c0, c1, c2) = name.str_components();
+                    let key = format!("{c0}/{c1}/{c2}");
+                    if key == self_key { None } else { Some(key) }
+                })
+                .collect()
+        } else {
+            std::collections::HashSet::new()
+        };
+
+        // Invite participants declared in config that are not already in the session.
         for participant in &channel_cfg.participants {
             let participant_name =
                 ProtoName::parse_name(participant).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let (c0, c1, c2) = participant_name.str_components();
+            let key = format!("{c0}/{c1}/{c2}");
+            if roster_set.contains(&key) {
+                tracing::debug!(channel = %channel_cfg.name, participant = %participant, "Participant already in session, skipping invite");
+                continue;
+            }
 
             app.set_route(&participant_name, conn_id)
                 .await
@@ -97,7 +174,7 @@ async fn create_channels_from_config(
                     )
                 })?;
 
-            controller
+            let completion = controller
                 .invite_participant(&participant_name)
                 .await
                 .map_err(|e| {
@@ -106,26 +183,34 @@ async fn create_channels_from_config(
                         participant,
                         channel_cfg.name
                     )
-                })?
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "failed to invite {} to channel {}: {e}",
-                        participant,
-                        channel_cfg.name
-                    )
                 })?;
+            completion.await.map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to invite {} to channel {}: {e}",
+                    participant,
+                    channel_cfg.name
+                )
+            })?;
         }
-
-        sessions
-            .add_session(channel_cfg.name.clone(), session)
-            .await?;
 
         info!(
             channel = %channel_cfg.name,
             participants = ?channel_cfg.participants,
-            "Created channel and invited participants"
+            "Channel ready"
         );
+    }
+
+    // Delete sessions that exist in the DB but are no longer in the config.
+    // Config is the source of truth in config mode.
+    let config_channels: std::collections::HashSet<&str> =
+        config.manager.channels.iter().map(|c| c.name.as_str()).collect();
+    for name in sessions.list_channel_names().await {
+        if !config_channels.contains(name.as_str()) {
+            info!(channel = %name, "Channel removed from config; deleting session");
+            if let Err(e) = sessions.remove_session(&name, app).await {
+                warn!(channel = %name, "Failed to delete removed channel: {e}");
+            }
+        }
     }
 
     Ok(())
@@ -256,14 +341,19 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => warn!("Failed to restore sessions: {e}"),
     }
 
-    // Create channels from configuration
-    if let Err(e) = create_channels_from_config(&arc_app, conn_id, &sessions, &config).await {
-        error!("Failed to create channels from config: {e}");
+    // Config mode: channels section is non-empty → config is the source of truth.
+    // API mode:    channels section is empty → DB (restored above) is the source of truth.
+    let config_mode = !config.manager.channels.is_empty();
+
+    if config_mode
+        && let Err(e) = create_channels_from_config(&arc_app, conn_id, &sessions, &config).await
+    {
+        error!("Failed to reconcile channels from config: {e}");
         return Err(e);
     }
 
     // Create gRPC server
-    let server = ChannelManagerServer::new(arc_app.clone(), conn_id, sessions.clone());
+    let server = ChannelManagerServer::new(arc_app.clone(), conn_id, sessions.clone(), config_mode);
     let svc = ChannelManagerServiceServer::new(server);
 
     info!(
@@ -298,15 +388,11 @@ async fn main() -> anyhow::Result<()> {
         .map(|p| p.delete_sessions_on_shutdown)
         .unwrap_or(true);
     if delete_on_shutdown {
-        match tokio::time::timeout(Duration::from_secs(5), sessions.delete_all(&arc_app)).await {
-            Ok(()) => info!("All sessions deleted"),
-            Err(_) => warn!("Session deletion timed out, forcing shutdown"),
-        }
+        sessions.delete_all(&arc_app).await;
+        info!("All sessions deleted");
     } else {
-        match tokio::time::timeout(Duration::from_secs(5), sessions.close_all()).await {
-            Ok(()) => info!("All sessions closed gracefully"),
-            Err(_) => warn!("Session close timed out, forcing shutdown"),
-        }
+        sessions.close_all().await;
+        info!("All sessions closed");
     }
     service
         .shutdown()

--- a/crates/channel-manager/src/config.rs
+++ b/crates/channel-manager/src/config.rs
@@ -26,9 +26,17 @@
 //!         - "agntcy/otel/exporter"
 //!         - "agntcy/otel/receiver"
 //!       mls-enabled: true
+//!   # Optional: persist sessions so they survive a restart.
+//!   # Omit this section entirely to keep everything in memory (default).
+//!   persistence:
+//!     path: /var/lib/slim/channel-manager
+//!     encryption-passphrase: "a-strong-passphrase"  # recommended
+//!     # Set to false to keep sessions in the store on clean shutdown so they
+//!     # are restored on next startup. Default is true (sessions are deleted).
+//!     delete-sessions-on-shutdown: false
 //! ```
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 use serde::Deserialize;
@@ -42,6 +50,35 @@ pub struct Config {
     /// Channel manager settings
     #[serde(rename = "channel-manager")]
     pub manager: ManagerConfig,
+}
+
+/// Persistence configuration for the channel manager.
+///
+/// When present, session state survives restarts: the session layer stores MLS
+/// group state and session records in an encrypted SQLite database, and the
+/// channel manager restores all previously-known sessions on startup.
+#[derive(Clone, Debug, Deserialize)]
+pub struct PersistenceConfig {
+    /// Directory where the SQLite database will be written.
+    pub path: PathBuf,
+
+    /// Optional passphrase used to derive the AES-256 encryption key.
+    /// Without one, values are still encrypted but the key is derived from
+    /// the (public) app name — adequate for at-rest protection but not a
+    /// strong secret.
+    #[serde(default, rename = "encryption-passphrase")]
+    pub encryption_passphrase: Option<String>,
+
+    /// Controls what happens to sessions when the channel manager shuts down.
+    ///
+    /// - `true` (default): sessions are fully deleted from SLIM on shutdown.
+    /// - `false`: sessions are closed (participants notified offline) but kept
+    ///   in the persistence store, so they are restored on the next startup.
+    #[serde(
+        default = "default_delete_sessions_on_shutdown",
+        rename = "delete-sessions-on-shutdown"
+    )]
+    pub delete_sessions_on_shutdown: bool,
 }
 
 /// Channel manager service configuration
@@ -68,6 +105,11 @@ pub struct ManagerConfig {
     /// Channels to create on startup
     #[serde(default)]
     pub channels: Vec<ChannelConfig>,
+
+    /// Optional persistence configuration.  When set, sessions survive a
+    /// channel-manager restart and are automatically restored on startup.
+    #[serde(default)]
+    pub persistence: Option<PersistenceConfig>,
 }
 
 /// Configuration for a single channel
@@ -85,6 +127,10 @@ pub struct ChannelConfig {
 }
 
 fn default_mls_enabled() -> bool {
+    true
+}
+
+fn default_delete_sessions_on_shutdown() -> bool {
     true
 }
 
@@ -121,6 +167,12 @@ impl Config {
 
         // Validate auth configuration
         self.manager.auth.validate()?;
+
+        if let Some(p) = &self.manager.persistence
+            && p.path.as_os_str().is_empty()
+        {
+            bail!("persistence.path cannot be empty");
+        }
 
         for (i, channel) in self.manager.channels.iter().enumerate() {
             if channel.name.is_empty() {
@@ -598,6 +650,56 @@ channel-manager:
             }
             _ => panic!("expected SharedSecret"),
         }
+    }
+
+    // ── Persistence config ───────────────────────────────────────────────
+
+    #[test]
+    fn test_persistence_config_parsed() {
+        let yaml = base_yaml(
+            r#"  persistence:
+    path: /var/lib/slim/channel-manager
+    encryption-passphrase: "secret""#,
+        );
+        let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
+        assert!(cfg.validate().is_ok());
+        let p = cfg.manager.persistence.unwrap();
+        assert_eq!(
+            p.path,
+            std::path::PathBuf::from("/var/lib/slim/channel-manager")
+        );
+        assert_eq!(p.encryption_passphrase.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn test_persistence_config_without_passphrase() {
+        let yaml = base_yaml(
+            r#"  persistence:
+    path: /var/lib/slim/channel-manager"#,
+        );
+        let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
+        assert!(cfg.validate().is_ok());
+        let p = cfg.manager.persistence.unwrap();
+        assert!(p.encryption_passphrase.is_none());
+    }
+
+    #[test]
+    fn test_persistence_absent_by_default() {
+        let yaml = base_yaml("");
+        let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
+        assert!(cfg.validate().is_ok());
+        assert!(cfg.manager.persistence.is_none());
+    }
+
+    #[test]
+    fn test_persistence_empty_path_fails() {
+        let yaml = base_yaml(
+            r#"  persistence:
+    path: """#,
+        );
+        let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("persistence.path"), "got: {err}");
     }
 
     // ── Config::load from file ───────────────────────────────────────────

--- a/crates/channel-manager/src/config.rs
+++ b/crates/channel-manager/src/config.rs
@@ -3,7 +3,38 @@
 
 //! Configuration module for the Channel Manager.
 //!
-//! Supports loading configuration from a YAML file with the following structure:
+//! ## Operating modes
+//!
+//! The `channels:` list selects the operating mode:
+//!
+//! - **Config mode** (`channels` non-empty): the config file is the source of
+//!   truth. On startup, each channel is reconciled against the persistence store:
+//!   if already restored, missing participants are invited; otherwise a fresh
+//!   session is created. gRPC write APIs (create/delete channel,
+//!   add/remove participant) return `FAILED_PRECONDITION` — modify the config
+//!   file and restart to change the topology.
+//!
+//! - **API mode** (`channels` empty): the persistence store is the source of
+//!   truth. All sessions restored from the store are used as-is and the full
+//!   gRPC API is available for dynamic channel management.
+//!
+//! ## Secret injection
+//!
+//! String values support provider references using the `${provider:ref}` syntax,
+//! resolved after YAML parsing (comments are never affected):
+//!
+//! - `${env:VAR_NAME}` — read from an environment variable
+//! - `${file:/path/to/secret}` — read from a file on disk
+//!
+//! Example using environment variables:
+//!
+//! ```yaml
+//! persistence:
+//!   path: ${env:CM_PERSISTENCE_PATH}
+//!   encryption-passphrase: ${env:CM_PASSPHRASE}
+//! ```
+//!
+//! ## Example configuration
 //!
 //! ```yaml
 //! channel-manager:
@@ -20,6 +51,7 @@
 //!     type: shared_secret
 //!     # id: "custom/identity/id"  # optional, defaults to local-name
 //!     secret: "a-very-long-shared-secret"
+//!   # Config mode: declare channels here. Leave empty for API mode.
 //!   channels:
 //!     - name: "agntcy/otel/channel"
 //!       participants:
@@ -29,8 +61,11 @@
 //!   # Optional: persist sessions so they survive a restart.
 //!   # Omit this section entirely to keep everything in memory (default).
 //!   persistence:
-//!     path: /var/lib/slim/channel-manager
-//!     encryption-passphrase: "a-strong-passphrase"  # recommended
+//!     path: ${env:CM_PERSISTENCE_PATH}
+//!     encryption-passphrase: ${env:CM_PASSPHRASE}
+//!     # Set insecure: true instead of encryption-passphrase to allow
+//!     # unencrypted storage. Not recommended for production.
+//!     # insecure: true
 //!     # Set to false to keep sessions in the store on clean shutdown so they
 //!     # are restored on next startup. Default is true (sessions are deleted).
 //!     delete-sessions-on-shutdown: false
@@ -42,6 +77,7 @@ use anyhow::{Context, bail};
 use serde::Deserialize;
 use slim_config::auth::AuthConfig;
 use slim_config::client::ClientConfig;
+use slim_config::provider::ConfigResolver;
 use slim_config::server::ServerConfig;
 
 /// Top-level configuration
@@ -62,12 +98,16 @@ pub struct PersistenceConfig {
     /// Directory where the SQLite database will be written.
     pub path: PathBuf,
 
-    /// Optional passphrase used to derive the AES-256 encryption key.
-    /// Without one, values are still encrypted but the key is derived from
-    /// the (public) app name — adequate for at-rest protection but not a
-    /// strong secret.
+    /// Passphrase used to derive the AES-256 encryption key for the store.
+    /// Required unless `insecure: true` is set explicitly.
     #[serde(default, rename = "encryption-passphrase")]
     pub encryption_passphrase: Option<String>,
+
+    /// Allow persistence without an encryption passphrase.
+    /// The fallback key is derived from the public app name and provides no
+    /// confidentiality. Do not use in production.
+    #[serde(default)]
+    pub insecure: bool,
 
     /// Controls what happens to sessions when the channel manager shuts down.
     ///
@@ -135,11 +175,24 @@ fn default_delete_sessions_on_shutdown() -> bool {
 }
 
 impl Config {
-    /// Load configuration from a YAML file
+    /// Load configuration from a YAML file.
+    ///
+    /// String values of the form `${env:VAR_NAME}` are resolved from the process
+    /// environment, and `${file:/path/to/file}` values are read from disk.
+    /// Resolution happens on the parsed YAML value tree so comments are never
+    /// affected. Use this to inject secrets (e.g.
+    /// `encryption-passphrase: ${env:CM_PASSPHRASE}`) without storing them in
+    /// the config file itself.
     pub fn load(path: &Path) -> anyhow::Result<Self> {
         let data = std::fs::read_to_string(path)
             .with_context(|| format!("reading config file {:?}", path))?;
-        let cfg: Config = serde_yaml::from_str(&data).with_context(|| "parsing config YAML")?;
+        let mut value: serde_yaml::Value =
+            serde_yaml::from_str(&data).with_context(|| "parsing config YAML")?;
+        ConfigResolver::new()
+            .resolve(&mut value)
+            .with_context(|| format!("resolving config values in {:?}", path))?;
+        let cfg: Config =
+            serde_yaml::from_value(value).with_context(|| "deserializing config YAML")?;
         cfg.validate()?;
         Ok(cfg)
     }
@@ -168,10 +221,21 @@ impl Config {
         // Validate auth configuration
         self.manager.auth.validate()?;
 
-        if let Some(p) = &self.manager.persistence
-            && p.path.as_os_str().is_empty()
-        {
-            bail!("persistence.path cannot be empty");
+        if let Some(p) = &self.manager.persistence {
+            if p.path.as_os_str().is_empty() {
+                bail!("persistence.path cannot be empty");
+            }
+            if p.encryption_passphrase.is_some() && p.insecure {
+                bail!(
+                    "persistence.insecure and persistence.encryption-passphrase are mutually exclusive"
+                );
+            }
+            if p.encryption_passphrase.is_none() && !p.insecure {
+                bail!(
+                    "persistence requires encryption-passphrase; \
+                     set insecure: true to allow unencrypted storage (not recommended for production)"
+                );
+            }
         }
 
         for (i, channel) in self.manager.channels.iter().enumerate() {
@@ -652,6 +716,33 @@ channel-manager:
         }
     }
 
+    // ── ConfigResolver ───────────────────────────────────────────────────
+
+    fn resolve_yaml(yaml: &str) -> serde_yaml::Value {
+        let mut value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        ConfigResolver::new().resolve(&mut value).unwrap();
+        value
+    }
+
+    #[test]
+    fn test_resolver_no_placeholders() {
+        let v = resolve_yaml("key: plain");
+        assert_eq!(v["key"].as_str(), Some("plain"));
+    }
+
+    #[test]
+    fn test_resolver_unknown_provider_errors() {
+        let mut value: serde_yaml::Value = serde_yaml::from_str("key: \"${unknown:VAR}\"").unwrap();
+        assert!(ConfigResolver::new().resolve(&mut value).is_err());
+    }
+
+    #[test]
+    fn test_resolver_missing_env_var_errors() {
+        let mut value: serde_yaml::Value =
+            serde_yaml::from_str("key: \"${env:_TEST_CM_DEFINITELY_NOT_SET_XYZ}\"").unwrap();
+        assert!(ConfigResolver::new().resolve(&mut value).is_err());
+    }
+
     // ── Persistence config ───────────────────────────────────────────────
 
     #[test]
@@ -672,15 +763,41 @@ channel-manager:
     }
 
     #[test]
-    fn test_persistence_config_without_passphrase() {
+    fn test_persistence_without_passphrase_or_insecure_fails() {
         let yaml = base_yaml(
             r#"  persistence:
     path: /var/lib/slim/channel-manager"#,
         );
         let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("encryption-passphrase"), "got: {err}");
+    }
+
+    #[test]
+    fn test_persistence_insecure_and_passphrase_together_fails() {
+        let yaml = base_yaml(
+            r#"  persistence:
+    path: /var/lib/slim/channel-manager
+    encryption-passphrase: "secret"
+    insecure: true"#,
+        );
+        let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("mutually exclusive"), "got: {err}");
+    }
+
+    #[test]
+    fn test_persistence_insecure_without_passphrase_passes() {
+        let yaml = base_yaml(
+            r#"  persistence:
+    path: /var/lib/slim/channel-manager
+    insecure: true"#,
+        );
+        let cfg: Config = serde_yaml::from_str(&yaml).unwrap();
         assert!(cfg.validate().is_ok());
         let p = cfg.manager.persistence.unwrap();
         assert!(p.encryption_passphrase.is_none());
+        assert!(p.insecure);
     }
 
     #[test]

--- a/crates/channel-manager/src/service.rs
+++ b/crates/channel-manager/src/service.rs
@@ -27,19 +27,43 @@ pub struct ChannelManagerServer {
     app: Arc<App<AuthProvider, AuthVerifier>>,
     conn_id: u64,
     sessions: Arc<SessionsList>,
+    /// When true, channels are owned by the config file and mutating APIs are disabled.
+    config_mode: bool,
 }
 
 impl ChannelManagerServer {
-    /// Create a new server instance
+    /// Create a new server instance.
+    ///
+    /// Set `config_mode` to `true` when the config file defines channels; this
+    /// makes all write operations return `FAILED_PRECONDITION` so the config
+    /// file remains the single source of truth.
     pub fn new(
         app: Arc<App<AuthProvider, AuthVerifier>>,
         conn_id: u64,
         sessions: Arc<SessionsList>,
+        config_mode: bool,
     ) -> Self {
         Self {
             app,
             conn_id,
             sessions,
+            config_mode,
+        }
+    }
+
+    /// Guard for mutating operations: returns an error response when the server
+    /// is running in config mode (channels are owned by the config file).
+    fn ensure_api_mode(&self) -> Option<CommandResponse> {
+        if self.config_mode {
+            Some(
+                self.error_response(
+                    "channel manager is running in config mode; \
+                 modify the config file and restart to change channels or participants"
+                        .to_string(),
+                ),
+            )
+        } else {
+            None
         }
     }
 
@@ -71,6 +95,9 @@ impl ChannelManagerServer {
     }
 
     async fn handle_create_channel(&self, req: CreateChannelRequest) -> CommandResponse {
+        if let Some(err) = self.ensure_api_mode() {
+            return err;
+        }
         let channel_name = &req.channel_name;
 
         // Check if the channel already exists before doing expensive SLIM work
@@ -138,6 +165,9 @@ impl ChannelManagerServer {
     }
 
     async fn handle_delete_channel(&self, req: DeleteChannelRequest) -> CommandResponse {
+        if let Some(err) = self.ensure_api_mode() {
+            return err;
+        }
         let channel_name = &req.channel_name;
 
         if let Err(e) = self.sessions.remove_session(channel_name, &self.app).await {
@@ -150,6 +180,9 @@ impl ChannelManagerServer {
     }
 
     async fn handle_add_participant(&self, req: AddParticipantRequest) -> CommandResponse {
+        if let Some(err) = self.ensure_api_mode() {
+            return err;
+        }
         let channel_name = &req.channel_name;
         let participant_name_str = &req.participant_name;
 
@@ -192,6 +225,9 @@ impl ChannelManagerServer {
     }
 
     async fn handle_delete_participant(&self, req: DeleteParticipantRequest) -> CommandResponse {
+        if let Some(err) = self.ensure_api_mode() {
+            return err;
+        }
         let channel_name = &req.channel_name;
         let participant_name_str = &req.participant_name;
 

--- a/crates/channel-manager/src/sessions.rs
+++ b/crates/channel-manager/src/sessions.rs
@@ -66,17 +66,11 @@ impl SessionsList {
         channel_name: &str,
         app: &App<AuthProvider, AuthVerifier>,
     ) -> anyhow::Result<()> {
-        // Remove from map and release the lock before the potentially slow SLIM call
-        let session = {
-            let mut channels = self.channels.write().await;
-            let channel = channels
-                .remove(channel_name)
-                .ok_or_else(|| anyhow::anyhow!("channel {channel_name} not found"))?;
-            channel.monitor.abort();
-            channel.session
-        };
+        let session = self
+            .take_channel(channel_name)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("channel {channel_name} not found"))?;
 
-        // Delete the SLIM session with a timeout to avoid hanging
         let s = session
             .upgrade()
             .ok_or_else(|| anyhow::anyhow!("session already closed"))?;
@@ -87,18 +81,12 @@ impl SessionsList {
         match tokio::time::timeout(std::time::Duration::from_secs(5), completion).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => {
-                warn!(
-                    channel = %channel_name,
-                    "Session deletion completed with error: {e}"
-                );
-                Ok(()) // Session was already removed from the map
+                warn!(channel = %channel_name, "Session deletion completed with error: {e}");
+                Ok(())
             }
             Err(_) => {
-                warn!(
-                    channel = %channel_name,
-                    "Session deletion did not complete in time"
-                );
-                Ok(()) // Session was already removed from the map
+                warn!(channel = %channel_name, "Session deletion did not complete in time");
+                Ok(())
             }
         }
     }
@@ -109,15 +97,51 @@ impl SessionsList {
         channels.keys().cloned().collect()
     }
 
-    /// Delete all sessions (used during shutdown)
+    /// Delete all sessions from SLIM (used on shutdown when persistence is disabled
+    /// or `delete-sessions-on-shutdown` is true).
     pub async fn delete_all(&self, app: &App<AuthProvider, AuthVerifier>) {
-        let names: Vec<String> = self.list_channel_names().await;
-        for name in names {
+        for name in self.list_channel_names().await {
             match self.remove_session(&name, app).await {
-                Ok(()) => info!("Deleted session for channel {name}"),
+                Ok(()) => info!(channel = %name, "Session deleted"),
                 Err(e) => warn!("{e}"),
             }
         }
+    }
+
+    /// Close all sessions gracefully (send Offline) without deleting them from
+    /// the persistence store. Use this on clean shutdown when sessions should be
+    /// restored on next startup (`delete-sessions-on-shutdown: false`).
+    pub async fn close_all(&self) {
+        for name in self.list_channel_names().await {
+            let Some(weak) = self.take_channel(&name).await else {
+                continue;
+            };
+            let Some(session) = weak.upgrade() else {
+                continue;
+            };
+            match session.close().await {
+                Ok(completion) => {
+                    if tokio::time::timeout(std::time::Duration::from_secs(5), completion)
+                        .await
+                        .is_err()
+                    {
+                        warn!(channel = %name, "Timed out waiting for session close confirmation");
+                    } else {
+                        info!(channel = %name, "Session closed gracefully");
+                    }
+                }
+                Err(e) => warn!(channel = %name, "Failed to close session: {e}"),
+            }
+        }
+    }
+
+    /// Remove a channel from the map and abort its monitor, returning the session weak ref.
+    async fn take_channel(&self, channel_name: &str) -> Option<Weak<SessionController>> {
+        let mut channels = self.channels.write().await;
+        channels.remove(channel_name).map(|ch| {
+            ch.monitor.abort();
+            ch.session
+        })
     }
 }
 

--- a/crates/channel-manager/src/sessions.rs
+++ b/crates/channel-manager/src/sessions.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Weak};
 use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
 use slim_service::app::App;
 use slim_session::context::SessionContext;
-use slim_session::session_controller::SessionController;
+use slim_session::session_controller::{CloseMode, SessionController};
 use slim_session::{AppChannelReceiver, SessionError};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
@@ -119,7 +119,7 @@ impl SessionsList {
             let Some(session) = weak.upgrade() else {
                 continue;
             };
-            match session.close().await {
+            match session.close_with_mode(CloseMode::Soft).await {
                 Ok(completion) => {
                     if tokio::time::timeout(std::time::Duration::from_secs(5), completion)
                         .await

--- a/crates/channel-manager/src/sessions.rs
+++ b/crates/channel-manager/src/sessions.rs
@@ -121,13 +121,15 @@ impl SessionsList {
             };
             match session.close_with_mode(CloseMode::Soft).await {
                 Ok(completion) => {
-                    if tokio::time::timeout(std::time::Duration::from_secs(5), completion)
-                        .await
-                        .is_err()
+                    match tokio::time::timeout(std::time::Duration::from_secs(5), completion).await
                     {
-                        warn!(channel = %name, "Timed out waiting for session close confirmation");
-                    } else {
-                        info!(channel = %name, "Session closed gracefully");
+                        Ok(Ok(())) => info!(channel = %name, "Session closed gracefully"),
+                        Ok(Err(e)) => {
+                            warn!(channel = %name, "Session close completed with error: {e}")
+                        }
+                        Err(_) => {
+                            warn!(channel = %name, "Timed out waiting for session close confirmation")
+                        }
                     }
                 }
                 Err(e) => warn!(channel = %name, "Failed to close session: {e}"),

--- a/crates/channel-manager/tests/integration_test.rs
+++ b/crates/channel-manager/tests/integration_test.rs
@@ -151,7 +151,7 @@ async fn start_channel_manager(
 
     // Create sessions list and gRPC server
     let sessions = Arc::new(SessionsList::new());
-    let server = ChannelManagerServer::new(app.clone(), conn_id, sessions.clone());
+    let server = ChannelManagerServer::new(app.clone(), conn_id, sessions.clone(), false);
     let svc = ChannelManagerServiceServer::new(server);
 
     // Start gRPC server using ServerConfig

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -777,7 +777,8 @@ where
         }.instrument(sessions_span));
     }
 
-    /// Remove a session from the pool and return a handle to optionally wait on
+    /// Remove a session from the pool and return a handle to optionally wait on.
+    /// Also removes the persisted session record from the KV store (if any).
     #[tracing::instrument(skip_all, fields(service_id = %self.service_id, session_id = id))]
     pub fn remove_session(&self, id: u32) -> Result<CompletionHandle, SessionError> {
         debug!(%id, "try to remove session");
@@ -787,6 +788,15 @@ where
 
         // leave the session and get the join handle
         let join_handle = session.leave()?;
+
+        // Remove the persisted record so a restart does not attempt to restore
+        // a session that no longer exists in SLIM.
+        if let Some(kv) = &self.kv_store {
+            let key = crate::persistence::session_key(id);
+            if let Err(e) = kv.delete(&key) {
+                warn!(%id, error = %e, "failed to delete persisted session record");
+            }
+        }
 
         // Return a CompletionHandle wrapping the oneshot receiver
         Ok(CompletionHandle::from_join_handle(join_handle))

--- a/crates/session/src/session_moderator.rs
+++ b/crates/session/src/session_moderator.rs
@@ -152,6 +152,13 @@ where
             } else {
                 None
             };
+
+            // Persist the initial session record so the channel survives a
+            // crash even before the first participant joins. The MLS group is
+            // not initialized yet (that happens in join()); persist_state()
+            // handles the None-group case and the record is overwritten with
+            // the full state when join() fires.
+            self.persist_state();
         }
 
         Ok(())


### PR DESCRIPTION
# Description

Integrates agntcy-slim-persistence into the channel-manager so that sessions survive a restart.

Session persistence on creation — SessionModerator::init() now calls persist_state() immediately when a session starts, writing the session record and app identity to the encrypted SQLite store. Previously, persistence only triggered when the first participant joined, so channels with no active participants were never durably recorded.

Session restore on startup — after connecting to SLIM and creating the app, the channel-manager reads all session records from the store and re-registers each session. Config-driven channels are skipped if they were already restored, avoiding duplicates.

Graceful shutdown mode — a new delete-sessions-on-shutdown flag (under persistence:) controls shutdown behaviour:
- true (default): sessions are fully deleted from SLIM on shutdown (same as before persistence was added)
- false: sessions are closed with UpdateParticipantState::Offline and kept in the store, so they are automatically restored on the next startup

KV cleanup on delete — session_layer::remove_session() now deletes the session record from the KV store when a session is explicitly removed, so a restart after a delete-sessions-on-shutdown: true shutdown does not attempt to restore stale sessions.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
