### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.9"
+version = "0.13.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -553,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.2.0"
+version = "3.0.0"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -553,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "3.0.0"
+version = "2.3.0"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.2.0" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.15.2" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.2.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.15.2" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.2.0" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.9" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.5" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.8" }
+agntcy-slim = { path = "crates/slim", version = "3.0.0" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.15.3" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "3.0.0" }
+agntcy-slim-config = { path = "crates/config", version = "0.16.0" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "3.0.0" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.13.0" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.6" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.9" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.9" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.2.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.9", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.9" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.24" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.6.0" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "3.0.0" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.10", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.10" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.25" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.18" }
-agntcy-slim-version = { path = "crates/version", version = "2.2.0" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.2.0" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.19" }
+agntcy-slim-version = { path = "crates/version", version = "3.0.0" }
+agntcy-slimctl = { path = "crates/slimctl", version = "3.0.0" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -238,7 +238,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.2.0"
+version = "3.0.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "3.0.0" }
+agntcy-slim = { path = "crates/slim", version = "2.3.0" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.15.3" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "3.0.0" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.3.0" }
 agntcy-slim-config = { path = "crates/config", version = "0.16.0" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "3.0.0" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.3.0" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.13.0" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.6" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.3.9" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.6.0" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "3.0.0" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.3.0" }
 agntcy-slim-service = { path = "crates/service", version = "0.12.10", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.7.10" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.25" }
 agntcy-slim-testing = { path = "crates/testing" }
 agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.19" }
-agntcy-slim-version = { path = "crates/version", version = "3.0.0" }
-agntcy-slimctl = { path = "crates/slimctl", version = "3.0.0" }
+agntcy-slim-version = { path = "crates/version", version = "2.3.0" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.3.0" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -238,7 +238,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "3.0.0"
+version = "2.3.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/agntcy/slim/compare/slim-auth-v0.15.2...slim-auth-v0.15.3) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.15.2](https://github.com/agntcy/slim/compare/slim-auth-v0.15.1...slim-auth-v0.15.2) - 2026-08-13
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.15.2"
+version = "0.15.3"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/agntcy/slim/compare/slim-config-v0.15.2...slim-config-v0.16.0) - 2026-08-13
+
+### Fixed
+
+- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
+
 ## [0.15.2](https://github.com/agntcy/slim/compare/slim-config-v0.15.1...slim-config-v0.15.2) - 2026-08-13
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.15.2"
+version = "0.16.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.2.0...slim-control-plane-v3.0.0) - 2026-08-13
+
+### Fixed
+
+- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
+
 ## [2.1.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.1.0...slim-control-plane-v2.1.1) - 2026-08-12
 
 ### Fixed

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.2.0...slim-control-plane-v3.0.0) - 2026-08-13
+## [2.3.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.2.0...slim-control-plane-v2.3.0) - 2026-08-13
 
 ### Fixed
 

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/agntcy/slim/compare/slim-controller-v0.12.9...slim-controller-v0.13.0) - 2026-08-13
+
+### Fixed
+
+- OIDC credentials for CP-managed links using dataplane.clients fallback ([#1989](https://github.com/agntcy/slim/pull/1989))
+- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
+
 ## [0.12.9](https://github.com/agntcy/slim/compare/slim-controller-v0.12.8...slim-controller-v0.12.9) - 2026-08-13
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.9"
+version = "0.13.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.6](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.5...slim-datapath-v0.18.6) - 2026-08-13
+
+### Fixed
+
+- prevent unbounded span nesting on reconnect cycles ([#1986](https://github.com/agntcy/slim/pull/1986))
+
 ## [0.18.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.4...slim-datapath-v0.18.5) - 2026-08-13
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.5"
+version = "0.18.6"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/agntcy/slim/compare/slim-mls-v0.3.8...slim-mls-v0.3.9) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.3.8](https://github.com/agntcy/slim/compare/slim-mls-v0.3.7...slim-mls-v0.3.8) - 2026-08-13
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.8"
+version = "0.3.9"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/agntcy/slim/compare/slim-proto-v0.5.9...slim-proto-v0.6.0) - 2026-08-13
+
+### Fixed
+
+- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
+
 ## [0.5.9](https://github.com/agntcy/slim/compare/slim-proto-v0.5.8...slim-proto-v0.5.9) - 2026-08-13
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.9"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.10](https://github.com/agntcy/slim/compare/slim-service-v0.12.9...slim-service-v0.12.10) - 2026-08-13
+
+### Fixed
+
+- OIDC credentials for CP-managed links using dataplane.clients fallback ([#1989](https://github.com/agntcy/slim/pull/1989))
+
 ## [0.12.9](https://github.com/agntcy/slim/compare/slim-service-v0.12.8...slim-service-v0.12.9) - 2026-08-13
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.9"
+version = "0.12.10"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.10](https://github.com/agntcy/slim/compare/slim-session-v0.7.9...slim-session-v0.7.10) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-mls
+
 ## [0.7.9](https://github.com/agntcy/slim/compare/slim-session-v0.7.8...slim-session-v0.7.9) - 2026-08-13
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.9"
+version = "0.7.10"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/agntcy/slim/compare/slim-signal-v0.1.24...slim-signal-v0.1.25) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.24](https://github.com/agntcy/slim/compare/slim-signal-v0.1.23...slim-signal-v0.1.24) - 2026-08-13
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.24"
+version = "0.1.25"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.19](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.18...slim-tracing-v0.4.19) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.18](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.17...slim-tracing-v0.4.18) - 2026-08-13
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.18"
+version = "0.4.19"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.2.0 -> 2.3.0
* `agntcy-slim-config`: 0.15.2 -> 0.16.0 (⚠ API breaking changes)
* `agntcy-slim-proto`: 0.5.9 -> 0.6.0 (⚠ API breaking changes)
* `agntcy-slim-datapath`: 0.18.5 -> 0.18.6 (✓ API compatible changes)
* `agntcy-slim-controller`: 0.12.9 -> 0.13.0 (⚠ API breaking changes)
* `agntcy-slim-service`: 0.12.9 -> 0.12.10 (✓ API compatible changes)
* `agntcy-slim`: 2.2.0 -> 2.3.0
* `agntcy-slim-channel-manager`: 2.2.0 -> 2.3.0
* `agntcy-slim-control-plane`: 2.2.0 -> 2.3.0 (⚠ API breaking changes)
* `agntcy-slim-bindings`: 2.2.0 -> 2.3.0
* `agntcy-slim-rpc`: 2.2.0 -> 2.3.0
* `agntcy-slimctl`: 2.2.0 -> 2.3.0
* `agntcy-slim-auth`: 0.15.2 -> 0.15.3
* `agntcy-slim-tracing`: 0.4.18 -> 0.4.19
* `agntcy-slim-mls`: 0.3.8 -> 0.3.9
* `agntcy-slim-session`: 0.7.9 -> 0.7.10
* `agntcy-slim-signal`: 0.1.24 -> 0.1.25

### ⚠ `agntcy-slim-config` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant RequiredAuthMethod::Spire 3 -> 4 in /tmp/.tmp8XqivK/slim/crates/config/src/client.rs:636

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant RequiredAuthMethod:Oidc in /tmp/.tmp8XqivK/slim/crates/config/src/client.rs:634
```

### ⚠ `agntcy-slim-proto` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthMethod:Oidc in /tmp/.tmp8XqivK/slim/crates/proto/src/gen/controller.proto.v1.rs:283
```

### ⚠ `agntcy-slim-controller` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ControlPlaneSettings.dataplane_clients in /tmp/.tmp8XqivK/slim/crates/controller/src/service.rs:76

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  slim_controller::config::Config::into_service now takes 6 parameters instead of 5, in /tmp/.tmp8XqivK/slim/crates/controller/src/config.rs:123
```

### ⚠ `agntcy-slim-control-plane` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthMethod:Oidc in /tmp/.tmp8XqivK/slim/crates/control-plane/src/db/model.rs:163
  variant AuthMethod:Oidc in /tmp/.tmp8XqivK/slim/crates/control-plane/src/db/model.rs:163
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.16.0](https://github.com/agntcy/slim/compare/slim-config-v0.15.2...slim-config-v0.16.0) - 2026-08-13

### Fixed

- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.6.0](https://github.com/agntcy/slim/compare/slim-proto-v0.5.9...slim-proto-v0.6.0) - 2026-08-13

### Fixed

- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.6](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.5...slim-datapath-v0.18.6) - 2026-08-13

### Fixed

- prevent unbounded span nesting on reconnect cycles ([#1986](https://github.com/agntcy/slim/pull/1986))
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.13.0](https://github.com/agntcy/slim/compare/slim-controller-v0.12.9...slim-controller-v0.13.0) - 2026-08-13

### Fixed

- OIDC credentials for CP-managed links using dataplane.clients fallback ([#1989](https://github.com/agntcy/slim/pull/1989))
- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.10](https://github.com/agntcy/slim/compare/slim-service-v0.12.9...slim-service-v0.12.10) - 2026-08-13

### Fixed

- OIDC credentials for CP-managed links using dataplane.clients fallback ([#1989](https://github.com/agntcy/slim/pull/1989))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.0.0](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.0) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.0.0](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.0) - 2026-08-04

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.3.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.2.0...slim-control-plane-v2.3.0) - 2026-08-13

### Fixed

- propagate OIDC auth through merge and diff_connections ([#1983](https://github.com/agntcy/slim/pull/1983))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.1.1...slim-bindings-v2.2.0) - 2026-08-13

### Added

- *(bindings)* expose OIDC authentication in language bindings ([#1982](https://github.com/agntcy/slim/pull/1982))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0...slim-rpc-v2.1.0) - 2026-08-12

### Fixed

- *(rpc)* signal end-of-stream with the status header, not an empty payload ([#1961](https://github.com/agntcy/slim/pull/1961))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.1.1](https://github.com/agntcy/slim/compare/slimctl-v2.1.0...slimctl-v2.1.1) - 2026-08-12

### Fixed

- windows build ([#1978](https://github.com/agntcy/slim/pull/1978))
- windows build ([#1977](https://github.com/agntcy/slim/pull/1977))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.15.3](https://github.com/agntcy/slim/compare/slim-auth-v0.15.2...slim-auth-v0.15.3) - 2026-08-13

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.19](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.18...slim-tracing-v0.4.19) - 2026-08-13

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.9](https://github.com/agntcy/slim/compare/slim-mls-v0.3.8...slim-mls-v0.3.9) - 2026-08-13

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.10](https://github.com/agntcy/slim/compare/slim-session-v0.7.9...slim-session-v0.7.10) - 2026-08-13

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-datapath, agntcy-slim-auth, agntcy-slim-mls
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.25](https://github.com/agntcy/slim/compare/slim-signal-v0.1.24...slim-signal-v0.1.25) - 2026-08-13

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).