### PR TITLE
fix(config): gate default_backoff() on not(wasm32)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,9 @@ jobs:
     name: Build & test
     uses: ./.github/workflows/reusable-rust-build-and-test.yaml
     with:
-      # wasm suites run nightly (ci-nightly): the browser suite is flaky
-      # (headless Chrome) and neither is on the PR critical path.
-      rust-test-wasm: false
+      # wasm unit-test suite runs on PRs so wasm32 compile regressions are
+      # caught early; the browser suite (headless Chrome) stays nightly-only.
+      rust-test-wasm: true
       rust-test-wasm-browser: false
 
   docker-build:

--- a/.github/workflows/release-slimctl.yaml
+++ b/.github/workflows/release-slimctl.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -316,6 +316,7 @@ fn default_require_header_mac() -> bool {
     true
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn default_backoff() -> BackoffConfig {
     BackoffConfig::new_fixed_interval(Duration::from_secs(2), usize::MAX)
 }


### PR DESCRIPTION
# Description

BackoffConfig is defined inside cfg(not(target_arch = "wasm32"))
but default_backoff() was missing the same gate. The function body
references BackoffConfig so it failed to compile on wasm32 even
though it is never called there (both use-sites are already gated).

Also enable rust-test-wasm on PRs in CI so wasm32 compile regressions
are caught before they reach a release.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
