### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -549,11 +549,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.1"
+version = "2.0.0"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -549,11 +549,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0"
+version = "2.0.1"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.14.5" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.14.4" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.5" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.1" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.4" }
+agntcy-slim = { path = "crates/slim", version = "2.0.1" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.14.6" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.1" }
+agntcy-slim-config = { path = "crates/config", version = "0.14.5" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.1" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.6" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.2" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.5" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.5" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.5", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.5" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.20" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.6" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.1" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.6", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.6" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.21" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.14" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.15" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.1" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.1" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -232,7 +232,7 @@ x25519-dalek = { version = "2", default-features = false, features = ["static_se
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.1" }
+agntcy-slim = { path = "crates/slim", version = "2.0.0" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.14.6" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.1" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0" }
 agntcy-slim-config = { path = "crates/config", version = "0.14.5" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.1" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.12.6" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.2" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.3.5" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.5.6" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.1" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0" }
 agntcy-slim-service = { path = "crates/service", version = "0.12.6", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.7.6" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.21" }
 agntcy-slim-testing = { path = "crates/testing" }
 agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.15" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.1" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.1" }
+agntcy-slim-version = { path = "crates/version", version = "2.0.0" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -232,7 +232,7 @@ x25519-dalek = { version = "2", default-features = false, features = ["static_se
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.0.1"
+version = "2.0.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.6](https://github.com/agntcy/slim/compare/slim-auth-v0.14.5...slim-auth-v0.14.6) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.14.5](https://github.com/agntcy/slim/compare/slim-auth-v0.14.4...slim-auth-v0.14.5) - 2026-08-04
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.14.5"
+version = "0.14.6"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.1) - 2026-08-04
+## [2.0.0](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.0) - 2026-08-04
 
 ### Other
 

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.1) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0-alpha.10...slim-channel-manager-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.5](https://github.com/agntcy/slim/compare/slim-config-v0.14.4...slim-config-v0.14.5) - 2026-08-04
+
+### Added
+
+- move to v2.0.0 stable ([#1946](https://github.com/agntcy/slim/pull/1946))
+
 ## [0.14.4](https://github.com/agntcy/slim/compare/slim-config-v0.14.3...slim-config-v0.14.4) - 2026-08-04
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.14.4"
+version = "0.14.5"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.0.1) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0-alpha.10...slim-control-plane-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.0.1) - 2026-08-04
+## [2.0.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.0.0) - 2026-08-04
 
 ### Other
 

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6](https://github.com/agntcy/slim/compare/slim-controller-v0.12.5...slim-controller-v0.12.6) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-session, agntcy-slim-signal
+
 ## [0.12.5](https://github.com/agntcy/slim/compare/slim-controller-v0.12.4...slim-controller-v0.12.5) - 2026-08-04
 
 ### Fixed

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.5"
+version = "0.12.6"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.1...slim-datapath-v0.18.2) - 2026-08-04
+
+### Added
+
+- move to v2.0.0 stable ([#1946](https://github.com/agntcy/slim/pull/1946))
+
 ## [0.18.1](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.0...slim-datapath-v0.18.1) - 2026-08-04
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.1"
+version = "0.18.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/agntcy/slim/compare/slim-mls-v0.3.4...slim-mls-v0.3.5) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.3.4](https://github.com/agntcy/slim/compare/slim-mls-v0.3.3...slim-mls-v0.3.4) - 2026-08-04
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.4"
+version = "0.3.5"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/agntcy/slim/compare/slim-proto-v0.5.5...slim-proto-v0.5.6) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.5.5](https://github.com/agntcy/slim/compare/slim-proto-v0.5.4...slim-proto-v0.5.5) - 2026-08-04
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6](https://github.com/agntcy/slim/compare/slim-service-v0.12.5...slim-service-v0.12.6) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.12.5](https://github.com/agntcy/slim/compare/slim-service-v0.12.4...slim-service-v0.12.5) - 2026-08-04
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.5"
+version = "0.12.6"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/agntcy/slim/compare/slim-session-v0.7.5...slim-session-v0.7.6) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-mls
+
 ## [0.7.5](https://github.com/agntcy/slim/compare/slim-session-v0.7.4...slim-session-v0.7.5) - 2026-08-04
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.5"
+version = "0.7.6"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/agntcy/slim/compare/slim-signal-v0.1.20...slim-signal-v0.1.21) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.20](https://github.com/agntcy/slim/compare/slim-signal-v0.1.19...slim-signal-v0.1.20) - 2026-08-04
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.20"
+version = "0.1.21"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.15...slim-bindings-v2.0.1) - 2026-08-04
+
+### Added
+
+- move to v2.0.0 stable ([#1946](https://github.com/agntcy/slim/pull/1946))
+
 ## [2.0.0-alpha.15](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.14...slim-bindings-v2.0.0-alpha.15) - 2026-08-04
 
 ### Other

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.15...slim-bindings-v2.0.1) - 2026-08-04
+## [2.0.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.15...slim-bindings-v2.0.0) - 2026-08-04
 
 ### Added
 

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.1) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-v2.0.0-alpha.10...slim-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.1) - 2026-08-04
+## [2.0.0](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.0) - 2026-08-04
 
 ### Other
 

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.0.1) - 2026-08-04
+## [2.0.0](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.0.0) - 2026-08-04
 
 ### Other
 

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.0.1) - 2026-08-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0-alpha.12](https://github.com/agntcy/slim/compare/slimctl-v2.0.0-alpha.11...slimctl-v2.0.0-alpha.12) - 2026-08-04
 
 ### Fixed

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.15](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.14...slim-tracing-v0.4.15) - 2026-08-04
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.14](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.13...slim-tracing-v0.4.14) - 2026-08-04
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.14"
+version = "0.4.15"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0
* `agntcy-slim-config`: 0.14.4 -> 0.14.5 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.18.1 -> 0.18.2 (✓ API compatible changes)
* `agntcy-slim`: 2.0.0 
* `agntcy-slim-channel-manager`: 2.0.0
* `agntcy-slim-control-plane`: 2.0.0
* `agntcy-slim-bindings`: 2.0.0-alpha.15 -> 2.0.0
* `agntcy-slim-rpc`: 2.0.0
* `agntcy-slimctl`: 2.0.0
* `agntcy-slim-auth`: 0.14.5 -> 0.14.6
* `agntcy-slim-proto`: 0.5.5 -> 0.5.6
* `agntcy-slim-tracing`: 0.4.14 -> 0.4.15
* `agntcy-slim-mls`: 0.3.4 -> 0.3.5
* `agntcy-slim-session`: 0.7.5 -> 0.7.6
* `agntcy-slim-signal`: 0.1.20 -> 0.1.21
* `agntcy-slim-controller`: 0.12.5 -> 0.12.6
* `agntcy-slim-service`: 0.12.5 -> 0.12.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.14.5](https://github.com/agntcy/slim/compare/slim-config-v0.14.4...slim-config-v0.14.5) - 2026-08-04

### Added

- move to v2.0.0 stable ([#1946](https://github.com/agntcy/slim/pull/1946))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.1...slim-datapath-v0.18.2) - 2026-08-04

### Added

- move to v2.0.0 stable ([#1946](https://github.com/agntcy/slim/pull/1946))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.1](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.1) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.1](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.1) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.0.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.0.1) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.0.1](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.15...slim-bindings-v2.0.1) - 2026-08-04

### Added

- move to v2.0.0 stable ([#1946](https://github.com/agntcy/slim/pull/1946))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.10...slim-rpc-v2.0.0-alpha.11) - 2026-08-03

### Other

- updated the following local packages: agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-service, agntcy-slim-bindings
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.0.1](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.0.1) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.14.6](https://github.com/agntcy/slim/compare/slim-auth-v0.14.5...slim-auth-v0.14.6) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.6](https://github.com/agntcy/slim/compare/slim-proto-v0.5.5...slim-proto-v0.5.6) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.15](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.14...slim-tracing-v0.4.15) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.5](https://github.com/agntcy/slim/compare/slim-mls-v0.3.4...slim-mls-v0.3.5) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.6](https://github.com/agntcy/slim/compare/slim-session-v0.7.5...slim-session-v0.7.6) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.21](https://github.com/agntcy/slim/compare/slim-signal-v0.1.20...slim-signal-v0.1.21) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.6](https://github.com/agntcy/slim/compare/slim-controller-v0.12.5...slim-controller-v0.12.6) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-session, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.6](https://github.com/agntcy/slim/compare/slim-service-v0.12.5...slim-service-v0.12.6) - 2026-08-04

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Published coordinated component updates across the platform.
  * Promoted v2.0.0 functionality to stable where applicable.
  * Updated package versions for authentication, configuration, controller, datapath, messaging, session, service, tracing, and related components.

* **Documentation**
  * Added dated changelog entries for all released components.
  * Recorded dependency updates and stable-release information accompanying the rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->