### PR TITLE
fix(control-plane): serialize node_registered with deregister/disconnect

### DIFF
--- a/crates/control-plane/src/route_service.rs
+++ b/crates/control-plane/src/route_service.rs
@@ -31,8 +31,9 @@ struct Inner {
     queue: WorkQueue<String>,
     /// Signals the periodic sweep task to stop.
     shutdown_tx: tokio::sync::watch::Sender<bool>,
-    /// Per-node mutex that serializes node_deregistered and node_disconnected
-    /// for the same node, preventing concurrent cleanup from corrupting state.
+    /// Per-node mutex that serializes node_registered, node_deregistered, and
+    /// node_disconnected for the same node, preventing a reconnect from racing
+    /// a still-in-flight cleanup and corrupting state.
     node_locks: tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     /// Per-domain mutex that serializes link creation for nodes in the same domain.
     /// Without this, two nodes from the same domain registering concurrently can

--- a/crates/control-plane/src/route_service/node_lifecycle.rs
+++ b/crates/control-plane/src/route_service/node_lifecycle.rs
@@ -26,6 +26,18 @@ impl super::RouteService {
         dp_connections: Vec<crate::api::proto::controller::proto::v1::ConnectionEntry>,
         dp_routes: Vec<crate::api::proto::controller::proto::v1::Route>,
     ) {
+        // Serialize with node_deregistered/node_disconnected for the same node,
+        // so a reconnect can't run while a delayed cleanup from the previous
+        // session is still in flight.
+        let node_lock = {
+            let mut locks = self.0.node_locks.lock().await;
+            locks
+                .entry(node_id.to_string())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        let _node_guard = node_lock.lock().await;
+
         // Serialize link creation and lifecycle operations across all nodes in the
         // same domain. This prevents: (1) concurrent registrations from creating
         // duplicate inter-domain links, and (2) a rapid disconnect-reconnect race


### PR DESCRIPTION
# Description

A node reconnecting under the same node id could race a still-in-flight `node_deregistered`/`node_disconnected` cleanup from its previous session, since `node_registered` only serialized on the domain lock while the other two used a separate per-node lock. The delayed cleanup could then act on state the reconnect had just created, leaving the re-established link stuck in `Connecting` forever. `node_registered` now takes the same per-node lock so a reconnect waits for any in-flight cleanup to finish first.

Fixes the CI flake in `test_reconnect_different_endpoint`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
