### PR TITLE
fix: OIDC credentials for CP-managed links using dataplane.clients fallback

### DIFF
--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -129,6 +129,11 @@ impl Config {
         // Used to extract connection type information required to connect to the node
         // (e.g., TLS settings). This information is used by the control plane.
         dataplane_servers: &[ServerConfig],
+        // List of client configurations for the dataplane services.
+        // Used as a credential fallback for CP-managed outbound links when no
+        // matching outbound_clients entry exists, so the client does not need to
+        // duplicate credentials it already has for a given endpoint.
+        dataplane_clients: &[ClientConfig],
         auth_provider: Option<slim_auth::auth_provider::AuthProvider>,
     ) -> ControlPlane {
         let connection_details = dataplane_servers.iter().map(from_server_config).collect();
@@ -139,6 +144,7 @@ impl Config {
             servers: self.servers.clone(),
             clients: self.clients.clone(),
             outbound_clients: self.outbound_clients.clone(),
+            dataplane_clients: dataplane_clients.to_vec(),
             message_processor,
             connection_details,
             auth_provider,
@@ -317,6 +323,7 @@ mod tests {
             domain_name,
             message_processor,
             &[server_config],
+            &[],
             None,
         );
     }

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -251,6 +251,7 @@ pub(crate) fn from_server_config(server_config: &ServerConfig) -> ConnectionDeta
         match &server_config.auth {
             AuthenticationConfig::Basic(_) => AuthMethod::Basic,
             AuthenticationConfig::Jwt(_) => AuthMethod::Jwt,
+            AuthenticationConfig::Oidc(_) => AuthMethod::Oidc,
             _ => AuthMethod::None,
         }
     } as i32;

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -70,6 +70,10 @@ pub struct ControlPlaneSettings {
     pub clients: Vec<ClientConfig>,
     /// Client configurations for server nodes
     pub outbound_clients: Vec<ClientConfig>,
+    /// Data-plane client configurations (dataplane.clients in the service config).
+    /// Used as a credential fallback for CP-managed outbound links when no
+    /// outbound_clients entry matches, so users don't have to duplicate credentials.
+    pub dataplane_clients: Vec<ClientConfig>,
     /// Message processor instance
     pub message_processor: MessageProcessor,
     /// array of connection details used by the control
@@ -126,6 +130,11 @@ struct ControllerServiceInternal {
 
     /// connection details for CP reconciled outbound data-plane connections
     outbound_clients: Vec<ClientConfig>,
+
+    /// Data-plane client configurations (dataplane.clients in the service config).
+    /// Used as a credential fallback for CP-managed outbound links when no
+    /// outbound_clients entry matches, so users don't need to duplicate credentials.
+    dataplane_clients: Vec<ClientConfig>,
 
     /// Optional auth provider for generating registration credentials.
     auth_provider: Option<AuthProvider>,
@@ -315,6 +324,7 @@ impl ControlPlane {
                     link_id_to_conn_id: parking_lot::RwLock::new(HashMap::new()),
                     stream_handles: parking_lot::Mutex::new(HashMap::new()),
                     outbound_clients: config.outbound_clients,
+                    dataplane_clients: config.dataplane_clients,
                     auth_provider: config.auth_provider,
                 }),
             },
@@ -756,6 +766,15 @@ impl ControllerService {
                                 .outbound_clients
                                 .iter()
                                 .find(|c| c.endpoint.is_empty())
+                        })
+                        .or_else(|| {
+                            // Finally fall back to dataplane.clients: reuse credentials
+                            // the node already has for this endpoint so users don't have
+                            // to duplicate them under controller.outbound_clients.
+                            self.inner
+                                .dataplane_clients
+                                .iter()
+                                .find(|c| c.endpoint == server_config.endpoint)
                         })
                         .cloned()
                         .unwrap_or_default();
@@ -2274,6 +2293,7 @@ mod tests {
             servers: vec![server_config.clone()],
             clients: vec![],
             outbound_clients: vec![],
+            dataplane_clients: vec![],
             message_processor: message_processor_server,
             connection_details: vec![from_server_config(&server_config)],
             auth_provider: None,
@@ -2285,6 +2305,7 @@ mod tests {
             servers: vec![],
             clients: vec![client_config.clone()],
             outbound_clients: vec![],
+            dataplane_clients: vec![],
             message_processor: message_processor_client,
             connection_details: vec![],
             auth_provider: None,
@@ -2880,6 +2901,7 @@ mod tests {
             servers: vec![],
             clients: vec![],
             outbound_clients,
+            dataplane_clients: vec![],
             message_processor: MessageProcessor::new(),
             connection_details: vec![],
             auth_provider: None,

--- a/crates/controller/src/service.rs
+++ b/crates/controller/src/service.rs
@@ -176,6 +176,25 @@ impl Drop for ControlPlane {
     }
 }
 
+/// Canonicalize a gRPC endpoint for comparison by ensuring the scheme's default
+/// port is always present. This lets "https://host" and "https://host:443"
+/// match even when one form omits the explicit port.
+fn canonical_endpoint(ep: &str) -> String {
+    let (prefix_len, default_port) = if ep.starts_with("https://") {
+        (8usize, "443")
+    } else if ep.starts_with("http://") {
+        (7usize, "80")
+    } else {
+        return ep.to_string();
+    };
+    let host_part = &ep[prefix_len..];
+    if !host_part.contains(':') {
+        format!("{}:{}", ep, default_port)
+    } else {
+        ep.to_string()
+    }
+}
+
 pub(crate) fn from_server_config(server_config: &ServerConfig) -> ConnectionDetails {
     let mut endpoint = server_config.endpoint.clone();
     let mut external_endpoint = None;
@@ -753,11 +772,12 @@ impl ControllerService {
                     error_msg = format!("Failed to parse config: {}", e);
                 }
                 Ok(server_config) => {
+                    let target_ep = canonical_endpoint(&server_config.endpoint);
                     let mut client_config = self
                         .inner
                         .outbound_clients
                         .iter()
-                        .find(|c| c.endpoint == server_config.endpoint)
+                        .find(|c| canonical_endpoint(&c.endpoint) == target_ep)
                         .or_else(|| {
                             // Fall back to the default outbound entry (empty endpoint),
                             // which acts as a credential template for any CP-assigned link
@@ -774,7 +794,7 @@ impl ControllerService {
                             self.inner
                                 .dataplane_clients
                                 .iter()
-                                .find(|c| c.endpoint == server_config.endpoint)
+                                .find(|c| canonical_endpoint(&c.endpoint) == target_ep)
                         })
                         .cloned()
                         .unwrap_or_default();

--- a/crates/service/src/service.rs
+++ b/crates/service/src/service.rs
@@ -689,6 +689,7 @@ impl Service {
             self.config.domain_name.clone(),
             self.message_processor.clone(),
             self.config.dataplane_servers(),
+            self.config.dataplane_clients(),
             auth_provider,
         );
 


### PR DESCRIPTION
## Summary

- Fix `from_server_config` so `AuthenticationConfig::Oidc` maps to `AuthMethod::Oidc` instead of falling through to `None`, ensuring the CP stores and forwards the correct auth method after node registration.
- Fix `merge_server_requirements` so `RequiredAuthMethod::None` from the CP no longer wipes local OIDC credentials (now a no-op).
- In `diff_connections`, after failing to find credentials in `outbound_clients` (exact endpoint match or empty-endpoint default), fall back to the node's own `dataplane.clients` by endpoint. This means a node that already authenticates to an endpoint via `dataplane.clients` (e.g. with OIDC) does not need to duplicate those credentials under `controller.outbound_clients` to satisfy CP-managed Remote links to the same endpoint.
- Normalize endpoints before comparison (`https://host` and `https://host:443` are treated as equivalent) so the fallback lookup matches even when the CP records an explicit port but the local config omits it.

## Test plan

- Build passes (`cargo build --bin slim`).
- All existing unit tests pass.
- Manually verified: CP-ordered Remote link to an endpoint that is already reachable via `dataplane.clients` with OIDC now inherits those credentials and connects successfully without duplicating config.