### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -546,11 +546,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.12" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0-alpha.13" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.14.5" }
 agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0-alpha.15" }
 agntcy-slim-config = { path = "crates/config", version = "0.14.4" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.12" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0-alpha.13" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.12.5" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.1" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.3.4" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.5.5" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.12" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0-alpha.13" }
 agntcy-slim-service = { path = "crates/service", version = "0.12.5", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.7.5" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.20" }
 agntcy-slim-testing = { path = "crates/testing" }
 agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.14" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.12" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.12" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0-alpha.13" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0-alpha.13" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -230,7 +230,7 @@ x25519-dalek = { version = "2", default-features = false, features = ["static_se
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.12...slim-channel-manager-v2.0.0-alpha.13) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.10...slim-channel-manager-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.12...slim-control-plane-v2.0.0-alpha.13) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.10...slim-control-plane-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.12...slim-v2.0.0-alpha.13) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.10...slim-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.11...slimctl-v2.0.0-alpha.13) - 2026-08-04
+
+### Fixed
+
+- *(slimctl)* resolve clap config param collision in slimctl ([#1935](https://github.com/agntcy/slim/pull/1935))
+
+### Other
+
+- release ([#1933](https://github.com/agntcy/slim/pull/1933))
+
 ## [2.0.0-alpha.12](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.11...slimctl-v2.0.0-alpha.12) - 2026-08-04
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0-alpha.12 -> 2.0.0-alpha.13
* `agntcy-slim-auth`: 0.14.4 -> 0.14.5
* `agntcy-slim-config`: 0.14.3 -> 0.14.4
* `agntcy-slim-proto`: 0.5.4 -> 0.5.5
* `agntcy-slim-tracing`: 0.4.13 -> 0.4.14
* `agntcy-slim-datapath`: 0.18.0 -> 0.18.1
* `agntcy-slim-mls`: 0.3.3 -> 0.3.4
* `agntcy-slim-session`: 0.7.4 -> 0.7.5
* `agntcy-slim-signal`: 0.1.19 -> 0.1.20
* `agntcy-slim-controller`: 0.12.4 -> 0.12.5
* `agntcy-slim-service`: 0.12.4 -> 0.12.5
* `agntcy-slim`: 2.0.0-alpha.12 -> 2.0.0-alpha.13 (✓ API compatible changes)
* `agntcy-slim-channel-manager`: 2.0.0-alpha.12 -> 2.0.0-alpha.13 (✓ API compatible changes)
* `agntcy-slim-control-plane`: 2.0.0-alpha.12 -> 2.0.0-alpha.13 (✓ API compatible changes)
* `agntcy-slim-bindings`: 2.0.0-alpha.14 -> 2.0.0-alpha.15
* `agntcy-slim-rpc`: 2.0.0-alpha.12 -> 2.0.0-alpha.13
* `agntcy-slimctl`: 2.0.0-alpha.11 -> 2.0.0-alpha.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.14.5](https://github.com/agntcy/slim/compare/slim-auth-v0.14.4...slim-auth-v0.14.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.14.4](https://github.com/agntcy/slim/compare/slim-config-v0.14.3...slim-config-v0.14.4) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.5](https://github.com/agntcy/slim/compare/slim-proto-v0.5.4...slim-proto-v0.5.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.14](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.13...slim-tracing-v0.4.14) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.0...slim-datapath-v0.18.1) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.4](https://github.com/agntcy/slim/compare/slim-mls-v0.3.3...slim-mls-v0.3.4) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.5](https://github.com/agntcy/slim/compare/slim-session-v0.7.4...slim-session-v0.7.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.20](https://github.com/agntcy/slim/compare/slim-signal-v0.1.19...slim-signal-v0.1.20) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.5](https://github.com/agntcy/slim/compare/slim-controller-v0.12.4...slim-controller-v0.12.5) - 2026-08-04

### Fixed

- *(controller)* derive tls_required from client_config.tls in server metadata ([#1938](https://github.com/agntcy/slim/pull/1938))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.5](https://github.com/agntcy/slim/compare/slim-service-v0.12.4...slim-service-v0.12.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-controller, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.12...slim-v2.0.0-alpha.13) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.12...slim-channel-manager-v2.0.0-alpha.13) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.12...slim-control-plane-v2.0.0-alpha.13) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.0-alpha.15](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.14...slim-bindings-v2.0.0-alpha.15) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-version, agntcy-slim-version, agntcy-slim-controller, agntcy-slim, agntcy-slim-auth, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-config, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-session, agntcy-slim-signal, agntcy-slim-service, agntcy-slim-service
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.10...slim-rpc-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim-bindings
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.0-alpha.13](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.11...slimctl-v2.0.0-alpha.13) - 2026-08-04

### Fixed

- *(slimctl)* resolve clap config param collision in slimctl ([#1935](https://github.com/agntcy/slim/pull/1935))

### Other

- release ([#1933](https://github.com/agntcy/slim/pull/1933))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).