### PR TITLE
fix: propagate OIDC auth through merge and diff_connections

### DIFF
--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -496,6 +496,7 @@ impl ClientConfig {
             }
             RequiredAuthMethod::Basic => {}
             RequiredAuthMethod::Jwt => {}
+            RequiredAuthMethod::Oidc => {}
         }
         if let Some(ms) = server.timeout {
             self.connect_timeout = Duration::from_millis(ms as u64).into();
@@ -632,6 +633,7 @@ pub enum RequiredAuthMethod {
     None,
     Basic,
     Jwt,
+    Oidc,
     #[cfg(not(target_family = "windows"))]
     Spire {
         trust_domain: Option<String>,
@@ -655,9 +657,10 @@ impl ServerConnectionConfig {
         let auth_method = match &client.auth {
             AuthenticationConfig::None => RequiredAuthMethod::None,
             AuthenticationConfig::Basic(_) => RequiredAuthMethod::Basic,
-            AuthenticationConfig::StaticJwt(_)
-            | AuthenticationConfig::Jwt(_)
-            | AuthenticationConfig::Oidc(_) => RequiredAuthMethod::Jwt,
+            AuthenticationConfig::StaticJwt(_) | AuthenticationConfig::Jwt(_) => {
+                RequiredAuthMethod::Jwt
+            }
+            AuthenticationConfig::Oidc(_) => RequiredAuthMethod::Oidc,
             #[cfg(not(target_family = "windows"))]
             AuthenticationConfig::Spire(cfg) => RequiredAuthMethod::Spire {
                 trust_domain: cfg.trust_domains.first().cloned(),

--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -456,9 +456,7 @@ impl ClientConfig {
         self.tls_setting.insecure = !server.tls_required;
 
         match &server.auth_method {
-            RequiredAuthMethod::None => {
-                self.auth = AuthenticationConfig::None;
-            }
+            RequiredAuthMethod::None => {}
             #[cfg(not(target_family = "windows"))]
             RequiredAuthMethod::Spire { trust_domain } => {
                 use crate::auth::spire::SpireConfig;
@@ -888,7 +886,10 @@ mod tests {
         client.merge_server_requirements(&server).unwrap();
         assert_eq!(client.endpoint, "http://new:5678");
         assert!(client.tls_setting.insecure);
-        assert_eq!(client.auth, AuthenticationConfig::None);
+        // None means "no auth required" — local credentials are preserved so that
+        // clients with OIDC/JWT configured (but served by a CP that doesn't model
+        // OIDC) can still authenticate.
+        assert_eq!(client.auth, AuthenticationConfig::Basic(Default::default()));
     }
 
     #[test]

--- a/crates/control-plane/src/db/model.rs
+++ b/crates/control-plane/src/db/model.rs
@@ -160,6 +160,7 @@ pub enum AuthMethod {
     Spire,
     Basic,
     Jwt,
+    Oidc,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable, Identifiable, Insertable)]

--- a/crates/control-plane/src/route_service/connection_config.rs
+++ b/crates/control-plane/src/route_service/connection_config.rs
@@ -139,6 +139,7 @@ pub(super) fn generate_config_data(
         model::AuthMethod::None => RequiredAuthMethod::None,
         model::AuthMethod::Basic => RequiredAuthMethod::Basic,
         model::AuthMethod::Jwt => RequiredAuthMethod::Jwt,
+        model::AuthMethod::Oidc => RequiredAuthMethod::Oidc,
     };
 
     let server_config = ServerConnectionConfig {

--- a/crates/control-plane/src/services/northbound.rs
+++ b/crates/control-plane/src/services/northbound.rs
@@ -180,6 +180,7 @@ impl ControlPlaneService for NorthboundApiService {
                             model::AuthMethod::Basic => ProtoAuthMethod::Basic as i32,
                             model::AuthMethod::Jwt => ProtoAuthMethod::Jwt as i32,
                             model::AuthMethod::None => ProtoAuthMethod::None as i32,
+                            model::AuthMethod::Oidc => ProtoAuthMethod::Oidc as i32,
                         },
                         spire_trust_domain: cd.spire_trust_domain.clone(),
                         ..Default::default()

--- a/crates/control-plane/src/services/southbound.rs
+++ b/crates/control-plane/src/services/southbound.rs
@@ -465,6 +465,7 @@ fn parse_conn_details(
             ProtoAuthMethod::Basic => AuthMethod::Basic,
             ProtoAuthMethod::Jwt => AuthMethod::Jwt,
             ProtoAuthMethod::None => AuthMethod::None,
+            ProtoAuthMethod::Oidc => AuthMethod::Oidc,
         },
         spire_trust_domain: detail.spire_trust_domain.clone(),
         ..Default::default()

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -124,12 +124,6 @@ struct ControllerServiceInternal {
     /// JoinHandles for control-plane stream processing tasks, keyed by endpoint.
     stream_handles: parking_lot::Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
 
-    /// Client configurations used to connect to the control plane.
-    /// Used as an auth fallback when no matching outbound_clients entry exists
-    /// for a CP-managed link — allows OIDC credentials configured here to be
-    /// reused for outbound data-plane connections without duplicating config.
-    clients: Vec<ClientConfig>,
-
     /// connection details for CP reconciled outbound data-plane connections
     outbound_clients: Vec<ClientConfig>,
 
@@ -303,7 +297,7 @@ impl ControlPlane {
 
         ControlPlane {
             servers: config.servers,
-            clients: config.clients.clone(),
+            clients: config.clients,
             controller: ControllerService {
                 inner: Arc::new(ControllerServiceInternal {
                     id: config.id,
@@ -319,7 +313,6 @@ impl ControlPlane {
                     route_subscription_ids: parking_lot::Mutex::new(HashMap::new()),
                     link_id_to_conn_id: parking_lot::RwLock::new(HashMap::new()),
                     stream_handles: parking_lot::Mutex::new(HashMap::new()),
-                    clients: config.clients,
                     outbound_clients: config.outbound_clients,
                     auth_provider: config.auth_provider,
                 }),
@@ -749,27 +742,22 @@ impl ControllerService {
                     error_msg = format!("Failed to parse config: {}", e);
                 }
                 Ok(server_config) => {
-                    let mut client_config =
-                        self.inner
-                            .outbound_clients
-                            .iter()
-                            .find(|c| c.endpoint == server_config.endpoint)
-                            .cloned()
-                            .unwrap_or_else(|| {
-                                // No specific outbound entry: inherit auth from controller.clients
-                                // so OIDC (or any JWT) credentials configured for the CP connection
-                                // are reused for CP-managed outbound links without requiring a
-                                // duplicate outbound_clients entry.
-                                let mut cfg = ClientConfig::default();
-                                if let Some(cp_client) =
-                                    self.inner.clients.iter().find(|c| {
-                                        !matches!(c.auth, ClientAuthenticationConfig::None)
-                                    })
-                                {
-                                    cfg.auth = cp_client.auth.clone();
-                                }
-                                cfg
-                            });
+                    let mut client_config = self
+                        .inner
+                        .outbound_clients
+                        .iter()
+                        .find(|c| c.endpoint == server_config.endpoint)
+                        .or_else(|| {
+                            // Fall back to the default outbound entry (empty endpoint),
+                            // which acts as a credential template for any CP-assigned link
+                            // that has no specific per-endpoint entry.
+                            self.inner
+                                .outbound_clients
+                                .iter()
+                                .find(|c| c.endpoint.is_empty())
+                        })
+                        .cloned()
+                        .unwrap_or_default();
                     match client_config.merge_server_requirements(&server_config) {
                         Err(err) => {
                             success = false;

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -749,27 +749,27 @@ impl ControllerService {
                     error_msg = format!("Failed to parse config: {}", e);
                 }
                 Ok(server_config) => {
-                    let mut client_config = self
-                        .inner
-                        .outbound_clients
-                        .iter()
-                        .find(|c| c.endpoint == server_config.endpoint)
-                        .cloned()
-                        .unwrap_or_else(|| {
-                            // No specific outbound entry: inherit auth from controller.clients
-                            // so OIDC (or any JWT) credentials configured for the CP connection
-                            // are reused for CP-managed outbound links without requiring a
-                            // duplicate outbound_clients entry.
-                            let mut cfg = ClientConfig::default();
-                            if let Some(cp_client) =
-                                self.inner.clients.iter().find(|c| {
-                                    !matches!(c.auth, ClientAuthenticationConfig::None)
-                                })
-                            {
-                                cfg.auth = cp_client.auth.clone();
-                            }
-                            cfg
-                        });
+                    let mut client_config =
+                        self.inner
+                            .outbound_clients
+                            .iter()
+                            .find(|c| c.endpoint == server_config.endpoint)
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                // No specific outbound entry: inherit auth from controller.clients
+                                // so OIDC (or any JWT) credentials configured for the CP connection
+                                // are reused for CP-managed outbound links without requiring a
+                                // duplicate outbound_clients entry.
+                                let mut cfg = ClientConfig::default();
+                                if let Some(cp_client) =
+                                    self.inner.clients.iter().find(|c| {
+                                        !matches!(c.auth, ClientAuthenticationConfig::None)
+                                    })
+                                {
+                                    cfg.auth = cp_client.auth.clone();
+                                }
+                                cfg
+                            });
                     match client_config.merge_server_requirements(&server_config) {
                         Err(err) => {
                             success = false;

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -33,6 +33,7 @@ use prost_types::Struct;
 use slim_config::client::{
     ClientConfig, RequiredAuthMethod, ServerConnectionConfig, TransportChannel,
 };
+use slim_config::grpc::client::AuthenticationConfig as ClientAuthenticationConfig;
 use slim_config::server::AuthenticationConfig;
 use slim_datapath::api::{
     MessageType::Link as LinkMessageType, MessageType::Subscribe,
@@ -122,6 +123,12 @@ struct ControllerServiceInternal {
 
     /// JoinHandles for control-plane stream processing tasks, keyed by endpoint.
     stream_handles: parking_lot::Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
+
+    /// Client configurations used to connect to the control plane.
+    /// Used as an auth fallback when no matching outbound_clients entry exists
+    /// for a CP-managed link — allows OIDC credentials configured here to be
+    /// reused for outbound data-plane connections without duplicating config.
+    clients: Vec<ClientConfig>,
 
     /// connection details for CP reconciled outbound data-plane connections
     outbound_clients: Vec<ClientConfig>,
@@ -296,7 +303,7 @@ impl ControlPlane {
 
         ControlPlane {
             servers: config.servers,
-            clients: config.clients,
+            clients: config.clients.clone(),
             controller: ControllerService {
                 inner: Arc::new(ControllerServiceInternal {
                     id: config.id,
@@ -312,6 +319,7 @@ impl ControlPlane {
                     route_subscription_ids: parking_lot::Mutex::new(HashMap::new()),
                     link_id_to_conn_id: parking_lot::RwLock::new(HashMap::new()),
                     stream_handles: parking_lot::Mutex::new(HashMap::new()),
+                    clients: config.clients,
                     outbound_clients: config.outbound_clients,
                     auth_provider: config.auth_provider,
                 }),
@@ -747,7 +755,21 @@ impl ControllerService {
                         .iter()
                         .find(|c| c.endpoint == server_config.endpoint)
                         .cloned()
-                        .unwrap_or_default();
+                        .unwrap_or_else(|| {
+                            // No specific outbound entry: inherit auth from controller.clients
+                            // so OIDC (or any JWT) credentials configured for the CP connection
+                            // are reused for CP-managed outbound links without requiring a
+                            // duplicate outbound_clients entry.
+                            let mut cfg = ClientConfig::default();
+                            if let Some(cp_client) =
+                                self.inner.clients.iter().find(|c| {
+                                    !matches!(c.auth, ClientAuthenticationConfig::None)
+                                })
+                            {
+                                cfg.auth = cp_client.auth.clone();
+                            }
+                            cfg
+                        });
                     match client_config.merge_server_requirements(&server_config) {
                         Err(err) => {
                             success = false;
@@ -759,14 +781,12 @@ impl ControllerService {
                         Ok(()) => {
                             if matches!(
                                 server_config.auth_method,
-                                // Spire config it not mandatory. If not set falls back to default
+                                // Spire config is not mandatory. If not set falls back to default
                                 // socket path.
-                                RequiredAuthMethod::Basic | RequiredAuthMethod::Jwt
-                            ) && !self
-                                .inner
-                                .outbound_clients
-                                .iter()
-                                .any(|c| c.endpoint == server_config.endpoint)
+                                RequiredAuthMethod::Basic
+                                    | RequiredAuthMethod::Jwt
+                                    | RequiredAuthMethod::Oidc
+                            ) && matches!(client_config.auth, ClientAuthenticationConfig::None)
                             {
                                 success = false;
                                 error_msg = format!(

--- a/crates/proto/proto/controller/v1/controller.proto
+++ b/crates/proto/proto/controller/v1/controller.proto
@@ -130,6 +130,7 @@ enum AuthMethod {
   AUTH_METHOD_SPIRE = 1;
   AUTH_METHOD_BASIC = 2;
   AUTH_METHOD_JWT = 3;
+  AUTH_METHOD_OIDC = 4;
 }
 
 message ConnectionDetails {

--- a/crates/proto/src/gen/controller.proto.v1.rs
+++ b/crates/proto/src/gen/controller.proto.v1.rs
@@ -280,6 +280,7 @@ pub enum AuthMethod {
     Spire = 1,
     Basic = 2,
     Jwt = 3,
+    Oidc = 4,
 }
 impl AuthMethod {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -292,6 +293,7 @@ impl AuthMethod {
             Self::Spire => "AUTH_METHOD_SPIRE",
             Self::Basic => "AUTH_METHOD_BASIC",
             Self::Jwt => "AUTH_METHOD_JWT",
+            Self::Oidc => "AUTH_METHOD_OIDC",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -301,6 +303,7 @@ impl AuthMethod {
             "AUTH_METHOD_SPIRE" => Some(Self::Spire),
             "AUTH_METHOD_BASIC" => Some(Self::Basic),
             "AUTH_METHOD_JWT" => Some(Self::Jwt),
+            "AUTH_METHOD_OIDC" => Some(Self::Oidc),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- `RequiredAuthMethod` lacked an `Oidc` variant, causing OIDC client configs to be silently folded into `Jwt` in `from_client_config`, with no matching arm in `merge_server_requirements`
- `diff_connections` had no access to `controller.clients` credentials as a fallback when no `outbound_clients` entry matched the CP-assigned endpoint
- `RequiredAuthMethod::None` was wiping local auth (`self.auth = None`), so any locally configured OIDC credentials were destroyed when the CP sent `None` for the auth method — which it does whenever it doesn't model the auth explicitly
- The proto `AuthMethod` enum and `model::AuthMethod` had no `Oidc` variant, so the CP could never signal OIDC to nodes

## Changes

**`crates/config/src/client.rs`**
- Add `RequiredAuthMethod::Oidc`; fix `from_client_config` to map `AuthenticationConfig::Oidc` → `RequiredAuthMethod::Oidc` (was `Jwt`)
- Add `RequiredAuthMethod::Oidc => {}` arm to `merge_server_requirements` (preserves local auth, matching `Jwt` behaviour)
- Change `RequiredAuthMethod::None` arm from `self.auth = None` to a no-op — `None` means "no auth required", not "force no auth", so locally configured credentials survive

**`crates/controller/src/service.rs`**
- Store `controller.clients` on `ControllerServiceInternal` for auth fallback
- `diff_connections` inherits auth from the first non-`None` `clients` entry when no `outbound_clients` entry matches the CP-assigned endpoint
- Credential guard updated to cover `Oidc` and check post-merge `client_config.auth` instead of `outbound_clients` membership

**`crates/control-plane/`**
- Add `AUTH_METHOD_OIDC = 4` to the controller proto enum and regenerate bindings
- Add `model::AuthMethod::Oidc` with full southbound (proto→model) and northbound (model→proto) round-trip
- Wire `model::AuthMethod::Oidc → RequiredAuthMethod::Oidc` in `generate_config_data`

## Test plan

- [ ] Build `agntcy-slim-config`, `agntcy-slim-controller`, and `agntcy-slim-control-plane` with no errors
- [ ] All 261+ `agntcy-slim-config` tests pass
- [ ] Node configured with OIDC in `controller.clients` can establish CP-managed outbound links without a duplicate `outbound_clients` entry
- [ ] Node with explicit `outbound_clients` entries continues to use those credentials (fallback not triggered)
- [ ] Node with `auth_method: None` on a link no longer has its local OIDC credentials wiped
- [ ] CP registered with `auth_method: oidc` correctly sends `RequiredAuthMethod::Oidc` to nodes