### PR TITLE
fix: update SPIRE to 1.15.3

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -33,10 +33,10 @@ jobs:
             version: latest
           - image: spire-server
             repo: ghcr.io/spiffe/spire-server
-            version: 1.15.2
+            version: 1.15.3
           - image: spire-agent
             repo: ghcr.io/spiffe/spire-agent
-            version: 1.15.2
+            version: 1.15.3
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/charts/slim-spire/Chart.yaml
+++ b/charts/slim-spire/Chart.yaml
@@ -7,7 +7,7 @@ description: >
   https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 type: application
 version: 2.0.0
-appVersion: "1.15.2"
+appVersion: "1.15.3"
 keywords:
   [
     "spiffe",

--- a/charts/slim-spire/charts/spire-agent/Chart.yaml
+++ b/charts/slim-spire/charts/spire-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-agent
 description: A Helm chart to install the SPIRE agent.
 type: application
 version: 0.1.0
-appVersion: "1.15.2"
+appVersion: "1.15.3"
 keywords: ["spiffe", "spire-agent"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:

--- a/charts/slim-spire/charts/spire-server/Chart.yaml
+++ b/charts/slim-spire/charts/spire-server/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-server
 description: A Helm chart to install the SPIRE server.
 type: application
 version: 0.1.0
-appVersion: "1.15.2"
+appVersion: "1.15.3"
 keywords: ["spiffe", "spire-server", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:

--- a/crates/testing/src/utils/spire_env.rs
+++ b/crates/testing/src/utils/spire_env.rs
@@ -25,7 +25,7 @@ use tokio::fs;
 
 const SPIRE_SERVER_IMAGE: &str = "ghcr.io/spiffe/spire-server";
 const SPIRE_AGENT_IMAGE: &str = "ghcr.io/spiffe/spire-agent";
-const SPIRE_VERSION: &str = "1.15.2";
+const SPIRE_VERSION: &str = "1.15.3";
 const TRUST_DOMAIN: &str = "example.org";
 
 /// Test environment for SPIRE server and agent

--- a/crates/testing/src/utils/spire_env.rs
+++ b/crates/testing/src/utils/spire_env.rs
@@ -134,15 +134,19 @@ impl SpireTestEnvironment {
         Ok(())
     }
 
-    /// Wait for a specific log message to appear in container logs
+    /// Wait for any of the given log messages to appear in container logs
     ///
-    /// This polls the container logs until the specified message is found or a timeout occurs.
+    /// This polls the container logs until one of the messages is found or a
+    /// timeout occurs. Several are accepted because SPIRE renames these lines
+    /// between releases: 1.15.3 replaced "Starting Workload and SDS APIs" with
+    /// "Starting agent APIs".
     async fn wait_for_log_message(
         &self,
         container_id: &str,
-        message: &str,
+        messages: &[&str],
         timeout: Duration,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let message = messages.join("' or '");
         tracing::info!(%message, "Waiting for log message");
 
         let logs_options = LogsOptions::<String> {
@@ -163,8 +167,8 @@ impl SpireTestEnvironment {
             if let Ok(log) = log_result {
                 let log_str = log.to_string();
                 tracing::debug!(container_log = %log_str);
-                if log_str.contains(message) {
-                    tracing::info!(%message, "Found log message");
+                if let Some(found) = messages.iter().find(|m| log_str.contains(*m)) {
+                    tracing::info!(message = %found, "Found log message");
                     return Ok(());
                 }
             }
@@ -321,7 +325,7 @@ plugins {{
         // Wait for server to be ready by watching logs
         self.wait_for_log_message(
             &server_container.id,
-            "Starting Server APIs",
+            &["Starting Server APIs"],
             Duration::from_secs(30),
         )
         .await?;
@@ -488,7 +492,7 @@ plugins {{
         // Wait for agent to be ready by watching logs
         self.wait_for_log_message(
             &agent_container.id,
-            "Starting Workload and SDS APIs",
+            &["Starting agent APIs", "Starting Workload and SDS APIs"],
             Duration::from_secs(30),
         )
         .await?;


### PR DESCRIPTION
Trivy reported 26 findings against the pinned 1.15.2 images, most of what the
code-scanning page shows. Scanning 1.15.3 locally:

| image | 1.15.2 | 1.15.3 |
|---|---|---|
| spire-agent | 14 | 2 |
| spire-server | 12 | 0 |

The 2 left are `golang.org/x/mod` v0.38.0 needing 0.40.0 — upstream's to fix.

Bumps the charts as well as the scan matrix, so the deployed version moves too
rather than only the version being scanned.

**Second commit:** 1.15.3 renamed the agent startup log from `Starting Workload
and SDS APIs` to `Starting agent APIs`
([spiffe/spire@v1.15.2...v1.15.3](https://github.com/spiffe/spire/compare/v1.15.2...v1.15.3)
`pkg/agent/endpoints/endpoints.go`), so the test harness timed out on a line the
agent no longer emits. Verified in the shipped binaries: 1.15.2 has only the old
string, 1.15.3 only the new. The matcher now accepts either.