### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-testing",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-testing",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-persistence",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -557,11 +557,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.3.0"
+version = "2.3.1"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.3.0" }
-agntcy-slim-auth = { path = "crates/auth", version = "0.15.3" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.3.0" }
-agntcy-slim-config = { path = "crates/config", version = "0.16.0" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.3.0" }
-agntcy-slim-controller = { path = "crates/controller", version = "0.13.0" }
-agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.6" }
-agntcy-slim-mls = { path = "crates/mls", version = "0.3.9" }
+agntcy-slim = { path = "crates/slim", version = "2.3.1" }
+agntcy-slim-auth = { path = "crates/auth", version = "0.15.4" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.3.1" }
+agntcy-slim-config = { path = "crates/config", version = "0.16.1" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.3.1" }
+agntcy-slim-controller = { path = "crates/controller", version = "0.13.1" }
+agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.7" }
+agntcy-slim-mls = { path = "crates/mls", version = "0.3.10" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
-agntcy-slim-proto = { path = "crates/proto", version = "0.6.0" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.3.0" }
-agntcy-slim-service = { path = "crates/service", version = "0.12.10", default-features = false }
-agntcy-slim-session = { path = "crates/session", version = "0.7.10" }
-agntcy-slim-signal = { path = "crates/signal", version = "0.1.25" }
+agntcy-slim-proto = { path = "crates/proto", version = "0.6.1" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.3.1" }
+agntcy-slim-service = { path = "crates/service", version = "0.12.11", default-features = false }
+agntcy-slim-session = { path = "crates/session", version = "0.7.11" }
+agntcy-slim-signal = { path = "crates/signal", version = "0.1.26" }
 agntcy-slim-testing = { path = "crates/testing" }
-agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.19" }
-agntcy-slim-version = { path = "crates/version", version = "2.3.0" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.3.0" }
+agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.20" }
+agntcy-slim-version = { path = "crates/version", version = "2.3.1" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.3.1" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -238,7 +238,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.3.0"
+version = "2.3.1"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.4](https://github.com/agntcy/slim/compare/slim-auth-v0.15.3...slim-auth-v0.15.4) - 2026-09-01
+
+### Other
+
+- *(deps)* update rust crate criterion to 0.8 ([#2013](https://github.com/agntcy/slim/pull/2013))
+- *(deps)* update rust crate hmac to 0.13 ([#2018](https://github.com/agntcy/slim/pull/2018))
+
 ## [0.15.3](https://github.com/agntcy/slim/compare/slim-auth-v0.15.2...slim-auth-v0.15.3) - 2026-08-13
 
 ### Other

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-auth"
-version = "0.15.3"
+version = "0.15.4"
 license = { workspace = true }
 edition = { workspace = true }
 description = "Authentication utilities for the Agntcy Slim framework"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.3.0...slim-channel-manager-v2.3.1) - 2026-09-01
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.0.0...slim-channel-manager-v2.0.0) - 2026-08-04
 
 ### Other

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/agntcy/slim/compare/slim-config-v0.16.0...slim-config-v0.16.1) - 2026-09-01
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.16.0](https://github.com/agntcy/slim/compare/slim-config-v0.15.2...slim-config-v0.16.0) - 2026-08-13
 
 ### Fixed

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-config"
-version = "0.16.0"
+version = "0.16.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Configuration utilities"

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.3.0...slim-control-plane-v2.3.1) - 2026-09-01
+
+### Fixed
+
+- *(control-plane)* serialize node_registered with deregister/disconnect ([#1997](https://github.com/agntcy/slim/pull/1997))
+
 ## [2.3.0](https://github.com/agntcy/slim/compare/slim-control-plane-v2.2.0...slim-control-plane-v2.3.0) - 2026-08-13
 
 ### Fixed

--- a/crates/controller/CHANGELOG.md
+++ b/crates/controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/agntcy/slim/compare/slim-controller-v0.13.0...slim-controller-v0.13.1) - 2026-09-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-signal
+
 ## [0.13.0](https://github.com/agntcy/slim/compare/slim-controller-v0.12.9...slim-controller-v0.13.0) - 2026-08-13
 
 ### Fixed

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-controller"
-version = "0.13.0"
+version = "0.13.1"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Controller service and control API to configure the SLIM data plane through the control plane."

--- a/crates/datapath/CHANGELOG.md
+++ b/crates/datapath/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.7](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.6...slim-datapath-v0.18.7) - 2026-09-01
+
+### Other
+
+- *(deps)* update rust crate criterion to 0.8 ([#2013](https://github.com/agntcy/slim/pull/2013))
+- *(deps)* update rust crate hmac to 0.13 ([#2018](https://github.com/agntcy/slim/pull/2018))
+- move to rust 1.98 ([#2009](https://github.com/agntcy/slim/pull/2009))
+
 ## [0.18.6](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.5...slim-datapath-v0.18.6) - 2026-08-13
 
 ### Fixed

--- a/crates/datapath/Cargo.toml
+++ b/crates/datapath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-datapath"
-version = "0.18.6"
+version = "0.18.7"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Core data plane functionality for SLIM"

--- a/crates/mls/CHANGELOG.md
+++ b/crates/mls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/agntcy/slim/compare/slim-mls-v0.3.9...slim-mls-v0.3.10) - 2026-09-01
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.9](https://github.com/agntcy/slim/compare/slim-mls-v0.3.8...slim-mls-v0.3.9) - 2026-08-13
 
 ### Other

--- a/crates/mls/Cargo.toml
+++ b/crates/mls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-mls"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.9"
+version = "0.3.10"
 description = "Messaging Layer Security for SLIM data plane."
 
 [lib]

--- a/crates/proto/CHANGELOG.md
+++ b/crates/proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/agntcy/slim/compare/slim-proto-v0.6.0...slim-proto-v0.6.1) - 2026-09-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.6.0](https://github.com/agntcy/slim/compare/slim-proto-v0.5.9...slim-proto-v0.6.0) - 2026-08-13
 
 ### Fixed

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "agntcy-slim-proto"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Consolidated protobuf/gRPC generated code for SLIM"

--- a/crates/service/CHANGELOG.md
+++ b/crates/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.11](https://github.com/agntcy/slim/compare/slim-service-v0.12.10...slim-service-v0.12.11) - 2026-09-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
+
 ## [0.12.10](https://github.com/agntcy/slim/compare/slim-service-v0.12.9...slim-service-v0.12.10) - 2026-08-13
 
 ### Fixed

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-service"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.12.10"
+version = "0.12.11"
 description = "Main service and public API to interact with SLIM data plane."
 
 [lib]

--- a/crates/session/CHANGELOG.md
+++ b/crates/session/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.11](https://github.com/agntcy/slim/compare/slim-session-v0.7.10...slim-session-v0.7.11) - 2026-09-01
+
+### Fixed
+
+- *(session)* accept multicast join requests in unreliable mode ([#1995](https://github.com/agntcy/slim/pull/1995))
+
+### Other
+
+- move to rust 1.98 ([#2009](https://github.com/agntcy/slim/pull/2009))
+
 ## [0.7.10](https://github.com/agntcy/slim/compare/slim-session-v0.7.9...slim-session-v0.7.10) - 2026-08-13
 
 ### Other

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-session"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.10"
+version = "0.7.11"
 description = "SLIM session internal implementation."
 
 [lib]

--- a/crates/signal/CHANGELOG.md
+++ b/crates/signal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.26](https://github.com/agntcy/slim/compare/slim-signal-v0.1.25...slim-signal-v0.1.26) - 2026-09-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-version
+
 ## [0.1.25](https://github.com/agntcy/slim/compare/slim-signal-v0.1.24...slim-signal-v0.1.25) - 2026-08-13
 
 ### Other

--- a/crates/signal/Cargo.toml
+++ b/crates/signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-signal"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.25"
+version = "0.1.26"
 description = "Small library to handle OS signals."
 
 [lib]

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1](https://github.com/agntcy/slim/compare/slim-v2.3.0...slim-v2.3.1) - 2026-09-01
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0](https://github.com/agntcy/slim/compare/slim-v2.0.0...slim-v2.0.0) - 2026-08-04
 
 ### Other

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1](https://github.com/agntcy/slim/compare/slimctl-v2.3.0...slimctl-v2.3.1) - 2026-09-01
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.1.1](https://github.com/agntcy/slim/compare/slimctl-v2.1.0...slimctl-v2.1.1) - 2026-08-12
 
 ### Fixed

--- a/crates/tracing/CHANGELOG.md
+++ b/crates/tracing/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.20](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.19...slim-tracing-v0.4.20) - 2026-09-01
+
+### Other
+
+- updated the following local packages: agntcy-slim-version, agntcy-slim-config
+
 ## [0.4.19](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.18...slim-tracing-v0.4.19) - 2026-08-13
 
 ### Other

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-slim-tracing"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.19"
+version = "0.4.20"
 description = "Observability for SLIM data plane: logs, traces and metrics infrastructure."
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.3.0 -> 2.3.1
* `agntcy-slim-auth`: 0.15.3 -> 0.15.4 (✓ API compatible changes)
* `agntcy-slim-config`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `agntcy-slim-datapath`: 0.18.6 -> 0.18.7 (✓ API compatible changes)
* `agntcy-slim-mls`: 0.3.9 -> 0.3.10 (✓ API compatible changes)
* `agntcy-slim-session`: 0.7.10 -> 0.7.11 (✓ API compatible changes)
* `agntcy-slim`: 2.3.0 -> 2.3.1 (✓ API compatible changes)
* `agntcy-slim-channel-manager`: 2.3.0 -> 2.3.1 (✓ API compatible changes)
* `agntcy-slim-control-plane`: 2.3.0 -> 2.3.1 (✓ API compatible changes)
* `agntcy-slim-bindings`: 2.3.0 -> 2.3.1
* `agntcy-slim-rpc`: 2.3.0 -> 2.3.1
* `agntcy-slimctl`: 2.3.0 -> 2.3.1
* `agntcy-slim-proto`: 0.6.0 -> 0.6.1
* `agntcy-slim-tracing`: 0.4.19 -> 0.4.20
* `agntcy-slim-signal`: 0.1.25 -> 0.1.26
* `agntcy-slim-controller`: 0.13.0 -> 0.13.1
* `agntcy-slim-service`: 0.12.10 -> 0.12.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.15.4](https://github.com/agntcy/slim/compare/slim-auth-v0.15.3...slim-auth-v0.15.4) - 2026-09-01

### Other

- *(deps)* update rust crate criterion to 0.8 ([#2013](https://github.com/agntcy/slim/pull/2013))
- *(deps)* update rust crate hmac to 0.13 ([#2018](https://github.com/agntcy/slim/pull/2018))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.16.1](https://github.com/agntcy/slim/compare/slim-config-v0.16.0...slim-config-v0.16.1) - 2026-09-01

### Other

- update Cargo.toml dependencies
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.7](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.6...slim-datapath-v0.18.7) - 2026-09-01

### Other

- *(deps)* update rust crate criterion to 0.8 ([#2013](https://github.com/agntcy/slim/pull/2013))
- *(deps)* update rust crate hmac to 0.13 ([#2018](https://github.com/agntcy/slim/pull/2018))
- move to rust 1.98 ([#2009](https://github.com/agntcy/slim/pull/2009))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.10](https://github.com/agntcy/slim/compare/slim-mls-v0.3.9...slim-mls-v0.3.10) - 2026-09-01

### Other

- update Cargo.toml dependencies
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.11](https://github.com/agntcy/slim/compare/slim-session-v0.7.10...slim-session-v0.7.11) - 2026-09-01

### Fixed

- *(session)* accept multicast join requests in unreliable mode ([#1995](https://github.com/agntcy/slim/pull/1995))

### Other

- move to rust 1.98 ([#2009](https://github.com/agntcy/slim/pull/2009))
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.3.1](https://github.com/agntcy/slim/compare/slim-v2.3.0...slim-v2.3.1) - 2026-09-01

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.3.1](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.3.0...slim-channel-manager-v2.3.1) - 2026-09-01

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.3.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.3.0...slim-control-plane-v2.3.1) - 2026-09-01

### Fixed

- *(control-plane)* serialize node_registered with deregister/disconnect ([#1997](https://github.com/agntcy/slim/pull/1997))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.1.1...slim-bindings-v2.2.0) - 2026-08-13

### Added

- *(bindings)* expose OIDC authentication in language bindings ([#1982](https://github.com/agntcy/slim/pull/1982))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0...slim-rpc-v2.1.0) - 2026-08-12

### Fixed

- *(rpc)* signal end-of-stream with the status header, not an empty payload ([#1961](https://github.com/agntcy/slim/pull/1961))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.3.1](https://github.com/agntcy/slim/compare/slimctl-v2.3.0...slimctl-v2.3.1) - 2026-09-01

### Other

- update Cargo.lock dependencies
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.6.1](https://github.com/agntcy/slim/compare/slim-proto-v0.6.0...slim-proto-v0.6.1) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.20](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.19...slim-tracing-v0.4.20) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.26](https://github.com/agntcy/slim/compare/slim-signal-v0.1.25...slim-signal-v0.1.26) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.13.1](https://github.com/agntcy/slim/compare/slim-controller-v0.13.0...slim-controller-v0.13.1) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.11](https://github.com/agntcy/slim/compare/slim-service-v0.12.10...slim-service-v0.12.11) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).