### PR TITLE
chore(helm): bump slim chart appVersion to 2.0.0-alpha.11

### DIFF
--- a/charts/slim/Chart.yaml
+++ b/charts/slim/Chart.yaml
@@ -24,4 +24,4 @@ version: 2.0.0-alpha.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha.8"
+appVersion: "2.0.0-alpha.11"

--- a/charts/slim/values.yaml
+++ b/charts/slim/values.yaml
@@ -44,7 +44,6 @@ slim:
         # SLIM nodes in different groups are connected via external_endpoint. See 'metadata' below.
         # group_name: "cluster-a"
         peers:
-          deployment_name: "slim-peers"
           topology: full_mesh
           discovery:
             type: kubernetes


### PR DESCRIPTION
## Summary

- Remove `deployment_name` from `peers` config in `values.yaml` — peer group identity is now derived from the service-level `domain_name`
- Bump `appVersion` to `2.0.0-alpha.11`