### PR TITLE
chore(deps): remove oauth2 dep with deprecated transients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,6 @@ dependencies = [
  "mls-rs-core",
  "mls-rs-crypto-awslc",
  "notify",
- "oauth2",
  "p256",
  "parking_lot",
  "pin-project",
@@ -573,17 +572,19 @@ dependencies = [
  "agntcy-slim-tracing",
  "agntcy-slim-version",
  "anyhow",
+ "base64 0.23.1",
  "chrono",
  "clap",
  "duration-string",
  "jsonwebtoken",
- "oauth2",
  "prost",
  "prost-types",
+ "rand 0.10.2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -4079,26 +4080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "getrandom 0.2.17",
- "http",
- "rand 0.8.8",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5551,17 +5532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6806,7 +6776,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,40 +1,40 @@
 [workspace]
 
 members = [
-  "crates/auth",
-  "crates/channel-manager",
-  "crates/config",
-  "crates/control-plane",
-  "crates/controller",
-  "crates/datapath",
-  "crates/examples",
-  "crates/mls",
-  "crates/persistence",
-  "crates/proto",
-  "crates/rpc",
-  "crates/service",
-  "crates/session",
-  "crates/signal",
-  "crates/slim",
-  "crates/slim-bindings",
-  "crates/slimctl",
-  "crates/testing",
-  "crates/tracing",
-  "crates/version",
+    "crates/auth",
+    "crates/channel-manager",
+    "crates/config",
+    "crates/control-plane",
+    "crates/controller",
+    "crates/datapath",
+    "crates/examples",
+    "crates/mls",
+    "crates/persistence",
+    "crates/proto",
+    "crates/rpc",
+    "crates/service",
+    "crates/session",
+    "crates/signal",
+    "crates/slim",
+    "crates/slim-bindings",
+    "crates/slimctl",
+    "crates/testing",
+    "crates/tracing",
+    "crates/version",
 ]
 default-members = [
-  "crates/control-plane",
-  "crates/channel-manager",
-  "crates/config",
-  "crates/datapath",
-  "crates/service",
-  "crates/signal",
-  "crates/slim",
-  "crates/tracing",
-  "crates/version",
-  "crates/examples",
-  "crates/slimctl",
-  "crates/testing",
+    "crates/control-plane",
+    "crates/channel-manager",
+    "crates/config",
+    "crates/datapath",
+    "crates/service",
+    "crates/signal",
+    "crates/slim",
+    "crates/tracing",
+    "crates/version",
+    "crates/examples",
+    "crates/slimctl",
+    "crates/testing",
 ]
 
 resolver = "2"
@@ -77,17 +77,17 @@ clap = { version = "4.5.23", features = ["derive", "env"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 diesel = { version = "2.3.10", features = ["sqlite"] }
 diesel-async = { version = "0.9", features = [
-  "sqlite",
-  "deadpool",
-  "migrations",
+    "sqlite",
+    "deadpool",
+    "migrations",
 ] }
 diesel_migrations = { version = "2" }
 display-error-chain = { version = "0.2" }
 drain = { version = "0.2", features = ["retain"] }
 duration-string = { version = "0.5.3", features = ["serde"] }
 fastwebsockets = { version = "0.10.0", features = [
-  "upgrade",
-  "unstable-split",
+    "upgrade",
+    "unstable-split",
 ] }
 fs2 = "0.4"
 futures = "0.3.31"
@@ -96,7 +96,7 @@ futures-timer = "3.0.3"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 # Browser WebSocket transport for the wasm32 build of the data plane.
 gloo-net = { version = "0.7", default-features = false, features = [
-  "websocket",
+    "websocket",
 ] }
 h2 = "0.4.7"
 headers = "0.4.1"
@@ -110,8 +110,8 @@ http = "1.2.0"
 http-body-util = "0.1.3"
 hyper = { version = "1.8.1", features = ["http1", "server", "client"] }
 hyper-rustls = { version = "0.27", features = [
-  "http2",
-  "aws-lc-rs",
+    "http2",
+    "aws-lc-rs",
 ], default-features = false }
 hyper-util = "0.1.10"
 indexmap = "2"
@@ -121,9 +121,9 @@ js-sys = "0.3"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 k8s-openapi = { version = "0.28", default-features = false }
 kube = { version = "4.2", default-features = false, features = [
-  "client",
-  "runtime",
-  "rustls-tls",
+    "client",
+    "runtime",
+    "rustls-tls",
 ] }
 
 lazy_static = "1.5.0"
@@ -139,24 +139,23 @@ mls-rs-crypto-webcrypto = { version = "0.15" }
 # Plain (statically-bundled) SQLite backend for the persistence crate; values
 # are encrypted by us via aws-lc-rs, so no SQLCipher/OpenSSL is linked.
 mls-rs-provider-sqlite = { version = "0.23", default-features = false, features = [
-  "sqlite-bundled",
+    "sqlite-bundled",
 ] }
 notify = "8.0.0"
 num_cpus = "1.16"
-oauth2 = { version = "5", default-features = false, features = ["reqwest"] }
 once_cell = "1.21.0"
 opentelemetry = { version = "0.32.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.32.0", features = [
-  "metrics",
-  "grpc-tonic",
+    "metrics",
+    "grpc-tonic",
 ] }
 opentelemetry-semantic-conventions = { version = "0.32.0", features = [
-  "semconv_experimental",
+    "semconv_experimental",
 ] }
 opentelemetry-stdout = "0.32.0"
 opentelemetry_sdk = { version = "0.32.0", default-features = false, features = [
-  "trace",
-  "rt-tokio",
+    "trace",
+    "rt-tokio",
 ] }
 parking_lot = "0.12.3"
 percent-encoding = "2.3"
@@ -173,13 +172,13 @@ regex = "1.11.1"
 regorus = "0.11.0"
 
 reqwest = { version = "0.12", features = [
-  "json",
-  "rustls-tls-no-provider",
-  "rustls-tls-native-roots-no-provider",
-  "charset",
-  "http2",
-  "system-proxy",
-  "blocking",
+    "json",
+    "rustls-tls-no-provider",
+    "rustls-tls-native-roots-no-provider",
+    "charset",
+    "http2",
+    "system-proxy",
+    "blocking",
 ], default-features = false }
 rlimit = "0.11.0"
 rstest = "0.25"
@@ -194,9 +193,9 @@ serde_yaml = "0.9.34"
 sha2 = "0.11"
 smallvec = "1"
 spiffe = { version = "0.12.0", features = [
-  "x509-source",
-  "jwt-source",
-  "jwt-verify-aws-lc-rs",
+    "x509-source",
+    "jwt-source",
+    "jwt-verify-aws-lc-rs",
 ] }
 tempfile = "3"
 test-fork = "0.1.3"
@@ -231,7 +230,7 @@ wiremock = "0.6"
 # Pure-Rust X25519 ECDH for the wasm32 inter-node link negotiation (aws-lc-rs is
 # native-only). `static_secrets` exposes the bytes we need for HKDF.
 x25519-dalek = { version = "2", default-features = false, features = [
-  "static_secrets",
+    "static_secrets",
 ] }
 zeroize = "1.9"
 
@@ -243,20 +242,20 @@ repository = "https://github.com/agntcy/slim"
 
 [workspace.metadata.cargo-machete]
 ignored = [
-  "agntcy-slim",
-  "agntcy-slim-auth",
-  "agntcy-slim-bindings",
-  "agntcy-slim-config",
-  "agntcy-slim-controller",
-  "agntcy-slim-datapath",
-  "agntcy-slim-mls",
-  "agntcy-slim-persistence",
-  "agntcy-slim-rpc",
-  "agntcy-slim-service",
-  "agntcy-slim-session",
-  "agntcy-slim-signal",
-  "agntcy-slim-testing",
-  "agntcy-slim-tracing",
-  "agntcy-slim-version",
-  "agntcy-slimctl",
+    "agntcy-slim",
+    "agntcy-slim-auth",
+    "agntcy-slim-bindings",
+    "agntcy-slim-config",
+    "agntcy-slim-controller",
+    "agntcy-slim-datapath",
+    "agntcy-slim-mls",
+    "agntcy-slim-persistence",
+    "agntcy-slim-rpc",
+    "agntcy-slim-service",
+    "agntcy-slim-session",
+    "agntcy-slim-signal",
+    "agntcy-slim-testing",
+    "agntcy-slim-tracing",
+    "agntcy-slim-version",
+    "agntcy-slimctl",
 ]

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -57,7 +57,6 @@ headers = { workspace = true }
 jsonwebtoken = { workspace = true }
 mls-rs-crypto-awslc = { workspace = true }
 notify = { workspace = true }
-oauth2 = { workspace = true, features = ["reqwest"] }
 pin-project = { workspace = true }
 regorus = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/auth/src/errors.rs
+++ b/crates/auth/src/errors.rs
@@ -54,8 +54,6 @@ pub enum AuthError {
     OidcMissingKidWithMultipleKeys,
     #[error("OIDC Token Provider does not support custom claims")]
     OidcUnsupportedCustomClaims,
-    #[error("OAuth2 request error: {0}")]
-    OAuth2Request(Box<dyn std::error::Error + Send + Sync>),
     #[error("Token endpoint error: status {status}, body: {body}")]
     TokenEndpointError { status: u16, body: String },
     #[error("Invalid client credentials")]

--- a/crates/auth/src/oidc.rs
+++ b/crates/auth/src/oidc.rs
@@ -5,13 +5,14 @@ use crate::errors::AuthError;
 use crate::jwt::extract_sub_claim_unsafe;
 use crate::resolver::JwksCache;
 use crate::traits::{TokenProvider, Verifier};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use display_error_chain::ErrorChainExt;
 use jsonwebtoken::jwk::{AlgorithmParameters, Jwk, JwkSet, KeyAlgorithm};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
 
 use crate::jwt::key_alg_to_algorithm;
 use crate::resolver::same_origin;
-use oauth2::{AuthUrl, ClientId, ClientSecret, Scope, TokenResponse, TokenUrl, basic::BasicClient};
 use parking_lot::RwLock;
 use reqwest::Client as ReqwestClient;
 use std::collections::HashMap;
@@ -247,33 +248,61 @@ impl OidcTokenProvider {
             });
         }
 
-        let auth_url_str = discovery_response
-            .get("authorization_endpoint")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("{}/authorize", self.config.issuer_url));
-
-        // Create OAuth2 client (updated for new oauth2 builder API)
-        let client = BasicClient::new(ClientId::new(self.config.client_id.clone()))
-            .set_client_secret(ClientSecret::new(self.config.client_secret.clone()))
-            .set_auth_uri(AuthUrl::new(auth_url_str)?)
-            .set_token_uri(TokenUrl::new(token_endpoint.to_string())?);
-
-        let mut token_request = client.exchange_client_credentials();
-
+        let mut params = vec![("grant_type", "client_credentials")];
         if let Some(ref scope) = self.config.scope {
-            token_request = token_request.add_scope(Scope::new(scope.clone()));
+            params.push(("scope", scope.as_str()));
         }
 
-        let token_response = token_request
-            .request_async(&self.client)
-            .await
-            .map_err(|e| AuthError::OAuth2Request(Box::new(e)))?;
+        // RFC 6749 section 2.3.1: authenticate via HTTP Basic auth, with the
+        // client_id and client_secret separately percent-encoded before being
+        // joined and base64-encoded (plain HTTP Basic auth does not do this,
+        // but the spec requires it so that a ':' inside either value can't be
+        // confused with the id:secret separator).
+        let urlencoded_id: String =
+            url::form_urlencoded::byte_serialize(self.config.client_id.as_bytes()).collect();
+        let urlencoded_secret: String =
+            url::form_urlencoded::byte_serialize(self.config.client_secret.as_bytes()).collect();
+        let basic_credential =
+            BASE64_STANDARD.encode(format!("{urlencoded_id}:{urlencoded_secret}"));
 
-        let access_token = token_response.access_token().secret();
+        let http_resp = self
+            .client
+            .post(token_endpoint)
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Basic {basic_credential}"),
+            )
+            .form(&params)
+            .send()
+            .await?;
+        let status = http_resp.status();
+        let body = http_resp.text().await?;
+        let token_response: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+
+        if let Some(err) = token_response.get("error").and_then(|v| v.as_str()) {
+            let desc = token_response
+                .get("error_description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("no description");
+            return Err(AuthError::TokenEndpointError {
+                status: status.as_u16(),
+                body: format!("{err}: {desc}"),
+            });
+        }
+        if !status.is_success() {
+            return Err(AuthError::TokenEndpointError {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let access_token = token_response
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .ok_or(AuthError::GetTokenError)?;
         let expires_in = token_response
-            .expires_in()
-            .map(|duration| duration.as_secs())
+            .get("expires_in")
+            .and_then(|v| v.as_u64())
             .unwrap_or(3600); // Default to 1 hour
 
         // Calculate expiry timestamp
@@ -646,7 +675,7 @@ mod tests {
     use super::*;
     use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
     use serde_json::json;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // Use the test utilities from the testutils module
@@ -672,6 +701,66 @@ mod tests {
         // Test token retrieval
         let token = provider.get_token().unwrap();
         assert_eq!(token, expected_token);
+    }
+
+    /// RFC 6749 section 2.3.1: the client_credentials grant must authenticate
+    /// via HTTP Basic auth (percent-encoded id/secret, base64-joined), not by
+    /// putting client_id/client_secret in the POST body. Providers that only
+    /// accept client_secret_basic (many enterprise IdPs) would silently reject
+    /// requests if this regressed.
+    #[tokio::test]
+    async fn test_oidc_token_provider_uses_http_basic_auth() {
+        slim_config::tls::provider::initialize_crypto_provider();
+
+        let mock_server = MockServer::start().await;
+        let issuer_url = mock_server.uri();
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "issuer": issuer_url,
+                "authorization_endpoint": format!("{}/auth", issuer_url),
+                "token_endpoint": format!("{}/token", issuer_url),
+                "jwks_uri": format!("{}/jwks.json", issuer_url),
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // client_id and client_secret each contain a ':' and a '/' to exercise
+        // the percent-encoding step, per RFC 6749 section 2.3.1.
+        let client_id = "cl:ent/id";
+        let client_secret = "se:cret/val";
+        let urlencoded_id: String =
+            url::form_urlencoded::byte_serialize(client_id.as_bytes()).collect();
+        let urlencoded_secret: String =
+            url::form_urlencoded::byte_serialize(client_secret.as_bytes()).collect();
+        let expected_credential =
+            BASE64_STANDARD.encode(format!("{urlencoded_id}:{urlencoded_secret}"));
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(header(
+                "Authorization",
+                format!("Basic {expected_credential}").as_str(),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "basic-auth-token",
+                "expires_in": 3600
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = OidcProviderConfig {
+            client_id: client_id.to_string(),
+            client_secret: client_secret.to_string(),
+            issuer_url,
+            scope: None,
+            timeout: None,
+        };
+        let provider = OidcTokenProvider::new(config).unwrap();
+
+        let token = provider.fetch_new_token().await.unwrap();
+        assert_eq!(token, "basic-auth-token");
     }
 
     #[tokio::test]
@@ -1141,20 +1230,20 @@ mod tests {
         let result = provider.fetch_new_token().await;
         assert!(result.is_err());
 
-        // Should get an OAuth2Request (boxed RequestTokenError) due to the OAuth2 error response
+        // Should get a TokenEndpointError describing the OAuth2 error response
         match result {
-            Err(AuthError::OAuth2Request(e)) => {
-                // The typed RequestTokenError implements Display; inspect its message
-                let msg = e.to_string();
+            Err(AuthError::TokenEndpointError { status, body }) => {
+                assert_eq!(status, 400);
                 assert!(
-                    msg.contains("Server returned error response"),
+                    body.contains("invalid_client")
+                        && body.contains("Client authentication failed"),
                     "OAuth2 error message did not contain expected text: {}",
-                    msg
+                    body
                 );
             }
             other => {
                 panic!(
-                    "Expected OAuth2Request containing OAuth2 error, but got: {:?}",
+                    "Expected TokenEndpointError containing OAuth2 error, but got: {:?}",
                     other
                 );
             }

--- a/crates/slimctl/Cargo.toml
+++ b/crates/slimctl/Cargo.toml
@@ -36,6 +36,9 @@ agntcy-slim-version = { workspace = true }
 # Error handling
 anyhow = { workspace = true }
 
+# OIDC PKCE/CSRF token generation
+base64 = { workspace = true }
+
 # Utilities
 chrono = { workspace = true }
 
@@ -46,14 +49,14 @@ clap = { workspace = true }
 duration-string = { workspace = true }
 jsonwebtoken = { workspace = true }
 
-# OIDC OAuth2 authenctication
-oauth2 = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }
 
 # Async

--- a/crates/slimctl/src/commands/login.rs
+++ b/crates/slimctl/src/commands/login.rs
@@ -4,12 +4,14 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use clap::Args;
 use jsonwebtoken::jwk::JwkSet;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
-use oauth2::{CsrfToken, PkceCodeChallenge};
 use reqwest::Client;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::time::Instant;
@@ -295,6 +297,19 @@ async fn validate_id_token(
     Ok(claims)
 }
 
+/// Random URL-safe (base64, no padding) token of `num_bytes` random bytes.
+/// Used for the PKCE code verifier and the CSRF state/nonce values.
+fn random_url_safe_token(num_bytes: usize) -> String {
+    let mut bytes = vec![0u8; num_bytes];
+    rand::fill(bytes.as_mut_slice());
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// RFC 7636 S256 PKCE code challenge derived from a code verifier.
+fn pkce_code_challenge(verifier: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
 // Constant-time comparison to resist timing oracle attacks on the CSRF state token.
 fn ct_str_eq(a: &str, b: &str) -> bool {
     a.len() == b.len() && {
@@ -356,9 +371,10 @@ pub async fn run(args: &LoginArgs, config_file: Option<&str>, server: Option<&st
         .context("redirect URI must include the port")?;
     let path = parsed_redirect.path().to_owned();
 
-    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
-    let state = CsrfToken::new_random();
-    let nonce = CsrfToken::new_random().secret().clone();
+    let pkce_verifier = random_url_safe_token(32);
+    let pkce_challenge = pkce_code_challenge(&pkce_verifier);
+    let state = random_url_safe_token(16);
+    let nonce = random_url_safe_token(16);
 
     let mut auth_url = Url::parse(&meta.authorization_endpoint)?;
     auth_url
@@ -367,9 +383,9 @@ pub async fn run(args: &LoginArgs, config_file: Option<&str>, server: Option<&st
         .append_pair("client_id", &args.client_id)
         .append_pair("redirect_uri", &args.redirect_uri)
         .append_pair("scope", "openid profile email offline_access groups")
-        .append_pair("state", state.secret())
+        .append_pair("state", &state)
         .append_pair("nonce", &nonce)
-        .append_pair("code_challenge", pkce_challenge.as_str())
+        .append_pair("code_challenge", &pkce_challenge)
         .append_pair("code_challenge_method", "S256");
     let listener = bind_callback_listener(host, port).await?;
     eprintln!("listening on {}", args.redirect_uri);
@@ -391,7 +407,7 @@ pub async fn run(args: &LoginArgs, config_file: Option<&str>, server: Option<&st
     eprintln!("\nOpen this URL if no browser window appeared:\n\n{auth_url}\n");
 
     let (code, got_state) = wait_for_callback(listener, &path, args.callback_timeout).await?;
-    if !ct_str_eq(&got_state, state.secret()) {
+    if !ct_str_eq(&got_state, &state) {
         bail!("state mismatch; discarding authorization code");
     }
 
@@ -400,7 +416,7 @@ pub async fn run(args: &LoginArgs, config_file: Option<&str>, server: Option<&st
         ("code", code.as_str()),
         ("redirect_uri", args.redirect_uri.as_str()),
         ("client_id", args.client_id.as_str()),
-        ("code_verifier", pkce_verifier.secret()),
+        ("code_verifier", pkce_verifier.as_str()),
     ];
 
     let token_resp: Value = http
@@ -470,6 +486,27 @@ pub async fn run(args: &LoginArgs, config_file: Option<&str>, server: Option<&st
 mod tests {
     use super::*;
     use clap::Parser;
+
+    // RFC 7636 Appendix B test vector.
+    #[test]
+    fn pkce_code_challenge_matches_rfc7636_vector() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(
+            pkce_code_challenge(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn random_url_safe_token_has_no_padding_and_varies() {
+        let a = random_url_safe_token(32);
+        let b = random_url_safe_token(32);
+        assert_ne!(a, b);
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+    }
 
     /// Wrap LoginArgs in a throwaway top-level parser so we can exercise clap
     /// validation without going through the full `Cli` struct.


### PR DESCRIPTION
# Description

`oauth2 5.0.0` dependency pins `reqwest = 0.12` with no path to `0.13`. As the `oauth2` crate is only used for a single client-credentials token exchange and PKCE/CSRF token generation, the local reimplementation is worthwhile for keeping the transient deps up-to-date. Unblocks PR #2044 .

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
