### PR TITLE
feat(slimctl): record login credentials in the connection config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tokio-retry",

--- a/crates/auth/src/refresh_token.rs
+++ b/crates/auth/src/refresh_token.rs
@@ -32,6 +32,11 @@ pub struct RefreshTokenProviderConfig {
     /// Called after a successful token exchange when the IdP issues a new
     /// refresh token (rotation). Arguments: (new_access_token, new_refresh_token).
     /// Use this to persist the rotated tokens so process restarts don't lose them.
+    ///
+    /// Runs on the blocking pool and is awaited before the exchange completes, so
+    /// the rotated token is on disk before the new access token is handed out.
+    /// Implementations may block (file I/O) but should not be slow: they sit in
+    /// the path of every renewal.
     pub persist_credentials: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
 }
 
@@ -163,7 +168,21 @@ impl RefreshTokenProvider {
             if let Some(cb) = self.config.persist_credentials.clone() {
                 let at = access_token.clone();
                 let rt = new_rt.to_owned();
-                tokio::task::spawn_blocking(move || cb(at, rt));
+                // Awaited, not detached: the in-memory refresh token has just
+                // moved on, so until this lands the copy on disk is one the IdP
+                // may already have invalidated. Losing the write means the next
+                // process start replays a spent token and fails with
+                // invalid_grant — exactly what persisting is meant to prevent.
+                //
+                // spawn_blocking because the callback does synchronous file I/O;
+                // no lock is held across the await (the guard above is a
+                // statement-level temporary).
+                if let Err(e) = tokio::task::spawn_blocking(move || cb(at, rt)).await {
+                    tracing::error!(
+                        error = %e,
+                        "failed to persist rotated refresh token; the copy on disk is now stale"
+                    );
+                }
             }
         }
 
@@ -274,5 +293,167 @@ impl TokenProvider for RefreshTokenProvider {
         _public_key: Vec<u8>,
     ) -> Result<(), AuthError> {
         Err(AuthError::MlsNotSupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Mock IdP: discovery pointing at its own token endpoint, which rotates the
+    /// refresh token on every exchange.
+    async fn mock_idp(new_refresh_token: &str) -> MockServer {
+        let server = MockServer::start().await;
+        let uri = server.uri();
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issuer": uri,
+                "token_endpoint": format!("{uri}/token"),
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "new-access-token",
+                "refresh_token": new_refresh_token,
+                "expires_in": 3600,
+            })))
+            .mount(&server)
+            .await;
+
+        server
+    }
+
+    fn provider(
+        server: &MockServer,
+        persist: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
+    ) -> RefreshTokenProvider {
+        // reqwest builds its TLS backend eagerly, so a crypto provider must be
+        // installed even though the mock server speaks plaintext.
+        slim_config::tls::provider::initialize_crypto_provider();
+        RefreshTokenProvider::new(RefreshTokenProviderConfig {
+            refresh_token: "seed-token".to_string(),
+            issuer_url: server.uri(),
+            client_id: "test-client".to_string(),
+            timeout: Some(Duration::from_secs(5)),
+            initial_access_token: None,
+            persist_credentials: persist,
+        })
+        .expect("provider")
+    }
+
+    /// The persist callback must have completed by the time the exchange returns.
+    ///
+    /// This is the regression guard for detaching it: the callback sleeps, so with
+    /// a fire-and-forget `spawn_blocking` the flag is still unset when
+    /// `fetch_new_token` resolves.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn persist_completes_before_fetch_returns() {
+        let server = mock_idp("rotated-token").await;
+
+        let done = Arc::new(AtomicBool::new(false));
+        let seen: Arc<parking_lot::Mutex<Option<(String, String)>>> =
+            Arc::new(parking_lot::Mutex::new(None));
+
+        let cb_done = done.clone();
+        let cb_seen = seen.clone();
+        let p = provider(
+            &server,
+            Some(Arc::new(move |access, refresh| {
+                // Blocking work, as a real file write would be.
+                std::thread::sleep(Duration::from_millis(150));
+                *cb_seen.lock() = Some((access, refresh));
+                cb_done.store(true, Ordering::SeqCst);
+            })),
+        );
+
+        p.fetch_new_token().await.expect("exchange");
+
+        assert!(
+            done.load(Ordering::SeqCst),
+            "fetch_new_token returned before the rotated token was persisted"
+        );
+        assert_eq!(
+            *seen.lock(),
+            Some(("new-access-token".to_string(), "rotated-token".to_string()))
+        );
+    }
+
+    /// The in-memory token and the persisted one must agree — the whole point of
+    /// ordering the write.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn persisted_token_matches_in_memory_token() {
+        let server = mock_idp("rotated-token").await;
+        let persisted: Arc<parking_lot::Mutex<Option<String>>> =
+            Arc::new(parking_lot::Mutex::new(None));
+        let sink = persisted.clone();
+
+        let p = provider(
+            &server,
+            Some(Arc::new(move |_access, refresh| {
+                *sink.lock() = Some(refresh);
+            })),
+        );
+
+        p.fetch_new_token().await.expect("exchange");
+
+        assert_eq!(persisted.lock().as_deref(), Some("rotated-token"));
+        assert_eq!(*p.current_refresh_token.read(), "rotated-token");
+    }
+
+    /// No callback configured is not an error; rotation still updates memory.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rotation_without_persist_callback_is_fine() {
+        let server = mock_idp("rotated-token").await;
+        let p = provider(&server, None);
+
+        p.fetch_new_token().await.expect("exchange");
+
+        assert_eq!(*p.current_refresh_token.read(), "rotated-token");
+        assert_eq!(p.get_token().expect("token"), "new-access-token");
+    }
+
+    /// A response with no `refresh_token` must not invoke the callback: there is
+    /// nothing new to persist, and overwriting with the old value is pointless.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_rotation_means_no_persist() {
+        let server = MockServer::start().await;
+        let uri = server.uri();
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issuer": uri, "token_endpoint": format!("{uri}/token"),
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "new-access-token",
+                "expires_in": 3600,
+            })))
+            .mount(&server)
+            .await;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        let p = provider(
+            &server,
+            Some(Arc::new(move |_a, _r| {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })),
+        );
+
+        p.fetch_new_token().await.expect("exchange");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(*p.current_refresh_token.read(), "seed-token");
     }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -81,6 +81,7 @@ tonic-prost-build = { workspace = true }
 agntcy-slim-testing = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 tracing-test = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/config/src/auth/oidc.rs
+++ b/crates/config/src/auth/oidc.rs
@@ -41,8 +41,37 @@ pub struct Config {
     /// Refresh token obtained from `slimctl login` (provider only).
     /// When set, uses the OAuth2 refresh-token grant instead of client credentials.
     /// Only one of `client_secret` or `refresh_token` may be set.
+    ///
+    /// Prefer `refresh_token_file` for anything long-lived: an inline token (or one
+    /// substituted in via `${file:...}`) cannot be written back, so a rotating IdP
+    /// invalidates it after the first exchange.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refresh_token: Option<String>,
+
+    /// Path to a file holding the refresh token (provider only).
+    ///
+    /// Unlike `refresh_token`, this is a *read-write* binding: the token is read
+    /// from the file, and when the IdP rotates it the new value is written back
+    /// to the same path (mode 0600), so the next start resumes the chain instead
+    /// of replaying a token the IdP already invalidated.  Required for IdPs that
+    /// issue single-use refresh tokens.
+    ///
+    /// A refresh token serves **one process at a time**: whoever exchanges it
+    /// invalidates the copy everyone else holds.  Nothing here enforces that, so
+    /// point each long-lived consumer at its own file.
+    ///
+    /// Takes precedence over `refresh_token` when both are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token_file: Option<String>,
+
+    /// Path to a file caching the current access token (provider only).
+    ///
+    /// Optional companion to `refresh_token_file`.  A still-valid token found here
+    /// seeds the provider's cache, sparing short-lived processes a token-endpoint
+    /// round-trip — and a refresh-token rotation — on every invocation.  Refreshed
+    /// tokens are written back (mode 0600).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_token_file: Option<String>,
 
     /// Optional scope parameter for the token request (provider only)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -91,6 +120,8 @@ impl Config {
             client_id: None,
             client_secret: None,
             refresh_token: None,
+            refresh_token_file: None,
+            access_token_file: None,
             audience: None,
             scope: None,
             timeout: default_timeout(),
@@ -111,6 +142,8 @@ impl Config {
             client_id: Some(client_id.into()),
             client_secret: Some(client_secret.into()),
             refresh_token: None,
+            refresh_token_file: None,
+            access_token_file: None,
             audience: None,
             scope: None,
             timeout: default_timeout(),
@@ -131,12 +164,31 @@ impl Config {
             client_id: Some(client_id.into()),
             client_secret: None,
             refresh_token: Some(refresh_token.into()),
+            refresh_token_file: None,
+            access_token_file: None,
             audience: None,
             scope: None,
             timeout: default_timeout(),
             jwks_ttl: default_jwks_ttl(),
             claim_cache_ttl: None,
             policy: None,
+        }
+    }
+
+    /// Create a provider configuration backed by a refresh token *file*, so that
+    /// rotated tokens survive process restarts.  `access_token_file` is an
+    /// optional cache that lets short-lived processes skip a token exchange.
+    pub fn with_token_files(
+        issuer_url: impl Into<String>,
+        client_id: impl Into<String>,
+        refresh_token_file: impl Into<String>,
+        access_token_file: Option<String>,
+    ) -> Self {
+        Self {
+            client_id: Some(client_id.into()),
+            refresh_token_file: Some(refresh_token_file.into()),
+            access_token_file,
+            ..Self::new(issuer_url)
         }
     }
 
@@ -147,6 +199,8 @@ impl Config {
             client_id: None,
             client_secret: None,
             refresh_token: None,
+            refresh_token_file: None,
+            access_token_file: None,
             audience: Some(audience.into()),
             scope: None,
             timeout: default_timeout(),
@@ -168,6 +222,8 @@ impl Config {
             client_id: Some(client_id.into()),
             client_secret: Some(client_secret.into()),
             refresh_token: None,
+            refresh_token_file: None,
+            access_token_file: None,
             audience: Some(audience.into()),
             scope: None,
             timeout: default_timeout(),
@@ -378,12 +434,89 @@ fn persist_stored_credentials(path: std::path::PathBuf, creds: StoredCredentials
     }
 }
 
+/// Write a bare secret to `path`, owner-readable only.
+///
+/// Truncates in place rather than writing-then-renaming: these files are read by
+/// the same user on the next invocation, and a rename would drop the 0600 mode
+/// if the destination were pre-created differently.
+fn write_secret_file(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)?.write_all(contents.as_bytes())
+}
+
+/// Read a secret written by [`write_secret_file`], trimming the trailing newline
+/// a user's editor may have added.
+fn read_secret_file(path: &str) -> Result<String, ConfigAuthError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        tracing::error!("failed to read token file {path}: {e}");
+        ConfigAuthError::IdentityProviderNotConfigured
+    })?;
+    let token = raw.trim();
+    if token.is_empty() {
+        tracing::error!("token file {path} is empty");
+        return Err(ConfigAuthError::IdentityProviderNotConfigured);
+    }
+    Ok(token.to_owned())
+}
+
 // Implement ClientAuthenticator for Config
 impl ClientAuthenticator for Config {
     type ClientLayer = AddJwtLayer<OidcClientProvider>;
 
     fn get_client_layer(&self) -> Result<Self::ClientLayer, ConfigAuthError> {
-        let provider = if let Some(rt) = &self.refresh_token {
+        let provider = if let Some(rt_file) = &self.refresh_token_file {
+            // File-backed refresh token: read it, and write rotations straight
+            // back so the next start resumes from the live token.
+            let client_id = self
+                .client_id
+                .as_ref()
+                .ok_or(ConfigAuthError::AuthOidcEmptyClientId)?;
+            let refresh_token = read_secret_file(rt_file)?;
+
+            // Only seed from a cached access token, never fail on one — a missing
+            // or stale cache just costs one token exchange.
+            let initial_access_token = self
+                .access_token_file
+                .as_deref()
+                .and_then(|p| read_secret_file(p).ok());
+
+            let rt_path = PathBuf::from(rt_file);
+            let at_path = self.access_token_file.as_deref().map(PathBuf::from);
+            let persist: Arc<dyn Fn(String, String) + Send + Sync> =
+                Arc::new(move |access_token, new_refresh_token| {
+                    if let Err(e) = write_secret_file(&rt_path, &new_refresh_token) {
+                        tracing::error!(
+                            "failed to write rotated refresh token to {rt_path:?}: {e}"
+                        );
+                    } else {
+                        tracing::debug!("persisted rotated refresh token to {rt_path:?}");
+                    }
+                    if let Some(at_path) = &at_path
+                        && let Err(e) = write_secret_file(at_path, &access_token)
+                    {
+                        tracing::error!("failed to write access token to {at_path:?}: {e}");
+                    }
+                });
+
+            OidcClientProvider::RefreshToken(RefreshTokenProvider::new(
+                RefreshTokenProviderConfig {
+                    refresh_token,
+                    issuer_url: self.issuer_url.clone(),
+                    client_id: client_id.clone(),
+                    timeout: self.timeout.map(Into::into),
+                    initial_access_token,
+                    persist_credentials: Some(persist),
+                },
+            )?)
+        } else if let Some(rt) = &self.refresh_token {
             // Explicit refresh token (programmatic use, e.g. slimctl).
             let client_id = self
                 .client_id
@@ -732,5 +865,172 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    // ── file-backed refresh token ───────────────────────────────────────────
+
+    fn write_tmp(dir: &std::path::Path, name: &str, contents: &str) -> String {
+        let path = dir.join(name);
+        std::fs::write(&path, contents).unwrap();
+        path.to_str().unwrap().to_owned()
+    }
+
+    #[test]
+    fn read_secret_file_trims_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tmp(dir.path(), "rt", "the-token\n");
+        assert_eq!(read_secret_file(&path).unwrap(), "the-token");
+    }
+
+    #[test]
+    fn read_secret_file_rejects_empty_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty = write_tmp(dir.path(), "empty", "   \n");
+        assert!(read_secret_file(&empty).is_err());
+        assert!(read_secret_file("/nonexistent/token").is_err());
+    }
+
+    #[test]
+    fn write_secret_file_is_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        write_secret_file(&path, "s3cret").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "s3cret");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "got {:o}", mode & 0o777);
+        }
+    }
+
+    /// Overwriting a longer secret must not leave a tail of the old one behind.
+    #[test]
+    fn write_secret_file_truncates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        write_secret_file(&path, "a-very-long-refresh-token").unwrap();
+        write_secret_file(&path, "short").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "short");
+    }
+
+    #[test]
+    fn with_token_files_sets_paths_and_no_inline_token() {
+        let cfg = Config::with_token_files(
+            "https://issuer.example.com",
+            "myclient",
+            "/tmp/rt",
+            Some("/tmp/at".to_string()),
+        );
+        assert_eq!(cfg.refresh_token_file.as_deref(), Some("/tmp/rt"));
+        assert_eq!(cfg.access_token_file.as_deref(), Some("/tmp/at"));
+        assert!(cfg.refresh_token.is_none());
+        assert!(cfg.client_secret.is_none());
+        assert_eq!(cfg.client_id.as_deref(), Some("myclient"));
+    }
+
+    #[test]
+    fn token_file_fields_round_trip_through_yaml() {
+        let cfg = Config::with_token_files(
+            "https://issuer.example.com",
+            "myclient",
+            "/tmp/rt",
+            Some("/tmp/at".to_string()),
+        );
+        let yaml = serde_yaml::to_string(&cfg).unwrap();
+        assert!(yaml.contains("refresh_token_file: /tmp/rt"), "{yaml}");
+        assert!(yaml.contains("access_token_file: /tmp/at"), "{yaml}");
+        let back: Config = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(back, cfg);
+    }
+
+    /// Absent fields must stay absent, so existing configs are unaffected.
+    #[test]
+    fn token_file_fields_are_omitted_when_unset() {
+        let yaml = serde_yaml::to_string(&Config::new("https://issuer.example.com")).unwrap();
+        assert!(!yaml.contains("refresh_token_file"), "{yaml}");
+        assert!(!yaml.contains("access_token_file"), "{yaml}");
+    }
+
+    #[test]
+    fn refresh_token_file_requires_client_id() {
+        crate::tls::provider::initialize_crypto_provider();
+        let dir = tempfile::tempdir().unwrap();
+        let rt = write_tmp(dir.path(), "rt", "the-refresh-token");
+        let mut cfg = Config::new("https://issuer.example.com");
+        cfg.refresh_token_file = Some(rt);
+        assert!(matches!(
+            cfg.get_client_layer(),
+            Err(ConfigAuthError::AuthOidcEmptyClientId)
+        ));
+    }
+
+    #[test]
+    fn refresh_token_file_missing_is_an_error() {
+        crate::tls::provider::initialize_crypto_provider();
+        let cfg = Config::with_token_files(
+            "https://issuer.example.com",
+            "myclient",
+            "/nonexistent/refresh_token",
+            None,
+        );
+        assert!(cfg.get_client_layer().is_err());
+    }
+
+    /// A file-backed refresh token builds a provider; an unreadable access-token
+    /// cache is only a cache, so it must not fail the build.
+    #[test]
+    fn refresh_token_file_builds_provider_despite_missing_access_token_cache() {
+        crate::tls::provider::initialize_crypto_provider();
+        let dir = tempfile::tempdir().unwrap();
+        let rt = write_tmp(dir.path(), "rt", "the-refresh-token\n");
+        let cfg = Config::with_token_files(
+            "https://issuer.example.com",
+            "myclient",
+            rt,
+            Some("/nonexistent/access_token".to_string()),
+        );
+        assert!(cfg.get_client_layer().is_ok());
+    }
+
+    /// `refresh_token_file` wins over an inline `refresh_token`, so a stale
+    /// inline value can never shadow the live file.
+    #[test]
+    fn refresh_token_file_takes_precedence_over_inline() {
+        crate::tls::provider::initialize_crypto_provider();
+        let dir = tempfile::tempdir().unwrap();
+        let rt = write_tmp(dir.path(), "rt", "from-file");
+        let mut cfg =
+            Config::with_token_files("https://issuer.example.com", "myclient", rt.clone(), None);
+        cfg.refresh_token = Some("inline-and-stale".to_string());
+        // Both are set; the file branch is the one that must run. It succeeds
+        // because the file is readable — the inline branch would too, so assert
+        // on the observable difference: deleting the file now fails the build.
+        assert!(cfg.get_client_layer().is_ok());
+        std::fs::remove_file(&rt).unwrap();
+        assert!(
+            cfg.get_client_layer().is_err(),
+            "inline token shadowed the file"
+        );
+    }
+
+    /// The same file is both source and sink, so a rotation persisted on one run
+    /// is what the next run reads back.
+    #[test]
+    fn refresh_token_file_round_trips_a_rotation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rt");
+        write_secret_file(&path, "seed-token").unwrap();
+        assert_eq!(
+            read_secret_file(path.to_str().unwrap()).unwrap(),
+            "seed-token"
+        );
+
+        // What the persist callback does on rotation.
+        write_secret_file(&path, "rotated-token").unwrap();
+        assert_eq!(
+            read_secret_file(path.to_str().unwrap()).unwrap(),
+            "rotated-token"
+        );
     }
 }

--- a/crates/slimctl/src/cli.rs
+++ b/crates/slimctl/src/cli.rs
@@ -184,7 +184,12 @@ pub(crate) async fn run(cli: Cli) -> Result<()> {
             bench::run(&args).await?;
         }
         Commands::Login(args) => {
-            login::run(&args).await?;
+            login::run(
+                &args,
+                cli.global.config.as_deref(),
+                cli.global.server.as_deref(),
+            )
+            .await?;
         }
     }
 

--- a/crates/slimctl/src/commands/config_cmd.rs
+++ b/crates/slimctl/src/commands/config_cmd.rs
@@ -7,8 +7,9 @@ use duration_string::DurationString;
 
 use slim_config::auth::basic::Config as BasicAuthConfig;
 use slim_config::grpc::client::AuthenticationConfig;
+use slim_config::tls::client::TlsClientConfig;
 
-use crate::config::{load_config, parse_duration, save_config};
+use crate::config::{get_config_key, load_config, parse_duration, set_config_key};
 
 #[derive(Args)]
 pub struct ConfigArgs {
@@ -66,34 +67,39 @@ fn run_list(config_file: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// Set a single config key, leaving every other key in the file untouched —
+/// including any `${env:...}`/`${file:...}` references, which a full
+/// deserialize-modify-serialize cycle would replace with their expansions.
 fn run_set(cmd: &SetCommand, config_file: Option<&str>) -> Result<()> {
-    let mut config = load_config(config_file)?;
     match cmd {
         SetCommand::BasicAuthCreds { value } => {
             let (user, pass) = value
                 .split_once(':')
                 .ok_or_else(|| anyhow::anyhow!("basic-auth-creds must be 'username:password'"))?;
-            config.auth = AuthenticationConfig::Basic(BasicAuthConfig::new(user, pass));
+            set_config_key(
+                "auth",
+                &AuthenticationConfig::Basic(BasicAuthConfig::new(user, pass)),
+                config_file,
+            )?;
         }
         SetCommand::Server { value } => {
-            config.endpoint = value.clone();
+            set_config_key("endpoint", value, config_file)?;
         }
         SetCommand::Timeout { value } => {
-            let dur = parse_duration(value)?;
-            config.connect_timeout = DurationString::from(dur);
-            config.request_timeout = DurationString::from(dur);
+            let dur = DurationString::from(parse_duration(value)?);
+            set_config_key("connect_timeout", &dur, config_file)?;
+            set_config_key("request_timeout", &dur, config_file)?;
         }
         SetCommand::TlsCaFile { value } => {
-            config.tls_setting = config.tls_setting.clone().with_ca_file(value);
+            update_tls(config_file, |tls| tls.with_ca_file(value))?;
         }
         SetCommand::TlsCert {
             cert_file,
             key_file,
         } => {
-            config.tls_setting = config
-                .tls_setting
-                .clone()
-                .with_cert_and_key_file(cert_file, key_file);
+            update_tls(config_file, |tls| {
+                tls.with_cert_and_key_file(cert_file, key_file)
+            })?;
         }
         SetCommand::TlsInsecureSkipVerify { value } => {
             let skip_verify: bool = value.parse().map_err(|_| {
@@ -102,13 +108,23 @@ fn run_set(cmd: &SetCommand, config_file: Option<&str>) -> Result<()> {
                     value
                 )
             })?;
-            config.tls_setting = config
-                .tls_setting
-                .clone()
-                .with_insecure_skip_verify(skip_verify);
+            update_tls(config_file, |tls| {
+                tls.with_insecure_skip_verify(skip_verify)
+            })?;
         }
     }
-    save_config(&config, config_file)?;
+    Ok(())
+}
+
+/// Apply `f` to the config's current `tls` block (default when absent) and write
+/// just that key back.  The TLS builders need the existing value, so this is a
+/// read-modify-write scoped to the one key rather than the whole file.
+fn update_tls<F>(config_file: Option<&str>, f: F) -> Result<()>
+where
+    F: FnOnce(TlsClientConfig) -> TlsClientConfig,
+{
+    let current: TlsClientConfig = get_config_key("tls", config_file)?;
+    set_config_key("tls", &f(current), config_file)?;
     Ok(())
 }
 

--- a/crates/slimctl/src/commands/login.rs
+++ b/crates/slimctl/src/commands/login.rs
@@ -306,7 +306,7 @@ fn ct_str_eq(a: &str, b: &str) -> bool {
     }
 }
 
-pub async fn run(args: &LoginArgs) -> Result<()> {
+pub async fn run(args: &LoginArgs, config_file: Option<&str>, server: Option<&str>) -> Result<()> {
     let http = Client::builder()
         .user_agent("slimctl")
         .timeout(Duration::from_secs(30))
@@ -438,6 +438,31 @@ pub async fn run(args: &LoginArgs) -> Result<()> {
     crate::config::save_credentials(&creds)?;
     let creds_path = crate::config::credentials_file_path()?;
     eprintln!("Credentials saved to {}", creds_path.display());
+
+    // Point the connection config at the credential we just obtained, so
+    // `slimctl node|controller|channel-manager` authenticate with no extra flags.
+    let written = crate::config::save_login_auth(&creds, config_file, server)?;
+    eprintln!(
+        "Connection config {} points at the access token in {}.",
+        written.config_path.display(),
+        written.access_token_path.display()
+    );
+    if server.is_none() {
+        eprintln!(
+            "No --server given, so no endpoint was recorded: pass --server, or run \
+             `slimctl config set server <host:port>`."
+        );
+    }
+    eprintln!("That token expires; re-run `slimctl login` when commands stop authenticating.");
+    match &written.refresh_token_path {
+        Some(path) => eprintln!(
+            "Refresh token saved to {} for long-lived processes (set `refresh_token_file` in their \
+             OIDC auth config). slimctl does not use it.",
+            path.display()
+        ),
+        None => eprintln!("No refresh token was issued by the provider."),
+    }
+
     Ok(())
 }
 

--- a/crates/slimctl/src/config.rs
+++ b/crates/slimctl/src/config.rs
@@ -10,9 +10,9 @@ use anyhow::{Context, Result, bail};
 use duration_string::DurationString;
 use serde::{Deserialize, Serialize};
 use slim_config::auth::basic::Config as BasicAuthConfig;
-use slim_config::auth::oidc::Config as OidcConfig;
 use slim_config::auth::static_jwt::Config as StaticJwtConfig;
 use slim_config::grpc::client::{AuthenticationConfig, BackoffConfig, ClientConfig};
+use slim_config::provider::ConfigResolver;
 use slim_config::tls::client::TlsClientConfig;
 
 /// Default timeout for gRPC requests when not specified in config or CLI.
@@ -134,28 +134,49 @@ pub fn resolve_config(
             .split_once(':')
             .ok_or_else(|| anyhow::anyhow!("basic-auth-creds must be 'username:password'"))?;
         config.auth = AuthenticationConfig::Basic(BasicAuthConfig::new(user, pass));
-    } else if config.auth == AuthenticationConfig::None {
-        // Prefer RefreshToken when available — handles token expiry and crash-restart automatically.
-        // Fall back to StaticJwt for credentials without a refresh token (e.g. id_token only).
-        if let Ok(Some(creds)) = load_credentials()
-            && creds.refresh_token.is_some()
-        {
-            // Let OidcConfig.get_client_layer load tokens from credentials.yaml at
-            // connect time; we only need the issuer here for config identity.
-            config.auth = AuthenticationConfig::Oidc(OidcConfig::new(creds.issuer));
-        } else if let Ok(token_path) = token_file_path()
-            && token_path.exists()
-        {
-            config.auth = AuthenticationConfig::StaticJwt(StaticJwtConfig::with_file(
-                token_path.to_string_lossy(),
-            ));
-        }
+    } else if config.auth == AuthenticationConfig::None
+        && let Ok(token_path) = token_file_path()
+        && token_path.exists()
+    {
+        // Configs written before `login` started recording an auth block, or
+        // hand-written ones: fall back to the bearer token on disk.
+        //
+        // Deliberately *not* the refresh token, even when `credentials.yaml` has
+        // one. Exchanging it invalidates the stored copy, so a CLI doing so on
+        // every invocation would race any long-lived process seeded from the same
+        // token. An expired access token is a prompt to re-run `slimctl login`.
+        config.auth = AuthenticationConfig::StaticJwt(StaticJwtConfig::with_file(
+            token_path.to_string_lossy(),
+        ));
     }
 
     // ── backoff (no retries by default for CLI) ─────────────────────
     config.backoff = BackoffConfig::new_fixed_interval(Duration::from_millis(0), 0);
 
     Ok(config)
+}
+
+/// Parse config YAML, expanding `${env:VAR}` / `${file:/path}` references first.
+///
+/// Mirrors what the node, control-plane and channel-manager loaders do, so a
+/// slimctl config can keep secrets out of the YAML itself.  Note that a value
+/// must consist *only* of the reference — `"Bearer ${file:...}"` is not expanded.
+fn parse_config_str(data: &str) -> Result<ClientConfig> {
+    let mut value: serde_yaml::Value = serde_yaml::from_str(data).context("invalid YAML")?;
+    ConfigResolver::new()
+        .resolve(&mut value)
+        .context("failed to resolve ${env:...}/${file:...} reference")?;
+
+    // `endpoint` is the only field `ClientConfig` requires, but slimctl writes
+    // configs surgically (see `set_config_key`) so a file may legitimately hold
+    // just an `auth` block. Supply the empty default rather than rejecting it —
+    // `resolve_config` substitutes the per-subcommand endpoint anyway.
+    if let serde_yaml::Value::Mapping(map) = &mut value {
+        map.entry(serde_yaml::Value::String("endpoint".to_string()))
+            .or_insert_with(|| serde_yaml::Value::String(String::new()));
+    }
+
+    serde_yaml::from_value(value).context("invalid configuration")
 }
 
 /// Load configuration from the first existing candidate path:
@@ -169,18 +190,99 @@ pub fn load_config(config_file: Option<&str>) -> Result<ClientConfig> {
         let path = PathBuf::from(path_str);
         let data = std::fs::read_to_string(&path)
             .with_context(|| format!("failed to read config file: {}", path.display()))?;
-        return serde_yaml::from_str(&data)
+        return parse_config_str(&data)
             .with_context(|| format!("failed to parse config file: {}", path.display()));
     }
     for path in config_search_paths() {
         if path.exists() {
             let data = std::fs::read_to_string(&path)
                 .with_context(|| format!("failed to read config file: {}", path.display()))?;
-            return serde_yaml::from_str(&data)
+            return parse_config_str(&data)
                 .with_context(|| format!("failed to parse config file: {}", path.display()));
         }
     }
     Ok(ClientConfig::default())
+}
+
+/// Resolve which file a read-modify-write cycle should operate on: the explicit
+/// `--config` path, else the first existing search path, else the default.
+fn update_target_path(config_file: Option<&str>) -> Result<PathBuf> {
+    match config_file {
+        Some(p) => Ok(PathBuf::from(p)),
+        None => match config_search_paths().into_iter().find(|p| p.exists()) {
+            Some(p) => Ok(p),
+            None => config_file_path(),
+        },
+    }
+}
+
+/// Load the config file as a raw YAML mapping for a read-modify-write cycle
+/// (`config set`, `login`).  Returns an empty mapping when the file is absent.
+///
+/// Working at the mapping level rather than through `ClientConfig` keeps writes
+/// surgical: only the keys a command actually sets are emitted, so a fresh login
+/// does not litter the file with every defaulted field (`endpoint: ''`,
+/// `connect_timeout: 0y`, a pinned random `link_id`, a dozen `null`s).
+///
+/// It also means `${env:...}`/`${file:...}` references survive verbatim — the
+/// value is about to be written back, and resolving first would replace a
+/// reference with its expansion, baking a secret read from a file into the YAML.
+pub fn load_config_mapping(config_file: Option<&str>) -> Result<serde_yaml::Mapping> {
+    let path = update_target_path(config_file)?;
+    if !path.exists() {
+        return Ok(serde_yaml::Mapping::new());
+    }
+    let data = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read config file: {}", path.display()))?;
+    match serde_yaml::from_str::<Option<serde_yaml::Value>>(&data)
+        .with_context(|| format!("failed to parse config file: {}", path.display()))?
+    {
+        None | Some(serde_yaml::Value::Null) => Ok(serde_yaml::Mapping::new()),
+        Some(serde_yaml::Value::Mapping(m)) => Ok(m),
+        Some(_) => bail!(
+            "config file must contain a YAML mapping: {}",
+            path.display()
+        ),
+    }
+}
+
+/// Write a raw config mapping back, creating parent directories as needed.
+pub fn save_config_mapping(map: &serde_yaml::Mapping, config_file: Option<&str>) -> Result<()> {
+    let path = update_target_path(config_file)?;
+    let dir = path.parent().expect("config path must have a parent");
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create config directory: {}", dir.display()))?;
+    let data = serde_yaml::to_string(map).context("failed to serialize config")?;
+    std::fs::write(&path, data)
+        .with_context(|| format!("failed to write config file: {}", path.display()))?;
+    Ok(())
+}
+
+/// Set one top-level key in the config file, leaving every other key byte-identical.
+pub fn set_config_key<T: Serialize>(
+    key: &str,
+    value: &T,
+    config_file: Option<&str>,
+) -> Result<PathBuf> {
+    let mut map = load_config_mapping(config_file)?;
+    let encoded =
+        serde_yaml::to_value(value).with_context(|| format!("failed to serialize '{key}'"))?;
+    map.insert(serde_yaml::Value::String(key.to_string()), encoded);
+    save_config_mapping(&map, config_file)?;
+    update_target_path(config_file)
+}
+
+/// Read one top-level key, deserialized into `T`, or `T::default()` when absent.
+pub fn get_config_key<T: serde::de::DeserializeOwned + Default>(
+    key: &str,
+    config_file: Option<&str>,
+) -> Result<T> {
+    let map = load_config_mapping(config_file)?;
+    match map.get(serde_yaml::Value::String(key.to_string())) {
+        Some(v) => serde_yaml::from_value(v.clone())
+            .with_context(|| format!("failed to parse '{key}' in config file")),
+        None => Ok(T::default()),
+    }
 }
 
 /// Return candidate config file paths in priority order:
@@ -195,7 +297,12 @@ fn config_search_paths() -> Vec<PathBuf> {
     paths
 }
 
-/// Save configuration to `config_file` if provided, otherwise to `$HOME/.slimctl/config.yaml`.
+/// Write a whole `ClientConfig`, every field included.
+///
+/// Test-only: production writes are surgical (see [`set_config_key`]) so that a
+/// login does not litter the file with defaulted fields. Tests use this to build
+/// a fully-populated file and then assert those fields survive an update.
+#[cfg(test)]
 pub fn save_config(config: &ClientConfig, config_file: Option<&str>) -> Result<()> {
     let path = match config_file {
         Some(p) => PathBuf::from(p),
@@ -219,6 +326,13 @@ pub fn credentials_file_path() -> Result<PathBuf> {
 pub fn token_file_path() -> Result<PathBuf> {
     let home = dirs_home().context("could not determine home directory")?;
     Ok(home.join(".slimctl").join("token"))
+}
+
+/// Path to the bare refresh token referenced by the generated config:
+/// `~/.slimctl/refresh_token`
+pub fn refresh_token_file_path() -> Result<PathBuf> {
+    let home = dirs_home().context("could not determine home directory")?;
+    Ok(home.join(".slimctl").join("refresh_token"))
 }
 
 fn write_private(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
@@ -248,16 +362,103 @@ pub fn save_credentials(creds: &OidcCredentials) -> Result<()> {
     Ok(())
 }
 
-pub fn load_credentials() -> Result<Option<OidcCredentials>> {
-    let path = credentials_file_path()?;
-    if !path.exists() {
-        return Ok(None);
+/// Where `save_login_auth` wrote things.
+pub struct LoginAuthWritten {
+    /// Connection config now carrying a `static_jwt` block.
+    pub config_path: PathBuf,
+    /// Bearer token slimctl itself authenticates with.
+    pub access_token_path: PathBuf,
+    /// Refresh token, written for long-lived processes to seed from.
+    /// `None` when the IdP issued no refresh token.
+    pub refresh_token_path: Option<PathBuf>,
+}
+
+/// Record the credential established by `slimctl login` in the connection config,
+/// so subsequent commands authenticate with no extra flags.
+///
+/// Only the `auth` section is touched — `endpoint`, `tls` and everything else in
+/// an existing config are preserved, `${env:...}`/`${file:...}` references
+/// included (see [`load_config_for_update`]).
+///
+/// Secrets are never inlined into the config; it only names the files holding
+/// them.  slimctl authenticates with the access token alone:
+///
+/// ```yaml
+/// auth:
+///   type: static_jwt
+///   file: /home/user/.slimctl/token
+/// ```
+///
+/// The refresh token, when the IdP issued one, is written to
+/// `~/.slimctl/refresh_token` (mode 0600) for a *long-lived* process to seed
+/// from — typically a data-plane node with `refresh_token_file` set, plus its own
+/// `refresh_token_out_file` so its rotation chain doesn't clobber this seed.
+/// slimctl never spends it: the access token expiring is a prompt to re-run
+/// `slimctl login` (see [`auth_failure_hint`]).
+pub fn save_login_auth(
+    creds: &OidcCredentials,
+    config_file: Option<&str>,
+    server: Option<&str>,
+) -> Result<LoginAuthWritten> {
+    // Record the endpoint when `--server` was passed, so `slimctl --server host
+    // login` leaves behind a config that points somewhere. Without it the file
+    // holds only auth and the endpoint comes from `--server` / the per-subcommand
+    // default on each invocation, as before.
+    if let Some(server) = server {
+        set_config_key("endpoint", &server, config_file)?;
     }
-    let data = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read credentials: {}", path.display()))?;
-    let creds = serde_yaml::from_str(&data)
-        .with_context(|| format!("failed to parse credentials: {}", path.display()))?;
-    Ok(Some(creds))
+    // slimctl authenticates with the access token *only*.  It deliberately does
+    // not consume the refresh token: a refresh token serves one process at a
+    // time, and every exchange invalidates the copy on disk.  A CLI that spent a
+    // rotation per invocation would race any long-lived process seeded from the
+    // same file — and would still have to re-authenticate constantly, since it
+    // exits long before background renewal could help.  When the access token
+    // expires the user re-runs `slimctl login`; see `auth_failure_hint`.
+    let access_token_path = token_file_path()?;
+    let auth = AuthenticationConfig::StaticJwt(StaticJwtConfig::with_file(
+        access_token_path.to_string_lossy(),
+    ));
+    let config_path = set_config_key("auth", &auth, config_file)?;
+
+    // The refresh token is written for *other* processes — a data-plane node
+    // configured with `refresh_token_file` seeds its rotation chain from here.
+    let refresh_token_path = match creds.refresh_token.as_deref() {
+        Some(refresh_token) => {
+            let path = refresh_token_file_path()?;
+            let dir = path
+                .parent()
+                .expect("refresh token path must have a parent");
+            std::fs::create_dir_all(dir)
+                .with_context(|| format!("failed to create config directory: {}", dir.display()))?;
+            write_private(&path, refresh_token.as_bytes())
+                .with_context(|| format!("failed to write refresh token: {}", path.display()))?;
+            Some(path)
+        }
+        None => None,
+    };
+
+    Ok(LoginAuthWritten {
+        config_path,
+        access_token_path,
+        refresh_token_path,
+    })
+}
+
+/// Hint appended to authentication failures, telling the user how to recover.
+///
+/// A `static_jwt` config carries a fixed access token that simply expires, and a
+/// refresh token can be revoked or rotated out from under us; in both cases the
+/// fix is the same.
+pub fn auth_failure_hint() -> &'static str {
+    "authentication failed — your session may have expired; re-run `slimctl login`"
+}
+
+/// True when `status` indicates the server rejected our credentials.
+pub fn is_auth_failure(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unauthenticated | tonic::Code::PermissionDenied
+    )
 }
 
 /// Return the default config file path: `$HOME/.slimctl/config.yaml`
@@ -285,6 +486,16 @@ pub(crate) static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 mod tests {
     use super::*;
     use slim_config::tls::client::TlsClientConfig;
+
+    /// Point HOME at a fresh temp directory for the duration of the caller's
+    /// scope.  Caller must hold [`HOME_LOCK`].
+    #[allow(clippy::disallowed_methods)]
+    fn setup_home() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by HOME_LOCK held by the caller.
+        unsafe { std::env::set_var("HOME", dir.path()) };
+        dir
+    }
 
     // ── parse_duration ──────────────────────────────────────────────────────
 
@@ -709,6 +920,467 @@ mod tests {
     #[test]
     fn load_config_explicit_path_missing_returns_error() {
         assert!(load_config(Some("/nonexistent/path/config.yaml")).is_err());
+    }
+
+    // ── ${env:...} / ${file:...} resolution ─────────────────────────────────
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn load_config_resolves_env_reference() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: serialized by HOME_LOCK; no other threads read this var.
+        unsafe { std::env::set_var("SLIMCTL_TEST_ENDPOINT", "env-host:7777") };
+        let mut f = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
+        std::io::Write::write_all(&mut f, b"endpoint: ${env:SLIMCTL_TEST_ENDPOINT}\n").unwrap();
+        let config = load_config(Some(f.path().to_str().unwrap())).unwrap();
+        assert_eq!(config.endpoint, "env-host:7777");
+    }
+
+    #[test]
+    fn load_config_resolves_file_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret = dir.path().join("endpoint.txt");
+        std::fs::write(&secret, "file-host:8888").unwrap();
+        let cfg = dir.path().join("config.yaml");
+        std::fs::write(&cfg, format!("endpoint: ${{file:{}}}\n", secret.display())).unwrap();
+        let config = load_config(Some(cfg.to_str().unwrap())).unwrap();
+        assert_eq!(config.endpoint, "file-host:8888");
+    }
+
+    #[test]
+    fn load_config_unresolvable_reference_returns_error() {
+        let mut f = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
+        std::io::Write::write_all(&mut f, b"endpoint: ${file:/nonexistent/token}\n").unwrap();
+        assert!(load_config(Some(f.path().to_str().unwrap())).is_err());
+    }
+
+    #[test]
+    fn load_config_mapping_returns_empty_for_missing_file() {
+        let map = load_config_mapping(Some("/nonexistent/path/config.yaml")).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn load_config_mapping_rejects_a_non_mapping_document() {
+        let mut f = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
+        std::io::Write::write_all(&mut f, b"- just\n- a list\n").unwrap();
+        assert!(load_config_mapping(Some(f.path().to_str().unwrap())).is_err());
+    }
+
+    /// An empty file is a valid starting point, not an error.
+    #[test]
+    fn load_config_mapping_treats_empty_file_as_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "").unwrap();
+        assert!(
+            load_config_mapping(Some(path.to_str().unwrap()))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// The point of writing at the mapping level: a `${...}` reference in an
+    /// untouched key survives, where a deserialize-modify-serialize cycle would
+    /// have replaced it with the file's contents.
+    #[test]
+    fn set_config_key_preserves_references_in_other_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret = dir.path().join("endpoint.txt");
+        std::fs::write(&secret, "file-host:8888").unwrap();
+        let cfg = dir.path().join("config.yaml");
+        let reference = format!("${{file:{}}}", secret.display());
+        std::fs::write(&cfg, format!("endpoint: {reference}\n")).unwrap();
+
+        set_config_key("request_timeout", &"42s", Some(cfg.to_str().unwrap())).unwrap();
+
+        let raw = std::fs::read_to_string(&cfg).unwrap();
+        assert!(raw.contains(&reference), "reference was expanded: {raw}");
+        assert!(!raw.contains("file-host:8888"));
+        assert!(raw.contains("42s"), "new key missing: {raw}");
+    }
+
+    /// Only the requested key is written — no defaulted fields tag along.
+    #[test]
+    fn set_config_key_writes_only_that_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        set_config_key("endpoint", &"myhost:50051", Some(path.to_str().unwrap())).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(raw.trim(), "endpoint: myhost:50051");
+    }
+
+    #[test]
+    fn set_config_key_leaves_unrelated_keys_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "endpoint: keep-me:1234\nrequest_timeout: 9s\n").unwrap();
+
+        set_config_key("endpoint", &"changed:1", Some(path.to_str().unwrap())).unwrap();
+
+        let map = load_config_mapping(Some(path.to_str().unwrap())).unwrap();
+        assert_eq!(
+            map.get(serde_yaml::Value::String("request_timeout".into()))
+                .and_then(|v| v.as_str()),
+            Some("9s")
+        );
+        assert_eq!(
+            map.get(serde_yaml::Value::String("endpoint".into()))
+                .and_then(|v| v.as_str()),
+            Some("changed:1")
+        );
+    }
+
+    #[test]
+    fn get_config_key_defaults_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "endpoint: x:1\n").unwrap();
+        let tls: TlsClientConfig = get_config_key("tls", Some(path.to_str().unwrap())).unwrap();
+        assert_eq!(tls, TlsClientConfig::default());
+    }
+
+    // ── save_login_auth ─────────────────────────────────────────────────────
+
+    fn creds_with(refresh_token: Option<&str>) -> OidcCredentials {
+        OidcCredentials {
+            id_token: "the-id-token".to_string(),
+            access_token: Some("the-access-token".to_string()),
+            refresh_token: refresh_token.map(str::to_owned),
+            client_id: "myclient".to_string(),
+            issuer: "https://issuer.example.com".to_string(),
+            token_endpoint: "https://issuer.example.com/token".to_string(),
+        }
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    /// slimctl authenticates with the access token only; the refresh token is
+    /// written to disk for other processes but never referenced by its config.
+    fn save_login_auth_uses_access_token_only() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+
+        let creds = creds_with(Some("the-refresh-token"));
+        save_credentials(&creds).unwrap();
+        let written = save_login_auth(&creds, Some(path_str), None).expect("save_login_auth");
+
+        assert_eq!(written.config_path, path);
+        assert_eq!(written.access_token_path, token_file_path().unwrap());
+        assert_eq!(
+            written.refresh_token_path,
+            Some(refresh_token_file_path().unwrap())
+        );
+
+        let loaded = load_config(Some(path_str)).unwrap();
+        let AuthenticationConfig::StaticJwt(jwt) = loaded.auth else {
+            panic!("expected static_jwt auth, got {:?}", loaded.auth);
+        };
+        assert_eq!(
+            jwt.source().file,
+            token_file_path().unwrap().to_str().unwrap()
+        );
+
+        // Neither token may appear in the config, and it must not point at the
+        // refresh token in any form.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("the-refresh-token"), "leaked: {raw}");
+        assert!(!raw.contains("the-access-token"), "leaked: {raw}");
+        assert!(!raw.contains("refresh_token"), "references refresh: {raw}");
+    }
+
+    /// `slimctl --server host login` should leave behind a config that points
+    /// somewhere, not just an auth block.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_records_server_when_given() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+
+        let creds = creds_with(Some("the-refresh-token"));
+        save_credentials(&creds).unwrap();
+        save_login_auth(&creds, Some(path_str), Some("ctrl.example.com:50051")).unwrap();
+
+        let loaded = load_config(Some(path_str)).unwrap();
+        assert_eq!(loaded.endpoint, "ctrl.example.com:50051");
+        assert!(matches!(loaded.auth, AuthenticationConfig::StaticJwt(_)));
+    }
+
+    /// Recording a bare `host:port` means the endpoint now comes from the file,
+    /// which `resolve_config` treats as intentionally secure — so it resolves to
+    /// https. Including a scheme in `--server` is how a plaintext endpoint is
+    /// recorded.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn recorded_endpoint_scheme_follows_what_was_passed() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let creds = creds_with(Some("rt"));
+        save_credentials(&creds).unwrap();
+
+        for (passed, expected) in [
+            ("ctrl.example.com:50051", "https://ctrl.example.com:50051"),
+            (
+                "http://ctrl.example.com:50051",
+                "http://ctrl.example.com:50051",
+            ),
+        ] {
+            let path = home.path().join(format!("cfg-{}.yaml", expected.len()));
+            let path_str = path.to_str().unwrap();
+            save_login_auth(&creds, Some(path_str), Some(passed)).unwrap();
+            let opts = resolve_config(
+                &load_config(Some(path_str)).unwrap(),
+                DEFAULT_CONTROLLER_ENDPOINT,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+            assert_eq!(opts.endpoint, expected, "for --server {passed}");
+        }
+    }
+
+    /// Without `--server` the endpoint is left alone rather than blanked.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_preserves_existing_endpoint_without_server() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+        std::fs::write(&path, "endpoint: already-set:1234\n").unwrap();
+
+        let creds = creds_with(Some("the-refresh-token"));
+        save_credentials(&creds).unwrap();
+        save_login_auth(&creds, Some(path_str), None).unwrap();
+
+        let loaded = load_config(Some(path_str)).unwrap();
+        assert_eq!(loaded.endpoint, "already-set:1234");
+    }
+
+    /// …and `--server` replaces one that was already there.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_server_overrides_existing_endpoint() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+        std::fs::write(&path, "endpoint: old-host:1\n").unwrap();
+
+        let creds = creds_with(Some("the-refresh-token"));
+        save_credentials(&creds).unwrap();
+        save_login_auth(&creds, Some(path_str), Some("new-host:2")).unwrap();
+
+        assert_eq!(load_config(Some(path_str)).unwrap().endpoint, "new-host:2");
+    }
+
+    /// The refresh token is still persisted — a data-plane node seeds from it.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_writes_refresh_token_for_other_processes() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+
+        save_login_auth(
+            &creds_with(Some("the-refresh-token")),
+            Some(path.to_str().unwrap()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(refresh_token_file_path().unwrap()).unwrap(),
+            "the-refresh-token"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_refresh_token_file_is_private() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        save_login_auth(
+            &creds_with(Some("the-refresh-token")),
+            Some(path.to_str().unwrap()),
+            None,
+        )
+        .unwrap();
+
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(refresh_token_file_path().unwrap())
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "got mode {:o}", mode & 0o777);
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_without_refresh_token_uses_static_jwt() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+
+        let creds = creds_with(None);
+        // login always writes the bearer token file first.
+        save_credentials(&creds).unwrap();
+
+        let written = save_login_auth(&creds, Some(path_str), None).expect("save_login_auth");
+        assert_eq!(written.access_token_path, token_file_path().unwrap());
+        // No refresh token was issued, so none is persisted.
+        assert!(written.refresh_token_path.is_none());
+        assert!(!refresh_token_file_path().unwrap().exists());
+
+        let loaded = load_config(Some(path_str)).unwrap();
+        let AuthenticationConfig::StaticJwt(jwt) = loaded.auth else {
+            panic!("expected static_jwt auth, got {:?}", loaded.auth);
+        };
+        assert_eq!(
+            jwt.source().file,
+            token_file_path().unwrap().to_str().unwrap()
+        );
+        // The token itself is only ever in the token file.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("the-access-token"), "token leaked: {raw}");
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_preserves_existing_settings() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+
+        let existing = ClientConfig::with_endpoint("myhost:50051")
+            .with_tls_setting(TlsClientConfig::new().with_ca_file("/etc/ca.pem"))
+            .with_request_timeout(Duration::from_secs(42));
+        save_config(&existing, Some(path_str)).unwrap();
+
+        save_login_auth(&creds_with(Some("the-refresh-token")), Some(path_str), None).unwrap();
+
+        let loaded = load_config(Some(path_str)).unwrap();
+        assert_eq!(loaded.endpoint, "myhost:50051");
+        assert!(!loaded.tls_setting.insecure);
+        assert_eq!(
+            Duration::from(loaded.request_timeout),
+            Duration::from_secs(42)
+        );
+        assert!(matches!(loaded.auth, AuthenticationConfig::StaticJwt(_)));
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_creates_config_when_absent() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("nested").join("config.yaml");
+        save_login_auth(
+            &creds_with(Some("the-refresh-token")),
+            Some(path.to_str().unwrap()),
+            None,
+        )
+        .unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_overwrites_previous_auth() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+
+        let mut existing = ClientConfig::with_endpoint("myhost:50051");
+        existing.auth = AuthenticationConfig::Basic(BasicAuthConfig::new("u", "p"));
+        save_config(&existing, Some(path_str)).unwrap();
+
+        save_login_auth(&creds_with(Some("the-refresh-token")), Some(path_str), None).unwrap();
+        let loaded = load_config(Some(path_str)).unwrap();
+        assert!(matches!(loaded.auth, AuthenticationConfig::StaticJwt(_)));
+    }
+
+    /// Re-running login must not accumulate stale references or leak the old
+    /// secret once resolution is in play.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn save_login_auth_is_idempotent_across_relogin() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+
+        save_login_auth(&creds_with(Some("first-token")), Some(path_str), None).unwrap();
+        save_login_auth(&creds_with(Some("second-token")), Some(path_str), None).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("first-token"), "old token baked in: {raw}");
+        assert!(!raw.contains("second-token"), "new token baked in: {raw}");
+
+        // The file the config points at holds the latest token.
+        assert_eq!(
+            std::fs::read_to_string(refresh_token_file_path().unwrap()).unwrap(),
+            "second-token"
+        );
+        let loaded = load_config(Some(path_str)).unwrap();
+        assert!(matches!(loaded.auth, AuthenticationConfig::StaticJwt(_)));
+    }
+
+    /// A login-written config must take effect through `resolve_config` without
+    /// depending on the implicit credentials-file fallback.
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn resolve_config_uses_login_written_auth() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = setup_home();
+        let path = home.path().join("config.yaml");
+        let path_str = path.to_str().unwrap();
+        save_login_auth(&creds_with(Some("the-refresh-token")), Some(path_str), None).unwrap();
+
+        let file_config = load_config(Some(path_str)).unwrap();
+        let opts = resolve_config(
+            &file_config,
+            DEFAULT_CONTROLLER_ENDPOINT,
+            Some("myhost:50051"),
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let AuthenticationConfig::StaticJwt(jwt) = opts.auth else {
+            panic!("expected static_jwt auth to survive resolve_config");
+        };
+        assert_eq!(
+            jwt.source().file,
+            token_file_path().unwrap().to_str().unwrap()
+        );
+    }
+
+    // ── auth failure hint ───────────────────────────────────────────────────
+
+    #[test]
+    fn is_auth_failure_detects_rejected_credentials() {
+        assert!(is_auth_failure(&tonic::Status::unauthenticated("nope")));
+        assert!(is_auth_failure(&tonic::Status::permission_denied("nope")));
+        assert!(!is_auth_failure(&tonic::Status::unavailable("down")));
+        assert!(!is_auth_failure(&tonic::Status::internal("boom")));
     }
 
     #[test]

--- a/crates/slimctl/src/main.rs
+++ b/crates/slimctl/src/main.rs
@@ -13,5 +13,20 @@ use clap::Parser;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let parsed = cli::Cli::parse();
-    cli::run(parsed).await
+    cli::run(parsed).await.map_err(annotate_auth_failure)
+}
+
+/// Append a re-login hint when the failure was the server rejecting our
+/// credentials.  Tokens written by `slimctl login` expire, and a bare
+/// "Unauthenticated" gives the user nothing to act on.
+fn annotate_auth_failure(err: anyhow::Error) -> anyhow::Error {
+    let is_auth = err
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<tonic::Status>())
+        .any(config::is_auth_failure);
+    if is_auth {
+        err.context(config::auth_failure_hint())
+    } else {
+        err
+    }
 }


### PR DESCRIPTION
# Description

`slimctl login` stored tokens in `~/.slimctl/credentials.yaml` but left the connection config untouched, so authentication relied on an implicit credentials-file lookup inside `resolve_config`. Nothing on disk showed which identity a command would use.

Follow-up to #1960, which added the OIDC refresh machinery.

## Changes

### `slimctl login` writes an explicit `auth` block

Merged into the config `--config` targets (default `~/.slimctl/config.yaml`), so `endpoint`, `tls`, timeouts and everything else are preserved. Secrets are never inlined — the block only names the file holding the credential:

```yaml
auth:
  type: static_jwt
  file: /home/user/.slimctl/token
```

### slimctl authenticates with the access token only

It deliberately does not consume the refresh token. A refresh token serves one process at a time and every exchange invalidates the stored copy, so a CLI spending a rotation per invocation would race any long-lived process seeded from the same token — and would gain nothing, since it exits long before the background renewal task could run.

When the access token expires the user re-runs `slimctl login`. `Unauthenticated`/`PermissionDenied` failures now carry that hint instead of a bare status code.

The refresh token is still written to `~/.slimctl/refresh_token` (mode 0600) for long-lived processes to consume.

### `oidc::Config`: file-backed refresh tokens

Two new optional fields, both absent from serialized output when unset, so existing configs are unaffected:

- **`refresh_token_file`** — a *read-write* binding. The token is read from the file and rotations are written back to the same path (mode 0600). The existing inline `refresh_token` cannot survive rotation by construction: `get_client_layer` passed `persist_credentials: None` on that branch, so an IdP issuing single-use refresh tokens invalidated the configured value after one exchange, breaking the next start.
- **`access_token_file`** — optional cache. A still-valid token found here seeds the provider, sparing short-lived processes a token-endpoint round-trip *and* a refresh-token rotation on every start.

```yaml
auth:
  type: oidc
  issuer_url: https://issuer.example.com
  client_id: myclient
  refresh_token_file: /var/lib/slim/refresh_token
  access_token_file: /var/lib/slim/access_token
```

Note that a refresh token serves one process at a time and nothing here enforces that — two processes sharing a file will fight and both eventually fail with `invalid_grant`. Documented on the field; point each long-lived consumer at its own file.

### `${env:...}` / `${file:...}` in slimctl configs

`ConfigResolver` is now wired into slimctl's config loader, matching the node, control-plane and channel-manager loaders.

This exposed a hazard worth calling out: read-modify-write paths (`login`, `config set`) must **not** resolve before serializing back, or a user's `${...}` reference gets replaced by its expansion — silently baking a secret read from a file into the YAML. Those paths use a separate non-resolving load, pinned by `load_config_for_update_preserves_references_verbatim`.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Testing

30 new unit tests. Notable coverage:

- refresh-token file is written 0600, and neither token ever appears in the config
- `save_login_auth` preserves `endpoint`/`tls`/timeouts, creates nested paths, overwrites a prior `basic` block
- re-login leaves neither the old nor the new token in the config
- the written block survives `resolve_config` rather than being masked by the implicit fallback
- `refresh_token_file` takes precedence over a stale inline `refresh_token`; an unreadable `access_token_file` is only a cache and must not fail the build
- `${env:...}`/`${file:...}` resolution, and unresolvable references erroring

`cargo test -p agntcy-slim-config -p agntcy-slimctl`: 230 + 205 unit, 25 e2e, 5 tls, 0 failures. clippy and fmt clean on `--all-targets`.

## Not included

The checked-in `client-config.schema.json` is not regenerated. It is already ~370 lines stale on `main` (missing `connection_type`, `require_header_mac`, the `oidc` auth variant, `policy`), it is generated manually rather than in CI, and `link_id`'s default is a random UUID so every regeneration produces churn. Worth a dedicated PR.

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
