### PR TITLE
feat(bindings): expose OIDC authentication in language bindings

### DIFF
--- a/crates/slim-bindings/src/common_config.rs
+++ b/crates/slim-bindings/src/common_config.rs
@@ -1,7 +1,10 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use slim_config::auth::basic::Config as BasicAuthConfig;
+use slim_config::auth::oidc::Config as OidcAuthConfig;
 use slim_config::tls::client::TlsClientConfig as CoreTlsClientConfig;
 use slim_config::tls::server::TlsServerConfig as CoreTlsServerConfig;
 
@@ -279,6 +282,112 @@ impl From<CoreTlsServerConfig> for TlsServerConfig {
     }
 }
 
+/// Policy evaluated against JWT claims on every authenticated request (server-side OIDC only)
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum OidcPolicyConfig {
+    /// Inline Rego policy (must define `package slim.auth` with `default allow = false`)
+    Rego { text: String },
+    /// Path to a Rego policy file read at server startup
+    RegoFile { path: String },
+    /// CEL expression evaluated against JWT claims (e.g. `"admin" in claims.groups`)
+    Cel { expression: String },
+}
+
+impl From<OidcPolicyConfig> for slim_config::auth::PolicyConfig {
+    fn from(config: OidcPolicyConfig) -> Self {
+        match config {
+            OidcPolicyConfig::Rego { text } => slim_config::auth::PolicyConfig::Rego(text),
+            OidcPolicyConfig::RegoFile { path } => {
+                slim_config::auth::PolicyConfig::RegoFile(std::path::PathBuf::from(path))
+            }
+            OidcPolicyConfig::Cel { expression } => {
+                slim_config::auth::PolicyConfig::Cel(expression)
+            }
+        }
+    }
+}
+
+impl From<slim_config::auth::PolicyConfig> for OidcPolicyConfig {
+    fn from(config: slim_config::auth::PolicyConfig) -> Self {
+        match config {
+            slim_config::auth::PolicyConfig::Rego(text) => OidcPolicyConfig::Rego { text },
+            slim_config::auth::PolicyConfig::RegoFile(path) => OidcPolicyConfig::RegoFile {
+                path: path.to_string_lossy().to_string(),
+            },
+            slim_config::auth::PolicyConfig::Cel(expression) => {
+                OidcPolicyConfig::Cel { expression }
+            }
+        }
+    }
+}
+
+/// OIDC authentication configuration (client-credentials, refresh-token, or JWKS verification)
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct OidcConfig {
+    /// OIDC issuer URL (e.g., https://auth.example.com)
+    pub issuer_url: String,
+    /// OAuth2 client ID (required for client-credentials and refresh-token flows)
+    pub client_id: Option<String>,
+    /// OAuth2 client secret (for client-credentials flow)
+    pub client_secret: Option<String>,
+    /// Expected audience for JWT tokens (required for server-side verification)
+    pub audience: Option<String>,
+    /// Inline refresh token (for authorization-code flow)
+    pub refresh_token: Option<String>,
+    /// Path to file holding the refresh token (rotated tokens are written back automatically)
+    pub refresh_token_file: Option<String>,
+    /// Path to a file caching the current access token (optional companion to refresh_token_file)
+    pub access_token_file: Option<String>,
+    /// OAuth2 scope parameter (client-side only)
+    pub scope: Option<String>,
+    /// HTTP timeout for token requests in seconds (default: 30, client-side only)
+    pub timeout: Option<Duration>,
+    /// JWKS cache TTL in seconds (default: 3600, server-side only)
+    pub jwks_ttl: Option<Duration>,
+    /// Cache TTL for merged JWT+userinfo claims in seconds (server-side only, absent = no cache)
+    pub claim_cache_ttl: Option<Duration>,
+    /// Policy evaluated against JWT claims on every authenticated request (server-side only)
+    pub policy: Option<OidcPolicyConfig>,
+}
+
+impl From<OidcConfig> for OidcAuthConfig {
+    fn from(config: OidcConfig) -> Self {
+        OidcAuthConfig {
+            issuer_url: config.issuer_url,
+            client_id: config.client_id,
+            client_secret: config.client_secret,
+            audience: config.audience,
+            refresh_token: config.refresh_token,
+            refresh_token_file: config.refresh_token_file,
+            access_token_file: config.access_token_file,
+            scope: config.scope,
+            timeout: config.timeout.map(|d| d.into()),
+            jwks_ttl: config.jwks_ttl.map(|d| d.into()),
+            claim_cache_ttl: config.claim_cache_ttl.map(|d| d.into()),
+            policy: config.policy.map(|p| p.into()),
+        }
+    }
+}
+
+impl From<OidcAuthConfig> for OidcConfig {
+    fn from(config: OidcAuthConfig) -> Self {
+        OidcConfig {
+            issuer_url: config.issuer_url,
+            client_id: config.client_id,
+            client_secret: config.client_secret,
+            audience: config.audience,
+            refresh_token: config.refresh_token,
+            refresh_token_file: config.refresh_token_file,
+            access_token_file: config.access_token_file,
+            scope: config.scope,
+            timeout: config.timeout.map(|ds| ds.into()),
+            jwks_ttl: config.jwks_ttl.map(|ds| ds.into()),
+            claim_cache_ttl: config.claim_cache_ttl.map(|ds| ds.into()),
+            policy: config.policy.map(|p| p.into()),
+        }
+    }
+}
+
 /// Basic authentication configuration
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct BasicAuth {
@@ -318,6 +427,10 @@ pub enum ClientAuthenticationConfig {
     Spire {
         config: SpireConfig,
     },
+    /// OIDC authentication (client-credentials or refresh-token flow)
+    Oidc {
+        config: OidcConfig,
+    },
     None,
 }
 
@@ -336,6 +449,9 @@ impl From<ClientAuthenticationConfig> for slim_config::grpc::client::Authenticat
             #[cfg(not(target_family = "windows"))]
             ClientAuthenticationConfig::Spire { config } => {
                 slim_config::grpc::client::AuthenticationConfig::Spire(config.into())
+            }
+            ClientAuthenticationConfig::Oidc { config } => {
+                slim_config::grpc::client::AuthenticationConfig::Oidc(config.into())
             }
             ClientAuthenticationConfig::None => {
                 slim_config::grpc::client::AuthenticationConfig::None
@@ -361,9 +477,10 @@ impl From<slim_config::grpc::client::AuthenticationConfig> for ClientAuthenticat
             slim_config::grpc::client::AuthenticationConfig::Jwt(jwt) => {
                 ClientAuthenticationConfig::Jwt { config: jwt.into() }
             }
-            slim_config::grpc::client::AuthenticationConfig::Oidc(_) => {
-                // OIDC (client-credentials / refresh-token) is set programmatically; not exposed to bindings.
-                ClientAuthenticationConfig::None
+            slim_config::grpc::client::AuthenticationConfig::Oidc(oidc) => {
+                ClientAuthenticationConfig::Oidc {
+                    config: oidc.into(),
+                }
             }
             #[cfg(not(target_family = "windows"))]
             slim_config::grpc::client::AuthenticationConfig::Spire(spire) => {
@@ -389,6 +506,10 @@ pub enum ServerAuthenticationConfig {
     Spire {
         config: SpireConfig,
     },
+    /// OIDC authentication (JWKS-based JWT verification with optional policy)
+    Oidc {
+        config: OidcConfig,
+    },
     None,
 }
 
@@ -404,6 +525,9 @@ impl From<ServerAuthenticationConfig> for slim_config::grpc::server::Authenticat
             #[cfg(not(target_family = "windows"))]
             ServerAuthenticationConfig::Spire { config } => {
                 slim_config::grpc::server::AuthenticationConfig::Spire(config.into())
+            }
+            ServerAuthenticationConfig::Oidc { config } => {
+                slim_config::grpc::server::AuthenticationConfig::Oidc(config.into())
             }
             ServerAuthenticationConfig::None => {
                 slim_config::grpc::server::AuthenticationConfig::None
@@ -432,10 +556,10 @@ impl From<slim_config::grpc::server::AuthenticationConfig> for ServerAuthenticat
                     config: spire.into(),
                 }
             }
-            slim_config::grpc::server::AuthenticationConfig::Oidc(_) => {
-                unimplemented!(
-                    "OIDC authentication is not supported in the language bindings layer"
-                )
+            slim_config::grpc::server::AuthenticationConfig::Oidc(oidc) => {
+                ServerAuthenticationConfig::Oidc {
+                    config: oidc.into(),
+                }
             }
         }
     }

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -688,6 +688,7 @@ mod tests {
         let config = DataplaneConfig {
             servers: vec![server_config],
             clients: vec![client_config],
+            outbound_clients: vec![],
         };
 
         let core_config: CoreControllerConfig = config.clone().into();
@@ -711,6 +712,7 @@ mod tests {
         let original = DataplaneConfig {
             servers: vec![ServerConfig::default()],
             clients: vec![ClientConfig::default()],
+            outbound_clients: vec![ClientConfig::default()],
         };
 
         let core: CoreControllerConfig = original.clone().into();
@@ -718,6 +720,7 @@ mod tests {
 
         assert_eq!(original.servers.len(), roundtrip.servers.len());
         assert_eq!(original.clients.len(), roundtrip.clients.len());
+        assert_eq!(original.outbound_clients.len(), roundtrip.outbound_clients.len());
     }
 
     #[test]
@@ -1223,6 +1226,7 @@ mod tests {
         let dataplane = DataplaneConfig {
             servers: vec![server_config.clone(), server_config],
             clients: vec![client_config.clone(), client_config],
+            outbound_clients: vec![],
         };
 
         let service_config = ServiceConfig {

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -41,14 +41,8 @@ use {
 pub struct DataplaneConfig {
     /// DataPlane GRPC server settings
     pub servers: Vec<ServerConfig>,
-    /// Client configs for connecting to the control plane
+    /// DataPlane client configs
     pub clients: Vec<ClientConfig>,
-    /// Per-endpoint credential templates for CP-managed outbound connections.
-    /// Matched by endpoint when the CP instructs this node to open a link.
-    /// Auth credentials (OIDC, JWT, Basic) and local settings (proxy, compression, etc.)
-    /// come from here; the CP supplies the endpoint, TLS requirement, and optional
-    /// backoff/timeout/keepalive overrides on top.
-    pub outbound_clients: Vec<ClientConfig>,
 }
 
 #[cfg(not(feature = "web"))]
@@ -71,14 +65,6 @@ impl From<DataplaneConfig> for CoreControllerConfig {
                 core
             })
             .collect();
-        core_config.outbound_clients = config
-            .outbound_clients
-            .into_iter()
-            .map(|c| {
-                let core: CoreClientConfig = c.into();
-                core
-            })
-            .collect();
         core_config
     }
 }
@@ -89,11 +75,6 @@ impl From<CoreControllerConfig> for DataplaneConfig {
         Self {
             servers: config.servers.into_iter().map(|s| s.into()).collect(),
             clients: config.clients.into_iter().map(|c| c.into()).collect(),
-            outbound_clients: config
-                .outbound_clients
-                .into_iter()
-                .map(|c| c.into())
-                .collect(),
         }
     }
 }
@@ -688,7 +669,6 @@ mod tests {
         let config = DataplaneConfig {
             servers: vec![server_config],
             clients: vec![client_config],
-            outbound_clients: vec![],
         };
 
         let core_config: CoreControllerConfig = config.clone().into();
@@ -712,7 +692,6 @@ mod tests {
         let original = DataplaneConfig {
             servers: vec![ServerConfig::default()],
             clients: vec![ClientConfig::default()],
-            outbound_clients: vec![ClientConfig::default()],
         };
 
         let core: CoreControllerConfig = original.clone().into();
@@ -720,7 +699,6 @@ mod tests {
 
         assert_eq!(original.servers.len(), roundtrip.servers.len());
         assert_eq!(original.clients.len(), roundtrip.clients.len());
-        assert_eq!(original.outbound_clients.len(), roundtrip.outbound_clients.len());
     }
 
     #[test]
@@ -1226,7 +1204,6 @@ mod tests {
         let dataplane = DataplaneConfig {
             servers: vec![server_config.clone(), server_config],
             clients: vec![client_config.clone(), client_config],
-            outbound_clients: vec![],
         };
 
         let service_config = ServiceConfig {

--- a/crates/slim-bindings/src/service.rs
+++ b/crates/slim-bindings/src/service.rs
@@ -41,8 +41,14 @@ use {
 pub struct DataplaneConfig {
     /// DataPlane GRPC server settings
     pub servers: Vec<ServerConfig>,
-    /// DataPlane client configs
+    /// Client configs for connecting to the control plane
     pub clients: Vec<ClientConfig>,
+    /// Per-endpoint credential templates for CP-managed outbound connections.
+    /// Matched by endpoint when the CP instructs this node to open a link.
+    /// Auth credentials (OIDC, JWT, Basic) and local settings (proxy, compression, etc.)
+    /// come from here; the CP supplies the endpoint, TLS requirement, and optional
+    /// backoff/timeout/keepalive overrides on top.
+    pub outbound_clients: Vec<ClientConfig>,
 }
 
 #[cfg(not(feature = "web"))]
@@ -65,6 +71,14 @@ impl From<DataplaneConfig> for CoreControllerConfig {
                 core
             })
             .collect();
+        core_config.outbound_clients = config
+            .outbound_clients
+            .into_iter()
+            .map(|c| {
+                let core: CoreClientConfig = c.into();
+                core
+            })
+            .collect();
         core_config
     }
 }
@@ -75,6 +89,11 @@ impl From<CoreControllerConfig> for DataplaneConfig {
         Self {
             servers: config.servers.into_iter().map(|s| s.into()).collect(),
             clients: config.clients.into_iter().map(|c| c.into()).collect(),
+            outbound_clients: config
+                .outbound_clients
+                .into_iter()
+                .map(|c| c.into())
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `OidcConfig` record (mirrors `slim_config::auth::oidc::Config`) with all fields: `issuer_url`, `client_id`, `client_secret`, `audience`, `refresh_token`, `refresh_token_file`, `access_token_file`, `scope`, `timeout`, `jwks_ttl`, `claim_cache_ttl`, `policy`
- Add `OidcPolicyConfig` enum (mirrors `slim_config::auth::PolicyConfig`) with `Rego`, `RegoFile`, and `Cel` variants
- Add `Oidc { config: OidcConfig }` variant to `ClientAuthenticationConfig` and `ServerAuthenticationConfig`
- Fix the placeholder that silently returned `None` for OIDC client auth and the `unimplemented!()` panic for OIDC server auth

## Test plan

- [ ] `cargo test -p agntcy-slim-bindings` passes (all 303 tests pass locally)
- [ ] Build succeeds on all platforms
- [ ] Verify OIDC client-credentials flow works from Go/Swift/Kotlin bindings
- [ ] Verify OIDC refresh-token flow works from bindings
- [ ] Verify OIDC server-side verification (JWKS) works from bindings