### PR TITLE
fix: propagate OIDC server auth requirement through CP to connecting nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -553,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.1.1" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.15.1" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.1.1" }
-agntcy-slim-config = { path = "crates/config", version = "0.15.1" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.1.1" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.12.8" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.4" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.7" }
+agntcy-slim = { path = "crates/slim", version = "2.2.0" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.15.2" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.2.0" }
+agntcy-slim-config = { path = "crates/config", version = "0.15.2" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.2.0" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.12.9" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.5" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.8" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.5.8" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.1.1" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.8", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.8" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.23" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.5.9" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.2.0" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.9", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.9" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.24" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.17" }
-agntcy-slim-version = { path = "crates/version", version = "2.1.1" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.1.1" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.18" }
+agntcy-slim-version = { path = "crates/version", version = "2.2.0" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.2.0" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -238,7 +238,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.1.1"
+version = "2.2.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/agntcy/slim/compare/slim-auth-v0.15.1...slim-auth-v0.15.2) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.15.1](https://github.com/agntcy/slim/compare/slim-auth-v0.15.0...slim-auth-v0.15.1) - 2026-08-12
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.15.1"
+version = "0.15.2"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/agntcy/slim/compare/slim-config-v0.15.1...slim-config-v0.15.2) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.15.1](https://github.com/agntcy/slim/compare/slim-config-v0.15.0...slim-config-v0.15.1) - 2026-08-12
 
 ### Other

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.15.1"
+version = "0.15.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/config/src/client.rs
+++ b/crates/config/src/client.rs
@@ -456,9 +456,7 @@ impl ClientConfig {
         self.tls_setting.insecure = !server.tls_required;
 
         match &server.auth_method {
-            RequiredAuthMethod::None => {
-                self.auth = AuthenticationConfig::None;
-            }
+            RequiredAuthMethod::None => {}
             #[cfg(not(target_family = "windows"))]
             RequiredAuthMethod::Spire { trust_domain } => {
                 use crate::auth::spire::SpireConfig;
@@ -496,6 +494,7 @@ impl ClientConfig {
             }
             RequiredAuthMethod::Basic => {}
             RequiredAuthMethod::Jwt => {}
+            RequiredAuthMethod::Oidc => {}
         }
         if let Some(ms) = server.timeout {
             self.connect_timeout = Duration::from_millis(ms as u64).into();
@@ -632,6 +631,7 @@ pub enum RequiredAuthMethod {
     None,
     Basic,
     Jwt,
+    Oidc,
     #[cfg(not(target_family = "windows"))]
     Spire {
         trust_domain: Option<String>,
@@ -655,9 +655,10 @@ impl ServerConnectionConfig {
         let auth_method = match &client.auth {
             AuthenticationConfig::None => RequiredAuthMethod::None,
             AuthenticationConfig::Basic(_) => RequiredAuthMethod::Basic,
-            AuthenticationConfig::StaticJwt(_)
-            | AuthenticationConfig::Jwt(_)
-            | AuthenticationConfig::Oidc(_) => RequiredAuthMethod::Jwt,
+            AuthenticationConfig::StaticJwt(_) | AuthenticationConfig::Jwt(_) => {
+                RequiredAuthMethod::Jwt
+            }
+            AuthenticationConfig::Oidc(_) => RequiredAuthMethod::Oidc,
             #[cfg(not(target_family = "windows"))]
             AuthenticationConfig::Spire(cfg) => RequiredAuthMethod::Spire {
                 trust_domain: cfg.trust_domains.first().cloned(),
@@ -885,7 +886,10 @@ mod tests {
         client.merge_server_requirements(&server).unwrap();
         assert_eq!(client.endpoint, "http://new:5678");
         assert!(client.tls_setting.insecure);
-        assert_eq!(client.auth, AuthenticationConfig::None);
+        // None means "no auth required" — local credentials are preserved so that
+        // clients with OIDC/JWT configured (but served by a CP that doesn't model
+        // OIDC) can still authenticate.
+        assert_eq!(client.auth, AuthenticationConfig::Basic(Default::default()));
     }
 
     #[test]

--- a/crates/control-plane/src/db/model.rs
+++ b/crates/control-plane/src/db/model.rs
@@ -160,6 +160,7 @@ pub enum AuthMethod {
     Spire,
     Basic,
     Jwt,
+    Oidc,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable, Identifiable, Insertable)]

--- a/crates/control-plane/src/route_service/connection_config.rs
+++ b/crates/control-plane/src/route_service/connection_config.rs
@@ -139,6 +139,7 @@ pub(super) fn generate_config_data(
         model::AuthMethod::None => RequiredAuthMethod::None,
         model::AuthMethod::Basic => RequiredAuthMethod::Basic,
         model::AuthMethod::Jwt => RequiredAuthMethod::Jwt,
+        model::AuthMethod::Oidc => RequiredAuthMethod::Oidc,
     };
 
     let server_config = ServerConnectionConfig {

--- a/crates/control-plane/src/services/northbound.rs
+++ b/crates/control-plane/src/services/northbound.rs
@@ -180,6 +180,7 @@ impl ControlPlaneService for NorthboundApiService {
                             model::AuthMethod::Basic => ProtoAuthMethod::Basic as i32,
                             model::AuthMethod::Jwt => ProtoAuthMethod::Jwt as i32,
                             model::AuthMethod::None => ProtoAuthMethod::None as i32,
+                            model::AuthMethod::Oidc => ProtoAuthMethod::Oidc as i32,
                         },
                         spire_trust_domain: cd.spire_trust_domain.clone(),
                         ..Default::default()

--- a/crates/control-plane/src/services/southbound.rs
+++ b/crates/control-plane/src/services/southbound.rs
@@ -465,6 +465,7 @@ fn parse_conn_details(
             ProtoAuthMethod::Basic => AuthMethod::Basic,
             ProtoAuthMethod::Jwt => AuthMethod::Jwt,
             ProtoAuthMethod::None => AuthMethod::None,
+            ProtoAuthMethod::Oidc => AuthMethod::Oidc,
         },
         spire_trust_domain: detail.spire_trust_domain.clone(),
         ..Default::default()

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.9](https://github.com/agntcy/slim/compare/slim-controller-v0.12.8...slim-controller-v0.12.9) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-signal
+
 ## [0.12.8](https://github.com/agntcy/slim/compare/slim-controller-v0.12.7...slim-controller-v0.12.8) - 2026-08-12
 
 ### Other

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.12.8"
+version = "0.12.9"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -129,6 +129,11 @@ impl Config {
         // Used to extract connection type information required to connect to the node
         // (e.g., TLS settings). This information is used by the control plane.
         dataplane_servers: &[ServerConfig],
+        // List of client configurations for the dataplane services.
+        // Used as a credential fallback for CP-managed outbound links when no
+        // matching outbound_clients entry exists, so the client does not need to
+        // duplicate credentials it already has for a given endpoint.
+        dataplane_clients: &[ClientConfig],
         auth_provider: Option<slim_auth::auth_provider::AuthProvider>,
     ) -> ControlPlane {
         let connection_details = dataplane_servers.iter().map(from_server_config).collect();
@@ -139,6 +144,7 @@ impl Config {
             servers: self.servers.clone(),
             clients: self.clients.clone(),
             outbound_clients: self.outbound_clients.clone(),
+            dataplane_clients: dataplane_clients.to_vec(),
             message_processor,
             connection_details,
             auth_provider,
@@ -317,6 +323,7 @@ mod tests {
             domain_name,
             message_processor,
             &[server_config],
+            &[],
             None,
         );
     }

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -251,6 +251,7 @@ pub(crate) fn from_server_config(server_config: &ServerConfig) -> ConnectionDeta
         match &server_config.auth {
             AuthenticationConfig::Basic(_) => AuthMethod::Basic,
             AuthenticationConfig::Jwt(_) => AuthMethod::Jwt,
+            AuthenticationConfig::Oidc(_) => AuthMethod::Oidc,
             _ => AuthMethod::None,
         }
     } as i32;

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -33,6 +33,7 @@ use prost_types::Struct;
 use slim_config::client::{
     ClientConfig, RequiredAuthMethod, ServerConnectionConfig, TransportChannel,
 };
+use slim_config::grpc::client::AuthenticationConfig as ClientAuthenticationConfig;
 use slim_config::server::AuthenticationConfig;
 use slim_datapath::api::{
     MessageType::Link as LinkMessageType, MessageType::Subscribe,
@@ -746,6 +747,15 @@ impl ControllerService {
                         .outbound_clients
                         .iter()
                         .find(|c| c.endpoint == server_config.endpoint)
+                        .or_else(|| {
+                            // Fall back to the default outbound entry (empty endpoint),
+                            // which acts as a credential template for any CP-assigned link
+                            // that has no specific per-endpoint entry.
+                            self.inner
+                                .outbound_clients
+                                .iter()
+                                .find(|c| c.endpoint.is_empty())
+                        })
                         .cloned()
                         .unwrap_or_default();
                     match client_config.merge_server_requirements(&server_config) {
@@ -759,14 +769,12 @@ impl ControllerService {
                         Ok(()) => {
                             if matches!(
                                 server_config.auth_method,
-                                // Spire config it not mandatory. If not set falls back to default
+                                // Spire config is not mandatory. If not set falls back to default
                                 // socket path.
-                                RequiredAuthMethod::Basic | RequiredAuthMethod::Jwt
-                            ) && !self
-                                .inner
-                                .outbound_clients
-                                .iter()
-                                .any(|c| c.endpoint == server_config.endpoint)
+                                RequiredAuthMethod::Basic
+                                    | RequiredAuthMethod::Jwt
+                                    | RequiredAuthMethod::Oidc
+                            ) && matches!(client_config.auth, ClientAuthenticationConfig::None)
                             {
                                 success = false;
                                 error_msg = format!(

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -70,6 +70,10 @@ pub struct ControlPlaneSettings {
     pub clients: Vec<ClientConfig>,
     /// Client configurations for server nodes
     pub outbound_clients: Vec<ClientConfig>,
+    /// Data-plane client configurations (dataplane.clients in the service config).
+    /// Used as a credential fallback for CP-managed outbound links when no
+    /// outbound_clients entry matches, so users don't have to duplicate credentials.
+    pub dataplane_clients: Vec<ClientConfig>,
     /// Message processor instance
     pub message_processor: MessageProcessor,
     /// array of connection details used by the control
@@ -126,6 +130,11 @@ struct ControllerServiceInternal {
 
     /// connection details for CP reconciled outbound data-plane connections
     outbound_clients: Vec<ClientConfig>,
+
+    /// Data-plane client configurations (dataplane.clients in the service config).
+    /// Used as a credential fallback for CP-managed outbound links when no
+    /// outbound_clients entry matches, so users don't need to duplicate credentials.
+    dataplane_clients: Vec<ClientConfig>,
 
     /// Optional auth provider for generating registration credentials.
     auth_provider: Option<AuthProvider>,
@@ -315,6 +324,7 @@ impl ControlPlane {
                     link_id_to_conn_id: parking_lot::RwLock::new(HashMap::new()),
                     stream_handles: parking_lot::Mutex::new(HashMap::new()),
                     outbound_clients: config.outbound_clients,
+                    dataplane_clients: config.dataplane_clients,
                     auth_provider: config.auth_provider,
                 }),
             },
@@ -756,6 +766,15 @@ impl ControllerService {
                                 .outbound_clients
                                 .iter()
                                 .find(|c| c.endpoint.is_empty())
+                        })
+                        .or_else(|| {
+                            // Finally fall back to dataplane.clients: reuse credentials
+                            // the node already has for this endpoint so users don't have
+                            // to duplicate them under controller.outbound_clients.
+                            self.inner
+                                .dataplane_clients
+                                .iter()
+                                .find(|c| c.endpoint == server_config.endpoint)
                         })
                         .cloned()
                         .unwrap_or_default();
@@ -2274,6 +2293,7 @@ mod tests {
             servers: vec![server_config.clone()],
             clients: vec![],
             outbound_clients: vec![],
+            dataplane_clients: vec![],
             message_processor: message_processor_server,
             connection_details: vec![from_server_config(&server_config)],
             auth_provider: None,
@@ -2285,6 +2305,7 @@ mod tests {
             servers: vec![],
             clients: vec![client_config.clone()],
             outbound_clients: vec![],
+            dataplane_clients: vec![],
             message_processor: message_processor_client,
             connection_details: vec![],
             auth_provider: None,
@@ -2880,6 +2901,7 @@ mod tests {
             servers: vec![],
             clients: vec![],
             outbound_clients,
+            dataplane_clients: vec![],
             message_processor: MessageProcessor::new(),
             connection_details: vec![],
             auth_provider: None,

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -176,6 +176,25 @@ impl Drop for ControlPlane {
     }
 }
 
+/// Canonicalize a gRPC endpoint for comparison by ensuring the scheme's default
+/// port is always present. This lets "https://host" and "https://host:443"
+/// match even when one form omits the explicit port.
+fn canonical_endpoint(ep: &str) -> String {
+    let (prefix_len, default_port) = if ep.starts_with("https://") {
+        (8usize, "443")
+    } else if ep.starts_with("http://") {
+        (7usize, "80")
+    } else {
+        return ep.to_string();
+    };
+    let host_part = &ep[prefix_len..];
+    if !host_part.contains(':') {
+        format!("{}:{}", ep, default_port)
+    } else {
+        ep.to_string()
+    }
+}
+
 pub(crate) fn from_server_config(server_config: &ServerConfig) -> ConnectionDetails {
     let mut endpoint = server_config.endpoint.clone();
     let mut external_endpoint = None;
@@ -753,11 +772,12 @@ impl ControllerService {
                     error_msg = format!("Failed to parse config: {}", e);
                 }
                 Ok(server_config) => {
+                    let target_ep = canonical_endpoint(&server_config.endpoint);
                     let mut client_config = self
                         .inner
                         .outbound_clients
                         .iter()
-                        .find(|c| c.endpoint == server_config.endpoint)
+                        .find(|c| canonical_endpoint(&c.endpoint) == target_ep)
                         .or_else(|| {
                             // Fall back to the default outbound entry (empty endpoint),
                             // which acts as a credential template for any CP-assigned link
@@ -774,7 +794,7 @@ impl ControllerService {
                             self.inner
                                 .dataplane_clients
                                 .iter()
-                                .find(|c| c.endpoint == server_config.endpoint)
+                                .find(|c| canonical_endpoint(&c.endpoint) == target_ep)
                         })
                         .cloned()
                         .unwrap_or_default();

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.5](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.4...slim-datapath-v0.18.5) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config, agntcy-slim-proto, agntcy-slim-tracing
+
 ## [0.18.4](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.3...slim-datapath-v0.18.4) - 2026-08-12
 
 ### Other

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.4"
+version = "0.18.5"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/agntcy/slim/compare/slim-mls-v0.3.7...slim-mls-v0.3.8) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth
+
 ## [0.3.7](https://github.com/agntcy/slim/compare/slim-mls-v0.3.6...slim-mls-v0.3.7) - 2026-08-12
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.7"
+version = "0.3.8"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/agntcy/slim/compare/slim-proto-v0.5.8...slim-proto-v0.5.9) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.5.8](https://github.com/agntcy/slim/compare/slim-proto-v0.5.7...slim-proto-v0.5.8) - 2026-08-12
 
 ### Other

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/proto/proto/controller/v1/controller.proto
+++ b/crates/proto/proto/controller/v1/controller.proto
@@ -130,6 +130,7 @@ enum AuthMethod {
   AUTH_METHOD_SPIRE = 1;
   AUTH_METHOD_BASIC = 2;
   AUTH_METHOD_JWT = 3;
+  AUTH_METHOD_OIDC = 4;
 }
 
 message ConnectionDetails {

--- a/crates/proto/src/gen/controller.proto.v1.rs
+++ b/crates/proto/src/gen/controller.proto.v1.rs
@@ -280,6 +280,7 @@ pub enum AuthMethod {
     Spire = 1,
     Basic = 2,
     Jwt = 3,
+    Oidc = 4,
 }
 impl AuthMethod {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -292,6 +293,7 @@ impl AuthMethod {
             Self::Spire => "AUTH_METHOD_SPIRE",
             Self::Basic => "AUTH_METHOD_BASIC",
             Self::Jwt => "AUTH_METHOD_JWT",
+            Self::Oidc => "AUTH_METHOD_OIDC",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -301,6 +303,7 @@ impl AuthMethod {
             "AUTH_METHOD_SPIRE" => Some(Self::Spire),
             "AUTH_METHOD_BASIC" => Some(Self::Basic),
             "AUTH_METHOD_JWT" => Some(Self::Jwt),
+            "AUTH_METHOD_OIDC" => Some(Self::Oidc),
             _ => None,
         }
     }

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.9](https://github.com/agntcy/slim/compare/slim-service-v0.12.8...slim-service-v0.12.9) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.12.8](https://github.com/agntcy/slim/compare/slim-service-v0.12.7...slim-service-v0.12.8) - 2026-08-12
 
 ### Other

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.8"
+version = "0.12.9"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -689,6 +689,7 @@ impl Service {
             self.config.domain_name.clone(),
             self.message_processor.clone(),
             self.config.dataplane_servers(),
+            self.config.dataplane_clients(),
             auth_provider,
         );
 

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.9](https://github.com/agntcy/slim/compare/slim-session-v0.7.8...slim-session-v0.7.9) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-datapath, agntcy-slim-mls
+
 ## [0.7.8](https://github.com/agntcy/slim/compare/slim-session-v0.7.7...slim-session-v0.7.8) - 2026-08-12
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.8"
+version = "0.7.9"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/agntcy/slim/compare/slim-signal-v0.1.23...slim-signal-v0.1.24) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.23](https://github.com/agntcy/slim/compare/slim-signal-v0.1.22...slim-signal-v0.1.23) - 2026-08-12
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.23"
+version = "0.1.24"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim-bindings/CHANGELOG.md
+++ b/crates/slim-bindings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.1.1...slim-bindings-v2.2.0) - 2026-08-13
+
+### Added
+
+- *(bindings)* expose OIDC authentication in language bindings ([#1982](https://github.com/agntcy/slim/pull/1982))
+
 ## [2.1.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.0.0...slim-bindings-v2.1.0) - 2026-08-12
 
 ### Added

--- a/crates/slim-bindings/src/common_config.rs
+++ b/crates/slim-bindings/src/common_config.rs
@@ -1,7 +1,10 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use slim_config::auth::basic::Config as BasicAuthConfig;
+use slim_config::auth::oidc::Config as OidcAuthConfig;
 use slim_config::tls::client::TlsClientConfig as CoreTlsClientConfig;
 use slim_config::tls::server::TlsServerConfig as CoreTlsServerConfig;
 
@@ -279,6 +282,112 @@ impl From<CoreTlsServerConfig> for TlsServerConfig {
     }
 }
 
+/// Policy evaluated against JWT claims on every authenticated request (server-side OIDC only)
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
+pub enum OidcPolicyConfig {
+    /// Inline Rego policy (must define `package slim.auth` with `default allow = false`)
+    Rego { text: String },
+    /// Path to a Rego policy file read at server startup
+    RegoFile { path: String },
+    /// CEL expression evaluated against JWT claims (e.g. `"admin" in claims.groups`)
+    Cel { expression: String },
+}
+
+impl From<OidcPolicyConfig> for slim_config::auth::PolicyConfig {
+    fn from(config: OidcPolicyConfig) -> Self {
+        match config {
+            OidcPolicyConfig::Rego { text } => slim_config::auth::PolicyConfig::Rego(text),
+            OidcPolicyConfig::RegoFile { path } => {
+                slim_config::auth::PolicyConfig::RegoFile(std::path::PathBuf::from(path))
+            }
+            OidcPolicyConfig::Cel { expression } => {
+                slim_config::auth::PolicyConfig::Cel(expression)
+            }
+        }
+    }
+}
+
+impl From<slim_config::auth::PolicyConfig> for OidcPolicyConfig {
+    fn from(config: slim_config::auth::PolicyConfig) -> Self {
+        match config {
+            slim_config::auth::PolicyConfig::Rego(text) => OidcPolicyConfig::Rego { text },
+            slim_config::auth::PolicyConfig::RegoFile(path) => OidcPolicyConfig::RegoFile {
+                path: path.to_string_lossy().to_string(),
+            },
+            slim_config::auth::PolicyConfig::Cel(expression) => {
+                OidcPolicyConfig::Cel { expression }
+            }
+        }
+    }
+}
+
+/// OIDC authentication configuration (client-credentials, refresh-token, or JWKS verification)
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct OidcConfig {
+    /// OIDC issuer URL (e.g., https://auth.example.com)
+    pub issuer_url: String,
+    /// OAuth2 client ID (required for client-credentials and refresh-token flows)
+    pub client_id: Option<String>,
+    /// OAuth2 client secret (for client-credentials flow)
+    pub client_secret: Option<String>,
+    /// Expected audience for JWT tokens (required for server-side verification)
+    pub audience: Option<String>,
+    /// Inline refresh token (for authorization-code flow)
+    pub refresh_token: Option<String>,
+    /// Path to file holding the refresh token (rotated tokens are written back automatically)
+    pub refresh_token_file: Option<String>,
+    /// Path to a file caching the current access token (optional companion to refresh_token_file)
+    pub access_token_file: Option<String>,
+    /// OAuth2 scope parameter (client-side only)
+    pub scope: Option<String>,
+    /// HTTP timeout for token requests in seconds (default: 30, client-side only)
+    pub timeout: Option<Duration>,
+    /// JWKS cache TTL in seconds (default: 3600, server-side only)
+    pub jwks_ttl: Option<Duration>,
+    /// Cache TTL for merged JWT+userinfo claims in seconds (server-side only, absent = no cache)
+    pub claim_cache_ttl: Option<Duration>,
+    /// Policy evaluated against JWT claims on every authenticated request (server-side only)
+    pub policy: Option<OidcPolicyConfig>,
+}
+
+impl From<OidcConfig> for OidcAuthConfig {
+    fn from(config: OidcConfig) -> Self {
+        OidcAuthConfig {
+            issuer_url: config.issuer_url,
+            client_id: config.client_id,
+            client_secret: config.client_secret,
+            audience: config.audience,
+            refresh_token: config.refresh_token,
+            refresh_token_file: config.refresh_token_file,
+            access_token_file: config.access_token_file,
+            scope: config.scope,
+            timeout: config.timeout.map(|d| d.into()),
+            jwks_ttl: config.jwks_ttl.map(|d| d.into()),
+            claim_cache_ttl: config.claim_cache_ttl.map(|d| d.into()),
+            policy: config.policy.map(|p| p.into()),
+        }
+    }
+}
+
+impl From<OidcAuthConfig> for OidcConfig {
+    fn from(config: OidcAuthConfig) -> Self {
+        OidcConfig {
+            issuer_url: config.issuer_url,
+            client_id: config.client_id,
+            client_secret: config.client_secret,
+            audience: config.audience,
+            refresh_token: config.refresh_token,
+            refresh_token_file: config.refresh_token_file,
+            access_token_file: config.access_token_file,
+            scope: config.scope,
+            timeout: config.timeout.map(|ds| ds.into()),
+            jwks_ttl: config.jwks_ttl.map(|ds| ds.into()),
+            claim_cache_ttl: config.claim_cache_ttl.map(|ds| ds.into()),
+            policy: config.policy.map(|p| p.into()),
+        }
+    }
+}
+
 /// Basic authentication configuration
 #[derive(uniffi::Record, Clone, Debug, PartialEq)]
 pub struct BasicAuth {
@@ -318,6 +427,10 @@ pub enum ClientAuthenticationConfig {
     Spire {
         config: SpireConfig,
     },
+    /// OIDC authentication (client-credentials or refresh-token flow)
+    Oidc {
+        config: OidcConfig,
+    },
     None,
 }
 
@@ -336,6 +449,9 @@ impl From<ClientAuthenticationConfig> for slim_config::grpc::client::Authenticat
             #[cfg(not(target_family = "windows"))]
             ClientAuthenticationConfig::Spire { config } => {
                 slim_config::grpc::client::AuthenticationConfig::Spire(config.into())
+            }
+            ClientAuthenticationConfig::Oidc { config } => {
+                slim_config::grpc::client::AuthenticationConfig::Oidc(config.into())
             }
             ClientAuthenticationConfig::None => {
                 slim_config::grpc::client::AuthenticationConfig::None
@@ -361,9 +477,10 @@ impl From<slim_config::grpc::client::AuthenticationConfig> for ClientAuthenticat
             slim_config::grpc::client::AuthenticationConfig::Jwt(jwt) => {
                 ClientAuthenticationConfig::Jwt { config: jwt.into() }
             }
-            slim_config::grpc::client::AuthenticationConfig::Oidc(_) => {
-                // OIDC (client-credentials / refresh-token) is set programmatically; not exposed to bindings.
-                ClientAuthenticationConfig::None
+            slim_config::grpc::client::AuthenticationConfig::Oidc(oidc) => {
+                ClientAuthenticationConfig::Oidc {
+                    config: oidc.into(),
+                }
             }
             #[cfg(not(target_family = "windows"))]
             slim_config::grpc::client::AuthenticationConfig::Spire(spire) => {
@@ -389,6 +506,10 @@ pub enum ServerAuthenticationConfig {
     Spire {
         config: SpireConfig,
     },
+    /// OIDC authentication (JWKS-based JWT verification with optional policy)
+    Oidc {
+        config: OidcConfig,
+    },
     None,
 }
 
@@ -404,6 +525,9 @@ impl From<ServerAuthenticationConfig> for slim_config::grpc::server::Authenticat
             #[cfg(not(target_family = "windows"))]
             ServerAuthenticationConfig::Spire { config } => {
                 slim_config::grpc::server::AuthenticationConfig::Spire(config.into())
+            }
+            ServerAuthenticationConfig::Oidc { config } => {
+                slim_config::grpc::server::AuthenticationConfig::Oidc(config.into())
             }
             ServerAuthenticationConfig::None => {
                 slim_config::grpc::server::AuthenticationConfig::None
@@ -432,10 +556,10 @@ impl From<slim_config::grpc::server::AuthenticationConfig> for ServerAuthenticat
                     config: spire.into(),
                 }
             }
-            slim_config::grpc::server::AuthenticationConfig::Oidc(_) => {
-                unimplemented!(
-                    "OIDC authentication is not supported in the language bindings layer"
-                )
+            slim_config::grpc::server::AuthenticationConfig::Oidc(oidc) => {
+                ServerAuthenticationConfig::Oidc {
+                    config: oidc.into(),
+                }
             }
         }
     }

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.18](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.17...slim-tracing-v0.4.18) - 2026-08-13
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.17](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.16...slim-tracing-v0.4.17) - 2026-08-12
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.17"
+version = "0.4.18"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION
## Summary

- Propagate `AUTH_METHOD_OIDC` through the full stack: proto, model, northbound/southbound conversions, `RequiredAuthMethod`, and `generate_config_data`.
- Fix `from_server_config` so `AuthenticationConfig::Oidc` maps to `AuthMethod::Oidc` instead of falling through to `None`.
- Fix `merge_server_requirements` so a `RequiredAuthMethod::None` from the CP does not wipe local OIDC credentials (now a no-op, preserving whatever the client has).
- In `diff_connections`, after failing to find a match in `outbound_clients` (exact endpoint or empty-endpoint default), fall back to the node's own `dataplane.clients` by endpoint. This means a node that already connects to an endpoint via `dataplane.clients` (e.g. with OIDC) does not need to duplicate those credentials under `controller.outbound_clients` just to satisfy CP-managed Remote links to the same endpoint.

## Test plan

- Build passes (`cargo build -p agntcy-slim-controller -p agntcy-slim-service`).
- All existing unit tests pass (diff_connections tests, merge_server_requirements tests).
- Manually tested with a real OIDC-authenticated `dataplane.clients` endpoint: CP-ordered Remote link to the same endpoint now inherits the credentials and connects successfully.