### PR TITLE
ci: bump scorecard workflow actions to latest pins

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -47,6 +47,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CI](https://github.com/agntcy/slim/actions/workflows/ci.yaml/badge.svg)](https://github.com/agntcy/slim/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/agntcy/slim/branch/main/graph/badge.svg)](https://codecov.io/gh/agntcy/slim)
 [![Coverage](https://img.shields.io/badge/Coverage-passing-brightgreen)](https://codecov.io/gh/agntcy/slim)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/agntcy/slim/badge)](https://scorecard.dev/viewer/?uri=github.com/agntcy/slim)
 
 # SLIM
 


### PR DESCRIPTION
Bumps action pins in the Scorecard workflow to the latest releases.

- actions/checkout to v7.0.1 (3d3c42e5aac5ba805825da76410c181273ba90b1)
- github/codeql-action/upload-sarif to v4.37.9 (cdf488f595d80d6e07e03d4674febd5ab45fa938)

Validation: `actionlint .github/workflows/scorecard.yaml` passes with no errors.