### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agntcy-slim"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-channel-manager"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-control-plane"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-bindings",
@@ -556,11 +556,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "agntcy-slimctl"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,24 +41,24 @@ resolver = "2"
 
 [workspace.dependencies]
 # Local dependencies
-agntcy-slim = { path = "crates/slim", version = "2.3.1" }
+agntcy-slim = { path = "crates/slim", version = "2.3.2" }
 agntcy-slim-auth = { path = "crates/auth", version = "0.15.4" }
-agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.3.1" }
+agntcy-slim-bindings = { path = "crates/slim-bindings", version = "2.3.2" }
 agntcy-slim-config = { path = "crates/config", version = "0.16.1" }
-agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.3.1" }
+agntcy-slim-control-plane = { path = "crates/control-plane", version = "2.3.2" }
 agntcy-slim-controller = { path = "crates/controller", version = "0.13.1" }
 agntcy-slim-datapath = { path = "crates/datapath", version = "0.18.7" }
 agntcy-slim-mls = { path = "crates/mls", version = "0.3.10" }
 agntcy-slim-persistence = { path = "crates/persistence", version = "0.1.0" }
 agntcy-slim-proto = { path = "crates/proto", version = "0.6.1" }
-agntcy-slim-rpc = { path = "crates/rpc", version = "2.3.1" }
+agntcy-slim-rpc = { path = "crates/rpc", version = "2.3.2" }
 agntcy-slim-service = { path = "crates/service", version = "0.12.11", default-features = false }
 agntcy-slim-session = { path = "crates/session", version = "0.7.11" }
 agntcy-slim-signal = { path = "crates/signal", version = "0.1.26" }
 agntcy-slim-testing = { path = "crates/testing" }
 agntcy-slim-tracing = { path = "crates/tracing", version = "0.4.20" }
-agntcy-slim-version = { path = "crates/version", version = "2.3.1" }
-agntcy-slimctl = { path = "crates/slimctl", version = "2.3.1" }
+agntcy-slim-version = { path = "crates/version", version = "2.3.2" }
+agntcy-slimctl = { path = "crates/slimctl", version = "2.3.2" }
 anyhow = "1.0.103"
 
 arc-swap = "1.9.1"
@@ -236,7 +236,7 @@ x25519-dalek = { version = "2", default-features = false, features = [
 zeroize = "1.9"
 
 [workspace.package]
-version = "2.3.1"
+version = "2.3.2"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/agntcy/slim"

--- a/crates/channel-manager/CHANGELOG.md
+++ b/crates/channel-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.3.0...slim-channel-manager-v2.3.2) - 2026-09-01
+
+### Other
+
+- release ([#1992](https://github.com/agntcy/slim/pull/1992))
+
 ## [2.3.1](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.3.0...slim-channel-manager-v2.3.1) - 2026-09-01
 
 ### Other

--- a/crates/control-plane/CHANGELOG.md
+++ b/crates/control-plane/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2](https://github.com/agntcy/slim/compare/slim-control-plane-v2.3.0...slim-control-plane-v2.3.2) - 2026-09-01
+
+### Fixed
+
+- *(control-plane)* serialize node_registered with deregister/disconnect ([#1997](https://github.com/agntcy/slim/pull/1997))
+
+### Other
+
+- release ([#1992](https://github.com/agntcy/slim/pull/1992))
+
 ## [2.3.1](https://github.com/agntcy/slim/compare/slim-control-plane-v2.3.0...slim-control-plane-v2.3.1) - 2026-09-01
 
 ### Fixed

--- a/crates/slim/CHANGELOG.md
+++ b/crates/slim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2](https://github.com/agntcy/slim/compare/slim-v2.3.0...slim-v2.3.2) - 2026-09-01
+
+### Other
+
+- release ([#1992](https://github.com/agntcy/slim/pull/1992))
+
 ## [2.3.1](https://github.com/agntcy/slim/compare/slim-v2.3.0...slim-v2.3.1) - 2026-09-01
 
 ### Other

--- a/crates/slimctl/CHANGELOG.md
+++ b/crates/slimctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2](https://github.com/agntcy/slim/compare/slimctl-v2.3.1...slimctl-v2.3.2) - 2026-09-01
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.3.1](https://github.com/agntcy/slim/compare/slimctl-v2.3.0...slimctl-v2.3.1) - 2026-09-01
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-version`: 2.3.1 -> 2.3.2
* `agntcy-slim-auth`: 0.15.3 -> 0.15.4
* `agntcy-slim-config`: 0.16.0 -> 0.16.1
* `agntcy-slim-proto`: 0.6.0 -> 0.6.1
* `agntcy-slim-tracing`: 0.4.19 -> 0.4.20
* `agntcy-slim-datapath`: 0.18.6 -> 0.18.7
* `agntcy-slim-mls`: 0.3.9 -> 0.3.10
* `agntcy-slim-session`: 0.7.10 -> 0.7.11
* `agntcy-slim-signal`: 0.1.25 -> 0.1.26
* `agntcy-slim-controller`: 0.13.0 -> 0.13.1
* `agntcy-slim-service`: 0.12.10 -> 0.12.11
* `agntcy-slim`: 2.3.0 -> 2.3.2
* `agntcy-slim-channel-manager`: 2.3.0 -> 2.3.2
* `agntcy-slim-control-plane`: 2.3.0 -> 2.3.2
* `agntcy-slim-bindings`: 2.3.1 -> 2.3.2
* `agntcy-slim-rpc`: 2.3.1 -> 2.3.2
* `agntcy-slimctl`: 2.3.1 -> 2.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `agntcy-slim-version`

<blockquote>

## [1.3.0](https://github.com/agntcy/slim/releases/tag/slim-version-v1.3.0) - 2026-03-20

### Added

- add agntcy-slim-version crate as single source of truth for version and build info ([#1360](https://github.com/agntcy/slim/pull/1360))
</blockquote>

## `agntcy-slim-auth`

<blockquote>

## [0.15.4](https://github.com/agntcy/slim/compare/slim-auth-v0.15.3...slim-auth-v0.15.4) - 2026-09-01

### Other

- *(deps)* update rust crate criterion to 0.8 ([#2013](https://github.com/agntcy/slim/pull/2013))
- *(deps)* update rust crate hmac to 0.13 ([#2018](https://github.com/agntcy/slim/pull/2018))
</blockquote>

## `agntcy-slim-config`

<blockquote>

## [0.16.1](https://github.com/agntcy/slim/compare/slim-config-v0.16.0...slim-config-v0.16.1) - 2026-09-01

### Other

- update Cargo.toml dependencies
</blockquote>

## `agntcy-slim-proto`

<blockquote>

## [0.6.1](https://github.com/agntcy/slim/compare/slim-proto-v0.6.0...slim-proto-v0.6.1) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-tracing`

<blockquote>

## [0.4.20](https://github.com/agntcy/slim/compare/slim-tracing-v0.4.19...slim-tracing-v0.4.20) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-config
</blockquote>

## `agntcy-slim-datapath`

<blockquote>

## [0.18.7](https://github.com/agntcy/slim/compare/slim-datapath-v0.18.6...slim-datapath-v0.18.7) - 2026-09-01

### Other

- *(deps)* update rust crate criterion to 0.8 ([#2013](https://github.com/agntcy/slim/pull/2013))
- *(deps)* update rust crate hmac to 0.13 ([#2018](https://github.com/agntcy/slim/pull/2018))
- move to rust 1.98 ([#2009](https://github.com/agntcy/slim/pull/2009))
</blockquote>

## `agntcy-slim-mls`

<blockquote>

## [0.3.10](https://github.com/agntcy/slim/compare/slim-mls-v0.3.9...slim-mls-v0.3.10) - 2026-09-01

### Other

- update Cargo.toml dependencies
</blockquote>

## `agntcy-slim-session`

<blockquote>

## [0.7.11](https://github.com/agntcy/slim/compare/slim-session-v0.7.10...slim-session-v0.7.11) - 2026-09-01

### Fixed

- *(session)* accept multicast join requests in unreliable mode ([#1995](https://github.com/agntcy/slim/pull/1995))

### Other

- move to rust 1.98 ([#2009](https://github.com/agntcy/slim/pull/2009))
</blockquote>

## `agntcy-slim-signal`

<blockquote>

## [0.1.26](https://github.com/agntcy/slim/compare/slim-signal-v0.1.25...slim-signal-v0.1.26) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version
</blockquote>

## `agntcy-slim-controller`

<blockquote>

## [0.13.1](https://github.com/agntcy/slim/compare/slim-controller-v0.13.0...slim-controller-v0.13.1) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-session, agntcy-slim-proto, agntcy-slim-tracing, agntcy-slim-signal
</blockquote>

## `agntcy-slim-service`

<blockquote>

## [0.12.11](https://github.com/agntcy/slim/compare/slim-service-v0.12.10...slim-service-v0.12.11) - 2026-09-01

### Other

- updated the following local packages: agntcy-slim-version, agntcy-slim-auth, agntcy-slim-config, agntcy-slim-datapath, agntcy-slim-mls, agntcy-slim-session, agntcy-slim-controller
</blockquote>

## `agntcy-slim`

<blockquote>

## [2.3.2](https://github.com/agntcy/slim/compare/slim-v2.3.0...slim-v2.3.2) - 2026-09-01

### Other

- release ([#1992](https://github.com/agntcy/slim/pull/1992))
</blockquote>

## `agntcy-slim-channel-manager`

<blockquote>

## [2.3.2](https://github.com/agntcy/slim/compare/slim-channel-manager-v2.3.0...slim-channel-manager-v2.3.2) - 2026-09-01

### Other

- release ([#1992](https://github.com/agntcy/slim/pull/1992))
</blockquote>

## `agntcy-slim-control-plane`

<blockquote>

## [2.3.2](https://github.com/agntcy/slim/compare/slim-control-plane-v2.3.0...slim-control-plane-v2.3.2) - 2026-09-01

### Fixed

- *(control-plane)* serialize node_registered with deregister/disconnect ([#1997](https://github.com/agntcy/slim/pull/1997))

### Other

- release ([#1992](https://github.com/agntcy/slim/pull/1992))
</blockquote>

## `agntcy-slim-bindings`

<blockquote>

## [2.2.0](https://github.com/agntcy/slim/compare/slim-bindings-v2.1.1...slim-bindings-v2.2.0) - 2026-08-13

### Added

- *(bindings)* expose OIDC authentication in language bindings ([#1982](https://github.com/agntcy/slim/pull/1982))
</blockquote>

## `agntcy-slim-rpc`

<blockquote>

## [2.1.0](https://github.com/agntcy/slim/compare/slim-rpc-v2.0.0...slim-rpc-v2.1.0) - 2026-08-12

### Fixed

- *(rpc)* signal end-of-stream with the status header, not an empty payload ([#1961](https://github.com/agntcy/slim/pull/1961))
</blockquote>

## `agntcy-slimctl`

<blockquote>

## [2.3.2](https://github.com/agntcy/slim/compare/slimctl-v2.3.1...slimctl-v2.3.2) - 2026-09-01

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).