### PR TITLE
ci(rust): add crate packaging dry-run check

### DIFF
--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -60,6 +60,11 @@ jobs:
           fetch-depth: 0
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
+      - name: Verify crate packaging
+        # cargo dry-run validates packaging (Cargo.toml metadata, build, etc.)
+        # without publishing; it warns (doesn't fail) if the version already
+        # shipped, so this is safe to run on every push.
+        run: cargo publish --dry-run -p agntcy-slim-version
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:


### PR DESCRIPTION
Adds a `cargo publish --dry-run` step so OpenSSF Scorecard's Packaging check can detect our Rust publishing workflow (it doesn't recognize `release-plz/action` as a publishing pattern).

- Runs on every push to `main` in `release-crates-pr`
- Safe to run repeatedly: cargo warns (doesn't fail) if the version already shipped, only fails on real packaging/build problems

Validation: ran locally, exits 0 with just a warning since `agntcy-slim-version` is already published; `actionlint` passes.