### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,20 @@ resolver = "2"
 # Local dependencies
 agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.10" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.14.3" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.12" }
-agntcy-slim-config = { path = "crates/config", version = "0.14.1" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.13" }
+agntcy-slim-config = { path = "crates/config", version = "0.14.2" }
 agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.10" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.2" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.17.2" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.3" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.17.3" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.3.2" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.2" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.3" }
 agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.10" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.2", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.2" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.3", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.3" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.18" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.11" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.12" }
 agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.10" }
 agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.10" }
 anyhow = "1.0.103"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.10...slim-channel-manager-v2.0.0-alpha.11) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
+
 ## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.7...slim-channel-manager-v2.0.0-alpha.8) - 2026-07-29
 
 ### Added

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2](https://github.com/agntcy/slim/compare/slim-config-v0.14.1...slim-config-v0.14.2) - 2026-08-03
+
+### Fixed
+
+- *(config)* gate default_backoff() on not(wasm32) ([#1927](https://github.com/agntcy/slim/pull/1927))
+
 ## [0.14.1](https://github.com/agntcy/slim/compare/slim-config-v0.14.0...slim-config-v0.14.1) - 2026-07-31
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.14.1"
+version = "0.14.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.10...slim-control-plane-v2.0.0-alpha.11) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-service
+
 ## [2.0.0-alpha.9](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.8...slim-control-plane-v2.0.0-alpha.9) - 2026-07-31
 
 ### Added

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3](https://github.com/agntcy/slim/compare/slim-controller-v0.12.2...slim-controller-v0.12.3) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session
+
 ## [0.12.2](https://github.com/agntcy/slim/compare/slim-controller-v0.12.1...slim-controller-v0.12.2) - 2026-07-31
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.2"
+version = "0.12.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.17.2...slim-datapath-v0.17.3) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
+
 ## [0.17.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.17.1...slim-datapath-v0.17.2) - 2026-07-31
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.17.2"
+version = "0.17.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/agntcy/slim/compare/slim-proto-v0.5.2...slim-proto-v0.5.3) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config
+
 ## [0.5.2](https://github.com/agntcy/slim/compare/slim-proto-v0.5.1...slim-proto-v0.5.2) - 2026-07-31
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/rpc/CHANGELOG.md
+++ b/crates/rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.10...slim-rpc-v2.0.0-alpha.11) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim-bindings
+
 ## [2.0.0-alpha.10](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.9...slim-rpc-v2.0.0-alpha.10) - 2026-07-31
 
 ### Fixed

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3](https://github.com/agntcy/slim/compare/slim-service-v0.12.2...slim-service-v0.12.3) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.12.2](https://github.com/agntcy/slim/compare/slim-service-v0.12.1...slim-service-v0.12.2) - 2026-07-31
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.2"
+version = "0.12.3"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/agntcy/slim/compare/slim-session-v0.7.2...slim-session-v0.7.3) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-datapath
+
 ## [0.7.2](https://github.com/agntcy/slim/compare/slim-session-v0.7.1...slim-session-v0.7.2) - 2026-07-31
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.2"
+version = "0.7.3"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.12...slim-bindings-v2.0.0-alpha.13) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-session, agntcy-slim-controller, agntcy-slim-service, agntcy-slim-service, agntcy-slim
+
 ## [2.0.0-alpha.12](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.11...slim-bindings-v2.0.0-alpha.12) - 2026-07-31
 
 ### Other

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.10...slim-v2.0.0-alpha.11) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-service
+
 ## [2.0.0-alpha.8](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.7...slim-v2.0.0-alpha.8) - 2026-07-29
 
 ### Other

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.10...slimctl-v2.0.0-alpha.11) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
+
 ## [2.0.0-alpha.9](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.8...slimctl-v2.0.0-alpha.9) - 2026-07-31
 
 ### Added

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.12](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.11...slim-tracing-v0.4.12) - 2026-08-03
+
+### Other
+
+- updated the following local packages: agntcy-slim-config
+
 ## [0.4.11](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.10...slim-tracing-v0.4.11) - 2026-07-31
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.11"
+version = "0.4.12"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-config`: 0.14.1 -> 0.14.2 (✓ API compatible changes)
* `agntcy-slim-proto`: 0.5.2 -> 0.5.3
* `agntcy-slim-tracing`: 0.4.11 -> 0.4.12
* `agntcy-slim-datapath`: 0.17.2 -> 0.17.3
* `agntcy-slim-session`: 0.7.2 -> 0.7.3
* `agntcy-slim-controller`: 0.12.2 -> 0.12.3
* `agntcy-slim-service`: 0.12.2 -> 0.12.3
* `agntcy-slim`: 2.0.0-alpha.10 -> 2.0.0-alpha.11
* `agntcy-slim-channel-manager`: 2.0.0-alpha.10 -> 2.0.0-alpha.11
* `agntcy-slim-control-plane`: 2.0.0-alpha.10 -> 2.0.0-alpha.11
* `agntcy-slim-bindings`: 2.0.0-alpha.12 -> 2.0.0-alpha.13
* `agntcy-slim-rpc`: 2.0.0-alpha.10 -> 2.0.0-alpha.11
* `agntcy-slimctl`: 2.0.0-alpha.10 -> 2.0.0-alpha.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-config`

<blockquote>

## [0.14.2](https://github.com/agntcy/slim/compare/slim-config-v0.14.1...slim-config-v0.14.2) - 2026-08-03

### Fixed

- *(config)* gate default_backoff() on not(wasm32) ([#1927](https://github.com/agntcy/slim/pull/1927))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.3](https://github.com/agntcy/slim/compare/slim-proto-v0.5.2...slim-proto-v0.5.3) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.12](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.11...slim-tracing-v0.4.12) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.17.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.17.2...slim-datapath-v0.17.3) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.3](https://github.com/agntcy/slim/compare/slim-session-v0.7.2...slim-session-v0.7.3) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-datapath
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.3](https://github.com/agntcy/slim/compare/slim-controller-v0.12.2...slim-controller-v0.12.3) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.3](https://github.com/agntcy/slim/compare/slim-service-v0.12.2...slim-service-v0.12.3) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-controller
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.10...slim-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-service
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.10...slim-channel-manager-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.10...slim-control-plane-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-service
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.12...slim-bindings-v2.0.0-alpha.13) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-session, agntcy-slim-controller, agntcy-slim-service, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.10...slim-rpc-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim-bindings
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.10...slimctl-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).