### PR TITLE
ci: cache rust toolchain packages

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -101,7 +101,7 @@ runs:
         for tool in \
           clang-19 \
           lldb-19 \
-          lld-19 \
+          ld.lld-19 \
           clangd-19 \
           pkg-config \
           make \

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -59,18 +59,57 @@ runs:
     - name: Setup Taskfile
       uses: ./.github/actions/setup-task
 
-    - name: Install C/C++ toolchain
+    - name: Configure LLVM apt repository
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        . /etc/os-release
+        codename="${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}"
+        if [[ -z "${codename}" ]]; then
+          echo "::error::Unable to determine the Linux distribution codename"
+          exit 1
+        fi
+
+        curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+        echo "deb https://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-19 main" \
+          | sudo tee /etc/apt/sources.list.d/apt.llvm.org.list > /dev/null
         sudo apt-get update
-        curl -L https://apt.llvm.org/llvm.sh -o /tmp/llvm.sh
-        chmod +x /tmp/llvm.sh
-        sudo /tmp/llvm.sh 19
-        sudo apt-get install -y \
+
+    - name: Install cached C/C++ toolchain
+      if: runner.os == 'Linux'
+      uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+      with:
+        packages: >-
+          clang-19
+          lldb-19
+          lld-19
+          clangd-19
+          pkg-config
+          make
+          gcc-aarch64-linux-gnu
+          g++-aarch64-linux-gnu
+          gcc-x86-64-linux-gnu
+          g++-x86-64-linux-gnu
+        version: llvm19-v1
+        execute_install_scripts: "true"
+
+    - name: Verify C/C++ toolchain
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        for tool in \
+          clang-19 \
+          lldb-19 \
+          lld-19 \
+          clangd-19 \
           pkg-config \
           make \
-          gcc-aarch64-linux-gnu \
-          g++-aarch64-linux-gnu \
-          gcc-x86-64-linux-gnu \
-          g++-x86-64-linux-gnu
+          aarch64-linux-gnu-gcc \
+          aarch64-linux-gnu-g++ \
+          x86_64-linux-gnu-gcc \
+          x86_64-linux-gnu-g++
+        do
+          command -v "${tool}"
+          "${tool}" --version | sed -n '1p'
+        done


### PR DESCRIPTION
# Description

Fixes #1756.

- configure the LLVM 19 apt repository using the Ubuntu runner codename
- install and cache LLVM and cross-compilation toolchain packages with a SHA-pinned action
- replay Debian package installation scripts when restoring the cache
- verify that the restored LLVM and cross-compiler commands are available

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: CI performance improvement

## Verification

- YAML parsing with PyYAML
- Bash syntax validation with `bash -n`
- `actionlint` 1.7.12
- `pinact` 4.1.1
- `zizmor` 1.29.0
- LLVM 19 and Ubuntu package availability checks
- `git diff --check`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced
- [x] I have verified this change is not present in another open pull request
- [x] Functionality is described in the composite action
- [x] All code style checks pass
- [x] The toolchain is verified before subsequent build steps
- [x] All applicable local validation passes
