### PR TITLE
chore: add Renovate for GitHub Actions and Cargo dependency updates

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,48 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Dependencies
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 */6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate with GitHub App Bot
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_KEY }}
+
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
+        with:
+          configurationFile: renovate.json
+          token: '${{ steps.app-token.outputs.token }}'
+        env:
+          RENOVATE_PLATFORM: 'github'
+          RENOVATE_REPOSITORIES: '${{ github.repository }}'
+          GITHUB_COM_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Remove unused fields from PR description
+          RENOVATE_PR_BODY_TEMPLATE: '{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}'
+          RENOVATE_DEPENDENCY_DASHBOARD_HEADER: ''

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":semanticCommitTypeAll(chore)",
+    ":dependencyDashboard"
+  ],
+  "configMigration": true,
+  "dependencyDashboardAutoclose": true,
+  "dependencyDashboardLabels": ["dependencies"],
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
+  "enabled": true,
+  "minimumReleaseAge": "7 days",
+  "schedule": ["before 8am on Monday"],
+  "enabledManagers": ["github-actions", "cargo"],
+  "labels": ["dependencies"],
+  "ignoreDeps": ["agntcy-slim*"],
+  "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+      "description": ["Ignore major dependency updates."]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "addLabels": ["rust"],
+      "description": ["Add rust label to PRs which bump Cargo dependencies."]
+    },
+    {
+      "groupName": "Rust patches",
+      "groupSlug": "rust-patches",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch"],
+      "description": ["Group Cargo dependency patch updates in a single PR."]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["ci"],
+      "description": ["Add ci label to PRs which bump GitHub Actions, and group them in a single PR."]
+    },
+    {
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion) or isVulnerabilityAlert = true"
+      ],
+      "enabled": true,
+      "description": [
+        "Always allow vulnerability/security fixes, even when other rules disable majors or specific dependencies."
+      ]
+    }
+  ],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 5,
+  "printConfig": false,
+  "rebaseWhen": "behind-base-branch",
+  "reviewersFromCodeOwners": true,
+  "semanticCommits": "enabled",
+  "timezone": "Etc/UTC",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` to enable automated dependency updates for GitHub Actions and Cargo crates.
- Adds `.github/workflows/dependencies.yaml`, a scheduled (every 6h) + manually-dispatchable workflow that runs Renovate via the official `renovatebot/github-action`, authenticating with a GitHub App bot token.
- Major version bumps are disabled by default; patch-level Cargo updates and GitHub Actions bumps are each grouped into a single PR; vulnerability fixes are always allowed regardless of other rules; internal workspace path-dependencies (`agntcy-slim*`) are excluded since they aren't real external dependencies to bump.

## Test plan
- [x] Confirm `PROJECT_APP_ID` / `PROJECT_APP_KEY` secrets (GitHub App) are configured for this repo, either at the org level or added here — the workflow will fail auth without them.
- [x] After merge, trigger the workflow manually (`workflow_dispatch`) and confirm Renovate runs successfully and opens/updates the Dependency Dashboard issue.
- [x] Confirm `ci-lint-gha` (actionlint/zizmor/pinact) passes on this PR.