### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.14.6"
+version = "0.15.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.14.5"
+version = "0.15.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -553,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0"
+version = "2.1.0"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.0.0" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.14.6" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.0.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.14.5" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.0.0" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.6" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.2" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.5" }
+agntcy-slim = { path = "crates/slim", version = "2.1.0" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.15.0" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.1.0" }
+agntcy-slim-config = { path = "crates/config", version = "0.15.0" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.1.0" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.7" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.3" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.6" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.6" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.0.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.6", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.6" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.21" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.7" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.1.0" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.7", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.7" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.22" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.15" }
-agntcy-slim-version = { path = "crates/version", version = "2.0.0" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.0.0" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.16" }
+agntcy-slim-version = { path = "crates/version", version = "2.1.0" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.1.0" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -238,7 +238,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/agntcy/slim/compare/slim-auth-v0.14.6...slim-auth-v0.15.0) - 2026-08-12
+
+### Added
+
+- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
+- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
+
+### Fixed
+
+- *(auth)* serialize concurrent refresh-token exchanges with file lock ([#1971](https://github.com/agntcy/slim/pull/1971))
+- *(auth)* await the rotated-credential persist instead of detaching it ([#1967](https://github.com/agntcy/slim/pull/1967))
+
 ## [0.14.6](https://github.com/agntcy/slim/compare/slim-auth-v0.14.5...slim-auth-v0.14.6) - 2026-08-04
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.14.6"
+version = "0.15.0"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/agntcy/slim/compare/slim-config-v0.14.5...slim-config-v0.15.0) - 2026-08-12
+
+### Added
+
+- *(slimctl)* record login credentials in the connection config ([#1965](https://github.com/agntcy/slim/pull/1965))
+- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
+- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
+
+### Fixed
+
+- *(auth)* serialize concurrent refresh-token exchanges with file lock ([#1971](https://github.com/agntcy/slim/pull/1971))
+
+### Other
+
+- *(config)* use DurationString for timeout and jwks_ttl in OIDC config ([#1964](https://github.com/agntcy/slim/pull/1964))
+
 ## [0.14.5](https://github.com/agntcy/slim/compare/slim-config-v0.14.4...slim-config-v0.14.5) - 2026-08-04
 
 ### Added

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.14.5"
+version = "0.15.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.1.0) - 2026-08-12
+
+### Added
+
+- *(control-plane)* support multiple northbound and southbound listeners ([#1966](https://github.com/agntcy/slim/pull/1966))
+
 ## [2.0.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.0.0) - 2026-08-04
 
 ### Other

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.7](https://github.com/agntcy/slim/compare/slim-controller-v0.12.6...slim-controller-v0.12.7) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-session, agntcy-slim-signal
+
 ## [0.12.6](https://github.com/agntcy/slim/compare/slim-controller-v0.12.5...slim-controller-v0.12.6) - 2026-08-04
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.6"
+version = "0.12.7"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.2...slim-datapath-v0.18.3) - 2026-08-12
+
+### Added
+
+- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
+
 ## [0.18.2](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.1...slim-datapath-v0.18.2) - 2026-08-04
 
 ### Added

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.2"
+version = "0.18.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/agntcy/slim/compare/slim-mls-v0.3.5...slim-mls-v0.3.6) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.3.5](https://github.com/agntcy/slim/compare/slim-mls-v0.3.4...slim-mls-v0.3.5) - 2026-08-04
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.5"
+version = "0.3.6"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7](https://github.com/agntcy/slim/compare/slim-proto-v0.5.6...slim-proto-v0.5.7) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.5.6](https://github.com/agntcy/slim/compare/slim-proto-v0.5.5...slim-proto-v0.5.6) - 2026-08-04
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/rpc/CHANGELOG.md
+++ b/crates/rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0...slim-rpc-v2.1.0) - 2026-08-12
+
+### Fixed
+
+- *(rpc)* signal end-of-stream with the status header, not an empty payload ([#1961](https://github.com/agntcy/slim/pull/1961))
+
 ## [2.0.0-alpha.11](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0-alpha.10...slim-rpc-v2.0.0-alpha.11) - 2026-08-03
 
 ### Other

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.7](https://github.com/agntcy/slim/compare/slim-service-v0.12.6...slim-service-v0.12.7) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.12.6](https://github.com/agntcy/slim/compare/slim-service-v0.12.5...slim-service-v0.12.6) - 2026-08-04
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.6"
+version = "0.12.7"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7](https://github.com/agntcy/slim/compare/slim-session-v0.7.6...slim-session-v0.7.7) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.7.6](https://github.com/agntcy/slim/compare/slim-session-v0.7.5...slim-session-v0.7.6) - 2026-08-04
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.6"
+version = "0.7.7"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/agntcy/slim/compare/slim-signal-v0.1.21...slim-signal-v0.1.22) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.21](https://github.com/agntcy/slim/compare/slim-signal-v0.1.20...slim-signal-v0.1.21) - 2026-08-04
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.21"
+version = "0.1.22"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0...slim-bindings-v2.1.0) - 2026-08-12
+
+### Added
+
+- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
+- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
+
 ## [2.0.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0-alpha.15...slim-bindings-v2.0.0) - 2026-08-04
 
 ### Added

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.1.0) - 2026-08-12
+
+### Added
+
+- *(slimctl)* record login credentials in the connection config ([#1965](https://github.com/agntcy/slim/pull/1965))
+- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
+- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
+- *(slimctl)* add login subcommand with OIDC auth code flow and PKCE ([#1955](https://github.com/agntcy/slim/pull/1955))
+
 ## [2.0.0](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.0.0) - 2026-08-04
 
 ### Other

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.16](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.15...slim-tracing-v0.4.16) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.15](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.14...slim-tracing-v0.4.15) - 2026-08-04
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.15"
+version = "0.4.16"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.0.0 -> 2.1.0
* `agntcy-slim-auth`: 0.14.6 -> 0.15.0 (⚠ API breaking changes)
* `agntcy-slim-config`: 0.14.5 -> 0.15.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.18.2 -> 0.18.3 (✓ API compatible changes)
* `agntcy-slim`: 2.0.0 -> 2.1.0
* `agntcy-slim-channel-manager`: 2.0.0 -> 2.1.0
* `agntcy-slim-control-plane`: 2.0.0 -> 2.1.0 (✓ API compatible changes)
* `agntcy-slim-bindings`: 2.0.0 -> 2.1.0 (✓ API compatible changes)
* `agntcy-slim-rpc`: 2.0.0 -> 2.1.0 (✓ API compatible changes)
* `agntcy-slimctl`: 2.0.0 -> 2.1.0
* `agntcy-slim-proto`: 0.5.6 -> 0.5.7
* `agntcy-slim-tracing`: 0.4.15 -> 0.4.16
* `agntcy-slim-mls`: 0.3.5 -> 0.3.6
* `agntcy-slim-session`: 0.7.6 -> 0.7.7
* `agntcy-slim-signal`: 0.1.21 -> 0.1.22
* `agntcy-slim-controller`: 0.12.6 -> 0.12.7
* `agntcy-slim-service`: 0.12.6 -> 0.12.7

### ⚠ `agntcy-slim-auth` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthError:OidcDiscoveryMissingIssuer in /tmp/.tmp180Cii/slim/crates/auth/src/errors.rs:44
  variant AuthError:OidcDiscoveryIssuerMismatch in /tmp/.tmp180Cii/slim/crates/auth/src/errors.rs:46
  variant AuthError:OidcDiscoveryUrlOriginMismatch in /tmp/.tmp180Cii/slim/crates/auth/src/errors.rs:48
  variant AuthError:OidcInsecureIssuerUrl in /tmp/.tmp180Cii/slim/crates/auth/src/errors.rs:50
  variant AuthError:RefreshTokenRevoked in /tmp/.tmp180Cii/slim/crates/auth/src/errors.rs:64
  variant AuthError:PolicyCompile in /tmp/.tmp180Cii/slim/crates/auth/src/errors.rs:179
```

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.refresh_token in /tmp/.tmp180Cii/slim/crates/config/src/auth/oidc.rs:49
  field Config.refresh_token_file in /tmp/.tmp180Cii/slim/crates/config/src/auth/oidc.rs:65
  field Config.access_token_file in /tmp/.tmp180Cii/slim/crates/config/src/auth/oidc.rs:74
  field Config.claim_cache_ttl in /tmp/.tmp180Cii/slim/crates/config/src/auth/oidc.rs:97
  field Config.policy in /tmp/.tmp180Cii/slim/crates/config/src/auth/oidc.rs:104

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthenticationConfig:Oidc in /tmp/.tmp180Cii/slim/crates/config/src/client.rs:133
  variant AuthenticationConfig:Oidc in /tmp/.tmp180Cii/slim/crates/config/src/client.rs:133
  variant AuthenticationConfig:Oidc in /tmp/.tmp180Cii/slim/crates/config/src/server.rs:76
  variant AuthenticationConfig:Oidc in /tmp/.tmp180Cii/slim/crates/config/src/server.rs:76
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.15.0](https://github.com/agntcy/slim/compare/slim-auth-v0.14.6...slim-auth-v0.15.0) - 2026-08-12

### Added

- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))

### Fixed

- *(auth)* serialize concurrent refresh-token exchanges with file lock ([#1971](https://github.com/agntcy/slim/pull/1971))
- *(auth)* await the rotated-credential persist instead of detaching it ([#1967](https://github.com/agntcy/slim/pull/1967))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.15.0](https://github.com/agntcy/slim/compare/slim-config-v0.14.5...slim-config-v0.15.0) - 2026-08-12

### Added

- *(slimctl)* record login credentials in the connection config ([#1965](https://github.com/agntcy/slim/pull/1965))
- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))

### Fixed

- *(auth)* serialize concurrent refresh-token exchanges with file lock ([#1971](https://github.com/agntcy/slim/pull/1971))

### Other

- *(config)* use DurationString for timeout and jwks_ttl in OIDC config ([#1964](https://github.com/agntcy/slim/pull/1964))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.2...slim-datapath-v0.18.3) - 2026-08-12

### Added

- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.0) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.0) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.1.0) - 2026-08-12

### Added

- *(control-plane)* support multiple northbound and southbound listeners ([#1966](https://github.com/agntcy/slim/pull/1966))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0...slim-bindings-v2.1.0) - 2026-08-12

### Added

- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0...slim-rpc-v2.1.0) - 2026-08-12

### Fixed

- *(rpc)* signal end-of-stream with the status header, not an empty payload ([#1961](https://github.com/agntcy/slim/pull/1961))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.1.0) - 2026-08-12

### Added

- *(slimctl)* record login credentials in the connection config ([#1965](https://github.com/agntcy/slim/pull/1965))
- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
- *(slimctl)* add login subcommand with OIDC auth code flow and PKCE ([#1955](https://github.com/agntcy/slim/pull/1955))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.7](https://github.com/agntcy/slim/compare/slim-proto-v0.5.6...slim-proto-v0.5.7) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.16](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.15...slim-tracing-v0.4.16) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.6](https://github.com/agntcy/slim/compare/slim-mls-v0.3.5...slim-mls-v0.3.6) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.7](https://github.com/agntcy/slim/compare/slim-session-v0.7.6...slim-session-v0.7.7) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.22](https://github.com/agntcy/slim/compare/slim-signal-v0.1.21...slim-signal-v0.1.22) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.7](https://github.com/agntcy/slim/compare/slim-controller-v0.12.6...slim-controller-v0.12.7) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-session, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.7](https://github.com/agntcy/slim/compare/slim-service-v0.12.6...slim-service-v0.12.7) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).