### PR TITLE
fix(session): remove record + MLS state + pool entry on close (both roles)

### DIFF
--- a/crates/persistence/src/group_storage.rs
+++ b/crates/persistence/src/group_storage.rs
@@ -109,6 +109,23 @@ impl SlimGroupStateStorage {
             SlimGroupStateStorage::Sqlite(_) => true,
         }
     }
+
+    /// Delete a group's stored MLS state so it can no longer be loaded. Used
+    /// when a session is permanently closed, so its MLS group is not left behind
+    /// in the store. Deleting an unknown group is a no-op.
+    pub fn delete_group(&self, group_id: &[u8]) -> Result<(), PersistenceError> {
+        match self {
+            SlimGroupStateStorage::InMemory(s) => {
+                s.delete_group(group_id);
+                Ok(())
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            SlimGroupStateStorage::Sqlite(s) => s
+                .inner
+                .delete_group(group_id)
+                .map_err(|e| PersistenceError::Storage(e.to_string())),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/service/src/app.rs
+++ b/crates/service/src/app.rs
@@ -249,6 +249,20 @@ where
         self.session_layer.remove_session(session.id())
     }
 
+    /// Look up a session by id in the layer pool, if still present. Returns
+    /// `None` once the session has been closed/removed. Primarily for tests and
+    /// introspection.
+    pub fn get_session(&self, id: u32) -> Option<std::sync::Arc<SessionController>> {
+        self.session_layer.get_session(id)
+    }
+
+    /// The MLS group ids currently held in the group store (for tests /
+    /// introspection).
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn stored_mls_group_ids(&self) -> Vec<Vec<u8>> {
+        self.session_layer.stored_mls_group_ids()
+    }
+
     /// Get the app name
     ///
     /// Returns a reference to the name that was provided when the App was created.

--- a/crates/service/tests/session_restore_test.rs
+++ b/crates/service/tests/session_restore_test.rs
@@ -458,6 +458,258 @@ async fn test_multicast_mls_moderator_restart_republish() {
     .await;
 }
 
+/// A hard `close()` must delete the session's persisted record, so it is NOT
+/// restored on a subsequent restart. This is the mirror of
+/// `test_multicast_mls_moderator_restart_republish`, where a graceful drop
+/// preserves the record and restore finds it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_hard_close_deletes_persisted_session() {
+    // 1. Start the SLIM node.
+    let port = reserve_local_port();
+    tokio::spawn(async move {
+        let _ = run_slim_node(port).await;
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let moderator_name = Name::from_strings(["org", "ns", "moderator"]);
+    let participant_name = Name::from_strings(["org", "ns", "participant"]);
+    let channel = Name::from_strings(["channel", "hardclose", "test"]);
+
+    let moderator_dir = tempfile::tempdir().unwrap();
+    let participant_dir = tempfile::tempdir().unwrap();
+
+    let moderator_secret = SharedSecret::new("moderator-identity", TEST_VALID_SECRET).unwrap();
+    let participant_secret = SharedSecret::new("participant-identity", TEST_VALID_SECRET).unwrap();
+
+    // 2. Participant (kept alive so the invite completes) + moderator, persistent.
+    let (_participant_app, mut participant_rx, _participant_conn, _participant_svc) =
+        create_persistent_app(
+            port,
+            &participant_name,
+            participant_secret,
+            participant_dir.path(),
+        )
+        .await;
+    let _participant_listener = tokio::spawn(async move {
+        while let Some(Ok(Notification::NewSession(_ctx))) = participant_rx.recv().await {}
+    });
+
+    let (moderator_app, _moderator_rx, moderator_conn, moderator_svc) = create_persistent_app(
+        port,
+        &moderator_name,
+        moderator_secret,
+        moderator_dir.path(),
+    )
+    .await;
+
+    // 3. Moderator creates a multicast MLS session and invites the participant,
+    //    which persists the moderator's session record.
+    let config = SessionConfig {
+        session_type: slim_datapath::api::ProtoSessionType::Multicast,
+        max_retries: Some(10),
+        interval: Some(Duration::from_secs(1)),
+        mls_settings: Some(MlsSettings::default()),
+        initiator: true,
+        metadata: Default::default(),
+    };
+    let (session_ctx, completion) = moderator_app
+        .create_session(config, channel.clone(), None)
+        .await
+        .expect("failed to create session");
+    completion.await.expect("session establishment failed");
+
+    moderator_app
+        .set_route(&participant_name, moderator_conn)
+        .await
+        .expect("failed to set route to participant");
+
+    let session = session_ctx.session_arc().expect("no session arc");
+    let session_id = session.id();
+    session
+        .invite_participant(&participant_name)
+        .await
+        .expect("invite failed")
+        .await
+        .expect("invite completion failed");
+
+    // Before closing: the session is in the layer pool and its MLS group is
+    // stored.
+    assert!(
+        moderator_app.get_session(session_id).is_some(),
+        "session should be in the pool before close"
+    );
+    assert!(
+        !moderator_app.stored_mls_group_ids().is_empty(),
+        "the MLS group should be stored before close"
+    );
+
+    // 4. Hard close the moderator session (CloseMode::Hard, via close()). This
+    //    should drop the persisted record and remove it from the layer pool.
+    session
+        .close()
+        .expect("hard close failed")
+        .await
+        .expect("close completion failed");
+    drop(session);
+    drop(session_ctx);
+    // Let the DeleteSession signal reach the layer, remove the pool entry and
+    // delete the record.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // The hard close removed the session from the layer pool and deleted its
+    // MLS group state.
+    assert!(
+        moderator_app.get_session(session_id).is_none(),
+        "a hard-closed session must be removed from the layer pool"
+    );
+    assert!(
+        moderator_app.stored_mls_group_ids().is_empty(),
+        "a hard-closed session's MLS group state must be deleted"
+    );
+
+    drop(moderator_app);
+    drop(moderator_svc);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 5. Restart the moderator against the same persistence dir. The record was
+    //    deleted by the hard close, so nothing should be restored.
+    let restarted_secret = SharedSecret::new("moderator-identity", TEST_VALID_SECRET).unwrap();
+    let (moderator_app2, _moderator_rx2, conn2, _moderator_svc2) = create_persistent_app(
+        port,
+        &moderator_name,
+        restarted_secret,
+        moderator_dir.path(),
+    )
+    .await;
+
+    let restored = moderator_app2
+        .restore_sessions(conn2)
+        .await
+        .expect("restore_sessions failed");
+    assert_eq!(
+        restored.len(),
+        0,
+        "a hard-closed session must not be restored"
+    );
+}
+
+/// The same teardown must work for a participant: when a participant hard-closes
+/// its own session, its pool entry, persisted record and MLS group state are all
+/// removed (the `DeleteSession` signal is emitted uniformly by the controller for
+/// both roles).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_participant_hard_close_deletes_persisted_session() {
+    // 1. Start the SLIM node.
+    let port = reserve_local_port();
+    tokio::spawn(async move {
+        let _ = run_slim_node(port).await;
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let moderator_name = Name::from_strings(["org", "ns", "moderator"]);
+    let participant_name = Name::from_strings(["org", "ns", "participant"]);
+    let channel = Name::from_strings(["channel", "phardclose", "test"]);
+
+    let moderator_dir = tempfile::tempdir().unwrap();
+    let participant_dir = tempfile::tempdir().unwrap();
+
+    let moderator_secret = SharedSecret::new("moderator-identity", TEST_VALID_SECRET).unwrap();
+    let participant_secret = SharedSecret::new("participant-identity", TEST_VALID_SECRET).unwrap();
+
+    let (moderator_app, _moderator_rx, moderator_conn, _moderator_svc) = create_persistent_app(
+        port,
+        &moderator_name,
+        moderator_secret,
+        moderator_dir.path(),
+    )
+    .await;
+    let (participant_app, mut participant_rx, _participant_conn, _participant_svc) =
+        create_persistent_app(
+            port,
+            &participant_name,
+            participant_secret,
+            participant_dir.path(),
+        )
+        .await;
+
+    // Capture the participant's own session controller when it is created.
+    let (arc_tx, arc_rx) = tokio::sync::oneshot::channel();
+    let mut arc_tx = Some(arc_tx);
+    let _participant_listener = tokio::spawn(async move {
+        while let Some(Ok(Notification::NewSession(ctx))) = participant_rx.recv().await {
+            if let (Some(arc), Some(tx)) = (ctx.session_arc(), arc_tx.take()) {
+                let _ = tx.send(arc);
+            }
+        }
+    });
+
+    // 2. Moderator creates a multicast MLS session and invites the participant,
+    //    which persists the participant's session record + MLS group.
+    let config = SessionConfig {
+        session_type: slim_datapath::api::ProtoSessionType::Multicast,
+        max_retries: Some(10),
+        interval: Some(Duration::from_secs(1)),
+        mls_settings: Some(MlsSettings::default()),
+        initiator: true,
+        metadata: Default::default(),
+    };
+    let (session_ctx, completion) = moderator_app
+        .create_session(config, channel.clone(), None)
+        .await
+        .expect("failed to create session");
+    completion.await.expect("session establishment failed");
+
+    moderator_app
+        .set_route(&participant_name, moderator_conn)
+        .await
+        .expect("failed to set route to participant");
+
+    let moderator_session = session_ctx.session_arc().expect("no session arc");
+    moderator_session
+        .invite_participant(&participant_name)
+        .await
+        .expect("invite failed")
+        .await
+        .expect("invite completion failed");
+
+    // 3. Grab the participant's session controller.
+    let participant_session = tokio::time::timeout(Duration::from_secs(10), arc_rx)
+        .await
+        .expect("timed out waiting for participant session arc")
+        .expect("participant arc channel dropped");
+    let session_id = participant_session.id();
+
+    // Before closing: the participant has the session in its pool and its MLS
+    // group is stored.
+    assert!(
+        participant_app.get_session(session_id).is_some(),
+        "participant session should be in the pool before close"
+    );
+    assert!(
+        !participant_app.stored_mls_group_ids().is_empty(),
+        "the participant's MLS group should be stored before close"
+    );
+
+    // 4. The participant hard-closes its own session.
+    participant_session
+        .close()
+        .expect("participant hard close failed")
+        .await
+        .expect("close completion failed");
+    drop(participant_session);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 5. The participant's pool entry and MLS group state are gone.
+    assert!(
+        participant_app.get_session(session_id).is_none(),
+        "a hard-closed participant session must be removed from the pool"
+    );
+    assert!(
+        participant_app.stored_mls_group_ids().is_empty(),
+        "a hard-closed participant session's MLS group state must be deleted"
+    );
+}
+
 /// Moderator invites two members, member2 goes offline (close), moderator then
 /// invites a third member (advancing the MLS epoch), and member2 rejoins.
 /// Because the epoch has moved on, the initial rejoin is NACKed and member2

--- a/crates/session/src/session_controller.rs
+++ b/crates/session/src/session_controller.rs
@@ -504,6 +504,19 @@ impl SessionController {
         if let Err(e) = inner.on_shutdown().await {
             tracing::error!(error = %e.chain(), "error during shutdown of session");
         }
+
+        // Signal the session layer that this session is done, so it removes it
+        // from the pool and deletes its persisted footprint (record + MLS
+        // state). Done here — once, for both moderator and participant — so the
+        // teardown is uniform regardless of role. On a graceful process
+        // shutdown the layer's receiver is already gone, so the signal is a
+        // no-op and the persisted state is preserved for restore.
+        let _ = settings
+            .tx_to_session_layer
+            .send(Ok(SessionMessage::DeleteSession {
+                session_id: settings.id,
+            }))
+            .await;
     }
 
     /// getters

--- a/crates/session/src/session_layer.rs
+++ b/crates/session/src/session_layer.rs
@@ -734,7 +734,9 @@ where
             Err(SessionError::CannotRejoinP2P) => {}
             Err(e) => {
                 warn!(%session_id, error = %e.chain(), "failed to send rejoin after restore; dropping session");
-                self.pool.write().remove(&session_id);
+                // Route removal through DeleteSession (the single pool-removal
+                // path) by terminating the just-restored controller.
+                let _ = controller.terminate();
                 return Err(e);
             }
         }
@@ -747,6 +749,9 @@ where
         mut rx_session: tokio::sync::mpsc::Receiver<Result<SessionMessage, SessionError>>,
     ) {
         let pool_clone = self.pool.clone();
+        // Cloned so a session teardown can also drop its persisted footprint.
+        let kv_store = self.kv_store.clone();
+        let group_storage = self.group_storage.clone();
         let sessions_span = tracing::info_span!(parent: None, "listen_from_sessions", service_id = %self.service_id);
 
         tokio::spawn(async move {
@@ -758,6 +763,30 @@ where
                                 debug!(%session_id, "received closing signal, cancel session from the pool");
                                 if pool_clone.write().remove(&session_id).is_none() {
                                     warn!(%session_id, "requested to delete unknown session");
+                                }
+                                // A DeleteSession is only sent on a permanent
+                                // teardown (hard close or group leave), never on
+                                // a graceful shutdown, so it is safe to drop the
+                                // session's whole persistent footprint here — its
+                                // MLS group state and its session record — so it
+                                // is not restored on the next start.
+                                if let Some(kv) = &kv_store {
+                                    let key = crate::persistence::session_key(session_id);
+                                    // Delete the MLS group state first: the group
+                                    // id lives in the session record we are about
+                                    // to remove, so read it before deleting.
+                                    if let Some(gs) = &group_storage
+                                        && let Ok(Some(bytes)) = kv.get(&key)
+                                        && let Ok(record) =
+                                            crate::persistence::PersistedSession::from_bytes(&bytes)
+                                        && let Some(group_id) = record.group_id
+                                        && let Err(e) = gs.delete_group(&group_id)
+                                    {
+                                        warn!(%session_id, error = %e.chain(), "failed to delete MLS group state");
+                                    }
+                                    if let Err(e) = kv.delete(&key) {
+                                        warn!(%session_id, error = %e.chain(), "failed to delete persisted session record");
+                                    }
                                 }
                             }
                             Some(Ok(m)) => {
@@ -791,19 +820,15 @@ where
 
     /// Clear all sessions and return completion handles to await on
     pub fn clear_all_sessions(&self) -> HashMap<u32, Result<CompletionHandle, SessionError>> {
-        let pool = {
-            let mut pool = self.pool.write();
-            let copy = pool.clone();
-            pool.clear();
-            copy
-        };
-
-        // Leave all sessions and return completion handles
-        pool.iter()
-            .map(|(id, session)| {
-                let result = session.terminate();
-                (*id, result)
-            })
+        // Terminate each session. Terminating cancels the processing loop, which
+        // emits `DeleteSession` — the single path that removes a session from the
+        // pool (and deletes its persisted footprint); we do not touch the pool
+        // directly here. `terminate` is synchronous and never re-enters the pool
+        // lock, so iterating under the read lock is safe.
+        self.pool
+            .read()
+            .iter()
+            .map(|(id, session)| (*id, session.terminate()))
             .collect()
     }
 
@@ -1048,6 +1073,16 @@ where
     /// Get a session from the pool (for testing purposes)
     pub fn get_session(&self, id: u32) -> Option<Arc<SessionController>> {
         self.pool.read().get(&id).cloned()
+    }
+
+    /// The MLS group ids currently held in the group store (for testing /
+    /// introspection). Empty when persistence/MLS storage is disabled.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn stored_mls_group_ids(&self) -> Vec<Vec<u8>> {
+        self.group_storage
+            .as_ref()
+            .and_then(|g| g.stored_groups().ok())
+            .unwrap_or_default()
     }
 }
 

--- a/crates/session/src/session_moderator.rs
+++ b/crates/session/src/session_moderator.rs
@@ -6,8 +6,6 @@ use std::{
     time::Duration,
 };
 
-use display_error_chain::ErrorChainExt;
-
 use slim_auth::traits::{TokenProvider, Verifier};
 use slim_datapath::{
     api::{
@@ -406,8 +404,9 @@ where
         // Shutdown inner layer
         MessageHandler::on_shutdown(&mut self.inner).await?;
 
-        self.send_close_signal().await;
-
+        // Note: signalling the session layer to delete the session is done
+        // uniformly for both roles in the controller's processing loop after
+        // `on_shutdown`, so there is nothing role-specific to do here.
         Ok(())
     }
 }
@@ -1963,24 +1962,6 @@ where
     #[allow(dead_code)]
     async fn on_mls_proposal(&mut self, _msg: Message) -> Result<(), SessionError> {
         todo!()
-    }
-
-    async fn send_close_signal(&mut self) {
-        debug!("Signal session layer to close the session, all tasks are done");
-
-        // notify the session layer
-        let res = self
-            .common
-            .settings
-            .tx_to_session_layer
-            .send(Ok(SessionMessage::DeleteSession {
-                session_id: self.common.settings.id,
-            }))
-            .await;
-
-        if let Err(e) = res {
-            tracing::error!(error = %e.chain(), "an error occurred while signaling session close");
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

When a session is closed it should leave no trace: removed from the session-layer pool, its persisted record deleted, **and** its MLS group state deleted — so it is neither left dangling in memory nor restored on the next start. A **graceful shutdown** must instead preserve everything so the session can be restored. This now works uniformly for **both moderator and participant** sessions.

## Design

The `DeleteSession` signal is emitted **once, by the session controller's processing loop** (right after `on_shutdown`), for **both roles**. Previously only the moderator sent it, via a role-specific `send_close_signal`; consolidating it in the controller means a participant's own hard close cleans up too.

The layer's `DeleteSession` handler — the single teardown point — does the full cleanup: removes the pool entry, reads the session record for its `group_id` and deletes the **MLS group state**, then deletes the **session record**. Pool removal is now centralized here: `clear_all_sessions` and the restore-failure path no longer mutate the pool directly — they `terminate()` (→ `DeleteSession`) instead, so every removal goes through the one path that also cleans up the record + MLS state.

This is safe for restore because the signal is a **no-op on a graceful shutdown**: when the whole app/service is dropped, the layer's `listen_from_sessions` receiver is already gone, so the send isn't processed and the persisted state is preserved. On a hard close (runtime alive) the send is processed and the footprint is removed.

## Behavior

| Path | Pool entry | Session record | MLS group state |
|------|------------|----------------|-----------------|
| Hard close — moderator or participant (runtime alive) | removed | **deleted** | **deleted** |
| Group leave (`on_leave_request`) | removed | **deleted** | **deleted** |
| Graceful shutdown / `Drop` | (torn down) | **kept** — restore works | **kept** |

## Changes

- `session_controller.rs`: emit `DeleteSession` from the processing loop after `on_shutdown`, for both roles.
- `session_moderator.rs`: drop the role-specific `send_close_signal` (now handled by the controller).
- `persistence/group_storage.rs`: add `SlimGroupStateStorage::delete_group` (delegates to the in-memory and SQLite providers).
- `session_layer.rs`: the `DeleteSession` handler deletes the MLS group state and the persisted record in addition to removing the pool entry; add `stored_mls_group_ids` introspection.
- `service/app.rs`: expose `App::get_session(id)` and `App::stored_mls_group_ids()` (introspection / test helpers).
- `session_restore_test.rs`: `test_hard_close_deletes_persisted_session` (moderator) and `test_participant_hard_close_deletes_persisted_session` (participant) assert the pool entry + record + MLS group state are present before the close and gone afterwards.

## Note

The SQLite provider's `delete_group` removes the group snapshot (which makes the group unloadable); a few prior-epoch rows may remain as harmless dead weight.

## Testing

- Workspace builds; 250 `session` unit tests pass.
- All 6 `session_restore_test` e2e tests pass: hard-close deletion for **both** moderator and participant, and the graceful-restart tests confirming shutdown preserves record **and** MLS state so restore works.
