### PR TITLE
rpc: add shared-responses multicast mode

### DIFF
--- a/crates/rpc/src/channel.rs
+++ b/crates/rpc/src/channel.rs
@@ -61,7 +61,9 @@ pub struct MulticastItem<T> {
 
 use super::{
     Context, METHOD_KEY, Metadata, RPC_DIR_KEY, RPC_DIR_REQ, RPC_ID_KEY, ReceivedMessage, RpcCode,
-    RpcError, SERVICE_KEY, STATUS_CODE_KEY, calculate_timeout_duration,
+    RpcError, SERVICE_KEY, SHARED_RESPONSES_ENABLED, SHARED_RESPONSES_KEY,
+    SHARED_RESPONSES_MEMBER_COUNT_KEY, STATUS_CODE_KEY,
+    calculate_timeout_duration,
     codec::{Decoder, Encoder},
     send_eos,
     session_wrapper::{SessionRx, SessionTx, new_session},
@@ -249,6 +251,10 @@ pub struct Channel {
     /// `true` for GROUP channels (`new_group` / `new_group_with_connection`),
     /// `false` for P2P channels (`new` / `new_with_connection`).
     is_group: bool,
+    /// When `true`, the session is created with `SHARED_RESPONSES_KEY` set in
+    /// `SessionConfig.metadata`, requesting that all servers in the group deliver
+    /// peer responses to their handlers. Only meaningful for GROUP channels.
+    shared_responses: bool,
     /// Initial group members set at construction time. Used to seed a new
     /// session on the first call. Dynamically invited members are stored
     /// in `ChannelSession::members` and inherited across session recreations.
@@ -272,6 +278,7 @@ impl Channel {
         app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
         members: Vec<Name>,
         is_group: bool,
+        shared_responses: bool,
         connection_id: Option<u64>,
         runtime: tokio::runtime::Handle,
     ) -> Result<Self, RpcError> {
@@ -296,6 +303,7 @@ impl Channel {
             app,
             remote,
             is_group,
+            shared_responses,
             initial_members: members_set,
             connection_id,
             runtime,
@@ -389,6 +397,8 @@ impl Channel {
         let app = self.app.clone();
         let remote = self.remote.clone();
         let connection_id = self.connection_id;
+        let shared_responses = self.shared_responses;
+        let member_count = self.initial_members.len();
         let runtime = &self.runtime;
 
         // Runs in a tokio task because create_session needs tokio runtime
@@ -411,12 +421,23 @@ impl Channel {
 
             tracing::debug!(remote = %remote, ?session_type, "Creating persistent session");
 
+            let mut session_metadata = HashMap::new();
+            if shared_responses {
+                session_metadata.insert(
+                    SHARED_RESPONSES_KEY.to_string(),
+                    SHARED_RESPONSES_ENABLED.to_string(),
+                );
+                session_metadata.insert(
+                    SHARED_RESPONSES_MEMBER_COUNT_KEY.to_string(),
+                    member_count.to_string(),
+                );
+            }
             let slim_config = slim_session::session_config::SessionConfig {
                 session_type,
                 max_retries: Some(10),
                 interval: Some(Duration::from_secs(1)),
                 initiator: true,
-                metadata: HashMap::new(),
+                metadata: session_metadata,
                 mls_settings: Some(MlsSettings::default()),
             };
 
@@ -497,15 +518,14 @@ impl Channel {
 
         // When the stream was empty `first` is still true: the EOS must carry
         // service + method so the server can dispatch without a preceding data frame.
-        let extra = if first {
-            Some(HashMap::from([
-                (SERVICE_KEY.to_string(), service_name.to_string()),
-                (METHOD_KEY.to_string(), method_name.to_string()),
-            ]))
-        } else {
-            None
-        };
-        send_eos(session, session.destination(), rpc_id, extra).await?;
+        // Always include dir=req so servers in shared-responses mode don't treat this
+        // client-originated EOS as a peer server response.
+        let mut extra = HashMap::from([(RPC_DIR_KEY.to_string(), RPC_DIR_REQ.to_string())]);
+        if first {
+            extra.insert(SERVICE_KEY.to_string(), service_name.to_string());
+            extra.insert(METHOD_KEY.to_string(), method_name.to_string());
+        }
+        send_eos(session, session.destination(), rpc_id, Some(extra)).await?;
         Ok(())
     }
 
@@ -898,6 +918,7 @@ impl Channel {
             app,
             members,
             is_group,
+            false,
             connection_id,
             tokio::runtime::Handle::current(),
         )
@@ -920,6 +941,7 @@ impl Channel {
         Self::new_with_members_internal(
             slim_app,
             vec![slim_name],
+            false,
             false,
             connection_id,
             tokio::runtime::Handle::current(),
@@ -944,6 +966,57 @@ impl Channel {
         Self::new_with_members_internal(
             slim_app,
             slim_names,
+            true,
+            false,
+            connection_id,
+            tokio::runtime::Handle::current(),
+        )
+    }
+
+    /// Create a GROUP channel in shared-responses mode.
+    ///
+    /// In shared-responses mode the session is flagged so that each server
+    /// receives both client requests AND the responses sent by all other servers
+    /// in the group. Servers must opt in by setting `accept_shared_responses`
+    /// on their [`Server`](crate::Server); servers that do not opt in will
+    /// return an error for the first RPC call on the shared session.
+    pub fn new_group_shared(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Arc<Name>>,
+    ) -> Result<Self, RpcError> {
+        Self::new_group_shared_with_connection(app, members, None)
+    }
+
+    /// Like [`new_group_shared`](Self::new_group_shared) but with a connection ID.
+    pub fn new_group_shared_with_connection(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Arc<Name>>,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        let slim_app = app.clone();
+        let slim_names = members.iter().map(|n| n.as_ref().clone()).collect();
+        Self::new_with_members_internal(
+            slim_app,
+            slim_names,
+            true,
+            true,
+            connection_id,
+            tokio::runtime::Handle::current(),
+        )
+    }
+
+    /// Like [`new_with_members`](Channel::new_with_members) but with shared-responses mode enabled.
+    ///
+    /// Equivalent to `new_with_members(..., is_group = true, shared_responses = true)`.
+    pub fn new_with_members_shared(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        members: Vec<Name>,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        Self::new_with_members_internal(
+            app,
+            members,
+            true,
             true,
             connection_id,
             tokio::runtime::Handle::current(),

--- a/crates/rpc/src/ffi.rs
+++ b/crates/rpc/src/ffi.rs
@@ -20,10 +20,10 @@ use slim_datapath::api::ProtoName as Name;
 
 use crate::{
     BidiStreamHandler, Channel, Context, DecodedStream, Metadata, MulticastBidiStreamHandler,
-    MulticastResponseReader, PeerResponseStream, RequestStreamWriter, ResponseSink,
-    ResponseStreamReader, RpcError, Server, StreamStreamHandler, StreamStreamSharedHandler,
-    StreamUnaryHandler, StreamUnarySharedHandler, UnaryStreamHandler, UnaryStreamSharedHandler,
-    UnaryUnaryHandler, UnaryUnarySharedHandler, UniffiPeerResponseStream, UniffiRequestStream,
+    MulticastResponseReader, PeerResponseReceiver, PeerResponseStream, RequestStreamWriter,
+    ResponseSink, ResponseStreamReader, RpcError, Server, StreamStreamHandler,
+    StreamStreamSharedHandler, StreamUnaryHandler, StreamUnarySharedHandler, UnaryStreamHandler,
+    UnaryStreamSharedHandler, UnaryUnaryHandler, UnaryUnarySharedHandler, UniffiRequestStream,
 };
 
 // ── Channel: FFI constructors ───────────────────────────────────────────────
@@ -83,7 +83,7 @@ impl Channel {
     /// Create a GROUP channel with shared-responses mode enabled.
     ///
     /// Each server in the group will receive response messages from peer servers
-    /// via their [`UniffiPeerResponseStream`] argument, in addition to the client's
+    /// via their [`PeerResponseStream`] argument, in addition to the client's
     /// request. Servers must be constructed with [`Server::new_with_shared_responses`]
     /// and register handlers via `register_*_shared` methods; servers that do not
     /// support shared-responses will reject the first RPC call with a
@@ -471,7 +471,7 @@ impl Server {
     /// Create a new RPC server that accepts shared-responses multicast sessions.
     ///
     /// Handlers registered via `register_*_shared` methods will receive response
-    /// messages from peer servers via a [`UniffiPeerResponseStream`] argument.
+    /// messages from peer servers via a [`PeerResponseStream`] argument.
     /// Sessions that request shared-responses mode (created via
     /// [`Channel::new_group_shared`]) will be accepted; all other sessions are
     /// handled normally.
@@ -640,9 +640,9 @@ impl Server {
         handler: Arc<dyn UnaryUnarySharedHandler>,
     ) {
         self.register_unary_unary_shared_internal(&service_name, &method_name,
-            move |request: Vec<u8>, context: crate::Context, peer_stream: PeerResponseStream| {
+            move |request: Vec<u8>, context: crate::Context, peer_stream: PeerResponseReceiver| {
                 let handler = handler.clone();
-                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                let peer_arc = Arc::new(PeerResponseStream::new(peer_stream.into_receiver()));
                 async move { handler.handle(request, Arc::new(context), peer_arc).await }
             },
         );
@@ -655,9 +655,9 @@ impl Server {
         handler: Arc<dyn UnaryStreamSharedHandler>,
     ) {
         self.register_unary_stream_shared_internal(&service_name, &method_name,
-            move |request: Vec<u8>, context: crate::Context, peer_stream: PeerResponseStream| {
+            move |request: Vec<u8>, context: crate::Context, peer_stream: PeerResponseReceiver| {
                 let handler = handler.clone();
-                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                let peer_arc = Arc::new(PeerResponseStream::new(peer_stream.into_receiver()));
                 async move {
                     let (sink, rx) = ResponseSink::receiver();
                     let sink_arc = Arc::new(sink);
@@ -687,10 +687,10 @@ impl Server {
         handler: Arc<dyn StreamUnarySharedHandler>,
     ) {
         self.register_stream_unary_shared_internal(&service_name, &method_name,
-            move |stream: DecodedStream<Vec<u8>>, context: crate::Context, peer_stream: PeerResponseStream| {
+            move |stream: DecodedStream<Vec<u8>>, context: crate::Context, peer_stream: PeerResponseReceiver| {
                 let handler = handler.clone();
                 let request_stream = Arc::new(UniffiRequestStream::new(stream));
-                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                let peer_arc = Arc::new(PeerResponseStream::new(peer_stream.into_receiver()));
                 async move { handler.handle(request_stream, Arc::new(context), peer_arc).await }
             },
         );
@@ -703,10 +703,10 @@ impl Server {
         handler: Arc<dyn StreamStreamSharedHandler>,
     ) {
         self.register_stream_stream_shared_internal(&service_name, &method_name,
-            move |stream: DecodedStream<Vec<u8>>, context: crate::Context, peer_stream: PeerResponseStream| {
+            move |stream: DecodedStream<Vec<u8>>, context: crate::Context, peer_stream: PeerResponseReceiver| {
                 let handler = handler.clone();
                 let request_stream = Arc::new(UniffiRequestStream::new(stream));
-                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                let peer_arc = Arc::new(PeerResponseStream::new(peer_stream.into_receiver()));
                 async move {
                     let (sink, rx) = ResponseSink::receiver();
                     let sink_arc = Arc::new(sink);

--- a/crates/rpc/src/ffi.rs
+++ b/crates/rpc/src/ffi.rs
@@ -114,6 +114,11 @@ impl Channel {
             slim_bindings::get_runtime(),
         )
     }
+
+    /// Returns the local SLIM name of the app that owns this channel.
+    pub fn local_name(&self) -> Arc<slim_bindings::Name> {
+        Arc::new(slim_bindings::Name::from(self.app.app_name().clone()))
+    }
 }
 
 // ── Channel: blocking raw-bytes RPC call API ────────────────────────

--- a/crates/rpc/src/ffi.rs
+++ b/crates/rpc/src/ffi.rs
@@ -117,7 +117,7 @@ impl Channel {
 
     /// Returns the local SLIM name of the app that owns this channel.
     pub fn local_name(&self) -> Arc<slim_bindings::Name> {
-        Arc::new(slim_bindings::Name::from(self.app.app_name().clone()))
+        Arc::new(slim_bindings::Name::from(self.app().app_name().clone()))
     }
 }
 

--- a/crates/rpc/src/ffi.rs
+++ b/crates/rpc/src/ffi.rs
@@ -20,9 +20,10 @@ use slim_datapath::api::ProtoName as Name;
 
 use crate::{
     BidiStreamHandler, Channel, Context, DecodedStream, Metadata, MulticastBidiStreamHandler,
-    MulticastResponseReader, RequestStreamWriter, ResponseSink, ResponseStreamReader, RpcError,
-    Server, StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler,
-    UniffiRequestStream,
+    MulticastResponseReader, PeerResponseStream, RequestStreamWriter, ResponseSink,
+    ResponseStreamReader, RpcError, Server, StreamStreamHandler, StreamStreamSharedHandler,
+    StreamUnaryHandler, StreamUnarySharedHandler, UnaryStreamHandler, UnaryStreamSharedHandler,
+    UnaryUnaryHandler, UnaryUnarySharedHandler, UniffiPeerResponseStream, UniffiRequestStream,
 };
 
 // ── Channel: FFI constructors ───────────────────────────────────────────────
@@ -45,6 +46,7 @@ impl Channel {
         Self::new_with_members_internal(
             slim_app,
             vec![slim_name],
+            false,
             false,
             connection_id,
             slim_bindings::get_runtime(),
@@ -71,6 +73,42 @@ impl Channel {
         Self::new_with_members_internal(
             slim_app,
             slim_names,
+            true,
+            false,
+            connection_id,
+            slim_bindings::get_runtime(),
+        )
+    }
+
+    /// Create a GROUP channel with shared-responses mode enabled.
+    ///
+    /// Each server in the group will receive response messages from peer servers
+    /// via their [`UniffiPeerResponseStream`] argument, in addition to the client's
+    /// request. Servers must be constructed with [`Server::new_with_shared_responses`]
+    /// and register handlers via `register_*_shared` methods; servers that do not
+    /// support shared-responses will reject the first RPC call with a
+    /// `failed_precondition` error.
+    #[uniffi::constructor]
+    pub fn new_group_shared(
+        app: Arc<slim_bindings::App>,
+        members: Vec<Arc<slim_bindings::Name>>,
+    ) -> Result<Self, RpcError> {
+        Self::new_group_shared_with_connection(app, members, None)
+    }
+
+    /// Like [`new_group_shared`](Self::new_group_shared) but with a connection ID.
+    #[uniffi::constructor]
+    pub fn new_group_shared_with_connection(
+        app: Arc<slim_bindings::App>,
+        members: Vec<Arc<slim_bindings::Name>>,
+        connection_id: Option<u64>,
+    ) -> Result<Self, RpcError> {
+        let slim_app = app.inner_app().clone();
+        let slim_names: Vec<Name> = members.iter().map(|n| n.as_slim_name().clone()).collect();
+        Self::new_with_members_internal(
+            slim_app,
+            slim_names,
+            true,
             true,
             connection_id,
             slim_bindings::get_runtime(),
@@ -429,6 +467,45 @@ impl Server {
             Some(slim_bindings::get_runtime()),
         )
     }
+
+    /// Create a new RPC server that accepts shared-responses multicast sessions.
+    ///
+    /// Handlers registered via `register_*_shared` methods will receive response
+    /// messages from peer servers via a [`UniffiPeerResponseStream`] argument.
+    /// Sessions that request shared-responses mode (created via
+    /// [`Channel::new_group_shared`]) will be accepted; all other sessions are
+    /// handled normally.
+    ///
+    /// A server built with the standard [`Server::new`] constructor will reject
+    /// any session that requests shared-responses mode with a `failed_precondition`
+    /// error on the first RPC call.
+    #[uniffi::constructor]
+    pub fn new_with_shared_responses(
+        app: &Arc<slim_bindings::App>,
+        base_name: Arc<slim_bindings::Name>,
+    ) -> Self {
+        Self::new_with_shared_responses_and_connection(app, base_name, None)
+    }
+
+    /// Like [`new_with_shared_responses`](Self::new_with_shared_responses) but
+    /// with an optional connection ID for routing setup.
+    #[uniffi::constructor]
+    pub fn new_with_shared_responses_and_connection(
+        app: &Arc<slim_bindings::App>,
+        base_name: Arc<slim_bindings::Name>,
+        connection_id: Option<u64>,
+    ) -> Self {
+        let app_inner = app.inner();
+        let rx = app.notification_receiver();
+
+        Self::new_with_shared_rx_and_shared_responses(
+            app_inner,
+            base_name.as_ref().into(),
+            connection_id,
+            rx,
+            Some(slim_bindings::get_runtime()),
+        )
+    }
 }
 
 // ── Server: trait-object handler registration ───────────────────────
@@ -547,6 +624,104 @@ impl Server {
                     drop(handler_task);
 
                     // Convert the receiver to a stream
+                    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+                    Ok(stream)
+                }
+            },
+        );
+    }
+
+    // ── Shared-responses handler registration ────────────────────────────────
+
+    pub fn register_unary_unary_shared(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn UnaryUnarySharedHandler>,
+    ) {
+        self.register_unary_unary_shared_internal(&service_name, &method_name,
+            move |request: Vec<u8>, context: crate::Context, peer_stream: PeerResponseStream| {
+                let handler = handler.clone();
+                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                async move { handler.handle(request, Arc::new(context), peer_arc).await }
+            },
+        );
+    }
+
+    pub fn register_unary_stream_shared(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn UnaryStreamSharedHandler>,
+    ) {
+        self.register_unary_stream_shared_internal(&service_name, &method_name,
+            move |request: Vec<u8>, context: crate::Context, peer_stream: PeerResponseStream| {
+                let handler = handler.clone();
+                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                async move {
+                    let (sink, rx) = ResponseSink::receiver();
+                    let sink_arc = Arc::new(sink);
+                    let handler_task = {
+                        let sink = sink_arc.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handler
+                                .handle(request, Arc::new(context), sink.clone(), peer_arc)
+                                .await
+                            {
+                                let _ = sink.send_error_async(e).await;
+                            }
+                        })
+                    };
+                    drop(handler_task);
+                    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+                    Ok(stream)
+                }
+            },
+        );
+    }
+
+    pub fn register_stream_unary_shared(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn StreamUnarySharedHandler>,
+    ) {
+        self.register_stream_unary_shared_internal(&service_name, &method_name,
+            move |stream: DecodedStream<Vec<u8>>, context: crate::Context, peer_stream: PeerResponseStream| {
+                let handler = handler.clone();
+                let request_stream = Arc::new(UniffiRequestStream::new(stream));
+                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                async move { handler.handle(request_stream, Arc::new(context), peer_arc).await }
+            },
+        );
+    }
+
+    pub fn register_stream_stream_shared(
+        &self,
+        service_name: String,
+        method_name: String,
+        handler: Arc<dyn StreamStreamSharedHandler>,
+    ) {
+        self.register_stream_stream_shared_internal(&service_name, &method_name,
+            move |stream: DecodedStream<Vec<u8>>, context: crate::Context, peer_stream: PeerResponseStream| {
+                let handler = handler.clone();
+                let request_stream = Arc::new(UniffiRequestStream::new(stream));
+                let peer_arc = Arc::new(UniffiPeerResponseStream::new(peer_stream.into_receiver()));
+                async move {
+                    let (sink, rx) = ResponseSink::receiver();
+                    let sink_arc = Arc::new(sink);
+                    let handler_task = {
+                        let sink = sink_arc.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handler
+                                .handle(request_stream, Arc::new(context), sink.clone(), peer_arc)
+                                .await
+                            {
+                                let _ = sink.send_error_async(e).await;
+                            }
+                        })
+                    };
+                    drop(handler_task);
                     let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
                     Ok(stream)
                 }

--- a/crates/rpc/src/handler_traits.rs
+++ b/crates/rpc/src/handler_traits.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use super::{Context, RpcError, stream_types::{RequestStream, ResponseSink}};
 
 #[cfg(feature = "uniffi")]
-use super::stream_types::UniffiPeerResponseStream;
+use super::stream_types::PeerResponseStream;
 
 /// Unary-to-Unary RPC handler trait
 ///
@@ -121,7 +121,7 @@ pub trait UnaryUnarySharedHandler: Send + Sync {
         &self,
         request: Vec<u8>,
         context: Arc<Context>,
-        peer_stream: Arc<UniffiPeerResponseStream>,
+        peer_stream: Arc<PeerResponseStream>,
     ) -> Result<Vec<u8>, RpcError>;
 }
 
@@ -137,7 +137,7 @@ pub trait UnaryStreamSharedHandler: Send + Sync {
         request: Vec<u8>,
         context: Arc<Context>,
         sink: Arc<ResponseSink>,
-        peer_stream: Arc<UniffiPeerResponseStream>,
+        peer_stream: Arc<PeerResponseStream>,
     ) -> Result<(), RpcError>;
 }
 
@@ -152,7 +152,7 @@ pub trait StreamUnarySharedHandler: Send + Sync {
         &self,
         stream: Arc<RequestStream>,
         context: Arc<Context>,
-        peer_stream: Arc<UniffiPeerResponseStream>,
+        peer_stream: Arc<PeerResponseStream>,
     ) -> Result<Vec<u8>, RpcError>;
 }
 
@@ -168,6 +168,6 @@ pub trait StreamStreamSharedHandler: Send + Sync {
         stream: Arc<RequestStream>,
         context: Arc<Context>,
         sink: Arc<ResponseSink>,
-        peer_stream: Arc<UniffiPeerResponseStream>,
+        peer_stream: Arc<PeerResponseStream>,
     ) -> Result<(), RpcError>;
 }

--- a/crates/rpc/src/handler_traits.rs
+++ b/crates/rpc/src/handler_traits.rs
@@ -8,10 +8,10 @@
 
 use std::sync::Arc;
 
-use super::{
-    Context, RpcError,
-    stream_types::{RequestStream, ResponseSink},
-};
+use super::{Context, RpcError, stream_types::{RequestStream, ResponseSink}};
+
+#[cfg(feature = "uniffi")]
+use super::stream_types::UniffiPeerResponseStream;
 
 /// Unary-to-Unary RPC handler trait
 ///
@@ -104,5 +104,70 @@ pub trait StreamStreamHandler: Send + Sync {
         stream: Arc<RequestStream>,
         context: Arc<Context>,
         sink: Arc<ResponseSink>,
+    ) -> Result<(), RpcError>;
+}
+
+// ── Shared-responses handler traits ────────────────────────────────────────
+
+/// Unary-to-Unary shared-responses RPC handler trait
+///
+/// Like [`UnaryUnaryHandler`] but also receives a stream of response messages
+/// from peer servers in the multicast GROUP.
+#[cfg(feature = "uniffi")]
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait UnaryUnarySharedHandler: Send + Sync {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        context: Arc<Context>,
+        peer_stream: Arc<UniffiPeerResponseStream>,
+    ) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Unary-to-Stream shared-responses RPC handler trait
+///
+/// Like [`UnaryStreamHandler`] but also receives peer response messages.
+#[cfg(feature = "uniffi")]
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait UnaryStreamSharedHandler: Send + Sync {
+    async fn handle(
+        &self,
+        request: Vec<u8>,
+        context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+        peer_stream: Arc<UniffiPeerResponseStream>,
+    ) -> Result<(), RpcError>;
+}
+
+/// Stream-to-Unary shared-responses RPC handler trait
+///
+/// Like [`StreamUnaryHandler`] but also receives peer response messages.
+#[cfg(feature = "uniffi")]
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait StreamUnarySharedHandler: Send + Sync {
+    async fn handle(
+        &self,
+        stream: Arc<RequestStream>,
+        context: Arc<Context>,
+        peer_stream: Arc<UniffiPeerResponseStream>,
+    ) -> Result<Vec<u8>, RpcError>;
+}
+
+/// Stream-to-Stream shared-responses RPC handler trait
+///
+/// Like [`StreamStreamHandler`] but also receives peer response messages.
+#[cfg(feature = "uniffi")]
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait StreamStreamSharedHandler: Send + Sync {
+    async fn handle(
+        &self,
+        stream: Arc<RequestStream>,
+        context: Arc<Context>,
+        sink: Arc<ResponseSink>,
+        peer_stream: Arc<UniffiPeerResponseStream>,
     ) -> Result<(), RpcError>;
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -162,23 +162,25 @@ pub use error::{InvalidRpcCode, RpcCode, RpcError};
 pub use rpc_session::{
     HandlerInfo, RpcSession, send_eos, send_error, send_error_for_rpc, send_response_stream,
 };
-pub use server::{HandlerType, RpcHandler, Server, StreamRpcHandler};
+pub use server::{HandlerType, RpcHandler, Server, SharedRpcHandler, SharedStreamRpcHandler, StreamRpcHandler};
 pub use session_wrapper::{ReceivedMessage, SessionRx, SessionTx, new_session};
 
 // Native/shared stream types.
-pub use stream_types::{DecodedStream, RawStream, StreamSource};
+pub use stream_types::{DecodedStream, PeerMessage, PeerResponseStream, RawStream, StreamSource};
 
 // UniFFI handler traits and FFI stream wrapper types (compiled only under the
 // `uniffi` feature).
 #[cfg(feature = "uniffi")]
 pub use handler_traits::{
-    StreamStreamHandler, StreamUnaryHandler, UnaryStreamHandler, UnaryUnaryHandler,
+    StreamStreamHandler, StreamStreamSharedHandler, StreamUnaryHandler, StreamUnarySharedHandler,
+    UnaryStreamHandler, UnaryStreamSharedHandler, UnaryUnaryHandler, UnaryUnarySharedHandler,
 };
 #[cfg(feature = "uniffi")]
 pub use stream_types::{
     BidiStreamHandler, MulticastBidiStreamHandler, MulticastResponseReader, MulticastStreamMessage,
-    RequestStream as UniffiRequestStream, RequestStreamWriter, ResponseSink, ResponseStreamReader,
-    RpcMessageContext, RpcMulticastItem, StreamMessage,
+    PeerStreamMessage, RequestStream as UniffiRequestStream, RequestStreamWriter, ResponseSink,
+    ResponseStreamReader, RpcMessageContext, RpcMulticastItem, StreamMessage,
+    UniffiPeerResponseStream,
 };
 
 /// Key used in metadata for RPC deadline/timeout
@@ -203,6 +205,25 @@ pub const RPC_DIR_KEY: &str = "slimrpc-dir";
 
 /// Value for [`RPC_DIR_KEY`] that marks a message as a client request.
 pub const RPC_DIR_REQ: &str = "req";
+
+/// Value for [`RPC_DIR_KEY`] that marks a message as a server response.
+/// Stamped on all server-originated data frames and EOS so that peers in a
+/// shared-responses multicast session can distinguish them from client requests.
+pub const RPC_DIR_RESP: &str = "resp";
+
+/// Session-level metadata key set by the client when creating a shared-responses
+/// multicast channel. Servers read this key to decide whether to deliver peer
+/// responses to their handlers.
+pub const SHARED_RESPONSES_KEY: &str = "slimrpc-shared-responses";
+
+/// Value for [`SHARED_RESPONSES_KEY`] that enables shared-responses mode.
+pub const SHARED_RESPONSES_ENABLED: &str = "true";
+
+/// Session-level metadata key carrying the total group member count as a decimal
+/// string. Set by the client alongside [`SHARED_RESPONSES_KEY`]. Servers use it
+/// to determine how many peer EOSes to wait for before closing the handler's
+/// [`PeerResponseStream`].
+pub const SHARED_RESPONSES_MEMBER_COUNT_KEY: &str = "slimrpc-member-count";
 
 /// Maximum timeout in seconds (10 hours)
 pub const MAX_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(36000);

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -166,7 +166,7 @@ pub use server::{HandlerType, RpcHandler, Server, SharedRpcHandler, SharedStream
 pub use session_wrapper::{ReceivedMessage, SessionRx, SessionTx, new_session};
 
 // Native/shared stream types.
-pub use stream_types::{DecodedStream, PeerMessage, PeerResponseStream, RawStream, StreamSource};
+pub use stream_types::{DecodedStream, PeerMessage, PeerResponseReceiver, RawStream, StreamSource};
 
 // UniFFI handler traits and FFI stream wrapper types (compiled only under the
 // `uniffi` feature).
@@ -178,9 +178,9 @@ pub use handler_traits::{
 #[cfg(feature = "uniffi")]
 pub use stream_types::{
     BidiStreamHandler, MulticastBidiStreamHandler, MulticastResponseReader, MulticastStreamMessage,
-    PeerStreamMessage, RequestStream as UniffiRequestStream, RequestStreamWriter, ResponseSink,
-    ResponseStreamReader, RpcMessageContext, RpcMulticastItem, StreamMessage,
-    UniffiPeerResponseStream,
+    PeerResponseStream, PeerStreamMessage, RequestStream as UniffiRequestStream,
+    RequestStreamWriter, ResponseSink, ResponseStreamReader, RpcMessageContext, RpcMulticastItem,
+    StreamMessage,
 };
 
 /// Key used in metadata for RPC deadline/timeout
@@ -222,7 +222,7 @@ pub const SHARED_RESPONSES_ENABLED: &str = "true";
 /// Session-level metadata key carrying the total group member count as a decimal
 /// string. Set by the client alongside [`SHARED_RESPONSES_KEY`]. Servers use it
 /// to determine how many peer EOSes to wait for before closing the handler's
-/// [`PeerResponseStream`].
+/// [`PeerResponseReceiver`].
 pub const SHARED_RESPONSES_MEMBER_COUNT_KEY: &str = "slimrpc-member-count";
 
 /// Maximum timeout in seconds (10 hours)

--- a/crates/rpc/src/rpc_session.rs
+++ b/crates/rpc/src/rpc_session.rs
@@ -17,7 +17,7 @@ use slim_datapath::api::ProtoName as Name;
 use super::{
     Context, RPC_DIR_KEY, RPC_DIR_RESP, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError,
     RpcHandler, STATUS_CODE_KEY, SessionTx, SharedRpcHandler, SharedStreamRpcHandler, StreamRpcHandler,
-    StreamSource, stream_types::PeerResponseStream,
+    StreamSource, stream_types::PeerResponseReceiver,
 };
 
 /// Handler information retrieved from registry
@@ -80,7 +80,7 @@ impl<'a> RpcSession<'a> {
         self,
         handler_info: HandlerInfo,
         rpc_id: Arc<str>,
-        peer_stream: Option<PeerResponseStream>,
+        peer_stream: Option<PeerResponseReceiver>,
     ) -> Result<(), RpcError> {
         let Self {
             session_tx,
@@ -123,13 +123,13 @@ impl<'a> RpcSession<'a> {
                         handler(stream_source, ctx, session_tx.clone(), source, rpc_id).await
                     }
                     HandlerInfo::SharedUnary(handler) => {
-                        let ps = peer_stream.unwrap_or_else(|| PeerResponseStream::new(
+                        let ps = peer_stream.unwrap_or_else(|| PeerResponseReceiver::new(
                             tokio::sync::mpsc::unbounded_channel::<crate::PeerMessage>().1
                         ));
                         handler(payload, ctx, session_tx.clone(), source, rpc_id, ps).await
                     }
                     HandlerInfo::SharedStream(handler) => {
-                        let ps = peer_stream.unwrap_or_else(|| PeerResponseStream::new(
+                        let ps = peer_stream.unwrap_or_else(|| PeerResponseReceiver::new(
                             tokio::sync::mpsc::unbounded_channel::<crate::PeerMessage>().1
                         ));
                         let stream_source = StreamSource { session_rx, payload, first_is_eos, first_code };

--- a/crates/rpc/src/rpc_session.rs
+++ b/crates/rpc/src/rpc_session.rs
@@ -15,14 +15,17 @@ use tokio::sync::mpsc;
 use slim_datapath::api::ProtoName as Name;
 
 use super::{
-    Context, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError, RpcHandler, STATUS_CODE_KEY,
-    SessionTx, StreamRpcHandler, StreamSource,
+    Context, RPC_DIR_KEY, RPC_DIR_RESP, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError,
+    RpcHandler, STATUS_CODE_KEY, SessionTx, SharedRpcHandler, SharedStreamRpcHandler, StreamRpcHandler,
+    StreamSource, stream_types::PeerResponseStream,
 };
 
 /// Handler information retrieved from registry
 pub enum HandlerInfo {
     Stream(StreamRpcHandler),
     Unary(RpcHandler),
+    SharedUnary(SharedRpcHandler),
+    SharedStream(SharedStreamRpcHandler),
 }
 
 /// RPC session handler for all four interaction patterns.
@@ -70,7 +73,15 @@ impl<'a> RpcSession<'a> {
     }
 
     /// Handle the session, dispatching to the appropriate interaction pattern.
-    pub async fn handle(self, handler_info: HandlerInfo, rpc_id: Arc<str>) -> Result<(), RpcError> {
+    ///
+    /// `peer_stream` is only `Some` for `SharedUnary` / `SharedStream` handler
+    /// variants; it is `None` for standard handlers.
+    pub async fn handle(
+        self,
+        handler_info: HandlerInfo,
+        rpc_id: Arc<str>,
+        peer_stream: Option<PeerResponseStream>,
+    ) -> Result<(), RpcError> {
         let Self {
             session_tx,
             session_rx,
@@ -103,13 +114,26 @@ impl<'a> RpcSession<'a> {
 
         let result = tokio::select! {
             result = async move {
-                match &handler_info {
+                match handler_info {
                     HandlerInfo::Unary(handler) => {
                         handler(payload, ctx, session_tx.clone(), source, rpc_id).await
                     }
                     HandlerInfo::Stream(handler) => {
                         let stream_source = StreamSource { session_rx, payload, first_is_eos, first_code };
                         handler(stream_source, ctx, session_tx.clone(), source, rpc_id).await
+                    }
+                    HandlerInfo::SharedUnary(handler) => {
+                        let ps = peer_stream.unwrap_or_else(|| PeerResponseStream::new(
+                            tokio::sync::mpsc::unbounded_channel::<crate::PeerMessage>().1
+                        ));
+                        handler(payload, ctx, session_tx.clone(), source, rpc_id, ps).await
+                    }
+                    HandlerInfo::SharedStream(handler) => {
+                        let ps = peer_stream.unwrap_or_else(|| PeerResponseStream::new(
+                            tokio::sync::mpsc::unbounded_channel::<crate::PeerMessage>().1
+                        ));
+                        let stream_source = StreamSource { session_rx, payload, first_is_eos, first_code };
+                        handler(stream_source, ctx, session_tx.clone(), source, rpc_id, ps).await
                     }
                 }
             } => result,
@@ -196,6 +220,7 @@ fn create_status_metadata(code: RpcCode, rpc_id: &str) -> HashMap<String, String
     let mut metadata = HashMap::new();
     let code_i32: i32 = code.into();
     metadata.insert(STATUS_CODE_KEY.to_string(), code_i32.to_string());
+    metadata.insert(RPC_DIR_KEY.to_string(), RPC_DIR_RESP.to_string());
     if !rpc_id.is_empty() {
         metadata.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
     }
@@ -210,6 +235,7 @@ fn create_status_metadata(code: RpcCode, rpc_id: &str) -> HashMap<String, String
 /// where `first_msg_metadata` / `continuation_metadata` already omit it.
 fn create_data_metadata(rpc_id: &str) -> HashMap<String, String> {
     let mut metadata = HashMap::new();
+    metadata.insert(RPC_DIR_KEY.to_string(), RPC_DIR_RESP.to_string());
     if !rpc_id.is_empty() {
         metadata.insert(RPC_ID_KEY.to_string(), rpc_id.to_string());
     }

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -703,19 +703,22 @@ async fn run_session_demux(
             };
             tracing::debug!(%rpc_id_str, source = %msg.source, is_eos = msg.is_eos(), is_self, "shared-responses: peer response");
             if !is_self {
-                if let Some(tx) = pending_peer_streams.get(rpc_id_str.as_str()) {
-                    let peer_msg = PeerMessage {
-                        source: msg.source.clone(),
-                        payload: msg.payload.clone(),
-                    };
-                    tracing::debug!(%rpc_id_str, payload_len = peer_msg.payload.len(), "forwarding peer message");
-                    if tx.send(peer_msg).is_err() {
-                        // Handler dropped PeerResponseReceiver — clean up immediately.
-                        pending_peer_streams.remove(rpc_id_str.as_str());
-                        peer_eos_counts.remove(rpc_id_str.as_str());
+                // Only forward data frames — EOS is a termination signal, not a payload.
+                if !msg.is_eos() {
+                    if let Some(tx) = pending_peer_streams.get(rpc_id_str.as_str()) {
+                        let peer_msg = PeerMessage {
+                            source: msg.source.clone(),
+                            payload: msg.payload.clone(),
+                        };
+                        tracing::debug!(%rpc_id_str, payload_len = peer_msg.payload.len(), "forwarding peer message");
+                        if tx.send(peer_msg).is_err() {
+                            // Handler dropped PeerResponseReceiver — clean up immediately.
+                            pending_peer_streams.remove(rpc_id_str.as_str());
+                            peer_eos_counts.remove(rpc_id_str.as_str());
+                        }
+                    } else {
+                        tracing::debug!(%rpc_id_str, "Dropping peer response: no handler registered yet");
                     }
-                } else {
-                    tracing::debug!(%rpc_id_str, "Dropping peer response: no handler registered yet");
                 }
                 // Count peer EOSes; only close the channel once all N-1 peers have finished.
                 if msg.is_eos() {

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -26,13 +26,16 @@ use slim_service::app::App as SlimApp;
 use slim_session::errors::SessionError;
 use slim_session::notification::Notification;
 
-use super::{RPC_DIR_KEY, RPC_DIR_REQ};
+use super::{
+    RPC_DIR_KEY, RPC_DIR_REQ, SHARED_RESPONSES_ENABLED, SHARED_RESPONSES_KEY,
+    SHARED_RESPONSES_MEMBER_COUNT_KEY,
+};
 
 use super::{
     Context, HandlerInfo, METHOD_KEY, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError, RpcSession,
     SERVICE_KEY, send_error_for_rpc,
     session_wrapper::{SessionRx, SessionTx, new_session},
-    stream_types::StreamSource,
+    stream_types::{PeerMessage, PeerResponseStream, StreamSource},
 };
 
 use super::{
@@ -51,6 +54,22 @@ pub type RpcHandler =
 /// Handler function type for stream-input RPC methods
 pub type StreamRpcHandler =
     Arc<dyn Fn(StreamSource, Context, SessionTx, Name, Arc<str>) -> ResponseStream + Send + Sync>;
+
+/// Handler function type for shared-responses unary-input RPC methods.
+/// Receives the decoded request bytes, context, session, source, rpc-id, and
+/// a stream of peer server responses.
+pub type SharedRpcHandler = Arc<
+    dyn Fn(Item, Context, SessionTx, Name, Arc<str>, PeerResponseStream) -> ResponseStream
+        + Send
+        + Sync,
+>;
+
+/// Handler function type for shared-responses stream-input RPC methods.
+pub type SharedStreamRpcHandler = Arc<
+    dyn Fn(StreamSource, Context, SessionTx, Name, Arc<str>, PeerResponseStream) -> ResponseStream
+        + Send
+        + Sync,
+>;
 
 /// Type of RPC handler
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,6 +91,10 @@ struct ServiceRegistry {
     handlers: HashMap<String, RpcHandler>,
     /// Map of method paths to stream handlers (for stream-input methods)
     stream_handlers: HashMap<String, StreamRpcHandler>,
+    /// Shared-responses variants (unary-input)
+    shared_handlers: HashMap<String, SharedRpcHandler>,
+    /// Shared-responses variants (stream-input)
+    shared_stream_handlers: HashMap<String, SharedStreamRpcHandler>,
 }
 
 impl ServiceRegistry {
@@ -80,6 +103,8 @@ impl ServiceRegistry {
         Self {
             handlers: HashMap::new(),
             stream_handlers: HashMap::new(),
+            shared_handlers: HashMap::new(),
+            shared_stream_handlers: HashMap::new(),
         }
     }
 
@@ -229,12 +254,183 @@ impl ServiceRegistry {
         self.stream_handlers.insert(method_path, wrapper);
     }
 
-    /// Get handler info (either stream or unary) in one lookup
+    /// Register a shared-responses unary-unary handler.
+    fn register_unary_unary_shared<F, Req, Res, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |bytes: Vec<u8>,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  _source: Name,
+                  rpc_id: Arc<str>,
+                  peer_stream: PeerResponseStream| {
+                let fut = Req::decode(bytes).map(|req| handler(req, ctx, peer_stream));
+                // Broadcast to the session group so all members (including peer servers)
+                // receive this response and can observe it via PeerResponseStream.
+                let group = session_tx.destination().clone();
+                async move {
+                    let encoded = fut?.await?.encode()?;
+                    send_response_stream(
+                        &session_tx,
+                        stream::once(std::future::ready(Ok(encoded))),
+                        &rpc_id,
+                        &group,
+                    )
+                    .await
+                }
+                .boxed()
+            },
+        );
+        self.shared_handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a shared-responses unary-stream handler.
+    pub fn register_unary_stream_shared<F, Req, Res, S, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |bytes: Vec<u8>,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  _source: Name,
+                  rpc_id: Arc<str>,
+                  peer_stream: PeerResponseStream| {
+                let fut = Req::decode(bytes).map(|req| handler(req, ctx, peer_stream));
+                // Broadcast to the session group so all members (including peer servers)
+                // receive this response and can observe it via PeerResponseStream.
+                let group = session_tx.destination().clone();
+                async move {
+                    let response_stream = fut?.await?;
+                    let byte_mapped = response_stream.map(|res| res.and_then(|r| r.encode()));
+                    send_response_stream(&session_tx, byte_mapped, &rpc_id, &group).await
+                }
+                .boxed()
+            },
+        );
+        self.shared_handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a shared-responses stream-unary handler.
+    pub fn register_stream_unary_shared<F, Req, Res, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |source: StreamSource,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  _target: Name,
+                  rpc_id: Arc<str>,
+                  peer_stream: PeerResponseStream| {
+                let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
+                    |res| res.and_then(|bytes| Req::decode(bytes));
+                let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
+                let fut = handler(decoded, ctx, peer_stream);
+                // Broadcast to the session group so all members (including peer servers)
+                // receive this response and can observe it via PeerResponseStream.
+                let group = session_tx.destination().clone();
+                async move {
+                    let encoded = fut.await?.encode()?;
+                    send_response_stream(
+                        &session_tx,
+                        stream::once(std::future::ready(Ok(encoded))),
+                        &rpc_id,
+                        &group,
+                    )
+                    .await
+                }
+                .boxed()
+            },
+        );
+        self.shared_stream_handlers.insert(method_path, wrapper);
+    }
+
+    /// Register a shared-responses stream-stream handler.
+    pub fn register_stream_stream_shared<F, Req, Res, S, Fut>(
+        &mut self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        let method_path = format!("{service_name}/{method_name}");
+        let wrapper = Arc::new(
+            move |source: StreamSource,
+                  ctx: Context,
+                  session_tx: SessionTx,
+                  _target: Name,
+                  rpc_id: Arc<str>,
+                  peer_stream: PeerResponseStream| {
+                let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
+                    |res| res.and_then(|bytes| Req::decode(bytes));
+                let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
+                let fut = handler(decoded, ctx, peer_stream);
+                // Broadcast to the session group so all members (including peer servers)
+                // receive this response and can observe it via PeerResponseStream.
+                let group = session_tx.destination().clone();
+                async move {
+                    let response_stream = fut.await?;
+                    let byte_mapped = response_stream.map(|res| res.and_then(|r| r.encode()));
+                    send_response_stream(&session_tx, byte_mapped, &rpc_id, &group).await
+                }
+                .boxed()
+            },
+        );
+        self.shared_stream_handlers.insert(method_path, wrapper);
+    }
+
+    /// Get handler info (either stream or unary) in one lookup.
+    /// Shared-responses variants take priority when present.
     fn get_handler_info(&self, method_path: &str) -> Option<HandlerInfo> {
-        self.stream_handlers
+        self.shared_stream_handlers
             .get(method_path)
             .cloned()
-            .map(HandlerInfo::Stream)
+            .map(HandlerInfo::SharedStream)
+            .or_else(|| {
+                self.shared_handlers
+                    .get(method_path)
+                    .cloned()
+                    .map(HandlerInfo::SharedUnary)
+            })
+            .or_else(|| {
+                self.stream_handlers
+                    .get(method_path)
+                    .cloned()
+                    .map(HandlerInfo::Stream)
+            })
             .or_else(|| {
                 self.handlers
                     .get(method_path)
@@ -247,6 +443,8 @@ impl ServiceRegistry {
     fn methods(&self) -> Vec<String> {
         let mut methods: Vec<String> = self.handlers.keys().cloned().collect();
         methods.extend(self.stream_handlers.keys().cloned());
+        methods.extend(self.shared_handlers.keys().cloned());
+        methods.extend(self.shared_stream_handlers.keys().cloned());
         methods
     }
 }
@@ -328,10 +526,20 @@ pub struct Server {
     drain_watch: RwLock<Option<drain::Watch>>,
     /// Runtime handle for spawning tasks (resolved at construction)
     pub(crate) runtime: tokio::runtime::Handle,
+    /// When `true`, sessions that request shared-responses mode are accepted and
+    /// peer response messages are forwarded to handlers via [`PeerResponseStream`].
+    /// When `false` (default), such sessions are rejected with a
+    /// `failed_precondition` error on their first RPC call.
+    accept_shared_responses: bool,
 }
 
 /// Spawn a handler task for a new RPC call and, for stream-input handlers, register the mpsc
 /// sender in `pending_streams` so that subsequent messages can be routed to the same task.
+///
+/// When `peer_rx` is `Some`, the handler is a shared-responses variant: the receiver is
+/// wrapped in a [`PeerResponseStream`] and passed to the handler alongside the request.
+/// The caller is responsible for storing the corresponding sender in `pending_peer_streams`.
+#[allow(clippy::too_many_arguments)]
 fn spawn_handler_task(
     handler_info: HandlerInfo,
     msg: ReceivedMessage,
@@ -340,21 +548,24 @@ fn spawn_handler_task(
     session_tx: SessionTx,
     pending_streams: &mut HashMap<Arc<str>, mpsc::UnboundedSender<ReceivedMessage>>,
     session_drain_watch: drain::Watch,
+    peer_rx: Option<mpsc::UnboundedReceiver<PeerMessage>>,
 ) {
     // For stream-input handlers, create the mpsc channel and register the sender
     // so that subsequent messages can be routed to the same handler task.
     // Only register if the first message is not already terminal; otherwise drop
     // stream_tx immediately so the handler's channel closes after the first message.
     let stream_rx = match &handler_info {
-        HandlerInfo::Stream(_) => {
+        HandlerInfo::Stream(_) | HandlerInfo::SharedStream(_) => {
             let (stream_tx, stream_rx) = mpsc::unbounded_channel();
             if !msg.is_eos() {
                 pending_streams.insert(rpc_id.clone(), stream_tx);
             }
             Some(stream_rx)
         }
-        HandlerInfo::Unary(_) => None,
+        HandlerInfo::Unary(_) | HandlerInfo::SharedUnary(_) => None,
     };
+
+    let peer_stream = peer_rx.map(PeerResponseStream::new);
 
     tokio::spawn(async move {
         let session = match stream_rx {
@@ -362,7 +573,7 @@ fn spawn_handler_task(
             None => RpcSession::new_unary(&session_tx, &method_path, msg),
         };
         let handler_fut = async {
-            match session.handle(handler_info, rpc_id.clone()).await {
+            match session.handle(handler_info, rpc_id.clone(), peer_stream).await {
                 Ok(_) => None,
                 Err(e) => {
                     tracing::error!(%method_path, error = %e, "Error in RPC handler");
@@ -386,16 +597,58 @@ fn spawn_handler_task(
 /// Per-session demultiplexer: routes incoming messages by `rpc-id` and dispatches each new
 /// RPC call to a dedicated handler task.  Runs until the drain signal fires or the session
 /// closes, then aborts any still-running handler tasks and cleans up the session.
+///
+/// When `accept_shared_responses` is `true` AND the session metadata contains
+/// `SHARED_RESPONSES_KEY = "true"`, peer response messages (tagged `RPC_DIR_KEY = "resp"`)
+/// are forwarded to the handler's [`PeerResponseStream`] instead of being dropped.
+/// If the session requests shared-responses but the server does not accept it
+/// (`accept_shared_responses = false`), the first RPC call on the session is rejected
+/// with a `failed_precondition` error.
 async fn run_session_demux(
     session_tx: SessionTx,
     mut session_rx: SessionRx,
     registry: ServiceRegistry,
     app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
     drain_watch: drain::Watch,
+    accept_shared_responses: bool,
+    own_name: Name,
 ) {
-    // Map rpc_id → mpsc sender for live stream-input handlers.
+    // Determine whether this session operates in shared-responses mode.
+    let session_wants_shared = session_tx
+        .metadata()
+        .get(SHARED_RESPONSES_KEY)
+        .map(String::as_str)
+        == Some(SHARED_RESPONSES_ENABLED);
+    let shared_mode = session_wants_shared && accept_shared_responses;
+    // When the client requests shared-responses but we don't support it, we
+    // reject the first RPC call then continue with normal (non-shared) filtering.
+    let should_reject_shared = session_wants_shared && !accept_shared_responses;
+
+    // Number of peer servers expected to respond per RPC in shared-responses mode.
+    // Derived from the member count the client embedded in session metadata.
+    // N members → N-1 peers per server. Falls back to 0 (no peers) if missing.
+    let expected_peers: usize = if shared_mode {
+        session_tx
+            .metadata()
+            .get(SHARED_RESPONSES_MEMBER_COUNT_KEY)
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|n| n.saturating_sub(1))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    // Map rpc_id → mpsc sender for live stream-input handlers (client requests).
     let mut pending_streams: HashMap<Arc<str>, mpsc::UnboundedSender<ReceivedMessage>> =
         HashMap::new();
+    // In shared-responses mode: map rpc_id → sender for the peer-response channel.
+    let mut pending_peer_streams: HashMap<Arc<str>, mpsc::UnboundedSender<PeerMessage>> =
+        HashMap::new();
+    // Count of peer EOSes received per rpc_id. When count reaches expected_peers,
+    // the peer channel is closed and the entry removed from pending_peer_streams.
+    let mut peer_eos_counts: HashMap<Arc<str>, usize> = HashMap::new();
+    // Track whether we have already sent the rejection for this session.
+    let mut rejection_sent = false;
 
     // Per-session drain: signals all active handler tasks when the session closes.
     // drain().await serves as a barrier — it resolves once every task has dropped its Watch.
@@ -427,13 +680,64 @@ async fn run_session_demux(
             continue;
         };
 
+        // ── Shared-responses: route peer response messages ────────────────────
+        // In shared-responses mode, messages tagged RPC_DIR_RESP belong to a peer
+        // server's response stream.  Route them to the handler's PeerResponseStream
+        // channel if one is registered, then skip normal dispatch.
+        // Self-echoes (source == our own name) are discarded — handlers only receive
+        // responses from *other* members, and the self-EOS must not close the channel
+        // prematurely before those arrive.
+        if shared_mode && msg.is_peer_response() {
+            // Compare only the three name components, ignoring the name_id suffix
+            // that the session layer appends.
+            let is_self = match (
+                msg.source.name.as_ref(),
+                own_name.name.as_ref(),
+            ) {
+                (Some(src), Some(own)) => {
+                    src.component_0 == own.component_0
+                        && src.component_1 == own.component_1
+                        && src.component_2 == own.component_2
+                }
+                _ => msg.source == own_name,
+            };
+            tracing::debug!(%rpc_id_str, source = %msg.source, is_eos = msg.is_eos(), is_self, "shared-responses: peer response");
+            if !is_self {
+                if let Some(tx) = pending_peer_streams.get(rpc_id_str.as_str()) {
+                    let peer_msg = PeerMessage {
+                        source: msg.source.clone(),
+                        payload: msg.payload.clone(),
+                    };
+                    tracing::debug!(%rpc_id_str, payload_len = peer_msg.payload.len(), "forwarding peer message");
+                    if tx.send(peer_msg).is_err() {
+                        // Handler dropped PeerResponseStream — clean up immediately.
+                        pending_peer_streams.remove(rpc_id_str.as_str());
+                        peer_eos_counts.remove(rpc_id_str.as_str());
+                    }
+                } else {
+                    tracing::debug!(%rpc_id_str, "Dropping peer response: no handler registered yet");
+                }
+                // Count peer EOSes; only close the channel once all N-1 peers have finished.
+                if msg.is_eos() {
+                    let rpc_id_arc: Arc<str> = Arc::from(rpc_id_str.as_str());
+                    let count = peer_eos_counts.entry(rpc_id_arc).or_insert(0);
+                    *count += 1;
+                    if *count >= expected_peers {
+                        peer_eos_counts.remove(rpc_id_str.as_str());
+                        pending_peer_streams.remove(rpc_id_str.as_str());
+                    }
+                }
+            }
+            continue;
+        }
+
         if let Some(tx) = pending_streams.get(rpc_id_str.as_str()).cloned() {
             // Route client request messages (data or EOS) to the existing stream-input handler.
             //
             // All client-originated messages carry RPC_DIR_KEY="req".  Server responses
             // (data frames, EOSes, and error replies — including echoes of this server's own
-            // responses in a GROUP session and responses from peer servers) do not carry
-            // this key.  Drop anything that isn't tagged as a client request.
+            // responses in a GROUP session and responses from peer servers) carry
+            // RPC_DIR_KEY="resp".  Drop anything that isn't tagged as a client request.
             if msg.metadata.get(RPC_DIR_KEY).map(String::as_str) != Some(RPC_DIR_REQ) {
                 tracing::trace!(%rpc_id_str, "Skipping server response for active stream");
                 continue;
@@ -451,9 +755,7 @@ async fn run_session_demux(
         // No active stream for this rpc_id.
         // Drop server responses: every client-originated message — data frame or
         // EOS — carries RPC_DIR_KEY="req", so anything without it is a response
-        // echoed back to us on a shared session.  (This used to key off
-        // STATUS_CODE_KEY, which no longer holds now that response data frames
-        // carry no status.)
+        // echoed back to us on a shared session.
         if msg.metadata.get(RPC_DIR_KEY).map(String::as_str) != Some(RPC_DIR_REQ) {
             tracing::trace!("Skipping server response (no pending stream)");
             continue;
@@ -461,6 +763,21 @@ async fn run_session_demux(
 
         // New RPC call — create Arc now that we know we need it.
         let rpc_id: Arc<str> = Arc::from(rpc_id_str.as_str());
+
+        // Reject if client requested shared-responses but this server doesn't support it.
+        if should_reject_shared && !rejection_sent {
+            rejection_sent = true;
+            tracing::warn!(%rpc_id, "Client requested shared-responses mode but server does not support it");
+            let _ = send_error_for_rpc(
+                &session_tx,
+                RpcError::failed_precondition(
+                    "Server does not support shared-responses mode; register handlers with register_*_shared and construct server with new_with_shared_responses",
+                ),
+                &rpc_id,
+            )
+            .await;
+            continue;
+        }
 
         let (Some(service), Some(method)) = (
             msg.metadata
@@ -491,6 +808,20 @@ async fn run_session_demux(
             continue;
         };
 
+        // In shared-responses mode, create a peer-response channel for the handler.
+        // When expected_peers == 0 (single-server group) the sender is dropped
+        // immediately so the handler's peer.next() returns None right away.
+        let peer_rx = if shared_mode {
+            let (peer_tx, peer_rx) = mpsc::unbounded_channel::<PeerMessage>();
+            if expected_peers > 0 {
+                pending_peer_streams.insert(rpc_id.clone(), peer_tx);
+                // peer_tx dropped here only when expected_peers == 0
+            }
+            Some(peer_rx)
+        } else {
+            None
+        };
+
         spawn_handler_task(
             handler_info,
             msg,
@@ -499,11 +830,14 @@ async fn run_session_demux(
             session_tx.clone(),
             &mut pending_streams,
             session_drain_watch.clone(),
+            peer_rx,
         );
     }
 
     // Drop mpsc senders so stream-input handlers see channel close at their next recv.
     drop(pending_streams);
+    drop(pending_peer_streams);
+    drop(peer_eos_counts);
     // Drop watch otherwise next call to drain would also wait for this
     drop(session_drain_watch);
     // Fire the session drain and wait: resolves once every handler task drops its Watch,
@@ -556,6 +890,7 @@ impl Server {
             None,
             NotificationReceiver::Owned(notification_rx),
             None,
+            false,
         )
     }
 
@@ -580,6 +915,7 @@ impl Server {
             connection_id,
             NotificationReceiver::Owned(notification_rx),
             runtime,
+            false,
         )
     }
 
@@ -622,6 +958,50 @@ impl Server {
             connection_id,
             NotificationReceiver::Shared(notification_rx),
             runtime,
+            false,
+        )
+    }
+
+    /// Create a server that accepts shared-responses multicast sessions.
+    ///
+    /// In a shared-responses session, each server receives both client requests
+    /// AND the responses from all other group members via a [`PeerResponseStream`].
+    /// Register handlers using `register_*_shared` variants to consume peer responses.
+    #[cfg(not(feature = "uniffi"))]
+    pub fn new_with_shared_responses(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: mpsc::Receiver<Result<Notification, SessionError>>,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            connection_id,
+            NotificationReceiver::Owned(notification_rx),
+            runtime,
+            true,
+        )
+    }
+
+    /// Like [`new_with_shared_responses`](Self::new_with_shared_responses) but with a shared notification receiver.
+    pub fn new_with_shared_rx_and_shared_responses(
+        app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
+        base_name: Name,
+        connection_id: Option<u64>,
+        notification_rx: Arc<
+            tokio::sync::RwLock<mpsc::Receiver<Result<Notification, SessionError>>>,
+        >,
+        runtime: Option<tokio::runtime::Handle>,
+    ) -> Self {
+        Self::construct_internal(
+            app,
+            base_name,
+            connection_id,
+            NotificationReceiver::Shared(notification_rx),
+            runtime,
+            true,
         )
     }
 
@@ -639,6 +1019,7 @@ impl Server {
         connection_id: Option<u64>,
         notification_rx: NotificationReceiver,
         runtime: Option<tokio::runtime::Handle>,
+        accept_shared_responses: bool,
     ) -> Self {
         let (drain_signal, drain_watch) = drain::channel();
 
@@ -657,6 +1038,7 @@ impl Server {
             drain_signal: RwLock::new(Some(drain_signal)),
             drain_watch: RwLock::new(Some(drain_watch)),
             runtime,
+            accept_shared_responses,
         }
     }
 
@@ -929,6 +1311,72 @@ impl Server {
             .register_stream_stream(service_name, method_name, handler);
     }
 
+    pub(crate) fn register_unary_unary_shared_internal<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_unary_unary_shared(service_name, method_name, handler);
+    }
+
+    pub(crate) fn register_unary_stream_shared_internal<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_unary_stream_shared(service_name, method_name, handler);
+    }
+
+    pub(crate) fn register_stream_unary_shared_internal<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_stream_unary_shared(service_name, method_name, handler);
+    }
+
+    pub(crate) fn register_stream_stream_shared_internal<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.registry
+            .write()
+            .register_stream_stream_shared(service_name, method_name, handler);
+    }
+
     /// Get all registered method paths
     ///
     /// Returns a list of all registered service/method paths in the format "Service/Method".
@@ -1013,6 +1461,7 @@ impl Server {
             .read()
             .clone()
             .ok_or_else(|| RpcError::internal("drain_watch not available"))?;
+        let accept_shared_responses = self.accept_shared_responses;
 
         let ret = self.runtime.spawn(Server::serve_internal(
             notification,
@@ -1021,6 +1470,7 @@ impl Server {
             base_name,
             app,
             drain_watch,
+            accept_shared_responses,
         ));
 
         Ok(ret)
@@ -1037,6 +1487,7 @@ impl Server {
         base_name: Name,
         app: Arc<SlimApp<AuthProvider, AuthVerifier>>,
         drain_watch: drain::Watch,
+        accept_shared_responses: bool,
     ) -> (NotificationReceiver, Result<(), RpcError>) {
         tracing::info!(
             %base_name,
@@ -1086,6 +1537,8 @@ impl Server {
                         registry.clone(),
                         app.clone(),
                         drain_watch.clone(),
+                        accept_shared_responses,
+                        base_name.clone(),
                     )));
                 }
             }
@@ -1263,6 +1716,79 @@ impl Server {
         Res: Encoder + Send + 'static,
     {
         self.register_stream_stream_internal(service_name, method_name, handler)
+    }
+
+}
+
+// ── Shared-responses handler registration — native (non-uniffi) API ──
+
+#[cfg(not(feature = "uniffi"))]
+impl Server {
+    /// Register a unary-to-unary shared-responses RPC handler.
+    ///
+    /// The handler receives a [`PeerResponseStream`] delivering response messages from
+    /// peer servers in the multicast group.  Only meaningful when the server was
+    /// constructed with [`Server::new_with_shared_responses`] and the client channel
+    /// was created with [`Channel::new_group_shared`].
+    pub fn register_unary_unary_shared<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.register_unary_unary_shared_internal(service_name, method_name, handler);
+    }
+
+    /// Register a unary-to-stream shared-responses RPC handler.
+    pub fn register_unary_stream_shared<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.register_unary_stream_shared_internal(service_name, method_name, handler);
+    }
+
+    /// Register a stream-to-unary shared-responses RPC handler.
+    pub fn register_stream_unary_shared<F, Req, Res, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.register_stream_unary_shared_internal(service_name, method_name, handler);
+    }
+
+    /// Register a stream-to-stream shared-responses RPC handler.
+    pub fn register_stream_stream_shared<F, Req, Res, S, Fut>(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        handler: F,
+    ) where
+        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
+        S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
+        Req: Decoder + Send + 'static,
+        Res: Encoder + Send + 'static,
+    {
+        self.register_stream_stream_shared_internal(service_name, method_name, handler);
     }
 }
 

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -35,7 +35,7 @@ use super::{
     Context, HandlerInfo, METHOD_KEY, RPC_ID_KEY, ReceivedMessage, RpcCode, RpcError, RpcSession,
     SERVICE_KEY, send_error_for_rpc,
     session_wrapper::{SessionRx, SessionTx, new_session},
-    stream_types::{PeerMessage, PeerResponseStream, StreamSource},
+    stream_types::{PeerMessage, PeerResponseReceiver, StreamSource},
 };
 
 use super::{
@@ -59,14 +59,14 @@ pub type StreamRpcHandler =
 /// Receives the decoded request bytes, context, session, source, rpc-id, and
 /// a stream of peer server responses.
 pub type SharedRpcHandler = Arc<
-    dyn Fn(Item, Context, SessionTx, Name, Arc<str>, PeerResponseStream) -> ResponseStream
+    dyn Fn(Item, Context, SessionTx, Name, Arc<str>, PeerResponseReceiver) -> ResponseStream
         + Send
         + Sync,
 >;
 
 /// Handler function type for shared-responses stream-input RPC methods.
 pub type SharedStreamRpcHandler = Arc<
-    dyn Fn(StreamSource, Context, SessionTx, Name, Arc<str>, PeerResponseStream) -> ResponseStream
+    dyn Fn(StreamSource, Context, SessionTx, Name, Arc<str>, PeerResponseReceiver) -> ResponseStream
         + Send
         + Sync,
 >;
@@ -261,7 +261,7 @@ impl ServiceRegistry {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(Req, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
         Res: Encoder + Send + 'static,
@@ -273,10 +273,10 @@ impl ServiceRegistry {
                   session_tx: SessionTx,
                   _source: Name,
                   rpc_id: Arc<str>,
-                  peer_stream: PeerResponseStream| {
+                  peer_stream: PeerResponseReceiver| {
                 let fut = Req::decode(bytes).map(|req| handler(req, ctx, peer_stream));
                 // Broadcast to the session group so all members (including peer servers)
-                // receive this response and can observe it via PeerResponseStream.
+                // receive this response and can observe it via PeerResponseReceiver.
                 let group = session_tx.destination().clone();
                 async move {
                     let encoded = fut?.await?.encode()?;
@@ -301,7 +301,7 @@ impl ServiceRegistry {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(Req, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
         S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
@@ -314,10 +314,10 @@ impl ServiceRegistry {
                   session_tx: SessionTx,
                   _source: Name,
                   rpc_id: Arc<str>,
-                  peer_stream: PeerResponseStream| {
+                  peer_stream: PeerResponseReceiver| {
                 let fut = Req::decode(bytes).map(|req| handler(req, ctx, peer_stream));
                 // Broadcast to the session group so all members (including peer servers)
-                // receive this response and can observe it via PeerResponseStream.
+                // receive this response and can observe it via PeerResponseReceiver.
                 let group = session_tx.destination().clone();
                 async move {
                     let response_stream = fut?.await?;
@@ -337,7 +337,7 @@ impl ServiceRegistry {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(DecodedStream<Req>, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
         Res: Encoder + Send + 'static,
@@ -349,13 +349,13 @@ impl ServiceRegistry {
                   session_tx: SessionTx,
                   _target: Name,
                   rpc_id: Arc<str>,
-                  peer_stream: PeerResponseStream| {
+                  peer_stream: PeerResponseReceiver| {
                 let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
                     |res| res.and_then(|bytes| Req::decode(bytes));
                 let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
                 let fut = handler(decoded, ctx, peer_stream);
                 // Broadcast to the session group so all members (including peer servers)
-                // receive this response and can observe it via PeerResponseStream.
+                // receive this response and can observe it via PeerResponseReceiver.
                 let group = session_tx.destination().clone();
                 async move {
                     let encoded = fut.await?.encode()?;
@@ -380,7 +380,7 @@ impl ServiceRegistry {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(DecodedStream<Req>, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
         S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
@@ -393,13 +393,13 @@ impl ServiceRegistry {
                   session_tx: SessionTx,
                   _target: Name,
                   rpc_id: Arc<str>,
-                  peer_stream: PeerResponseStream| {
+                  peer_stream: PeerResponseReceiver| {
                 let decode_fn: fn(Result<Vec<u8>, RpcError>) -> Result<Req, RpcError> =
                     |res| res.and_then(|bytes| Req::decode(bytes));
                 let decoded: DecodedStream<Req> = source.into_raw_stream().map(decode_fn);
                 let fut = handler(decoded, ctx, peer_stream);
                 // Broadcast to the session group so all members (including peer servers)
-                // receive this response and can observe it via PeerResponseStream.
+                // receive this response and can observe it via PeerResponseReceiver.
                 let group = session_tx.destination().clone();
                 async move {
                     let response_stream = fut.await?;
@@ -527,7 +527,7 @@ pub struct Server {
     /// Runtime handle for spawning tasks (resolved at construction)
     pub(crate) runtime: tokio::runtime::Handle,
     /// When `true`, sessions that request shared-responses mode are accepted and
-    /// peer response messages are forwarded to handlers via [`PeerResponseStream`].
+    /// peer response messages are forwarded to handlers via [`PeerResponseReceiver`].
     /// When `false` (default), such sessions are rejected with a
     /// `failed_precondition` error on their first RPC call.
     accept_shared_responses: bool,
@@ -537,7 +537,7 @@ pub struct Server {
 /// sender in `pending_streams` so that subsequent messages can be routed to the same task.
 ///
 /// When `peer_rx` is `Some`, the handler is a shared-responses variant: the receiver is
-/// wrapped in a [`PeerResponseStream`] and passed to the handler alongside the request.
+/// wrapped in a [`PeerResponseReceiver`] and passed to the handler alongside the request.
 /// The caller is responsible for storing the corresponding sender in `pending_peer_streams`.
 #[allow(clippy::too_many_arguments)]
 fn spawn_handler_task(
@@ -565,7 +565,7 @@ fn spawn_handler_task(
         HandlerInfo::Unary(_) | HandlerInfo::SharedUnary(_) => None,
     };
 
-    let peer_stream = peer_rx.map(PeerResponseStream::new);
+    let peer_stream = peer_rx.map(PeerResponseReceiver::new);
 
     tokio::spawn(async move {
         let session = match stream_rx {
@@ -600,7 +600,7 @@ fn spawn_handler_task(
 ///
 /// When `accept_shared_responses` is `true` AND the session metadata contains
 /// `SHARED_RESPONSES_KEY = "true"`, peer response messages (tagged `RPC_DIR_KEY = "resp"`)
-/// are forwarded to the handler's [`PeerResponseStream`] instead of being dropped.
+/// are forwarded to the handler's [`PeerResponseReceiver`] instead of being dropped.
 /// If the session requests shared-responses but the server does not accept it
 /// (`accept_shared_responses = false`), the first RPC call on the session is rejected
 /// with a `failed_precondition` error.
@@ -682,7 +682,7 @@ async fn run_session_demux(
 
         // ── Shared-responses: route peer response messages ────────────────────
         // In shared-responses mode, messages tagged RPC_DIR_RESP belong to a peer
-        // server's response stream.  Route them to the handler's PeerResponseStream
+        // server's response stream.  Route them to the handler's PeerResponseReceiver
         // channel if one is registered, then skip normal dispatch.
         // Self-echoes (source == our own name) are discarded — handlers only receive
         // responses from *other* members, and the self-EOS must not close the channel
@@ -710,7 +710,7 @@ async fn run_session_demux(
                     };
                     tracing::debug!(%rpc_id_str, payload_len = peer_msg.payload.len(), "forwarding peer message");
                     if tx.send(peer_msg).is_err() {
-                        // Handler dropped PeerResponseStream — clean up immediately.
+                        // Handler dropped PeerResponseReceiver — clean up immediately.
                         pending_peer_streams.remove(rpc_id_str.as_str());
                         peer_eos_counts.remove(rpc_id_str.as_str());
                     }
@@ -965,7 +965,7 @@ impl Server {
     /// Create a server that accepts shared-responses multicast sessions.
     ///
     /// In a shared-responses session, each server receives both client requests
-    /// AND the responses from all other group members via a [`PeerResponseStream`].
+    /// AND the responses from all other group members via a [`PeerResponseReceiver`].
     /// Register handlers using `register_*_shared` variants to consume peer responses.
     #[cfg(not(feature = "uniffi"))]
     pub fn new_with_shared_responses(
@@ -1317,7 +1317,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(Req, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
         Res: Encoder + Send + 'static,
@@ -1333,7 +1333,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(Req, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
         S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
@@ -1350,7 +1350,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(DecodedStream<Req>, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
         Res: Encoder + Send + 'static,
@@ -1366,7 +1366,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(DecodedStream<Req>, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
         S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
@@ -1726,7 +1726,7 @@ impl Server {
 impl Server {
     /// Register a unary-to-unary shared-responses RPC handler.
     ///
-    /// The handler receives a [`PeerResponseStream`] delivering response messages from
+    /// The handler receives a [`PeerResponseReceiver`] delivering response messages from
     /// peer servers in the multicast group.  Only meaningful when the server was
     /// constructed with [`Server::new_with_shared_responses`] and the client channel
     /// was created with [`Channel::new_group_shared`].
@@ -1736,7 +1736,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(Req, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
         Res: Encoder + Send + 'static,
@@ -1751,7 +1751,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(Req, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(Req, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
         S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
@@ -1767,7 +1767,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(DecodedStream<Req>, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,
         Res: Encoder + Send + 'static,
@@ -1782,7 +1782,7 @@ impl Server {
         method_name: &str,
         handler: F,
     ) where
-        F: Fn(DecodedStream<Req>, Context, PeerResponseStream) -> Fut + Send + Sync + 'static,
+        F: Fn(DecodedStream<Req>, Context, PeerResponseReceiver) -> Fut + Send + Sync + 'static,
         Fut: futures::Future<Output = Result<S, RpcError>> + Send + 'static,
         S: Stream<Item = Result<Res, RpcError>> + Send + 'static,
         Req: Decoder + Send + 'static,

--- a/crates/rpc/src/session_wrapper.rs
+++ b/crates/rpc/src/session_wrapper.rs
@@ -19,7 +19,7 @@ use slim_session::context::SessionContext;
 use slim_session::errors::SessionError;
 use slim_session::{AppChannelReceiver, CompletionHandle};
 
-use super::{RpcCode, RpcError, STATUS_CODE_KEY};
+use super::{RPC_DIR_KEY, RPC_DIR_RESP, RpcCode, RpcError, STATUS_CODE_KEY};
 
 /// Received message from a session
 #[derive(Debug, Clone)]
@@ -50,6 +50,12 @@ impl ReceivedMessage {
             && RpcCode::from_metadata_str(self.metadata.get(STATUS_CODE_KEY).map(String::as_str))
                 == RpcCode::Ok
             && self.payload.is_empty()
+    }
+
+    /// Returns `true` when this message is a peer server response (carries
+    /// `slimrpc-dir = "resp"`), as opposed to a client request (`"req"`).
+    pub fn is_peer_response(&self) -> bool {
+        self.metadata.get(RPC_DIR_KEY).map(String::as_str) == Some(RPC_DIR_RESP)
     }
 }
 

--- a/crates/rpc/src/stream_types.rs
+++ b/crates/rpc/src/stream_types.rs
@@ -12,6 +12,8 @@ use std::task::Poll;
 
 use tokio::sync::mpsc;
 
+use slim_datapath::api::ProtoName as Name;
+
 use super::{ReceivedMessage, RpcCode, RpcError, STATUS_CODE_KEY};
 
 // The UniFFI FFI stream wrapper types below use these; the native raw stream
@@ -163,6 +165,106 @@ impl StreamSource {
             first_code: self.first_code,
             first_done: false,
             done: false,
+        }
+    }
+}
+
+// ── Shared-responses types ────────────────────────────────────────────────────
+
+/// A single response message received from a peer server in shared-responses
+/// multicast mode.
+///
+/// The payload is the raw encoded bytes of the peer's response; the application
+/// should decode them as the expected `Res` type using [`Decoder::decode`].
+#[derive(Debug, Clone)]
+pub struct PeerMessage {
+    /// The server that produced this response.
+    pub source: Name,
+    /// Raw encoded response bytes.
+    pub payload: Vec<u8>,
+}
+
+/// Async stream of peer response messages delivered in shared-responses
+/// multicast mode.
+///
+/// Yields [`PeerMessage`] items as peer servers send their responses. Returns
+/// `None` when all peers have finished (their EOS markers have been processed).
+pub struct PeerResponseStream {
+    rx: mpsc::UnboundedReceiver<PeerMessage>,
+}
+
+impl PeerResponseStream {
+    pub fn new(rx: mpsc::UnboundedReceiver<PeerMessage>) -> Self {
+        Self { rx }
+    }
+
+    /// Receive the next peer response, or `None` if all peers are done.
+    pub async fn next(&mut self) -> Option<PeerMessage> {
+        self.rx.recv().await
+    }
+
+    /// Consume `self` and return the inner mpsc receiver.
+    pub fn into_receiver(self) -> mpsc::UnboundedReceiver<PeerMessage> {
+        self.rx
+    }
+}
+
+#[cfg(feature = "uniffi")]
+/// A single message from the peer response stream, returned by [`UniffiPeerResponseStream::next`].
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum PeerStreamMessage {
+    /// A peer server sent a response.
+    Data {
+        /// SLIM name of the peer that produced the response.
+        source: Arc<slim_bindings::Name>,
+        /// Raw encoded response bytes (decode as the expected `Res` type).
+        payload: Vec<u8>,
+    },
+    /// All peers have finished — the stream has ended.
+    End,
+}
+
+#[cfg(feature = "uniffi")]
+/// Peer-response stream reader for shared-responses multicast mode.
+///
+/// Yields one item per response sent by a peer server in the GROUP session.
+/// Returns [`PeerStreamMessage::End`] when all peers have finished.
+///
+/// Obtain an instance by registering a handler via one of the `register_*_shared`
+/// methods on [`Server`](crate::Server); the runtime passes it as the last
+/// argument to the handler callback.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct UniffiPeerResponseStream {
+    inner: TokioMutex<mpsc::UnboundedReceiver<PeerMessage>>,
+}
+
+#[cfg(feature = "uniffi")]
+impl UniffiPeerResponseStream {
+    /// Create a new peer response stream wrapper from the raw mpsc receiver.
+    pub fn new(rx: mpsc::UnboundedReceiver<PeerMessage>) -> Self {
+        Self {
+            inner: TokioMutex::new(rx),
+        }
+    }
+}
+
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
+impl UniffiPeerResponseStream {
+    /// Pull the next peer response message (blocking version).
+    pub fn next(&self) -> PeerStreamMessage {
+        crate::get_runtime().block_on(self.next_async())
+    }
+
+    /// Pull the next peer response message (async version).
+    pub async fn next_async(&self) -> PeerStreamMessage {
+        let mut rx = self.inner.lock().await;
+        match rx.recv().await {
+            Some(msg) => PeerStreamMessage::Data {
+                source: Arc::new(slim_bindings::Name::from_slim_name(msg.source)),
+                payload: msg.payload,
+            },
+            None => PeerStreamMessage::End,
         }
     }
 }

--- a/crates/rpc/src/stream_types.rs
+++ b/crates/rpc/src/stream_types.rs
@@ -184,16 +184,18 @@ pub struct PeerMessage {
     pub payload: Vec<u8>,
 }
 
-/// Async stream of peer response messages delivered in shared-responses
-/// multicast mode.
+/// Async channel of peer response messages delivered in shared-responses
+/// multicast mode (native Rust handler side).
 ///
 /// Yields [`PeerMessage`] items as peer servers send their responses. Returns
 /// `None` when all peers have finished (their EOS markers have been processed).
-pub struct PeerResponseStream {
+///
+/// Language-binding callers receive [`PeerResponseStream`] instead.
+pub struct PeerResponseReceiver {
     rx: mpsc::UnboundedReceiver<PeerMessage>,
 }
 
-impl PeerResponseStream {
+impl PeerResponseReceiver {
     pub fn new(rx: mpsc::UnboundedReceiver<PeerMessage>) -> Self {
         Self { rx }
     }
@@ -210,7 +212,7 @@ impl PeerResponseStream {
 }
 
 #[cfg(feature = "uniffi")]
-/// A single message from the peer response stream, returned by [`UniffiPeerResponseStream::next`].
+/// A single message from the peer response stream, returned by [`PeerResponseStream::next`].
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum PeerStreamMessage {
     /// A peer server sent a response.
@@ -234,12 +236,12 @@ pub enum PeerStreamMessage {
 /// methods on [`Server`](crate::Server); the runtime passes it as the last
 /// argument to the handler callback.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct UniffiPeerResponseStream {
+pub struct PeerResponseStream {
     inner: TokioMutex<mpsc::UnboundedReceiver<PeerMessage>>,
 }
 
 #[cfg(feature = "uniffi")]
-impl UniffiPeerResponseStream {
+impl PeerResponseStream {
     /// Create a new peer response stream wrapper from the raw mpsc receiver.
     pub fn new(rx: mpsc::UnboundedReceiver<PeerMessage>) -> Self {
         Self {
@@ -250,7 +252,7 @@ impl UniffiPeerResponseStream {
 
 #[cfg(feature = "uniffi")]
 #[uniffi::export]
-impl UniffiPeerResponseStream {
+impl PeerResponseStream {
     /// Pull the next peer response message (blocking version).
     pub fn next(&self) -> PeerStreamMessage {
         crate::get_runtime().block_on(self.next_async())

--- a/crates/rpc/tests/multicast.rs
+++ b/crates/rpc/tests/multicast.rs
@@ -39,7 +39,8 @@ use slim_service::service::Service;
 const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
 
 use slim_rpc::{
-    Channel, Context, DecodedStream, Decoder, Encoder, MulticastItem, RpcError, Server,
+    Channel, Context, DecodedStream, Decoder, Encoder, MulticastItem, PeerMessage,
+    PeerResponseStream, RpcError, Server,
 };
 
 // ============================================================================
@@ -1089,6 +1090,567 @@ async fn test_channel_close_after_rpc() {
         collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "second call").await;
     assert_eq!(responses.len(), NUM_MEMBERS);
     assert!(responses.iter().all(|r| r.message.result == "second"));
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Shared-responses helpers
+// ============================================================================
+
+/// Build a fresh `MulticastTestEnv` whose channel uses shared-responses mode
+/// and whose servers opt in via `Server::new_with_shared_responses`.
+async fn new_shared_env(test_name: &str, num_members: usize) -> MulticastTestEnv {
+    let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+    let service = Arc::new(Service::new(id));
+
+    let mut member_servers = Vec::new();
+    let mut member_app_names = Vec::new();
+    for i in 0..num_members {
+        let member_app_name = Name::from_strings(["org", "ns", &format!("shared-member-{i}")]);
+        let secret = SharedSecret::new("test", TEST_VALID_SECRET).unwrap();
+        let (app, notifications) = service
+            .create_app(
+                &member_app_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        let app = Arc::new(app);
+        let server = Arc::new(Server::new_with_shared_responses(
+            app.clone(),
+            member_app_name.clone(),
+            None,
+            notifications,
+            None,
+        ));
+        member_app_names.push(member_app_name);
+        member_servers.push(server);
+    }
+
+    let client_name = Name::from_strings(["org", "ns", "shared-client"]);
+    let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+    let (client_app, _) = service
+        .create_app(
+            &client_name,
+            AuthProvider::shared_secret(secret.clone()),
+            AuthVerifier::shared_secret(secret),
+        )
+        .unwrap();
+    let channel =
+        Channel::new_with_members_shared(Arc::new(client_app), member_app_names, None)
+            .expect("failed to create shared-responses channel");
+
+    MulticastTestEnv {
+        service,
+        member_servers,
+        channel,
+    }
+}
+
+/// Collect at most `n` `PeerMessage`s from `peer_stream` within `timeout`.
+async fn collect_peer_messages(
+    peer_stream: &mut PeerResponseStream,
+    n: usize,
+    timeout: Duration,
+) -> Vec<PeerMessage> {
+    let mut out = Vec::new();
+    let _ = tokio::time::timeout(timeout, async {
+        for _ in 0..n {
+            match peer_stream.next().await {
+                Some(msg) => out.push(msg),
+                None => break,
+            }
+        }
+    })
+    .await;
+    out
+}
+
+// ============================================================================
+// Test: shared-responses unary
+// ============================================================================
+
+/// Two servers opt in; client uses `new_with_members_shared`.
+/// Each server handler collects the *other* server's response via `PeerResponseStream`,
+/// while the client also collects both responses via the multicast stream.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_shared_responses_unary() {
+    use std::sync::Mutex;
+
+    const NUM_MEMBERS: usize = 2;
+    let mut env = new_shared_env("test-shared-unary", NUM_MEMBERS).await;
+
+    // Each server records the peer messages it received.
+    let peer_payloads: Vec<Arc<Mutex<Vec<Vec<u8>>>>> = (0..NUM_MEMBERS)
+        .map(|_| Arc::new(Mutex::new(Vec::new())))
+        .collect();
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        let collected = peer_payloads[i].clone();
+        server.register_unary_unary_shared(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseStream| {
+                let collected = collected.clone();
+                async move {
+                    // Collect peer responses in the background so this handler can
+                    // return its own response without deadlocking on the other server.
+                    tokio::spawn(async move {
+                        let peers = collect_peer_messages(
+                            &mut peer,
+                            NUM_MEMBERS - 1,
+                            Duration::from_secs(5),
+                        )
+                        .await;
+                        let mut guard = collected.lock().unwrap();
+                        for p in peers {
+                            guard.push(p.payload.clone());
+                        }
+                    });
+                    Ok(TestResponse {
+                        member_id: i,
+                        result: format!("M{i}: {}", req.message),
+                        count: req.value + i as i32,
+                    })
+                }
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "hello".to_string(),
+            value: 10,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses =
+        collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "shared-unary").await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+
+    // Give handlers time to finish collecting peer messages.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Each server should have seen exactly one peer message.
+    for (i, collected) in peer_payloads.iter().enumerate() {
+        let guard = collected.lock().unwrap();
+        assert_eq!(
+            guard.len(),
+            NUM_MEMBERS - 1,
+            "server {i} saw {} peer messages, expected {}",
+            guard.len(),
+            NUM_MEMBERS - 1
+        );
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: shared-responses stream
+// ============================================================================
+
+/// Two servers opt in with stream handlers.
+/// Each server collects the other's response frames via `PeerResponseStream`.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_shared_responses_stream() {
+    use std::sync::Mutex;
+
+    const NUM_MEMBERS: usize = 2;
+    let mut env = new_shared_env("test-shared-stream", NUM_MEMBERS).await;
+
+    let peer_counts: Vec<Arc<Mutex<usize>>> = (0..NUM_MEMBERS)
+        .map(|_| Arc::new(Mutex::new(0usize)))
+        .collect();
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        let counter = peer_counts[i].clone();
+        server.register_unary_stream_shared(
+            "TestService",
+            "StreamEcho",
+            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseStream| {
+                let counter = counter.clone();
+                async move {
+                    let c = req.value as usize;
+                    // Concurrently drain the peer stream.
+                    tokio::spawn(async move {
+                        let mut seen = 0usize;
+                        while let Some(_msg) = peer.next().await {
+                            seen += 1;
+                        }
+                        *counter.lock().unwrap() = seen;
+                    });
+                    // Return `c` response frames.
+                    let responses: Vec<Result<TestResponse, RpcError>> = (0..c)
+                        .map(|j| {
+                            Ok(TestResponse {
+                                member_id: i,
+                                result: format!("M{i}:{j}"),
+                                count: j as i32,
+                            })
+                        })
+                        .collect();
+                    Ok(stream::iter(responses))
+                }
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let frames_each = 2usize;
+    let stream = env.channel.multicast_unary_stream::<TestRequest, TestResponse>(
+        "TestService",
+        "StreamEcho",
+        TestRequest {
+            message: "stream".to_string(),
+            value: frames_each as i32,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses = collect_n_multicast(
+        stream,
+        NUM_MEMBERS * frames_each,
+        Duration::from_secs(10),
+        "shared-stream",
+    )
+    .await;
+    assert_eq!(responses.len(), NUM_MEMBERS * frames_each);
+
+    // Give peer-drain tasks time to finish.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Each server should have seen >= frames_each peer frames from the other server.
+    for (i, counter) in peer_counts.iter().enumerate() {
+        let seen = *counter.lock().unwrap();
+        assert!(
+            seen >= frames_each,
+            "server {i} saw {seen} peer frames, expected >= {frames_each}"
+        );
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: peer EOS does not close the request stream
+// ============================================================================
+
+/// Verify that the handler's `DecodedStream<Req>` remains open after the peer
+/// sends its EOS — the two streams are completely independent.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_shared_responses_peer_eos_not_terminal() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = new_shared_env("test-shared-peer-eos", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_stream_unary_shared(
+            "TestService",
+            "Sum",
+            move |mut req_stream: DecodedStream<TestRequest>,
+                  _ctx: Context,
+                  mut peer: PeerResponseStream| async move {
+                let mut total = 0i32;
+                while let Some(r) = req_stream.next().await {
+                    let req = r?;
+                    total += req.value;
+                }
+                // Drain peer stream in background so we can send our response
+                // without deadlocking on the other server's peer EOS.
+                tokio::spawn(async move {
+                    while let Some(_) = peer.next().await {}
+                });
+                Ok(TestResponse {
+                    member_id: i,
+                    result: "sum".to_string(),
+                    count: total,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let requests: Vec<TestRequest> = (1..=3)
+        .map(|v| TestRequest {
+            message: "n".to_string(),
+            value: v,
+        })
+        .collect();
+    let request_stream = stream::iter(requests);
+    let result_stream = env
+        .channel
+        .multicast_stream_unary::<TestRequest, TestResponse>(
+            "TestService",
+            "Sum",
+            request_stream,
+            Some(Duration::from_secs(10)),
+            None,
+        );
+    let responses =
+        collect_n_multicast(result_stream, NUM_MEMBERS, Duration::from_secs(10), "peer-eos").await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    for r in &responses {
+        assert_eq!(r.message.count, 6, "server {} returned wrong sum", r.message.member_id);
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: server rejects shared-responses session
+// ============================================================================
+
+/// One server opts in (`accept_shared_responses = true`), the other does not.
+/// The non-opting server should return a `failed_precondition` error while the
+/// opting server succeeds.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_shared_responses_server_rejects() {
+    use slim_rpc::RpcCode;
+
+    let id = ID::new_with_name(Kind::new("slim").unwrap(), "test-shared-reject").unwrap();
+    let service = Arc::new(Service::new(id));
+
+    let make_app = |app_name: &Name| {
+        let secret = SharedSecret::new("test", TEST_VALID_SECRET).unwrap();
+        let (app, notifications) = service
+            .create_app(
+                app_name,
+                AuthProvider::shared_secret(secret.clone()),
+                AuthVerifier::shared_secret(secret),
+            )
+            .unwrap();
+        (Arc::new(app), notifications)
+    };
+
+    // Member 0 — accepts shared-responses.
+    let name0 = Name::from_strings(["org", "ns", "reject-member-0"]);
+    let (app0, notif0) = make_app(&name0);
+    let server0 = Arc::new(Server::new_with_shared_responses(
+        app0.clone(),
+        name0.clone(),
+        None,
+        notif0,
+        None,
+    ));
+    server0.register_unary_unary_shared(
+        "TestService",
+        "Echo",
+        |req: TestRequest, _ctx: Context, _peer: PeerResponseStream| async move {
+            Ok(TestResponse {
+                member_id: 0,
+                result: req.message,
+                count: 0,
+            })
+        },
+    );
+
+    // Member 1 — standard server, does NOT accept shared-responses.
+    let name1 = Name::from_strings(["org", "ns", "reject-member-1"]);
+    let (app1, notif1) = make_app(&name1);
+    let server1 = Arc::new(Server::new(app1.clone(), name1.clone(), notif1));
+    server1.register_unary_unary(
+        "TestService",
+        "Echo",
+        |req: TestRequest, _ctx: Context| async move {
+            Ok(TestResponse {
+                member_id: 1,
+                result: req.message,
+                count: 0,
+            })
+        },
+    );
+
+    let s0 = server0.clone();
+    tokio::spawn(async move { s0.serve().await });
+    let s1 = server1.clone();
+    tokio::spawn(async move { s1.serve().await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client_name = Name::from_strings(["org", "ns", "reject-client"]);
+    let secret = SharedSecret::new("client", TEST_VALID_SECRET).unwrap();
+    let (client_app, _) = service
+        .create_app(
+            &client_name,
+            AuthProvider::shared_secret(secret.clone()),
+            AuthVerifier::shared_secret(secret),
+        )
+        .unwrap();
+    let channel =
+        Channel::new_with_members_shared(Arc::new(client_app), vec![name0, name1], None)
+            .expect("channel creation ok");
+
+    let stream = channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "test".to_string(),
+            value: 0,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    // Collect 2 items: one success (server0) and one error (server1).
+    let results =
+        collect_n_mixed(stream, 2, Duration::from_secs(10), "reject-test").await;
+    assert_eq!(results.len(), 2);
+    let errors: Vec<_> = results.iter().filter(|r| r.is_err()).collect();
+    let successes: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+    assert_eq!(successes.len(), 1, "expected 1 success");
+    assert_eq!(errors.len(), 1, "expected 1 error");
+    let err = errors[0].as_ref().unwrap_err();
+    assert_eq!(
+        err.code(),
+        RpcCode::FailedPrecondition,
+        "rejecting server must return failed_precondition, got {:?}",
+        err.code()
+    );
+
+    channel.close(None).await.ok();
+    server0.shutdown().await;
+    server1.shutdown().await;
+    service.shutdown().await.unwrap();
+}
+
+// ============================================================================
+// Test: shared-responses default off (regression)
+// ============================================================================
+
+/// Standard GROUP channel + standard servers (no opt-in).
+/// No peer messages should arrive; existing behavior unchanged.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_shared_responses_default_off() {
+    const NUM_MEMBERS: usize = 2;
+    let mut env = MulticastTestEnv::new("test-shared-default-off", NUM_MEMBERS).await;
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        server.register_unary_unary(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context| async move {
+                Ok(TestResponse {
+                    member_id: i,
+                    result: req.message,
+                    count: req.value,
+                })
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "normal".to_string(),
+            value: 1,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses = collect_n_multicast(
+        stream,
+        NUM_MEMBERS,
+        Duration::from_secs(10),
+        "default-off",
+    )
+    .await;
+    assert_eq!(responses.len(), NUM_MEMBERS);
+    for r in &responses {
+        assert_eq!(r.message.result, "normal");
+    }
+
+    env.shutdown().await;
+}
+
+// ============================================================================
+// Test: shared-responses with 3 servers (N>2 regression)
+// ============================================================================
+
+/// Three servers each register a unary-unary-shared handler.
+/// Each server should receive exactly 2 peer messages (one from each other server).
+/// This is a regression test for the single-EOS-closes bug that affected N>2 groups.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_multicast_shared_responses_three_servers() {
+    use std::sync::Mutex;
+
+    const NUM_MEMBERS: usize = 3;
+    let mut env = new_shared_env("test-shared-three", NUM_MEMBERS).await;
+
+    let peer_payloads: Vec<Arc<Mutex<Vec<Vec<u8>>>>> = (0..NUM_MEMBERS)
+        .map(|_| Arc::new(Mutex::new(Vec::new())))
+        .collect();
+
+    for (i, server) in env.member_servers.iter().enumerate() {
+        let collected = peer_payloads[i].clone();
+        server.register_unary_unary_shared(
+            "TestService",
+            "Echo",
+            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseStream| {
+                let collected = collected.clone();
+                async move {
+                    // Collect peer responses in background so no deadlock.
+                    tokio::spawn(async move {
+                        let peers = collect_peer_messages(
+                            &mut peer,
+                            NUM_MEMBERS - 1,
+                            Duration::from_secs(5),
+                        )
+                        .await;
+                        let mut guard = collected.lock().unwrap();
+                        for p in peers {
+                            guard.push(p.payload.clone());
+                        }
+                    });
+                    Ok(TestResponse {
+                        member_id: i,
+                        result: format!("M{i}: {}", req.message),
+                        count: req.value + i as i32,
+                    })
+                }
+            },
+        );
+    }
+    env.start_all_servers().await;
+
+    let stream = env.channel.multicast_unary::<TestRequest, TestResponse>(
+        "TestService",
+        "Echo",
+        TestRequest {
+            message: "three".to_string(),
+            value: 1,
+        },
+        Some(Duration::from_secs(10)),
+        None,
+    );
+    let responses =
+        collect_n_multicast(stream, NUM_MEMBERS, Duration::from_secs(10), "three-servers").await;
+    assert_eq!(responses.len(), NUM_MEMBERS, "client should receive all 3 responses");
+
+    // Give background peer-collection tasks time to finish.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // Each server should have received exactly 2 peer messages (one from each other server).
+    for (i, collected) in peer_payloads.iter().enumerate() {
+        let guard = collected.lock().unwrap();
+        assert_eq!(
+            guard.len(),
+            NUM_MEMBERS - 1,
+            "server {i} saw {} peer messages, expected {}",
+            guard.len(),
+            NUM_MEMBERS - 1
+        );
+    }
 
     env.shutdown().await;
 }

--- a/crates/rpc/tests/multicast.rs
+++ b/crates/rpc/tests/multicast.rs
@@ -40,7 +40,7 @@ const TEST_VALID_SECRET: &str = "test-shared-secret-value-0123456789abcdef";
 
 use slim_rpc::{
     Channel, Context, DecodedStream, Decoder, Encoder, MulticastItem, PeerMessage,
-    PeerResponseStream, RpcError, Server,
+    PeerResponseReceiver, RpcError, Server,
 };
 
 // ============================================================================
@@ -1150,7 +1150,7 @@ async fn new_shared_env(test_name: &str, num_members: usize) -> MulticastTestEnv
 
 /// Collect at most `n` `PeerMessage`s from `peer_stream` within `timeout`.
 async fn collect_peer_messages(
-    peer_stream: &mut PeerResponseStream,
+    peer_stream: &mut PeerResponseReceiver,
     n: usize,
     timeout: Duration,
 ) -> Vec<PeerMessage> {
@@ -1172,7 +1172,7 @@ async fn collect_peer_messages(
 // ============================================================================
 
 /// Two servers opt in; client uses `new_with_members_shared`.
-/// Each server handler collects the *other* server's response via `PeerResponseStream`,
+/// Each server handler collects the *other* server's response via `PeerResponseReceiver`,
 /// while the client also collects both responses via the multicast stream.
 #[tokio::test]
 #[tracing_test::traced_test]
@@ -1192,7 +1192,7 @@ async fn test_multicast_shared_responses_unary() {
         server.register_unary_unary_shared(
             "TestService",
             "Echo",
-            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseStream| {
+            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseReceiver| {
                 let collected = collected.clone();
                 async move {
                     // Collect peer responses in the background so this handler can
@@ -1257,7 +1257,7 @@ async fn test_multicast_shared_responses_unary() {
 // ============================================================================
 
 /// Two servers opt in with stream handlers.
-/// Each server collects the other's response frames via `PeerResponseStream`.
+/// Each server collects the other's response frames via `PeerResponseReceiver`.
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn test_multicast_shared_responses_stream() {
@@ -1275,7 +1275,7 @@ async fn test_multicast_shared_responses_stream() {
         server.register_unary_stream_shared(
             "TestService",
             "StreamEcho",
-            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseStream| {
+            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseReceiver| {
                 let counter = counter.clone();
                 async move {
                     let c = req.value as usize;
@@ -1357,7 +1357,7 @@ async fn test_multicast_shared_responses_peer_eos_not_terminal() {
             "Sum",
             move |mut req_stream: DecodedStream<TestRequest>,
                   _ctx: Context,
-                  mut peer: PeerResponseStream| async move {
+                  mut peer: PeerResponseReceiver| async move {
                 let mut total = 0i32;
                 while let Some(r) = req_stream.next().await {
                     let req = r?;
@@ -1444,7 +1444,7 @@ async fn test_multicast_shared_responses_server_rejects() {
     server0.register_unary_unary_shared(
         "TestService",
         "Echo",
-        |req: TestRequest, _ctx: Context, _peer: PeerResponseStream| async move {
+        |req: TestRequest, _ctx: Context, _peer: PeerResponseReceiver| async move {
             Ok(TestResponse {
                 member_id: 0,
                 result: req.message,
@@ -1596,7 +1596,7 @@ async fn test_multicast_shared_responses_three_servers() {
         server.register_unary_unary_shared(
             "TestService",
             "Echo",
-            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseStream| {
+            move |req: TestRequest, _ctx: Context, mut peer: PeerResponseReceiver| {
                 let collected = collected.clone();
                 async move {
                     // Collect peer responses in background so no deadlock.

--- a/crates/rpc/tests/multicast.rs
+++ b/crates/rpc/tests/multicast.rs
@@ -1327,12 +1327,12 @@ async fn test_multicast_shared_responses_stream() {
     // Give peer-drain tasks time to finish.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Each server should have seen >= frames_each peer frames from the other server.
+    // Each server should have seen exactly frames_each peer data frames (no EOS leak).
     for (i, counter) in peer_counts.iter().enumerate() {
         let seen = *counter.lock().unwrap();
-        assert!(
-            seen >= frames_each,
-            "server {i} saw {seen} peer frames, expected >= {frames_each}"
+        assert_eq!(
+            seen, frames_each,
+            "server {i} saw {seen} peer frames, expected {frames_each}"
         );
     }
 


### PR DESCRIPTION
## Description

Adds shared-responses multicast mode to SlimRPC. In a GROUP session each server
normally handles the client's request in isolation. Shared-responses mode lets
every server also receive the response payloads of its peers, enabling
coordination patterns (aggregation, quorum, fan-in) without an external
message bus.

**Design** — per-call opt-in via metadata:

- Pass `SHARED_RESPONSES_KEY = "true"` in the per-call `metadata` argument
  to enable shared-responses for a single RPC call on any GROUP channel.
  Plain multicast and shared-responses calls can mix freely on the same channel.
- `make_shared_responses_metadata() -> Metadata` UniFFI helper builds the map.
- Each server handler receives a `PeerResponseReceiver` / `PeerResponseStream`
  (UniFFI) that delivers `PeerMessage { source, payload }` frames from peers.
- Peer count is derived at call-dispatch time from `SessionController::participants_list()`
  (excludes self and the request source/client), so no client-side member count needed.
- `Channel::local_name()` accessor added for UniFFI callers that need the app name.

**Breaking changes vs prior draft:**

- Removed `Channel::new_group_shared` / `new_group_shared_with_connection`
- Removed `Server::new_with_shared_responses` / `new_with_shared_responses_and_connection`
- Removed `SHARED_RESPONSES_MEMBER_COUNT_KEY` constant
- `UniffiPeerResponseStream` renamed to `PeerResponseStream` (bindings-visible name)

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass