### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -553,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.1.0"
+version = "2.1.1"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.1.0" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.15.0" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.1.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.15.0" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.1.0" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.7" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.3" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.6" }
+agntcy-slim = { path = "crates/slim", version = "2.1.1" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.15.1" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.1.1" }
+agntcy-slim-config = { path = "crates/config", version = "0.15.1" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.1.1" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.8" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.4" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.7" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.7" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.1.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.7", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.7" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.22" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.8" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.1.1" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.8", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.8" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.23" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.16" }
-agntcy-slim-version = { path = "crates/version", version = "2.1.0" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.1.0" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.17" }
+agntcy-slim-version = { path = "crates/version", version = "2.1.1" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.1.1" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -238,7 +238,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.1.0"
+version = "2.1.1"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/agntcy/slim/compare/slim-auth-v0.15.0...slim-auth-v0.15.1) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.15.0](https://github.com/agntcy/slim/compare/slim-auth-v0.14.6...slim-auth-v0.15.0) - 2026-08-12
 
 ### Added

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.15.0"
+version = "0.15.1"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/agntcy/slim/compare/slim-config-v0.15.0...slim-config-v0.15.1) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.15.0](https://github.com/agntcy/slim/compare/slim-config-v0.14.5...slim-config-v0.15.0) - 2026-08-12
 
 ### Added

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.15.0"
+version = "0.15.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.1.0...slim-control-plane-v2.1.1) - 2026-08-12
+
+### Fixed
+
+- windows build ([#1978](https://github.com/agntcy/slim/pull/1978))
+
 ## [2.1.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.0.0...slim-control-plane-v2.1.0) - 2026-08-12
 
 ### Added

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.8](https://github.com/agntcy/slim/compare/slim-controller-v0.12.7...slim-controller-v0.12.8) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-signal
+
 ## [0.12.7](https://github.com/agntcy/slim/compare/slim-controller-v0.12.6...slim-controller-v0.12.7) - 2026-08-12
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.7"
+version = "0.12.8"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.3...slim-datapath-v0.18.4) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
+
 ## [0.18.3](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.2...slim-datapath-v0.18.3) - 2026-08-12
 
 ### Added

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.3"
+version = "0.18.4"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/agntcy/slim/compare/slim-mls-v0.3.6...slim-mls-v0.3.7) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.3.6](https://github.com/agntcy/slim/compare/slim-mls-v0.3.5...slim-mls-v0.3.6) - 2026-08-12
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.6"
+version = "0.3.7"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/agntcy/slim/compare/slim-proto-v0.5.7...slim-proto-v0.5.8) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.5.7](https://github.com/agntcy/slim/compare/slim-proto-v0.5.6...slim-proto-v0.5.7) - 2026-08-12
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.8](https://github.com/agntcy/slim/compare/slim-service-v0.12.7...slim-service-v0.12.8) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.12.7](https://github.com/agntcy/slim/compare/slim-service-v0.12.6...slim-service-v0.12.7) - 2026-08-12
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.7"
+version = "0.12.8"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8](https://github.com/agntcy/slim/compare/slim-session-v0.7.7...slim-session-v0.7.8) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.7.7](https://github.com/agntcy/slim/compare/slim-session-v0.7.6...slim-session-v0.7.7) - 2026-08-12
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.7"
+version = "0.7.8"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/agntcy/slim/compare/slim-signal-v0.1.22...slim-signal-v0.1.23) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.22](https://github.com/agntcy/slim/compare/slim-signal-v0.1.21...slim-signal-v0.1.22) - 2026-08-12
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.22"
+version = "0.1.23"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/agntcy/slim/compare/slimctl-v2.1.0...slimctl-v2.1.1) - 2026-08-12
+
+### Fixed
+
+- windows build ([#1978](https://github.com/agntcy/slim/pull/1978))
+- windows build ([#1977](https://github.com/agntcy/slim/pull/1977))
+
 ## [2.1.0](https://github.com/agntcy/slim/compare/slimctl-v2.0.0...slimctl-v2.1.0) - 2026-08-12
 
 ### Added

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.17](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.16...slim-tracing-v0.4.17) - 2026-08-12
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.16](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.15...slim-tracing-v0.4.16) - 2026-08-12
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.16"
+version = "0.4.17"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.1.0 -> 2.1.1
* `agntcy-slim`: 2.1.0 -> 2.1.1
* `agntcy-slim-channel-manager`: 2.1.0 -> 2.1.1
* `agntcy-slim-control-plane`: 2.1.0 -> 2.1.1 (✓ API compatible changes)
* `agntcy-slim-bindings`: 2.1.0 -> 2.1.1
* `agntcy-slim-rpc`: 2.1.0 -> 2.1.1
* `agntcy-slimctl`: 2.1.0 -> 2.1.1
* `agntcy-slim-auth`: 0.15.0 -> 0.15.1
* `agntcy-slim-config`: 0.15.0 -> 0.15.1
* `agntcy-slim-proto`: 0.5.7 -> 0.5.8
* `agntcy-slim-tracing`: 0.4.16 -> 0.4.17
* `agntcy-slim-datapath`: 0.18.3 -> 0.18.4
* `agntcy-slim-mls`: 0.3.6 -> 0.3.7
* `agntcy-slim-session`: 0.7.7 -> 0.7.8
* `agntcy-slim-signal`: 0.1.22 -> 0.1.23
* `agntcy-slim-controller`: 0.12.7 -> 0.12.8
* `agntcy-slim-service`: 0.12.7 -> 0.12.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.0) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.0) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.1.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.1.0...slim-control-plane-v2.1.1) - 2026-08-12

### Fixed

- windows build ([#1978](https://github.com/agntcy/slim/pull/1978))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0...slim-bindings-v2.1.0) - 2026-08-12

### Added

- *(slimctl)* OIDC token refresh for long-lived nodes ([#1960](https://github.com/agntcy/slim/pull/1960))
- *(auth)* OIDC and static JWT validation with claim-based access control ([#1957](https://github.com/agntcy/slim/pull/1957))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0...slim-rpc-v2.1.0) - 2026-08-12

### Fixed

- *(rpc)* signal end-of-stream with the status header, not an empty payload ([#1961](https://github.com/agntcy/slim/pull/1961))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.1.1](https://github.com/agntcy/slim/compare/slimctl-v2.1.0...slimctl-v2.1.1) - 2026-08-12

### Fixed

- windows build ([#1978](https://github.com/agntcy/slim/pull/1978))
- windows build ([#1977](https://github.com/agntcy/slim/pull/1977))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.15.1](https://github.com/agntcy/slim/compare/slim-auth-v0.15.0...slim-auth-v0.15.1) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.15.1](https://github.com/agntcy/slim/compare/slim-config-v0.15.0...slim-config-v0.15.1) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.5.8](https://github.com/agntcy/slim/compare/slim-proto-v0.5.7...slim-proto-v0.5.8) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.17](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.16...slim-tracing-v0.4.17) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.3...slim-datapath-v0.18.4) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.7](https://github.com/agntcy/slim/compare/slim-mls-v0.3.6...slim-mls-v0.3.7) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.8](https://github.com/agntcy/slim/compare/slim-session-v0.7.7...slim-session-v0.7.8) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.23](https://github.com/agntcy/slim/compare/slim-signal-v0.1.22...slim-signal-v0.1.23) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.12.8](https://github.com/agntcy/slim/compare/slim-controller-v0.12.7...slim-controller-v0.12.8) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.8](https://github.com/agntcy/slim/compare/slim-service-v0.12.7...slim-service-v0.12.8) - 2026-08-12

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).