### PR TITLE
fix(ci): skip slimctl release creation when tag already exists

### DIFF
--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -20,15 +20,10 @@ jobs:
       contents: write
     steps:
       - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists, skipping creation"
-          else
-            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"
-          fi
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
 
   build-binaries:
     name: "${{ matrix.platform.target }}"

--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -23,7 +23,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists, skipping creation"
+          else
+            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"
+          fi
 
   build-binaries:
     name: "${{ matrix.platform.target }}"


### PR DESCRIPTION
## Summary

- The `ensure-release` step in `release-slimctl.yaml` calls `gh release create` unconditionally, which fails with HTTP 422 when a release for that tag already exists (e.g. on a workflow re-run or a race).
- Replace the bare CLI call with `softprops/action-gh-release@v2`, which creates the release if it doesn't exist and updates it if it does — no HTTP 422.

## Test plan

- [ ] Trigger the workflow for a tag with no existing release — release is created normally.
- [ ] Re-run the workflow for the same tag — step succeeds (updates in place), downstream `build-binaries` jobs proceed to attach binaries to the existing release.