### PR TITLE
chore(config): use DurationString for timeout and jwks_ttl in OIDC config

### DIFF
--- a/crates/config/src/auth/oidc.rs
+++ b/crates/config/src/auth/oidc.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use duration_string::DurationString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slim_auth::jwt_middleware::{AddJwtLayer, PolicyCheckLayer, ValidateJwtLayer};
@@ -41,13 +42,13 @@ pub struct Config {
     #[serde(default = "default_timeout")]
     #[schemars(with = "String")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeout: Option<Duration>,
+    pub timeout: Option<DurationString>,
 
     /// JWKS cache TTL (default: 1 hour, verifier only)
     #[serde(default = "default_jwks_ttl")]
     #[schemars(with = "String")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jwks_ttl: Option<Duration>,
+    pub jwks_ttl: Option<DurationString>,
 
     /// Rego policy evaluated against JWT claims on every request.
     /// Input shape: `{ "claims": { <all JWT payload fields> } }`.
@@ -57,12 +58,12 @@ pub struct Config {
     pub policy: Option<PolicyConfig>,
 }
 
-fn default_timeout() -> Option<Duration> {
-    Some(Duration::from_secs(30))
+fn default_timeout() -> Option<DurationString> {
+    Some(Duration::from_secs(30).into())
 }
 
-fn default_jwks_ttl() -> Option<Duration> {
-    Some(Duration::from_secs(3600)) // 1 hour
+fn default_jwks_ttl() -> Option<DurationString> {
+    Some(Duration::from_secs(3600).into()) // 1 hour
 }
 
 impl Config {
@@ -156,13 +157,13 @@ impl Config {
 
     /// Set the HTTP timeout for token requests (provider functionality)
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = Some(timeout);
+        self.timeout = Some(timeout.into());
         self
     }
 
     /// Set the JWKS cache TTL (verifier functionality)
     pub fn with_jwks_ttl(mut self, ttl: Duration) -> Self {
-        self.jwks_ttl = Some(ttl);
+        self.jwks_ttl = Some(ttl.into());
         self
     }
 
@@ -210,7 +211,7 @@ impl Config {
             client_secret: client_secret.clone(),
             issuer_url: self.issuer_url.clone(),
             scope: self.scope.clone(),
-            timeout: self.timeout,
+            timeout: self.timeout.map(|d| d.into()),
         })
     }
 
@@ -228,12 +229,11 @@ impl Config {
             .as_ref()
             .ok_or(ConfigAuthError::AuthJwtAudienceRequired)?;
 
-        let verifier = OidcVerifier::new(&self.issuer_url, audience);
-        Ok(if let Some(ttl) = self.jwks_ttl {
-            verifier.with_jwks_ttl(ttl)
-        } else {
-            verifier
-        })
+        let mut verifier = OidcVerifier::new(&self.issuer_url, audience);
+        if let Some(ttl) = self.jwks_ttl {
+            verifier = verifier.with_jwks_ttl(ttl.into());
+        }
+        Ok(verifier)
     }
 }
 
@@ -343,7 +343,7 @@ mod tests {
         assert_eq!(config.client_secret, Some("test-client-secret".to_string()));
         assert_eq!(config.issuer_url, "https://auth.example.com");
         assert_eq!(config.scope, Some("api:read".to_string()));
-        assert_eq!(config.timeout, Some(Duration::from_secs(45)));
+        assert_eq!(config.timeout, Some(Duration::from_secs(45).into()));
         assert!(config.can_provide());
         assert!(!config.can_verify());
     }
@@ -355,7 +355,7 @@ mod tests {
 
         assert_eq!(config.issuer_url, "https://auth.example.com");
         assert_eq!(config.audience, Some("test-audience".to_string()));
-        assert_eq!(config.jwks_ttl, Some(Duration::from_secs(1800)));
+        assert_eq!(config.jwks_ttl, Some(Duration::from_secs(1800).into()));
         assert!(!config.can_provide());
         assert!(config.can_verify());
     }
@@ -376,7 +376,7 @@ mod tests {
         assert_eq!(config.client_secret, Some("client-secret".to_string()));
         assert_eq!(config.audience, Some("audience".to_string()));
         assert_eq!(config.scope, Some("api:read".to_string()));
-        assert_eq!(config.jwks_ttl, Some(Duration::from_secs(1800)));
+        assert_eq!(config.jwks_ttl, Some(Duration::from_secs(1800).into()));
         assert!(config.can_provide());
         assert!(config.can_verify());
     }
@@ -393,8 +393,8 @@ mod tests {
         assert!(config.can_provide());
         assert!(config.can_verify());
         assert_eq!(config.scope, Some("api:read".to_string()));
-        assert_eq!(config.timeout, Some(Duration::from_secs(45)));
-        assert_eq!(config.jwks_ttl, Some(Duration::from_secs(1800)));
+        assert_eq!(config.timeout, Some(Duration::from_secs(45).into()));
+        assert_eq!(config.jwks_ttl, Some(Duration::from_secs(1800).into()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Change `timeout` and `jwks_ttl` fields in the OIDC `Config` struct from `Option<Duration>` to `Option<DurationString>` for consistent serde-friendly duration handling
- Update default functions and builder methods to convert with `.into()`
- Update `to_auth_config` and `create_verifier` to convert back to `Duration` at the call site
- Fix test assertions to compare against `DurationString` values