### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.14"
+version = "2.0.0-alpha.15"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -546,11 +546,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.11" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.14.4" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.14" }
-agntcy-slim-config = { path = "crates/config", version = "0.14.3" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.11" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.4" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.0" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.3" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.12" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.14.5" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.15" }
+agntcy-slim-config = { path = "crates/config", version = "0.14.4" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.12" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.5" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.1" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.4" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.4" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.11" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.4", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.4" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.19" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.5" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.12" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.5", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.5" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.20" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.13" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.11" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.11" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.14" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.12" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.12" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -230,7 +230,7 @@ x25519-dalek = { version = "2", default-features = false, features = ["static_se
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.0.0-alpha.11"
+version = "2.0.0-alpha.12"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.5](https://github.com/agntcy/slim/compare/slim-auth-v0.14.4...slim-auth-v0.14.5) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.14.4](https://github.com/agntcy/slim/compare/slim-auth-v0.14.3...slim-auth-v0.14.4) - 2026-08-03
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.14.4"
+version = "0.14.5"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.4](https://github.com/agntcy/slim/compare/slim-config-v0.14.3...slim-config-v0.14.4) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.14.3](https://github.com/agntcy/slim/compare/slim-config-v0.14.2...slim-config-v0.14.3) - 2026-08-03
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.14.3"
+version = "0.14.4"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5](https://github.com/agntcy/slim/compare/slim-controller-v0.12.4...slim-controller-v0.12.5) - 2026-08-04
+
+### Fixed
+
+- *(controller)* derive tls_required from client_config.tls in server metadata ([#1938](https://github.com/agntcy/slim/pull/1938))
+
 ## [0.12.4](https://github.com/agntcy/slim/compare/slim-controller-v0.12.3...slim-controller-v0.12.4) - 2026-08-03
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.4"
+version = "0.12.5"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.0...slim-datapath-v0.18.1) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
+
 ## [0.18.0](https://github.com/agntcy/slim/compare/slim-datapath-v0.17.3...slim-datapath-v0.18.0) - 2026-08-03
 
 ### Added

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.0"
+version = "0.18.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/agntcy/slim/compare/slim-mls-v0.3.3...slim-mls-v0.3.4) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.3.3](https://github.com/agntcy/slim/compare/slim-mls-v0.3.2...slim-mls-v0.3.3) - 2026-08-03
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.3"
+version = "0.3.4"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/agntcy/slim/compare/slim-proto-v0.5.4...slim-proto-v0.5.5) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.5.4](https://github.com/agntcy/slim/compare/slim-proto-v0.5.3...slim-proto-v0.5.4) - 2026-08-03
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5](https://github.com/agntcy/slim/compare/slim-service-v0.12.4...slim-service-v0.12.5) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-controller, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session
+
 ## [0.12.4](https://github.com/agntcy/slim/compare/slim-service-v0.12.3...slim-service-v0.12.4) - 2026-08-03
 
 ### Added

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.4"
+version = "0.12.5"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/agntcy/slim/compare/slim-session-v0.7.4...slim-session-v0.7.5) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.7.4](https://github.com/agntcy/slim/compare/slim-session-v0.7.3...slim-session-v0.7.4) - 2026-08-03
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.4"
+version = "0.7.5"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/agntcy/slim/compare/slim-signal-v0.1.19...slim-signal-v0.1.20) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.19](https://github.com/agntcy/slim/compare/slim-signal-v0.1.18...slim-signal-v0.1.19) - 2026-08-03
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.19"
+version = "0.1.20"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.15](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.14...slim-bindings-v2.0.0-alpha.15) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-version, agntcy-slim-controller, agntcy-slim, agntcy-slim-auth, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-session, agntcy-slim-signal, agntcy-slim-service, agntcy-slim-service
+
 ## [2.0.0-alpha.14](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.13...slim-bindings-v2.0.0-alpha.14) - 2026-08-03
 
 ### Other

--- a/crates/slim-bindings/Cargo.toml
+++ b/crates/slim-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.14"
+version = "2.0.0-alpha.15"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.12](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.11...slimctl-v2.0.0-alpha.12) - 2026-08-04
+
+### Fixed
+
+- *(slimctl)* resolve clap config param collision in slimctl ([#1935](https://github.com/agntcy/slim/pull/1935))
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.10...slimctl-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.14](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.13...slim-tracing-v0.4.14) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.13](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.12...slim-tracing-v0.4.13) - 2026-08-03
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.13"
+version = "0.4.14"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.11 -> 2.0.0-alpha.12
* `agntcy-slim-controller`: 0.12.4 -> 0.12.5 (✓ API compatible changes)
* `agntcy-slim`: 2.0.0-alpha.11 -> 2.0.0-alpha.12
* `agntcy-slim-channel-manager`: 2.0.0-alpha.11 -> 2.0.0-alpha.12
* `agntcy-slim-control-plane`: 2.0.0-alpha.11 -> 2.0.0-alpha.12
* `agntcy-slim-rpc`: 2.0.0-alpha.11 -> 2.0.0-alpha.12
* `agntcy-slimctl`: 2.0.0-alpha.11 -> 2.0.0-alpha.12
* `agntcy-slim-auth`: 0.14.4 -> 0.14.5
* `agntcy-slim-config`: 0.14.3 -> 0.14.4
* `agntcy-slim-proto`: 0.5.4 -> 0.5.5
* `agntcy-slim-tracing`: 0.4.13 -> 0.4.14
* `agntcy-slim-datapath`: 0.18.0 -> 0.18.1
* `agntcy-slim-mls`: 0.3.3 -> 0.3.4
* `agntcy-slim-session`: 0.7.4 -> 0.7.5
* `agntcy-slim-signal`: 0.1.19 -> 0.1.20
* `agntcy-slim-service`: 0.12.4 -> 0.12.5
* `agntcy-slim-bindings`: 2.0.0-alpha.14 -> 2.0.0-alpha.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.5](https://github.com/agntcy/slim/compare/slim-controller-v0.12.4...slim-controller-v0.12.5) - 2026-08-04

### Fixed

- *(controller)* derive tls_required from client_config.tls in server metadata ([#1938](https://github.com/agntcy/slim/pull/1938))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.10...slim-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-service
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.10...slim-channel-manager-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.10...slim-control-plane-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-service
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.10...slim-rpc-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim-bindings
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.12](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.11...slimctl-v2.0.0-alpha.12) - 2026-08-04

### Fixed

- *(slimctl)* resolve clap config param collision in slimctl ([#1935](https://github.com/agntcy/slim/pull/1935))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.14.5](https://github.com/agntcy/slim/compare/slim-auth-v0.14.4...slim-auth-v0.14.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.14.4](https://github.com/agntcy/slim/compare/slim-config-v0.14.3...slim-config-v0.14.4) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.5](https://github.com/agntcy/slim/compare/slim-proto-v0.5.4...slim-proto-v0.5.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.14](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.13...slim-tracing-v0.4.14) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.0...slim-datapath-v0.18.1) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.4](https://github.com/agntcy/slim/compare/slim-mls-v0.3.3...slim-mls-v0.3.4) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.5](https://github.com/agntcy/slim/compare/slim-session-v0.7.4...slim-session-v0.7.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.20](https://github.com/agntcy/slim/compare/slim-signal-v0.1.19...slim-signal-v0.1.20) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.5](https://github.com/agntcy/slim/compare/slim-service-v0.12.4...slim-service-v0.12.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-controller, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.15](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.14...slim-bindings-v2.0.0-alpha.15) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-version, agntcy-slim-controller, agntcy-slim, agntcy-slim-auth, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-session, agntcy-slim-signal, agntcy-slim-service, agntcy-slim-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).