### PR TITLE
ci: move to trusted publishing to release slim crates

### DIFF
--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -37,7 +37,6 @@ jobs:
           config: ./.release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-crates-pr:
@@ -66,4 +65,3 @@ jobs:
           config: ./.release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
# Description

Trusted Publishing is a secure way to publish slim crates
from gh actions without manually managing API tokens.

It uses OpenID Connect (OIDC) to verify that the release
workflow is running from your repository, then provides a
short-lived token for publishing.

This allows not to store long-lived API tokens in repository
secrets, as gh actions will authenticate directly with crates.io.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] CICD

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
