### PR TITLE
fix(auth): serialize concurrent refresh-token exchanges with file lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "drain",
  "duration-string",
  "fastwebsockets",
+ "fs2",
  "futures",
  "getrandom 0.4.3",
  "gloo-net",
@@ -2270,6 +2271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4571,7 +4582,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ fastwebsockets = { version = "0.10.0", features = [
     "upgrade",
     "unstable-split",
 ] }
+fs2 = "0.4"
 futures = "0.3.31"
 futures-timer = "3.0.3"
 

--- a/crates/auth/src/jwt.rs
+++ b/crates/auth/src/jwt.rs
@@ -162,6 +162,12 @@ struct ExpClaim {
     exp: u64,
 }
 
+#[derive(serde::Deserialize)]
+struct ExpIatClaim {
+    exp: u64,
+    iat: u64,
+}
+
 /// JWT implementation that uses the jsonwebtoken crate.
 #[derive(Clone)]
 pub struct Jwt<T> {
@@ -726,6 +732,12 @@ impl Verifier for VerifierJwt {
 pub(crate) fn extract_exp_claim_unsafe(token: &str) -> Result<u64, AuthError> {
     let data = jsonwebtoken::dangerous::insecure_decode::<ExpClaim>(token)?;
     Ok(data.claims.exp)
+}
+
+/// Extract `exp` and `iat` from a JWT without signature verification.
+pub(crate) fn extract_exp_iat_claims_unsafe(token: &str) -> Result<(u64, u64), AuthError> {
+    let data = jsonwebtoken::dangerous::insecure_decode::<ExpIatClaim>(token)?;
+    Ok((data.claims.exp, data.claims.iat))
 }
 
 /// Helper function to extract the 'sub' claim from a JWT token without signature validation

--- a/crates/auth/src/refresh_token.rs
+++ b/crates/auth/src/refresh_token.rs
@@ -9,11 +9,17 @@ use parking_lot::RwLock;
 use reqwest::Client as ReqwestClient;
 
 use crate::errors::AuthError;
-use crate::jwt::{extract_exp_claim_unsafe, extract_sub_claim_unsafe};
+use crate::jwt::{
+    extract_exp_claim_unsafe, extract_exp_iat_claims_unsafe, extract_sub_claim_unsafe,
+};
 use crate::resolver::same_origin;
 use crate::traits::TokenProvider;
 
 const REFRESH_BUFFER_SECS: u64 = 60;
+
+/// Return type of the `lock_and_reload` callback: `(refresh_token, maybe_access_token, lock_guard)`.
+pub type LockAndReloadFn =
+    Arc<dyn Fn() -> Option<(String, Option<String>, Box<dyn Send>)> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct RefreshTokenProviderConfig {
@@ -38,6 +44,18 @@ pub struct RefreshTokenProviderConfig {
     /// Implementations may block (file I/O) but should not be slow: they sit in
     /// the path of every renewal.
     pub persist_credentials: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
+    /// Called at the start of every token exchange to acquire an exclusive lock on
+    /// the backing store and return the current tokens from it. The tuple is
+    /// (refresh_token, maybe_access_token, guard). The guard holds the lock; it is
+    /// dropped after `persist_credentials` completes, so no concurrent process can
+    /// exchange the same token.
+    ///
+    /// When `maybe_access_token` is `Some` and still fresh, `fetch_new_token` skips
+    /// the IdP call and updates the in-memory cache from the on-disk value instead —
+    /// avoiding a redundant rotation when another process already refreshed.
+    ///
+    /// `None` means the provider is not file-backed and no locking is needed.
+    pub lock_and_reload: Option<LockAndReloadFn>,
 }
 
 struct CachedToken {
@@ -115,7 +133,53 @@ impl RefreshTokenProvider {
 
     async fn fetch_new_token(&self) -> Result<(), AuthError> {
         let token_endpoint = self.get_token_endpoint().await?;
-        let refresh_token = self.current_refresh_token.read().clone();
+
+        // File-backed path: acquire an exclusive lock on the backing store and
+        // re-read the refresh token from disk under that lock. If another process
+        // finished an exchange while we were waiting, we get its rotated token here
+        // instead of replaying the one it already consumed.
+        //
+        // _lock_guard is held for the rest of this function — including across the
+        // IdP call and the persist_credentials write — so no other process can start
+        // an exchange until ours is fully committed to disk.
+        let _lock_guard: Option<Box<dyn Send>>;
+        let refresh_token = if let Some(ref lock_fn) = self.config.lock_and_reload {
+            let Some((rt, maybe_at, guard)) = lock_fn() else {
+                return Err(AuthError::GetTokenError);
+            };
+            *self.current_refresh_token.write() = rt.clone();
+            _lock_guard = Some(guard);
+
+            // If the backing store returned a cached access token, check whether it
+            // is still fresh enough to skip the IdP call. Another process may have
+            // just refreshed; reusing its token avoids an unnecessary rotation.
+            //
+            // The threshold matches the background task: refresh_at = iat + lifetime*2/3.
+            // If we haven't reached that point yet, the token is fresh.
+            if let Some(at) = maybe_at
+                && let Ok((exp, iat)) = extract_exp_iat_claims_unsafe(&at)
+            {
+                let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+                let lifetime = exp.saturating_sub(iat);
+                let refresh_at_unix = iat + lifetime * 2 / 3;
+                if now < refresh_at_unix {
+                    let remaining = exp.saturating_sub(now);
+                    let refresh_at = tokio::time::Instant::now()
+                        + Duration::from_secs((remaining * 2 / 3).max(REFRESH_BUFFER_SECS + 1));
+                    *self.cached.write() = Some(CachedToken {
+                        token: at,
+                        exp,
+                        refresh_at,
+                    });
+                    return Ok(());
+                }
+            }
+
+            rt
+        } else {
+            _lock_guard = None;
+            self.current_refresh_token.read().clone()
+        };
 
         let http_resp = self
             .client
@@ -345,6 +409,7 @@ mod tests {
             timeout: Some(Duration::from_secs(5)),
             initial_access_token: None,
             persist_credentials: persist,
+            lock_and_reload: None,
         })
         .expect("provider")
     }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -29,6 +29,7 @@ display-error-chain = { workspace = true }
 drain = { workspace = true }
 duration-string = { workspace = true }
 fastwebsockets = { workspace = true }
+fs2 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }

--- a/crates/config/src/auth/oidc.rs
+++ b/crates/config/src/auth/oidc.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use slim_auth::errors::AuthError;
 use slim_auth::jwt_middleware::{AddJwtLayer, PolicyCheckLayer, ValidateJwtLayer};
 use slim_auth::metadata::MetadataMap;
-use slim_auth::refresh_token::{RefreshTokenProvider, RefreshTokenProviderConfig};
+use slim_auth::refresh_token::{LockAndReloadFn, RefreshTokenProvider, RefreshTokenProviderConfig};
 use slim_auth::traits::TokenProvider;
 use tower_layer::Stack;
 
@@ -490,7 +490,12 @@ impl ClientAuthenticator for Config {
 
             let rt_path = PathBuf::from(rt_file);
             let at_path = self.access_token_file.as_deref().map(PathBuf::from);
-            let persist: Arc<dyn Fn(String, String) + Send + Sync> =
+
+            // Wrapped in a block so rt_path and at_path can be cloned before they
+            // are moved into the persist closure below.
+            let persist: Arc<dyn Fn(String, String) + Send + Sync> = {
+                let rt_path = rt_path.clone();
+                let at_path = at_path.clone();
                 Arc::new(move |access_token, new_refresh_token| {
                     if let Err(e) = write_secret_file(&rt_path, &new_refresh_token) {
                         tracing::error!(
@@ -504,7 +509,41 @@ impl ClientAuthenticator for Config {
                     {
                         tracing::error!("failed to write access token to {at_path:?}: {e}");
                     }
-                });
+                })
+            };
+
+            let lock_and_reload: LockAndReloadFn = {
+                // Companion lock file: a sibling path used only as a locking target.
+                // Keeping it separate from the token file means write_secret_file can
+                // open and truncate the token file freely without hitting a re-entrant
+                // flock from the same process.
+                let lock_path = {
+                    let mut s = rt_path.clone().into_os_string();
+                    s.push(".lock");
+                    PathBuf::from(s)
+                };
+                let rt_path = rt_path.clone();
+                Arc::new(move || {
+                    use fs2::FileExt;
+                    // Create the lock file if absent, then block until we hold an
+                    // exclusive lock. The fd is the guard: closing it releases the lock.
+                    let lock_file = std::fs::OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(false)
+                        .open(&lock_path)
+                        .ok()?;
+                    lock_file.lock_exclusive().ok()?;
+                    // Re-read both token files now that we hold the lock. Another
+                    // process may have rotated them while we were waiting. The access
+                    // token lets fetch_new_token skip the IdP call if it is still fresh.
+                    let token = read_secret_file(rt_path.to_str()?).ok()?;
+                    let access_token = at_path
+                        .as_ref()
+                        .and_then(|p| read_secret_file(p.to_str()?).ok());
+                    Some((token, access_token, Box::new(lock_file) as Box<dyn Send>))
+                })
+            };
 
             OidcClientProvider::RefreshToken(RefreshTokenProvider::new(
                 RefreshTokenProviderConfig {
@@ -514,6 +553,7 @@ impl ClientAuthenticator for Config {
                     timeout: self.timeout.map(Into::into),
                     initial_access_token,
                     persist_credentials: Some(persist),
+                    lock_and_reload: Some(lock_and_reload),
                 },
             )?)
         } else if let Some(rt) = &self.refresh_token {
@@ -530,6 +570,7 @@ impl ClientAuthenticator for Config {
                     timeout: self.timeout.map(Into::into),
                     initial_access_token: None,
                     persist_credentials: None,
+                    lock_and_reload: None,
                 },
             )?)
         } else if self.client_secret.is_some() {
@@ -565,6 +606,7 @@ impl ClientAuthenticator for Config {
                     timeout: self.timeout.map(Into::into),
                     initial_access_token: creds.access_token,
                     persist_credentials: persist,
+                    lock_and_reload: None,
                 },
             )?)
         };
@@ -1031,6 +1073,70 @@ mod tests {
         assert_eq!(
             read_secret_file(path.to_str().unwrap()).unwrap(),
             "rotated-token"
+        );
+    }
+
+    /// Two concurrent callers of the lock_and_reload closure must never read the
+    /// same refresh token. The second caller blocks at flock until the first has
+    /// written the rotated token to disk, then reads that new value.
+    #[test]
+    fn concurrent_lock_and_reload_closures_serialize_token_reads() {
+        use fs2::FileExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let rt_path = dir.path().join("rt");
+        let lock_path = {
+            let mut s = rt_path.clone().into_os_string();
+            s.push(".lock");
+            PathBuf::from(s)
+        };
+
+        write_secret_file(&rt_path, "token-1").unwrap();
+
+        // Replicates the lock_and_reload closure built in get_client_layer.
+        let make_closure = |rt: PathBuf, lk: PathBuf| -> LockAndReloadFn {
+            Arc::new(move || {
+                let lock_file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&lk)
+                    .ok()?;
+                lock_file.lock_exclusive().ok()?;
+                let token = read_secret_file(rt.to_str()?).ok()?;
+                Some((token, None, Box::new(lock_file) as Box<dyn Send>))
+            })
+        };
+
+        let cb_a = make_closure(rt_path.clone(), lock_path.clone());
+        let cb_b = make_closure(rt_path.clone(), lock_path.clone());
+
+        // Thread A: acquires the lock, writes the rotated token (simulating persist),
+        // signals B that the new token is on disk, then holds the lock a moment longer
+        // to ensure B is already blocking on flock before the lock releases.
+        let rt_for_write = rt_path.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+        let thread_a = std::thread::spawn(move || {
+            let (token, _at, guard) = cb_a().expect("cb_a");
+            write_secret_file(&rt_for_write, "token-2").unwrap();
+            ready_tx.send(()).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            drop(guard);
+            token
+        });
+
+        // Wait until A has written token-2, then contend on the lock.
+        // B will block at flock until A's sleep expires and the guard drops.
+        ready_rx.recv().unwrap();
+        let (token_b, _at_b, guard_b) = cb_b().expect("cb_b");
+        drop(guard_b);
+
+        let token_a = thread_a.join().unwrap();
+
+        assert_eq!(token_a, "token-1");
+        assert_eq!(
+            token_b, "token-2",
+            "B must read the token A wrote, not the original"
         );
     }
 }

--- a/crates/config/src/auth/oidc.rs
+++ b/crates/config/src/auth/oidc.rs
@@ -537,6 +537,9 @@ impl ClientAuthenticator for Config {
                     // Re-read both token files now that we hold the lock. Another
                     // process may have rotated them while we were waiting. The access
                     // token lets fetch_new_token skip the IdP call if it is still fresh.
+                    // Note: the freshness optimization only activates when access_token_file
+                    // is configured alongside refresh_token_file. Without it, access_token
+                    // is None here and the full exchange always runs.
                     let token = read_secret_file(rt_path.to_str()?).ok()?;
                     let access_token = at_path
                         .as_ref()


### PR DESCRIPTION
# Description

Two processes sharing the same `refresh_token_file` could both read the same refresh token and send it to the IdP concurrently. The first succeeds and rotates the token; the second gets `invalid_grant` and its background renewal loop exits permanently.

# Changes
- Add `lock_and_reload` callback to `RefreshTokenProviderConfig` that acquires an exclusive lock and returns the current tokens from the backing store
- In `fetch_new_token`, acquire the lock before the IdP call and hold it until `persist_credentials` completes
- Skip the IdP call if the access token from disk is still fresh (within the first 2/3 of its lifetime), consistent with the background task's refresh threshold
- Add `extract_exp_iat_claims_unsafe` to the JWT module for the freshness check
- Wire up the `lock_and_reload` closure in the `refresh_token_file` branch of `get_client_layer`, using a companion `.lock` file as the locking target so `write_secret_file` can open the token file freely without a re-entrant lock
- Use `fs2::FileExt::lock_exclusive` for cross-platform file locking without unsafe
- Add a test verifying that concurrent callers of the lock closure are serialized and read distinct tokens

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
