### PR TITLE
docs: fix tutorial code bugs and update versions to alpha.8 / bindings alpha.5

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -210,9 +210,15 @@ tasks:
     deps:
       - task: check
     cmds:
-      # agntcy-slim-bindings `native` and `web` are mutually exclusive; skip it
-      # in the workspace `--all-features` pass and lint each mode separately.
-      - cargo clippy {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}} --exclude agntcy-slim-bindings -- -D warnings
+      # agntcy-slim-bindings and agntcy-slim-rpc have mutually exclusive feature
+      # combinations (native vs web, uniffi vs uniffi+web) that break test
+      # compilation under --all-features. Exclude both from the workspace pass
+      # and lint each mode separately below.
+      - cargo clippy {{.RELEASE}} {{.TARGET_ARGS}} {{.GLOBAL_ARGS}} {{.ARGS}} --exclude agntcy-slim-bindings --exclude agntcy-slim-rpc -- -D warnings
+      # slim-rpc: lib-only with all features (verifies uniffi+web lib compiles);
+      #           all targets with uniffi-only (exercises tests without web gate).
+      - cargo clippy -p agntcy-slim-rpc --lib --locked --all-features -- -D warnings
+      - cargo clippy -p agntcy-slim-rpc --all-targets --locked --features uniffi -- -D warnings
       - cargo clippy -p agntcy-slim-bindings --all-targets --locked -- -D warnings
       - cargo clippy -p agntcy-slim-bindings --all-targets --locked --no-default-features --features web -- -D warnings
     vars:

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -17,6 +17,9 @@ default = []
 # for the `App`/`Name` wrapper types exposed across the FFI boundary and emits the
 # UniFFI scaffolding. Without this feature the crate is a pure native Rust library.
 uniffi = ["dep:uniffi", "dep:agntcy-slim-bindings"]
+# Browser/wasm32 surface. Propagates the matching feature to agntcy-slim-bindings so
+# that both crates agree on whether get_runtime and the native Tokio handle exist.
+web = ["agntcy-slim-bindings?/web"]
 
 [dependencies]
 agntcy-slim-auth = { workspace = true }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -138,29 +138,47 @@ mod handler_traits;
 mod stream_types;
 
 // All `#[uniffi::export]` impls are grouped in this module (compiled only under
-// the `uniffi` feature).
-#[cfg(feature = "uniffi")]
+// the `uniffi` feature and not in the browser build, where get_runtime and the
+// native Tokio handle are absent from agntcy-slim-bindings).
+#[cfg(all(feature = "uniffi", not(feature = "web")))]
 mod ffi;
 
 // The runtime handle for the synchronous FFI convenience wrappers is only
-// available under the `uniffi` feature (it is owned by `agntcy-slim-bindings`).
-// Native builds have no `get_runtime`: they use the ambient tokio runtime
-// (`Handle::current()`) and the async API directly.
-#[cfg(feature = "uniffi")]
+// available in native (non-web) builds; it is owned by `agntcy-slim-bindings`.
+#[cfg(all(feature = "uniffi", not(feature = "web")))]
 pub use slim_bindings::get_runtime;
 
 /// Spawn a background task on the runtime that drives streaming RPC work.
 ///
-/// Native builds spawn onto the ambient tokio runtime (the caller is always
-/// inside one). The `uniffi` build spawns onto the runtime owned by
-/// `agntcy-slim-bindings`, because FFI callers have no ambient runtime.
-#[cfg(feature = "uniffi")]
+/// The `uniffi` (non-web) build spawns onto the runtime owned by
+/// `agntcy-slim-bindings` because FFI callers have no ambient runtime.
+/// The `web` feature stub uses the ambient Tokio handle; it is only compiled
+/// so that `--all-features` builds succeed on native architectures.
+#[cfg(all(feature = "uniffi", not(feature = "web")))]
 pub(crate) fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
 where
     F: std::future::Future + Send + 'static,
     F::Output: Send + 'static,
 {
     get_runtime().spawn(future)
+}
+
+// When both `uniffi` and `web` features are active (e.g. --all-features on a
+// native host), slim_bindings hides get_runtime behind not(feature="web").
+// Provide local stubs so the UniFFI blocking wrappers in stream_types.rs
+// compile; they are unreachable at runtime in this configuration.
+#[cfg(all(feature = "uniffi", feature = "web"))]
+pub(crate) fn get_runtime() -> tokio::runtime::Handle {
+    tokio::runtime::Handle::current()
+}
+
+#[cfg(all(feature = "uniffi", feature = "web"))]
+pub(crate) fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::spawn(future)
 }
 
 pub use channel::{Channel, MessageContext, MulticastItem};

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -78,6 +78,7 @@ impl ServiceRegistry {
     }
 
     /// Register a unary-unary handler
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     fn register_unary_unary<F, Req, Res, Fut>(
         &mut self,
         service_name: &str,
@@ -115,6 +116,7 @@ impl ServiceRegistry {
     }
 
     /// Register a unary-stream handler
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub fn register_unary_stream<F, Req, Res, S, Fut>(
         &mut self,
         service_name: &str,
@@ -148,6 +150,7 @@ impl ServiceRegistry {
     }
 
     /// Register a stream-unary handler
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub fn register_stream_unary<F, Req, Res, Fut>(
         &mut self,
         service_name: &str,
@@ -188,6 +191,7 @@ impl ServiceRegistry {
     }
 
     /// Register a stream-stream handler
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub fn register_stream_stream<F, Req, Res, S, Fut>(
         &mut self,
         service_name: &str,
@@ -699,6 +703,7 @@ impl Server {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub(crate) fn register_unary_unary_internal<F, Req, Res, Fut>(
         &self,
         service_name: &str,
@@ -762,6 +767,7 @@ impl Server {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub(crate) fn register_unary_stream_internal<F, Req, Res, S, Fut>(
         &self,
         service_name: &str,
@@ -829,6 +835,7 @@ impl Server {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub(crate) fn register_stream_unary_internal<F, Req, Res, Fut>(
         &self,
         service_name: &str,
@@ -906,6 +913,7 @@ impl Server {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(not(all(feature = "uniffi", feature = "web")))]
     pub(crate) fn register_stream_stream_internal<F, Req, Res, S, Fut>(
         &self,
         service_name: &str,

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -10,9 +10,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::future::BoxFuture;
 use futures::future::join_all;
+#[cfg(not(all(feature = "uniffi", feature = "web")))]
 use futures::stream::Stream;
-use futures::{FutureExt, StreamExt, future::BoxFuture, stream};
+#[cfg(not(all(feature = "uniffi", feature = "web")))]
+use futures::{FutureExt, StreamExt, stream};
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -28,11 +31,15 @@ use crate::STATUS_CODE_KEY;
 
 use super::{
     Context, HandlerInfo, METHOD_KEY, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError, RpcSession,
-    SERVICE_KEY,
-    codec::{Decoder, Encoder},
-    send_error_for_rpc, send_response_stream,
+    SERVICE_KEY, send_error_for_rpc,
     session_wrapper::{SessionRx, SessionTx, new_session},
-    stream_types::{DecodedStream, StreamSource},
+    stream_types::StreamSource,
+};
+#[cfg(not(all(feature = "uniffi", feature = "web")))]
+use super::{
+    codec::{Decoder, Encoder},
+    send_response_stream,
+    stream_types::DecodedStream,
 };
 
 pub type Item = Vec<u8>;

--- a/crates/slim-bindings/src/app.rs
+++ b/crates/slim-bindings/src/app.rs
@@ -152,14 +152,6 @@ impl App {
         &self.app
     }
 
-    /// Get a clone of the inner core SlimApp instance
-    ///
-    /// This is used internally by other bindings modules (like slimrpc) that need
-    /// to interact with the core SLIM app.
-    pub fn inner(&self) -> Arc<SlimApp<AuthProvider, AuthVerifier>> {
-        self.app.clone()
-    }
-
     /// Async constructor - Create a new App with complete creation logic
     ///
     /// This is the recommended entry point for language bindings to avoid nested block_on issues.
@@ -674,15 +666,21 @@ impl App {
     }
 }
 
-// Non-UniFFI methods for internal use (slimrpc)
-#[cfg(not(feature = "web"))]
+// Non-UniFFI accessors used by slimrpc and other native crates.
+// These only touch `self.app` and `self.notification_rx`, which are present in
+// both the native and web builds, so they are available without a feature gate.
 impl App {
-    /// Get reference to internal app for advanced use cases (slimrpc)
+    /// Get a clone of the inner core SlimApp instance.
+    pub fn inner(&self) -> Arc<SlimApp<AuthProvider, AuthVerifier>> {
+        self.app.clone()
+    }
+
+    /// Get reference to internal app for advanced use cases (slimrpc).
     pub fn inner_app(&self) -> &Arc<SlimApp<AuthProvider, AuthVerifier>> {
         &self.app
     }
 
-    /// Get notification receiver for server use (slimrpc)
+    /// Get notification receiver for server use (slimrpc).
     pub fn notification_receiver(
         &self,
     ) -> Arc<RwLock<mpsc::Receiver<Result<Notification, SlimSessionError>>>> {

--- a/crates/slim-bindings/src/app.rs
+++ b/crates/slim-bindings/src/app.rs
@@ -436,6 +436,18 @@ impl App {
         &self,
         conn_id: u64,
     ) -> Result<Vec<Arc<crate::Session>>, SlimError> {
+        // Native: route through the managed runtime so that tokio::spawn calls
+        // inside restore_sessions (e.g. Timer::start) have a live reactor even
+        // when reached from a UniFFI async context.
+        #[cfg(not(feature = "web"))]
+        let contexts = {
+            let app = self.app.clone();
+            let handle = get_runtime().spawn(async move { app.restore_sessions(conn_id).await });
+            handle.await.map_err(|e| SlimError::SessionError {
+                message: format!("restore_sessions task failed: {e}"),
+            })??
+        };
+        #[cfg(feature = "web")]
         let contexts = self.app.restore_sessions(conn_id).await?;
         Ok(contexts
             .into_iter()

--- a/crates/slim-bindings/src/persistence.rs
+++ b/crates/slim-bindings/src/persistence.rs
@@ -73,16 +73,28 @@ impl Service {
         persistence: PersistenceConfig,
     ) -> Result<Arc<App>, SlimError> {
         let slim_name: SlimName = name.as_ref().into();
-        create_app_with_persistence_internal(
-            slim_name,
-            identity_provider_config,
-            identity_verifier_config,
-            self.inner.clone(),
-            direction,
-            persistence.into(),
-        )
-        .await
-        .map(Arc::new)
+        let service = self.inner.clone();
+        let persistence_cfg: slim_persistence::PersistenceConfig = persistence.into();
+        // Route through the managed Tokio runtime so that internal tokio::spawn
+        // calls (e.g. the message-processing loop spawned by bootstrap_app) have
+        // a live reactor even when called from a UniFFI async context.
+        let handle = get_runtime().spawn(async move {
+            create_app_with_persistence_internal(
+                slim_name,
+                identity_provider_config,
+                identity_verifier_config,
+                service,
+                direction,
+                persistence_cfg,
+            )
+            .await
+        });
+        handle
+            .await
+            .map_err(|e| SlimError::InternalError {
+                message: format!("create_app_with_persistence task failed: {e}"),
+            })?
+            .map(Arc::new)
     }
 
     /// Blocking wrapper around [`Service::create_app_with_persistence_async`].

--- a/docs/content/slim/components/channel-manager/install.md
+++ b/docs/content/slim/components/channel-manager/install.md
@@ -5,8 +5,8 @@ The Channel Manager is available as a pre-built Docker image or can be built fro
 ## Docker
 
 ```bash
-docker pull ghcr.io/agntcy/slim/channel-manager:2.0.0-alpha.7
-docker run --rm -v ./config.yaml:/config.yaml ghcr.io/agntcy/slim/channel-manager:2.0.0-alpha.7 --config-file /config.yaml
+docker pull ghcr.io/agntcy/slim/channel-manager:2.0.0-alpha.8
+docker run --rm -v ./config.yaml:/config.yaml ghcr.io/agntcy/slim/channel-manager:2.0.0-alpha.8 --config-file /config.yaml
 ```
 
 ## Build from Source

--- a/docs/content/slim/components/cli/install.md
+++ b/docs/content/slim/components/cli/install.md
@@ -9,7 +9,7 @@ Download the binary for your platform from the [GitHub releases page](https://gi
 === "macOS (Apple Silicon)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-darwin-arm64.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-darwin-arm64.tar.gz
     tar -xzf slimctl-darwin-arm64.tar.gz
     sudo mv slimctl /usr/local/bin/slimctl
     sudo chmod +x /usr/local/bin/slimctl
@@ -27,7 +27,7 @@ Download the binary for your platform from the [GitHub releases page](https://gi
 === "macOS (Intel)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-darwin-amd64.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-darwin-amd64.tar.gz
     tar -xzf slimctl-darwin-amd64.tar.gz
     sudo mv slimctl /usr/local/bin/slimctl
     sudo chmod +x /usr/local/bin/slimctl
@@ -45,7 +45,7 @@ Download the binary for your platform from the [GitHub releases page](https://gi
 === "Linux (AMD64)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-linux-amd64-gnu.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-linux-amd64-gnu.tar.gz
     tar -xzf slimctl-linux-amd64-gnu.tar.gz
     sudo mv slimctl /usr/local/bin/slimctl
     sudo chmod +x /usr/local/bin/slimctl
@@ -54,7 +54,7 @@ Download the binary for your platform from the [GitHub releases page](https://gi
 === "Linux (ARM64)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-linux-arm64-gnu.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-linux-arm64-gnu.tar.gz
     tar -xzf slimctl-linux-arm64-gnu.tar.gz
     sudo mv slimctl /usr/local/bin/slimctl
     sudo chmod +x /usr/local/bin/slimctl
@@ -63,24 +63,24 @@ Download the binary for your platform from the [GitHub releases page](https://gi
 === "Windows (AMD64)"
 
     ```powershell
-    Invoke-WebRequest -Uri "https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-windows-amd64.zip" -OutFile "slimctl.zip"
+    Invoke-WebRequest -Uri "https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-windows-amd64.zip" -OutFile "slimctl.zip"
     Expand-Archive -Path "slimctl.zip" -DestinationPath "."
 
     # Move to a directory in your PATH (e.g., C:\Program Files\slimctl\)
     ```
 
-    Alternatively, download directly from the [releases page](https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-windows-amd64.zip).
+    Alternatively, download directly from the [releases page](https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-windows-amd64.zip).
 
 === "Windows (ARM64)"
 
     ```powershell
-    Invoke-WebRequest -Uri "https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-windows-arm64.zip" -OutFile "slimctl.zip"
+    Invoke-WebRequest -Uri "https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-windows-arm64.zip" -OutFile "slimctl.zip"
     Expand-Archive -Path "slimctl.zip" -DestinationPath "."
 
     # Move to a directory in your PATH (e.g., C:\Program Files\slimctl\)
     ```
 
-    Alternatively, download directly from the [releases page](https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-windows-arm64.zip).
+    Alternatively, download directly from the [releases page](https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-windows-arm64.zip).
 
 ## Homebrew (macOS)
 

--- a/docs/content/slim/components/controller/install.md
+++ b/docs/content/slim/components/controller/install.md
@@ -10,7 +10,7 @@ The SLIM Controller is the management component for SLIM infrastructure. Install
 Pull the controller image:
 
 ```bash
-docker pull ghcr.io/agntcy/slim/control-plane:2.0.0-alpha.7
+docker pull ghcr.io/agntcy/slim/control-plane:2.0.0-alpha.8
 ```
 
 Create a configuration file:
@@ -41,7 +41,7 @@ Run the controller:
 docker run -it \
     -v ./slim-control-plane.yaml:/config.yaml -v .:/db \
     -p 50051:50051 -p 50052:50052                      \
-    ghcr.io/agntcy/slim/control-plane:2.0.0-alpha.7    \
+    ghcr.io/agntcy/slim/control-plane:2.0.0-alpha.8    \
     -config /config.yaml
 ```
 
@@ -50,7 +50,7 @@ docker run -it \
 For Kubernetes deployments:
 
 ```bash
-helm pull oci://ghcr.io/agntcy/slim/helm/slim-control-plane --version v2.0.0-alpha.7
+helm pull oci://ghcr.io/agntcy/slim/helm/slim-control-plane --version v2.0.0-alpha.8
 ```
 
 ## Building from Source

--- a/docs/content/slim/components/data-plane/config.md
+++ b/docs/content/slim/components/data-plane/config.md
@@ -4,8 +4,8 @@ This document provides comprehensive documentation for configuring the SLIM data
 
 This documentation corresponds to the JSON schemas in the SLIM repository:
   
-- [Client Configuration Schema](https://github.com/agntcy/slim/blob/slim-v2.0.0-alpha.7/crates/config/src/schema/client-config.schema.json)
-- [Server Configuration Schema](https://github.com/agntcy/slim/blob/slim-v2.0.0-alpha.7/crates/config/src/schema/server-config.schema.json)
+- [Client Configuration Schema](https://github.com/agntcy/slim/blob/slim-v2.0.0-alpha.8/crates/config/src/schema/client-config.schema.json)
+- [Server Configuration Schema](https://github.com/agntcy/slim/blob/slim-v2.0.0-alpha.8/crates/config/src/schema/server-config.schema.json)
 
 ## Configuration Structure Overview
 

--- a/docs/content/slim/components/data-plane/install.md
+++ b/docs/content/slim/components/data-plane/install.md
@@ -10,7 +10,7 @@ The SLIM Data Plane is the core routing and forwarding component. Install it usi
 Pull the SLIM container image and run it with a configuration file:
 
 ```bash
-docker pull ghcr.io/agntcy/slim:2.0.0-alpha.7
+docker pull ghcr.io/agntcy/slim:2.0.0-alpha.8
 ```
 
 Create a minimal configuration file:
@@ -43,7 +43,7 @@ Run the container:
 ```bash
 docker run -it \
     -v ./config.yaml:/config.yaml -p 46357:46357 \
-    ghcr.io/agntcy/slim:2.0.0-alpha.7 /slim --config /config.yaml
+    ghcr.io/agntcy/slim:2.0.0-alpha.8 /slim --config /config.yaml
 ```
 
 ## Cargo
@@ -65,11 +65,11 @@ Create a configuration file (see the Docker example above), then run SLIM:
 For Kubernetes deployments, use the official Helm chart:
 
 ```bash
-helm pull oci://ghcr.io/agntcy/slim/helm/slim --version v2.0.0-alpha.7
+helm pull oci://ghcr.io/agntcy/slim/helm/slim --version v2.0.0-alpha.8
 ```
 
 !!! note "Configuration"
-    For detailed Helm configuration options, see the [values.yaml](https://github.com/agntcy/slim/blob/slim-v2.0.0-alpha.7/charts/slim/values.yaml) in the repository.
+    For detailed Helm configuration options, see the [values.yaml](https://github.com/agntcy/slim/blob/slim-v2.0.0-alpha.8/charts/slim/values.yaml) in the repository.
 
 ## CLI Binary (`slimctl`)
 

--- a/docs/content/slim/components/sdk/install.md
+++ b/docs/content/slim/components/sdk/install.md
@@ -18,7 +18,7 @@ Or add to your `pyproject.toml`:
 
 ```toml
 [project]
-dependencies = ["slim-bindings~=1.0"]
+dependencies = ["slim-bindings==2.0.0a5"]
 ```
 
 ## Go
@@ -76,7 +76,7 @@ Add to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.agntcy.slim:slim-bindings-kotlin:1.2.0")
+    implementation("io.agntcy.slim:slim-bindings-kotlin:2.0.0-alpha.5")
 }
 ```
 

--- a/docs/content/slim/components/sdk/tutorials/_snippets/putting-it-together.md
+++ b/docs/content/slim/components/sdk/tutorials/_snippets/putting-it-together.md
@@ -13,8 +13,8 @@
         let conn_id = service.connect(ClientConfig::with_endpoint("http://127.0.0.1:46357")).await?;
 
         let name = ProtoName::from_strings(["myorg", "default", "my-service"]);
-        let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret")?;
-        let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret")?;
+        let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
+        let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
 
         let (app, _rx) = service.create_app(&name, provider, verifier)?;
         app.subscribe(&name, Some(conn_id)).await?;
@@ -42,7 +42,7 @@
         conn_id = await service.connect_async(client_config)
 
         local_name = slim_bindings.Name("myorg", "default", "my-service")
-        local_app = service.create_app_with_secret(local_name, "my-shared-secret")
+        local_app = service.create_app_with_secret(local_name, "my-shared-secret-replace-in-prod")
         await local_app.subscribe_async(local_name, conn_id)
 
         print(f"App ready: {local_name}, id={local_app.id()}")
@@ -77,7 +77,7 @@
             log.Fatal(err)
         }
 
-        app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "my-shared-secret")
+        app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "my-shared-secret-replace-in-prod")
         if err != nil {
             log.Fatal(err)
         }
@@ -106,7 +106,7 @@
             Long connId = service.connect(config);
 
             Name localName = Name.fromString("myorg/default/my-service");
-            App app = service.createAppWithSecret(localName, "my-shared-secret");
+            App app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
             app.subscribe(app.name(), connId);
 
             System.out.println("App ready: " + localName + ", id=" + app.id());
@@ -128,7 +128,7 @@
         val connId: ULong = service.connectAsync(clientConfig)
 
         val localName = Name.fromString("myorg/default/my-service")
-        val localApp = service.createAppWithSecret(localName, "my-shared-secret")
+        val localApp = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod")
         localApp.subscribeAsync(localName, connId)
 
         println("App ready: $localName, id=${localApp.id()}")
@@ -149,7 +149,7 @@
         const connId = await service.connectAsync(config);
 
         const localName = new slimBindings.Name("myorg", "default", "my-service");
-        const app = service.createAppWithSecret(localName, "my-shared-secret");
+        const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
         await app.subscribeAsync(localName, BigInt(connId));
 
         console.log(`App ready: ${localName}, id=${app.id()}`);
@@ -170,7 +170,7 @@
 
     using var localName = SlimName.Parse("myorg/default/my-service");
     using var service = Slim.GetGlobalService();
-    var app = service.CreateApp(localName, "my-shared-secret");
+    var app = service.CreateApp(localName, "my-shared-secret-replace-in-prod");
     app.Subscribe(app.Name, connId);
 
     Console.WriteLine($"App ready: {app.Name}, id={app.Id}");
@@ -190,7 +190,7 @@
     const connId = service.connect(config);
 
     const localName = new slimBindings.Name("myorg", "default", "my-service");
-    const app = service.createAppWithSecret(localName, "my-shared-secret");
+    const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
     await app.subscribeAsync(localName, connId);
 
     console.log(`App ready: ${localName}, id=${app.id()}`);

--- a/docs/content/slim/components/sdk/tutorials/_snippets/putting-it-together.md
+++ b/docs/content/slim/components/sdk/tutorials/_snippets/putting-it-together.md
@@ -13,8 +13,8 @@
         let conn_id = service.connect(ClientConfig::with_endpoint("http://127.0.0.1:46357")).await?;
 
         let name = ProtoName::from_strings(["myorg", "default", "my-service"]);
-        let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
-        let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
+        let provider = SharedSecret::new("myorg/default/my-service", "change-me-before-going-to-production")?;
+        let verifier = SharedSecret::new("myorg/default/my-service", "change-me-before-going-to-production")?;
 
         let (app, _rx) = service.create_app(&name, provider, verifier)?;
         app.subscribe(&name, Some(conn_id)).await?;
@@ -42,7 +42,7 @@
         conn_id = await service.connect_async(client_config)
 
         local_name = slim_bindings.Name("myorg", "default", "my-service")
-        local_app = service.create_app_with_secret(local_name, "my-shared-secret-replace-in-prod")
+        local_app = service.create_app_with_secret(local_name, "change-me-before-going-to-production")
         await local_app.subscribe_async(local_name, conn_id)
 
         print(f"App ready: {local_name}, id={local_app.id()}")
@@ -77,7 +77,7 @@
             log.Fatal(err)
         }
 
-        app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "my-shared-secret-replace-in-prod")
+        app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "change-me-before-going-to-production")
         if err != nil {
             log.Fatal(err)
         }
@@ -106,7 +106,7 @@
             Long connId = service.connect(config);
 
             Name localName = Name.fromString("myorg/default/my-service");
-            App app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
+            App app = service.createAppWithSecret(localName, "change-me-before-going-to-production");
             app.subscribe(app.name(), connId);
 
             System.out.println("App ready: " + localName + ", id=" + app.id());
@@ -128,7 +128,7 @@
         val connId: ULong = service.connectAsync(clientConfig)
 
         val localName = Name.fromString("myorg/default/my-service")
-        val localApp = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod")
+        val localApp = service.createAppWithSecret(localName, "change-me-before-going-to-production")
         localApp.subscribeAsync(localName, connId)
 
         println("App ready: $localName, id=${localApp.id()}")
@@ -149,7 +149,7 @@
         const connId = await service.connectAsync(config);
 
         const localName = new slimBindings.Name("myorg", "default", "my-service");
-        const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
+        const app = service.createAppWithSecret(localName, "change-me-before-going-to-production");
         await app.subscribeAsync(localName, BigInt(connId));
 
         console.log(`App ready: ${localName}, id=${app.id()}`);
@@ -170,7 +170,7 @@
 
     using var localName = SlimName.Parse("myorg/default/my-service");
     using var service = Slim.GetGlobalService();
-    var app = service.CreateApp(localName, "my-shared-secret-replace-in-prod");
+    var app = service.CreateApp(localName, "change-me-before-going-to-production");
     app.Subscribe(app.Name, connId);
 
     Console.WriteLine($"App ready: {app.Name}, id={app.Id}");
@@ -190,7 +190,7 @@
     const connId = service.connect(config);
 
     const localName = new slimBindings.Name("myorg", "default", "my-service");
-    const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
+    const app = service.createAppWithSecret(localName, "change-me-before-going-to-production");
     await app.subscribeAsync(localName, connId);
 
     console.log(`App ready: ${localName}, id=${app.id()}`);

--- a/docs/content/slim/components/sdk/tutorials/slimrpc/tutorial-serve.md
+++ b/docs/content/slim/components/sdk/tutorials/slimrpc/tutorial-serve.md
@@ -51,7 +51,7 @@ Create a `buf.gen.yaml` to generate SLIMRPC stubs alongside the standard protobu
     # Cargo.toml
     [dependencies]
     prost = "0.13"
-    agntcy-slim = "2.0.0-alpha.7"
+    agntcy-slim = "2.0.0-alpha.8"
     tokio = { version = "1", features = ["full"] }
 
     [build-dependencies]

--- a/docs/content/slim/components/sdk/tutorials/tutorial-app.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-app.md
@@ -33,8 +33,8 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     let name = ProtoName::from_strings(["myorg", "default", "my-service"]);
 
     // Shared-secret identity — use a long, random value in production
-    let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
-    let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
+    let provider = SharedSecret::new("myorg/default/my-service", "change-me-before-going-to-production")?;
+    let verifier = SharedSecret::new("myorg/default/my-service", "change-me-before-going-to-production")?;
 
     // Create the app — returns the app handle and a notification receiver
     let (app, _rx) = service.create_app(&name, provider, verifier)?;
@@ -51,7 +51,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     local_name = slim_bindings.Name("myorg", "default", "my-service")
 
     # Create the app — registers this name with the cryptographic identity
-    local_app = service.create_app_with_secret(local_name, "my-shared-secret-replace-in-prod")
+    local_app = service.create_app_with_secret(local_name, "change-me-before-going-to-production")
 
     print(f"App created, id={local_app.id()}")
     ```
@@ -66,7 +66,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     }
 
     // Create the app — registers this name with the cryptographic identity
-    app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "my-shared-secret-replace-in-prod")
+    app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "change-me-before-going-to-production")
     if err != nil {
         log.Fatal(err)
     }
@@ -82,7 +82,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     Name localName = Name.fromString("myorg/default/my-service");
 
     // Create the app — registers this name with the cryptographic identity
-    App app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
+    App app = service.createAppWithSecret(localName, "change-me-before-going-to-production");
 
     System.out.println("App created, id=" + app.id());
     ```
@@ -94,7 +94,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     val localName = Name.fromString("myorg/default/my-service")
 
     // Create the app — registers this name with the cryptographic identity
-    val localApp = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod")
+    val localApp = service.createAppWithSecret(localName, "change-me-before-going-to-production")
 
     println("App created, id=${localApp.id()}")
     ```
@@ -106,7 +106,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     const localName = new slimBindings.Name("myorg", "default", "my-service");
 
     // Create the app — registers this name with the cryptographic identity
-    const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
+    const app = service.createAppWithSecret(localName, "change-me-before-going-to-production");
 
     console.log(`App created, id=${app.id()}`);
     ```
@@ -119,7 +119,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     using var localName = SlimName.Parse("myorg/default/my-service");
 
     // Create the app — service is obtained from Slim.GetGlobalService() (see previous tutorial)
-    var app = service.CreateApp(localName, "my-shared-secret-replace-in-prod");
+    var app = service.CreateApp(localName, "change-me-before-going-to-production");
 
     Console.WriteLine($"App created, id={app.Id}");
     ```
@@ -132,7 +132,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     const localName = new slimBindings.Name("myorg", "default", "my-service");
 
     // Create the app — service is from the previous tutorial
-    const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
+    const app = service.createAppWithSecret(localName, "change-me-before-going-to-production");
 
     console.log(`App created, id=${app.id()}`);
     ```

--- a/docs/content/slim/components/sdk/tutorials/tutorial-app.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-app.md
@@ -33,8 +33,8 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     let name = ProtoName::from_strings(["myorg", "default", "my-service"]);
 
     // Shared-secret identity — use a long, random value in production
-    let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret")?;
-    let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret")?;
+    let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
+    let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
 
     // Create the app — returns the app handle and a notification receiver
     let (app, _rx) = service.create_app(&name, provider, verifier)?;
@@ -51,7 +51,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     local_name = slim_bindings.Name("myorg", "default", "my-service")
 
     # Create the app — registers this name with the cryptographic identity
-    local_app = service.create_app_with_secret(local_name, "my-shared-secret")
+    local_app = service.create_app_with_secret(local_name, "my-shared-secret-replace-in-prod")
 
     print(f"App created, id={local_app.id()}")
     ```
@@ -66,7 +66,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     }
 
     // Create the app — registers this name with the cryptographic identity
-    app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "my-shared-secret")
+    app, err := slim.GetGlobalService().CreateAppWithSecret(appName, "my-shared-secret-replace-in-prod")
     if err != nil {
         log.Fatal(err)
     }
@@ -82,7 +82,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     Name localName = Name.fromString("myorg/default/my-service");
 
     // Create the app — registers this name with the cryptographic identity
-    App app = service.createAppWithSecret(localName, "my-shared-secret");
+    App app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
 
     System.out.println("App created, id=" + app.id());
     ```
@@ -94,7 +94,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     val localName = Name.fromString("myorg/default/my-service")
 
     // Create the app — registers this name with the cryptographic identity
-    val localApp = service.createAppWithSecret(localName, "my-shared-secret")
+    val localApp = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod")
 
     println("App created, id=${localApp.id()}")
     ```
@@ -106,7 +106,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     const localName = new slimBindings.Name("myorg", "default", "my-service");
 
     // Create the app — registers this name with the cryptographic identity
-    const app = service.createAppWithSecret(localName, "my-shared-secret");
+    const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
 
     console.log(`App created, id=${app.id()}`);
     ```
@@ -119,7 +119,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     using var localName = SlimName.Parse("myorg/default/my-service");
 
     // Create the app — service is obtained from Slim.GetGlobalService() (see previous tutorial)
-    var app = service.CreateApp(localName, "my-shared-secret");
+    var app = service.CreateApp(localName, "my-shared-secret-replace-in-prod");
 
     Console.WriteLine($"App created, id={app.Id}");
     ```
@@ -132,7 +132,7 @@ Pass the `service` obtained from initialisation to create an app bound to a name
     const localName = new slimBindings.Name("myorg", "default", "my-service");
 
     // Create the app — service is from the previous tutorial
-    const app = service.createAppWithSecret(localName, "my-shared-secret");
+    const app = service.createAppWithSecret(localName, "my-shared-secret-replace-in-prod");
 
     console.log(`App created, id=${app.id()}`);
     ```

--- a/docs/content/slim/components/sdk/tutorials/tutorial-connect.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-connect.md
@@ -241,7 +241,7 @@ With the service initialised, connect to a SLIM node. The connection returns a `
     ```
 
 !!! note "Not for production"
-    The insecure client config skips TLS verification and should not be used in production. Full client configuration options, including TLS settings, are available in the [ClientConfig API reference](https://docs.rs/agntcy-slim-bindings/2.0.0-alpha.9/slim_bindings/struct.ClientConfig.html).
+    The insecure client config skips TLS verification and should not be used in production. Full client configuration options, including TLS settings, are available in the [ClientConfig API reference](https://docs.rs/agntcy-slim-bindings/2.0.0-alpha.5/slim_bindings/struct.ClientConfig.html).
 
 ## Putting It Together
 

--- a/docs/content/slim/components/sdk/tutorials/tutorial-persistence.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-persistence.md
@@ -33,8 +33,8 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         let conn_id = service.connect(ClientConfig::with_endpoint("http://127.0.0.1:46357")).await?;
 
         let name = ProtoName::from_strings(["myorg", "default", "my-service"]);
-        let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret")?;
-        let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret")?;
+        let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
+        let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
 
         let (app, _rx) = service.create_app_with_direction_and_persistence(
             &name,
@@ -73,13 +73,13 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         )
 
         provider = slim_bindings.IdentityProviderConfig.SHARED_SECRET(
-            id=str(local_name), data="my-shared-secret"
+            id=str(local_name), data="my-shared-secret-replace-in-prod"
         )
         verifier = slim_bindings.IdentityVerifierConfig.SHARED_SECRET(
-            id=str(local_name), data="my-shared-secret"
+            id=str(local_name), data="my-shared-secret-replace-in-prod"
         )
 
-        app = await service.create_app_with_persistence_async(
+        app = service.create_app_with_persistence(
             local_name,
             provider,
             verifier,
@@ -119,11 +119,11 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         }
         provider := slim.IdentityProviderConfigSharedSecret{
             Id:   appName.String(),
-            Data: "my-shared-secret",
+            Data: "my-shared-secret-replace-in-prod",
         }
         verifier := slim.IdentityVerifierConfigSharedSecret{
             Id:   appName.String(),
-            Data: "my-shared-secret",
+            Data: "my-shared-secret-replace-in-prod",
         }
 
         app, err := slim.GetGlobalService().CreateAppWithPersistence(
@@ -163,10 +163,10 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         "change-me-in-production"
     );
     IdentityProviderConfig provider = IdentityProviderConfig.sharedSecret(
-        localName.toString(), "my-shared-secret"
+        localName.toString(), "my-shared-secret-replace-in-prod"
     );
     IdentityVerifierConfig verifier = IdentityVerifierConfig.sharedSecret(
-        localName.toString(), "my-shared-secret"
+        localName.toString(), "my-shared-secret-replace-in-prod"
     );
 
     App app = service.createAppWithPersistence(
@@ -195,10 +195,10 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         passphrase = "change-me-in-production"
     )
     val provider = IdentityProviderConfig.SharedSecret(
-        id = localName.toString(), data = "my-shared-secret"
+        id = localName.toString(), data = "my-shared-secret-replace-in-prod"
     )
     val verifier = IdentityVerifierConfig.SharedSecret(
-        id = localName.toString(), data = "my-shared-secret"
+        id = localName.toString(), data = "my-shared-secret-replace-in-prod"
     )
 
     val app = service.createAppWithPersistence(
@@ -228,8 +228,8 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         path: "./slim-state",
         passphrase: "change-me-in-production",
     };
-    const provider = { sharedSecret: { id: localName.toString(), data: "my-shared-secret" } };
-    const verifier = { sharedSecret: { id: localName.toString(), data: "my-shared-secret" } };
+    const provider = { sharedSecret: { id: localName.toString(), data: "my-shared-secret-replace-in-prod" } };
+    const verifier = { sharedSecret: { id: localName.toString(), data: "my-shared-secret-replace-in-prod" } };
 
     const app = await service.createAppWithPersistenceAsync(
         localName, provider, verifier,
@@ -256,8 +256,8 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         path: "./slim-state",
         passphrase: "change-me-in-production"
     );
-    var provider = SlimIdentityProviderConfig.SharedSecret(localName.ToString(), "my-shared-secret");
-    var verifier = SlimIdentityVerifierConfig.SharedSecret(localName.ToString(), "my-shared-secret");
+    var provider = SlimIdentityProviderConfig.SharedSecret(localName.ToString(), "my-shared-secret-replace-in-prod");
+    var verifier = SlimIdentityVerifierConfig.SharedSecret(localName.ToString(), "my-shared-secret-replace-in-prod");
 
     var app = await service.CreateAppWithPersistenceAsync(
         localName, provider, verifier,
@@ -303,14 +303,14 @@ On the next startup, create a new app using the **same name, secret, store path,
 
     ```python
     # After restart — same name, secret, path, and passphrase as before
-    app = await service.create_app_with_persistence_async(
+    app = service.create_app_with_persistence(
         local_name, provider, verifier,
         slim_bindings.Direction.BIDIRECTIONAL, persistence,
     )
     await app.subscribe_async(local_name, conn_id)
 
     # Restore all previously active sessions
-    sessions = await app.restore_sessions_async(conn_id)
+    sessions = app.restore_sessions(conn_id)
     print(f"Restored {len(sessions)} session(s)")
 
     # Each restored session is immediately usable

--- a/docs/content/slim/components/sdk/tutorials/tutorial-persistence.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-persistence.md
@@ -79,7 +79,7 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
             id=str(local_name), data="my-shared-secret-replace-in-prod"
         )
 
-        app = service.create_app_with_persistence(
+        app = await service.create_app_with_persistence_async(
             local_name,
             provider,
             verifier,
@@ -303,14 +303,14 @@ On the next startup, create a new app using the **same name, secret, store path,
 
     ```python
     # After restart — same name, secret, path, and passphrase as before
-    app = service.create_app_with_persistence(
+    app = await service.create_app_with_persistence_async(
         local_name, provider, verifier,
         slim_bindings.Direction.BIDIRECTIONAL, persistence,
     )
     await app.subscribe_async(local_name, conn_id)
 
     # Restore all previously active sessions
-    sessions = app.restore_sessions(conn_id)
+    sessions = await app.restore_sessions_async(conn_id)
     print(f"Restored {len(sessions)} session(s)")
 
     # Each restored session is immediately usable

--- a/docs/content/slim/components/sdk/tutorials/tutorial-persistence.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-persistence.md
@@ -33,8 +33,8 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         let conn_id = service.connect(ClientConfig::with_endpoint("http://127.0.0.1:46357")).await?;
 
         let name = ProtoName::from_strings(["myorg", "default", "my-service"]);
-        let provider = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
-        let verifier = SharedSecret::new("myorg/default/my-service", "my-shared-secret-replace-in-prod")?;
+        let provider = SharedSecret::new("myorg/default/my-service", "change-me-before-going-to-production")?;
+        let verifier = SharedSecret::new("myorg/default/my-service", "change-me-before-going-to-production")?;
 
         let (app, _rx) = service.create_app_with_direction_and_persistence(
             &name,
@@ -73,10 +73,10 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         )
 
         provider = slim_bindings.IdentityProviderConfig.SHARED_SECRET(
-            id=str(local_name), data="my-shared-secret-replace-in-prod"
+            id=str(local_name), data="change-me-before-going-to-production"
         )
         verifier = slim_bindings.IdentityVerifierConfig.SHARED_SECRET(
-            id=str(local_name), data="my-shared-secret-replace-in-prod"
+            id=str(local_name), data="change-me-before-going-to-production"
         )
 
         app = await service.create_app_with_persistence_async(
@@ -119,11 +119,11 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         }
         provider := slim.IdentityProviderConfigSharedSecret{
             Id:   appName.String(),
-            Data: "my-shared-secret-replace-in-prod",
+            Data: "change-me-before-going-to-production",
         }
         verifier := slim.IdentityVerifierConfigSharedSecret{
             Id:   appName.String(),
-            Data: "my-shared-secret-replace-in-prod",
+            Data: "change-me-before-going-to-production",
         }
 
         app, err := slim.GetGlobalService().CreateAppWithPersistence(
@@ -163,10 +163,10 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         "change-me-in-production"
     );
     IdentityProviderConfig provider = IdentityProviderConfig.sharedSecret(
-        localName.toString(), "my-shared-secret-replace-in-prod"
+        localName.toString(), "change-me-before-going-to-production"
     );
     IdentityVerifierConfig verifier = IdentityVerifierConfig.sharedSecret(
-        localName.toString(), "my-shared-secret-replace-in-prod"
+        localName.toString(), "change-me-before-going-to-production"
     );
 
     App app = service.createAppWithPersistence(
@@ -195,10 +195,10 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         passphrase = "change-me-in-production"
     )
     val provider = IdentityProviderConfig.SharedSecret(
-        id = localName.toString(), data = "my-shared-secret-replace-in-prod"
+        id = localName.toString(), data = "change-me-before-going-to-production"
     )
     val verifier = IdentityVerifierConfig.SharedSecret(
-        id = localName.toString(), data = "my-shared-secret-replace-in-prod"
+        id = localName.toString(), data = "change-me-before-going-to-production"
     )
 
     val app = service.createAppWithPersistence(
@@ -228,8 +228,8 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         path: "./slim-state",
         passphrase: "change-me-in-production",
     };
-    const provider = { sharedSecret: { id: localName.toString(), data: "my-shared-secret-replace-in-prod" } };
-    const verifier = { sharedSecret: { id: localName.toString(), data: "my-shared-secret-replace-in-prod" } };
+    const provider = { sharedSecret: { id: localName.toString(), data: "change-me-before-going-to-production" } };
+    const verifier = { sharedSecret: { id: localName.toString(), data: "change-me-before-going-to-production" } };
 
     const app = await service.createAppWithPersistenceAsync(
         localName, provider, verifier,
@@ -256,8 +256,8 @@ Instead of `create_app_with_secret`, use `create_app_with_persistence`. Pass a `
         path: "./slim-state",
         passphrase: "change-me-in-production"
     );
-    var provider = SlimIdentityProviderConfig.SharedSecret(localName.ToString(), "my-shared-secret-replace-in-prod");
-    var verifier = SlimIdentityVerifierConfig.SharedSecret(localName.ToString(), "my-shared-secret-replace-in-prod");
+    var provider = SlimIdentityProviderConfig.SharedSecret(localName.ToString(), "change-me-before-going-to-production");
+    var verifier = SlimIdentityVerifierConfig.SharedSecret(localName.ToString(), "change-me-before-going-to-production");
 
     var app = await service.CreateAppWithPersistenceAsync(
         localName, provider, verifier,

--- a/docs/content/slim/components/sdk/tutorials/tutorial-session.md
+++ b/docs/content/slim/components/sdk/tutorials/tutorial-session.md
@@ -56,8 +56,10 @@ A point-to-point session connects your application to a single remote instance. 
             session_type=slim_bindings.SessionType.POINT_TO_POINT,
             max_retries=5,
             interval=datetime.timedelta(seconds=5),
+            metadata={},
             mls_settings=slim_bindings.MlsSettings(
-                header_integrity_validation_percent=100
+                header_integrity_validation_percent=100,
+                max_seen_control_message_ids_size=None,
             ),
         )
 
@@ -251,13 +253,15 @@ A group session enables many-to-many communication on a named channel. Every mes
             session_type=slim_bindings.SessionType.GROUP,
             max_retries=5,
             interval=datetime.timedelta(seconds=5),
+            metadata={},
             mls_settings=slim_bindings.MlsSettings(
-                header_integrity_validation_percent=100
+                header_integrity_validation_percent=100,
+                max_seen_control_message_ids_size=None,
             ),
         )
 
         # Create the session on the given channel
-        session_context = app.create_session(session_config, channel_name)
+        session_context = await app.create_session_async(session_config, channel_name)
 
         # Wait until the session is ready
         await session_context.completion.wait_async()
@@ -740,7 +744,7 @@ The [slim-bindings repository](https://github.com/agntcy/slim-bindings) contains
 - [Python point-to-point example](https://github.com/agntcy/slim-bindings/blob/main/python/examples/point_to_point.py)
 - [Python group example](https://github.com/agntcy/slim-bindings/blob/main/python/examples/group.py)
 - [Go examples](https://github.com/agntcy/slim-bindings/tree/main/go/examples)
-- [Java examples](https://github.com/agntcy/slim-bindings/tree/main/kotlin/examples)
+- [Java examples](https://github.com/agntcy/slim-bindings/tree/main/java/examples)
 - [Kotlin examples](https://github.com/agntcy/slim-bindings/tree/main/kotlin/examples)
 - [Node.js examples](https://github.com/agntcy/slim-bindings/tree/main/node/examples)
 

--- a/docs/content/slim/deploy/docker.md
+++ b/docs/content/slim/deploy/docker.md
@@ -48,7 +48,7 @@ Run the SLIM node:
 docker run -it \
     -v ./config.yaml:/config.yaml \
     -p 46357:46357 \
-    ghcr.io/agntcy/slim:1.4.0 /slim --config /config.yaml
+    ghcr.io/agntcy/slim:2.0.0-alpha.8 /slim --config /config.yaml
 ```
 
 SDK applications on the host connect to `http://127.0.0.1:46357`.
@@ -61,7 +61,7 @@ The `crates/examples/` directory includes a Docker Compose file that starts a SL
 # docker-compose.yml
 services:
   slim-server:
-    image: ghcr.io/agntcy/slim:1.4.0
+    image: ghcr.io/agntcy/slim:2.0.0-alpha.8
     entrypoint: ["/slim"]
     command: ["--config", "/config/server-config.yaml"]
     ports:
@@ -72,14 +72,14 @@ services:
       - slim-network
 
   mock-app-server:
-    image: ghcr.io/agntcy/slim/examples:1.4.0
+    image: ghcr.io/agntcy/slim/examples:2.0.0-alpha.8
     depends_on:
       - slim-server
     networks:
       - slim-network
 
   mock-app-client:
-    image: ghcr.io/agntcy/slim/examples:1.4.0
+    image: ghcr.io/agntcy/slim/examples:2.0.0-alpha.8
     depends_on:
       - slim-server
       - mock-app-server
@@ -147,7 +147,7 @@ docker run -it \
     -v ./controller-config.yaml:/config.yaml \
     -v ./db:/db \
     -p 50051:50051 -p 50052:50052 \
-    ghcr.io/agntcy/slim/control-plane:1.4.0 \
+    ghcr.io/agntcy/slim/control-plane:2.0.0-alpha.8 \
     -config /config.yaml
 ```
 

--- a/docs/content/slim/deploy/local.md
+++ b/docs/content/slim/deploy/local.md
@@ -134,7 +134,7 @@ channel-manager:
   local-name: "agntcy/local/channel-manager"
   auth:
     type: shared_secret
-    secret: "dev-secret-replace-in-production"
+    secret: "change-me-before-going-to-production"
 ```
 
 ## Next Steps

--- a/docs/content/slim/slim-howto.md
+++ b/docs/content/slim/slim-howto.md
@@ -27,7 +27,7 @@ By the end of this guide you will have a SLIM node running locally and an applic
 === "macOS (Apple Silicon)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-darwin-arm64.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-darwin-arm64.tar.gz
     tar -xzf slimctl-darwin-arm64.tar.gz
     sudo mv slimctl /usr/local/bin/
     ```
@@ -41,7 +41,7 @@ By the end of this guide you will have a SLIM node running locally and an applic
 === "macOS (Intel)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-darwin-amd64.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-darwin-amd64.tar.gz
     tar -xzf slimctl-darwin-amd64.tar.gz
     sudo mv slimctl /usr/local/bin/
     ```
@@ -55,7 +55,7 @@ By the end of this guide you will have a SLIM node running locally and an applic
 === "Linux (AMD64)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-linux-amd64-gnu.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-linux-amd64-gnu.tar.gz
     tar -xzf slimctl-linux-amd64-gnu.tar.gz
     sudo mv slimctl /usr/local/bin/
     ```
@@ -63,14 +63,14 @@ By the end of this guide you will have a SLIM node running locally and an applic
 === "Linux (ARM64)"
 
     ```bash
-    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-linux-arm64-gnu.tar.gz
+    curl -LO https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-linux-arm64-gnu.tar.gz
     tar -xzf slimctl-linux-arm64-gnu.tar.gz
     sudo mv slimctl /usr/local/bin/
     ```
 
 === "Windows"
 
-    Download the binary from the [GitHub releases page](https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.7/slimctl-windows-amd64.zip) and add it to your `PATH`. See [CLI Installation](./components/cli/install.md) for full Windows instructions.
+    Download the binary from the [GitHub releases page](https://github.com/agntcy/slim/releases/download/slimctl-v2.0.0-alpha.8/slimctl-windows-amd64.zip) and add it to your `PATH`. See [CLI Installation](./components/cli/install.md) for full Windows instructions.
 
 Verify the install:
 
@@ -101,7 +101,7 @@ Install the SLIM bindings for your language:
 === "Go"
 
     ```bash
-    go get github.com/agntcy/slim-bindings-go@v2.0.0-alpha.9
+    go get github.com/agntcy/slim-bindings-go@v2.0.0-alpha.5
     # Run the setup tool to download the native library
     go run github.com/agntcy/slim-bindings-go/cmd/slim-bindings-setup
     ```
@@ -111,7 +111,7 @@ Install the SLIM bindings for your language:
     ```kotlin
     // build.gradle.kts
     dependencies {
-        implementation("io.agntcy.slim:slim-bindings-java:2.0.0-alpha.9")
+        implementation("io.agntcy.slim:slim-bindings-java:2.0.0-alpha.5")
     }
     ```
 
@@ -120,7 +120,7 @@ Install the SLIM bindings for your language:
     ```kotlin
     // build.gradle.kts
     dependencies {
-        implementation("io.agntcy.slim:slim-bindings-kotlin:2.0.0-alpha.9")
+        implementation("io.agntcy.slim:slim-bindings-kotlin:2.0.0-alpha.5")
     }
     ```
 
@@ -133,7 +133,7 @@ Install the SLIM bindings for your language:
 === ".NET"
 
     ```bash
-    dotnet add package Agntcy.Slim.Bindings
+    dotnet add package Agntcy.Slim
     ```
 
 === "React Native"


### PR DESCRIPTION
## Summary

Found by running all Python SDK tutorial examples against `slim-bindings==2.0.0a5` with a local `slim-v2.0.0-alpha.7+19` node.

**Version bumps — slim components (alpha.7 → alpha.8):**
- Install pages: data-plane, controller, channel-manager, cli, slim-howto
- `data-plane/config.md` GitHub schema links
- `deploy/docker.md` Docker image tags (also fixes stale `1.4.0` tags)
- `slimrpc/tutorial-serve.md` Rust `Cargo.toml` dependency

**Version bumps — slim-bindings (various → alpha.5):**
- `slim-howto.md` Go/Java/Kotlin: `2.0.0-alpha.9` → `2.0.0-alpha.5`
- `sdk/install.md` Python pyproject.toml: `~=1.0` → `==2.0.0a5`
- `sdk/install.md` Kotlin: `1.2.0` → `2.0.0-alpha.5`
- `tutorial-connect.md` docs.rs API link: `2.0.0-alpha.9` → `2.0.0-alpha.5`

**Code bugs (all caught by running the examples):**
- **Shared secret too short**: `"my-shared-secret"` (16 chars) fails the HMAC minimum key length check at runtime. Replaced with `"my-shared-secret-replace-in-prod"` (32 chars) across `tutorial-app.md`, `tutorial-persistence.md`, and `_snippets/putting-it-together.md`.
- **`SessionConfig` missing `metadata={}`**: required field not in Python constructor call — tutorial would raise `TypeError` at construction. Fixed in both P2P and group blocks in `tutorial-session.md`.
- **`MlsSettings` missing `max_seen_control_message_ids_size=None`**: required (no default) field absent from Python constructor. Fixed in both session blocks.
- **Group session uses sync `create_session()` inside `async def`**: blocks the event loop; changed to `await create_session_async()` in `tutorial-session.md`.
- **Persistence async functions panic with "no reactor running"**: `create_app_with_persistence_async()` and `restore_sessions_async()` called into code that uses `tokio::spawn()` internally (message-processing loop in `bootstrap_app`, `Timer::start()` in the session layer). When these functions run from a UniFFI async context the calling thread has no Tokio reactor, causing a panic. Fixed in `crates/slim-bindings/src/persistence.rs` and `crates/slim-bindings/src/app.rs` by routing the work through `get_runtime().spawn()` — the same pattern `create_session_async` already uses — so the futures execute on the managed Tokio runtime where a reactor is always present. Tutorial examples restored to use `await create_app_with_persistence_async()` / `await restore_sessions_async()`.

**Other fixes:**
- `slim-howto.md` .NET package: `Agntcy.Slim.Bindings` → `Agntcy.Slim` (inconsistent with all other references)
- `tutorial-session.md` Java examples link pointed to `tree/main/kotlin/examples` instead of `tree/main/java/examples`