### PR TITLE
helm: update charts to v2.0.0 stable release

### DIFF
--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -1,6 +1,7 @@
 {
-  "charts/slim": "2.0.0-alpha.1",
+  "charts/slim": "2.0.0",
   "crates/testing": "0.7.1",
-  "charts/slim-control-plane": "2.0.0-alpha.0",
+  "charts/slim-control-plane": "2.0.0",
+  "charts/slim-channel-manager": "2.0.0",
   "charts/slim-spire": "1.4.0"
 }

--- a/charts/slim-channel-manager/Chart.yaml
+++ b/charts/slim-channel-manager/Chart.yaml
@@ -17,9 +17,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 2.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha.10"
+appVersion: "2.0.0"

--- a/charts/slim-control-plane/Chart.yaml
+++ b/charts/slim-control-plane/Chart.yaml
@@ -17,9 +17,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-alpha.0
+version: 2.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha.8"
+appVersion: "2.0.0"

--- a/charts/slim/Chart.yaml
+++ b/charts/slim/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-alpha.1
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha.12"
+appVersion: "2.0.0"


### PR DESCRIPTION
# Description

Updates all SLIM Helm charts to pick up the v2.0.0 stable Docker images following the 2.0.0 release.

Changes:
- `charts/slim`: chart version `2.0.0-alpha.1` → `2.0.0`, appVersion `2.0.0-alpha.12` → `2.0.0`
- `charts/slim-control-plane`: chart version `2.0.0-alpha.0` → `2.0.0`, appVersion `2.0.0-alpha.8` → `2.0.0`
- `charts/slim-channel-manager`: chart version `0.1.0` → `2.0.0`, appVersion `2.0.0-alpha.10` → `2.0.0`
- `.github/release-manifest.json`: updated versions to `2.0.0` and added missing `charts/slim-channel-manager` entry

Since `tag: ""` in each chart's `values.yaml` defaults to `appVersion`, this will cause deployments to pull the stable `2.0.0` images from `ghcr.io/agntcy/slim`.

Refs: #1946

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

Release update: bump Helm chart versions and appVersions to track the v2.0.0 stable release.

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Promoted the Slim, Slim Control Plane, and Slim Channel Manager Helm charts to the stable 2.0.0 release.
  - Updated application versions and release metadata to align all related charts under version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->