### PR TITLE
feat!: update slim-control-plane chart appVersion to 2.0.0

### DIFF
--- a/charts/slim-control-plane/Chart.yaml
+++ b/charts/slim-control-plane/Chart.yaml
@@ -22,4 +22,4 @@ version: 2.0.0-alpha.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha.8"
+appVersion: "2.0.0"


### PR DESCRIPTION
# Description

Updates the `slim-control-plane` Helm chart `appVersion` to `2.0.0` to pick up the v2.0.0 stable Docker image (`ghcr.io/agntcy/slim/control-plane:2.0.0`).

The `Release-As: 2.0.0` footer instructs release-please to set the chart version to `2.0.0`.

Refs: #1946

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

Release update: bump `appVersion` to track the v2.0.0 stable release.

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] All new and existing tests pass

Release-As: 2.0.0